### PR TITLE
Fix bugs in ambiguity management

### DIFF
--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -91,6 +91,7 @@ void ts_document_set_input(TSDocument *, TSInput);
 void ts_document_set_input_string(TSDocument *, const char *);
 TSDebugger ts_document_debugger(const TSDocument *);
 void ts_document_set_debugger(TSDocument *, TSDebugger);
+void ts_document_print_debugging_graphs(TSDocument *, bool);
 void ts_document_edit(TSDocument *, TSInputEdit);
 int ts_document_parse(TSDocument *);
 void ts_document_invalidate(TSDocument *);

--- a/spec/helpers/tree_helpers.cc
+++ b/spec/helpers/tree_helpers.cc
@@ -7,13 +7,12 @@ using std::string;
 using std::to_string;
 using std::ostream;
 
-static const char *symbol_names[24] = {
+const char *symbol_names[24] = {
   "ERROR", "END",  "two", "three", "four", "five", "six", "seven", "eight",
   "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen",
   "sixteen", "seventeen", "eighteen", "nineteen", "twenty", "twenty-one",
   "twenty-two", "twenty-three"
 };
-
 
 TSTree ** tree_array(std::vector<TSTree *> trees) {
   TSTree ** result = (TSTree **)calloc(trees.size(), sizeof(TSTree *));

--- a/spec/helpers/tree_helpers.h
+++ b/spec/helpers/tree_helpers.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <string>
 
+extern const char *symbol_names[24];
 TSTree ** tree_array(std::vector<TSTree *> trees);
 
 std::ostream &operator<<(std::ostream &stream, const TSTree *tree);

--- a/spec/integration/corpus_specs.cc
+++ b/spec/integration/corpus_specs.cc
@@ -112,6 +112,7 @@ describe("The Corpus", []() {
         document = ts_document_make();
         ts_document_set_language(document, get_test_language(language_name));
         // ts_document_set_debugger(document, log_debugger_make(true));
+        // ts_document_print_debugging_graphs(document, true);
       });
 
       after_each([&]() {

--- a/spec/runtime/tree_spec.cc
+++ b/spec/runtime/tree_spec.cc
@@ -14,17 +14,6 @@ enum {
   hog,
 };
 
-static const char *names[] = {
-  "ERROR",
-  "END",
-  "cat",
-  "dog",
-  "eel",
-  "fox",
-  "goat",
-  "hog",
-};
-
 describe("Tree", []() {
   TSTree *tree1, *tree2, *parent1;
   TSSymbolMetadata visible = {true, true, false, true};

--- a/src/runtime/array.h
+++ b/src/runtime/array.h
@@ -43,13 +43,9 @@ extern "C" {
     array_grow((self), (self)->capacity * 2)) && \
    ((self)->contents[(self)->size++] = (element), true))
 
-#define array_splice(self, index, old_count, new_count, new_elements) \
-  array__splice((VoidArray *)(self),                                  \
-                array__elem_size(self),                               \
-                index,                                                \
-                old_count,                                            \
-                new_count,                                            \
-                new_elements)                                         \
+#define array_splice(self, index, old_count, new_count, new_elements)          \
+  array__splice((VoidArray *)(self), array__elem_size(self), index, old_count, \
+                new_count, new_elements)
 
 #define array_pop(self) ((self)->contents[--(self)->size])
 
@@ -118,11 +114,11 @@ static inline bool array__splice(VoidArray *self, size_t element_size,
 
   char *contents = (char *)self->contents;
   if (self->size > old_end)
-    memmove(contents + new_end * element_size,
-            contents + old_end * element_size,
+    memmove(contents + new_end * element_size, contents + old_end * element_size,
             (self->size - old_end) * element_size);
   if (new_count > 0)
-    memcpy((contents + index * element_size), elements, new_count * element_size);
+    memcpy((contents + index * element_size), elements,
+           new_count * element_size);
   self->size += new_count - old_count;
   return true;
 }

--- a/src/runtime/array.h
+++ b/src/runtime/array.h
@@ -40,7 +40,7 @@ extern "C" {
 
 #define array_push(self, element)                \
   (((self)->size < (self)->capacity ||           \
-    array_grow((self), (self)->capacity * 2)) && \
+    array_grow((self), (self)->capacity ? (self)->capacity * 2 : 4)) && \
    ((self)->contents[(self)->size++] = (element), true))
 
 #define array_splice(self, index, old_count, new_count, new_elements)          \

--- a/src/runtime/document.c
+++ b/src/runtime/document.c
@@ -52,6 +52,10 @@ void ts_document_set_debugger(TSDocument *self, TSDebugger debugger) {
   ts_parser_set_debugger(&self->parser, debugger);
 }
 
+void ts_document_print_debugging_graphs(TSDocument *self, bool should_print) {
+  self->parser.print_debugging_graphs = should_print;
+}
+
 TSInput ts_document_input(TSDocument *self) {
   return self->input;
 }

--- a/src/runtime/node.c
+++ b/src/runtime/node.c
@@ -207,9 +207,7 @@ TSSymbol ts_node_symbol(TSNode self) {
 TSSymbolIterator ts_node_symbols(TSNode self) {
   const TSTree *tree = ts_node__tree(self);
   return (TSSymbolIterator){
-    .value = tree->symbol,
-    .done = false,
-    .data = (void *)tree,
+    .value = tree->symbol, .done = false, .data = (void *)tree,
   };
 }
 
@@ -280,7 +278,8 @@ char *ts_node_string(TSNode self, const TSDocument *document) {
   static char SCRATCH[1];
   const TSTree *tree = ts_node__tree(self);
   const char **symbol_names = document->parser.language->symbol_names;
-  size_t size = ts_tree__write_to_string(tree, symbol_names, SCRATCH, 0, true, false) + 1;
+  size_t size =
+    ts_tree__write_to_string(tree, symbol_names, SCRATCH, 0, true, false) + 1;
   char *result = ts_malloc(size * sizeof(char));
   ts_tree__write_to_string(tree, symbol_names, result, size, true, false);
   return result;

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -15,8 +15,6 @@
  *  Debugging
  */
 
-bool TS_PARSER_PRINT_STACKS = false;
-
 #define LOG(...)                                                               \
   if (self->lexer.debugger.debug_fn) {                                         \
     snprintf(self->lexer.debug_buffer, TS_DEBUG_BUFFER_SIZE, __VA_ARGS__);     \
@@ -26,14 +24,14 @@ bool TS_PARSER_PRINT_STACKS = false;
 
 #define LOG_ACTION(...)                   \
   LOG(__VA_ARGS__);                       \
-  if (TS_PARSER_PRINT_STACKS) {           \
+  if (self->print_debugging_graphs) {     \
     fprintf(stderr, "graph {\nlabel=\""); \
     fprintf(stderr, __VA_ARGS__);         \
     fprintf(stderr, "\"\n}\n\n");         \
   }
 
 #define LOG_STACK()                                                      \
-  if (TS_PARSER_PRINT_STACKS) {                                          \
+  if (self->print_debugging_graphs) {                                    \
     fputs(ts_stack_dot_graph(self->stack, self->language->symbol_names), \
           stderr);                                                       \
     fputs("\n\n", stderr);                                               \

--- a/src/runtime/parser.h
+++ b/src/runtime/parser.h
@@ -18,6 +18,7 @@ typedef struct {
   Array(TSTree *) reduce_parents;
   TSTree *finished_tree;
   bool is_split;
+  bool print_debugging_graphs;
 } TSParser;
 
 bool ts_parser_init(TSParser *);

--- a/src/runtime/stack.c
+++ b/src/runtime/stack.c
@@ -12,12 +12,19 @@
 #define STARTING_TREE_CAPACITY 10
 #define MAX_NODE_POOL_SIZE 50
 
-typedef struct StackNode {
+typedef struct StackNode StackNode;
+
+typedef struct {
+  StackNode *node;
+  TSTree *tree;
+} StackLink;
+
+struct StackNode {
   StackEntry entry;
-  struct StackNode *successors[MAX_SUCCESSOR_COUNT];
+  StackLink successors[MAX_SUCCESSOR_COUNT];
   short unsigned int successor_count;
   short unsigned int ref_count;
-} StackNode;
+};
 
 typedef struct {
   size_t goal_tree_count;
@@ -100,11 +107,6 @@ TSLength ts_stack_top_position(const Stack *self, int head) {
   return entry ? entry->position : ts_length_zero();
 }
 
-TSTree *ts_stack_top_tree(const Stack *self, int head) {
-  StackEntry *entry = ts_stack_head((Stack *)self, head);
-  return entry ? entry->tree : NULL;
-}
-
 StackEntry *ts_stack_head(Stack *self, int head) {
   StackNode *node = self->heads.contents[head];
   return node ? &node->entry : NULL;
@@ -119,7 +121,7 @@ int ts_stack_entry_next_count(const StackEntry *entry) {
 }
 
 StackEntry *ts_stack_entry_next(const StackEntry *entry, int i) {
-  return &((const StackNode *)entry)->successors[i]->entry;
+  return &((const StackNode *)entry)->successors[i].node->entry;
 }
 
 /*
@@ -139,9 +141,10 @@ static bool stack_node_release(Stack *self, StackNode *node) {
   assert(node->ref_count != 0);
   node->ref_count--;
   if (node->ref_count == 0) {
-    for (int i = 0; i < node->successor_count; i++)
-      stack_node_release(self, node->successors[i]);
-    ts_tree_release(node->entry.tree);
+    for (int i = 0; i < node->successor_count; i++) {
+      stack_node_release(self, node->successors[i].node);
+      ts_tree_release(node->successors[i].tree);
+    }
 
     if (self->node_pool.size >= MAX_NODE_POOL_SIZE)
       ts_free(node);
@@ -174,24 +177,10 @@ static StackNode *stack_node_new(Stack *self, StackNode *next, TSStateId state,
   *node = (StackNode){
     .ref_count = 1,
     .successor_count = 1,
-    .successors = { next, NULL, NULL },
-    .entry = {.state = state, .tree = tree, .position = position },
+    .successors = { {next, tree} },
+    .entry = {.state = state, .position = position },
   };
   return node;
-}
-
-static void ts_stack__add_alternative_tree(Stack *self, StackNode *node,
-                                           TSTree *tree) {
-  if (tree != node->entry.tree) {
-    int comparison = self->tree_selection_function(self->tree_selection_payload,
-                                                   node->entry.tree, tree);
-
-    if (comparison > 0) {
-      ts_tree_retain(tree);
-      ts_tree_release(node->entry.tree);
-      node->entry.tree = tree;
-    }
-  }
 }
 
 static void ts_stack__clear_pop_result(Stack *self, StackPopResult *result) {
@@ -230,27 +219,31 @@ static void ts_stack__add_alternative_pop_result(Stack *self,
   }
 }
 
-static void ts_stack__add_node_successor(Stack *self, StackNode *node,
-                                         StackNode *new_successor) {
-  for (int i = 0; i < node->successor_count; i++) {
-    StackNode *successor = node->successors[i];
-    if (successor == new_successor)
-      return;
-    if (!successor)
-      continue;
-
-    if (successor->entry.state == new_successor->entry.state) {
-      ts_stack__add_alternative_tree(self, successor, new_successor->entry.tree);
-      for (int j = 0; j < new_successor->successor_count; j++)
-        ts_stack__add_node_successor(self, successor,
-                                     new_successor->successors[j]);
-      return;
+static void stack_node__add_successor(StackNode *self,
+                                      TSTree *new_tree,
+                                      StackNode *new_node) {
+  for (int i = 0; i < self->successor_count; i++) {
+    StackLink successor = self->successors[i];
+    if (successor.tree == new_tree) {
+      if (successor.node == new_node)
+        return;
+      if (successor.node && new_node &&
+          successor.node->entry.state == new_node->entry.state) {
+        for (int j = 0; j < new_node->successor_count; j++) {
+          stack_node__add_successor(successor.node,
+            new_node->successors[j].tree, new_node->successors[j].node);
+        }
+        return;
+      }
     }
   }
 
-  stack_node_retain(new_successor);
-  node->successors[node->successor_count] = new_successor;
-  node->successor_count++;
+  stack_node_retain(new_node);
+  ts_tree_retain(new_tree);
+  self->successors[self->successor_count++] = (StackLink){
+    new_node,
+    new_tree,
+  };
 }
 
 /*
@@ -296,8 +289,7 @@ StackPushResult ts_stack_push(Stack *self, int head_index, TSStateId state,
     StackEntry prior_entry = prior_node->entry;
     if (prior_entry.state == state &&
         ts_length_eq(prior_entry.position, position)) {
-      ts_stack__add_alternative_tree(self, prior_node, tree);
-      ts_stack__add_node_successor(self, prior_node, current_head);
+      stack_node__add_successor(prior_node, tree, current_head);
       ts_stack_remove_head(self, head_index);
       return StackPushResultMerged;
     }
@@ -349,38 +341,43 @@ StackPopResultArray ts_stack_pop(Stack *self, int head_index, int child_count,
 
       if (!node || path->trees.size == path->goal_tree_count)
         continue;
-
       all_paths_done = false;
-
-      /*
-       *  Children that are 'extra' do not count towards the total child count.
-       */
-      if (node->entry.tree->extra && !count_extra)
-        path->goal_tree_count++;
 
       /*
        *  If a node has more than one successor, create new paths for each of
        *  the additional successors.
        */
-      if (path->is_shared) {
-        path->trees = (TreeArray)array_copy(&path->trees);
-        for (size_t j = 0; j < path->trees.size; j++)
-          ts_tree_retain(path->trees.contents[j]);
-        path->is_shared = false;
-      }
+      for (int j = 0; j < node->successor_count; j++) {
+        StackLink successor = node->successors[j];
 
-      ts_tree_retain(node->entry.tree);
-      if (!array_push(&path->trees, node->entry.tree))
-        goto error;
+        PopPath *next_path;
+        if (j == 0) {
+          next_path = path;
+        } else {
+          if (!array_push(&self->pop_paths, *path))
+            goto error;
+          next_path = array_back(&self->pop_paths);
+          next_path->is_shared = true;
+        }
 
-      path->node = path->node->successors[0];
-      for (int j = 1; j < node->successor_count; j++) {
-        if (!array_push(&self->pop_paths, *path))
+        if (next_path->is_shared) {
+          next_path->trees = (TreeArray)array_copy(&path->trees);
+          next_path->trees.size--;
+          for (size_t j = 0; j < next_path->trees.size; j++)
+            ts_tree_retain(next_path->trees.contents[j]);
+          next_path->is_shared = false;
+        }
+
+        next_path->node = successor.node;
+        ts_tree_retain(successor.tree);
+        if (!array_push(&next_path->trees, successor.tree))
           goto error;
 
-        PopPath *next_path = array_back(&self->pop_paths);
-        next_path->node = node->successors[j];
-        next_path->is_shared = true;
+        /*
+         *  Children that are 'extra' do not count towards the total child count.
+         */
+        if (successor.tree->extra && !count_extra)
+          next_path->goal_tree_count++;
       }
     }
   }
@@ -440,7 +437,7 @@ void ts_stack_shrink(Stack *self, int head_index, int count) {
   for (int i = 0; i < count; i++) {
     if (new_head->successor_count == 0)
       break;
-    new_head = new_head->successors[0];
+    new_head = new_head->successors[0].node;
   }
   stack_node_retain(new_head);
   stack_node_release(self, head);
@@ -475,9 +472,11 @@ void ts_stack_delete(Stack *self) {
   ts_free(self);
 }
 
-static const char *graph_colors[] = {
+static const char *COLORS[] = {
   "red", "blue", "orange", "green", "purple",
 };
+
+static size_t COLOR_COUNT = sizeof(COLORS) / sizeof(COLORS[0]);
 
 size_t ts_stack__write_dot_graph(Stack *self, char *string, size_t n,
                                  const char **symbol_names) {
@@ -486,15 +485,15 @@ size_t ts_stack__write_dot_graph(Stack *self, char *string, size_t n,
   cursor += snprintf(*s, n, "digraph stack {\n");
   cursor += snprintf(*s, n, "rankdir=\"RL\";\n");
 
+  Array(StackNode *) visited_nodes;
+  array_init(&visited_nodes);
+
   array_clear(&self->pop_paths);
   for (size_t i = 0; i < self->heads.size; i++) {
     StackNode *node = self->heads.contents[i];
-    const char *color =
-      graph_colors[i % (sizeof(graph_colors) / sizeof(graph_colors[0]))];
+    const char *color = COLORS[i % COLOR_COUNT];
     cursor += snprintf(*s, n, "node_%p [color=%s];\n", node, color);
-    array_push(&self->pop_paths, ((PopPath){
-                                   .node = node,
-                                 }));
+    array_push(&self->pop_paths, ((PopPath){ .node = node }));
   }
 
   bool all_paths_done = false;
@@ -505,38 +504,47 @@ size_t ts_stack__write_dot_graph(Stack *self, char *string, size_t n,
       PopPath *path = &self->pop_paths.contents[i];
       StackNode *node = path->node;
 
+      for (size_t j = 0; j < visited_nodes.size; j++) {
+        if (visited_nodes.contents[j] == node) {
+          node = NULL;
+          break;
+        }
+      }
+
       if (!node)
         continue;
-
       all_paths_done = false;
 
-      cursor +=
-        snprintf(*s, n, "node_%p [label=\"%s\\n%d\"];\n", node,
-                 symbol_names[node->entry.tree->symbol], node->entry.state);
+      cursor += snprintf(*s, n, "node_%p [label=%d];\n", node, node->entry.state);
 
-      path->node = node->successors[0];
-      cursor +=
-        snprintf(*s, n, "node_%p -> node_%p;\n", node, node->successors[0]);
+      for (int j = 0; j < node->successor_count; j++) {
+        StackLink successor = node->successors[j];
+        cursor += snprintf(*s, n, "node_%p -> node_%p [label=\"%s\"];\n", node,
+          successor.node, symbol_names[successor.tree->symbol]);
 
-      for (int j = 1; j < node->successor_count; j++) {
-        if (!array_push(&self->pop_paths, *path))
-          goto error;
-        cursor +=
-          snprintf(*s, n, "node_%p -> node_%p;\n", node, node->successors[j]);
-
-        PopPath *next_path = array_back(&self->pop_paths);
-        next_path->node = node->successors[j];
-        next_path->is_shared = true;
+        if (j == 0) {
+          path->node = successor.node;
+        } else {
+          if (!array_push(&self->pop_paths, *path))
+            goto error;
+          PopPath *next_path = array_back(&self->pop_paths);
+          next_path->node = successor.node;
+        }
       }
+
+      if (!array_push(&visited_nodes, node))
+        goto error;
     }
   }
 
-  cursor += snprintf(*s, n, "node_%p [label=\"-\\n0\"];\n", NULL);
+  cursor += snprintf(*s, n, "node_%p [label=0];\n", NULL);
   cursor += snprintf(*s, n, "}\n");
 
+  array_delete(&visited_nodes);
   return cursor - string;
 
 error:
+  array_delete(&visited_nodes);
   return (size_t)-1;
 }
 

--- a/src/runtime/stack.h
+++ b/src/runtime/stack.h
@@ -119,6 +119,8 @@ void ts_stack_clear(Stack *);
 void ts_stack_set_tree_selection_callback(Stack *, void *,
                                           TreeSelectionFunction);
 
+char *ts_stack_dot_graph(Stack *, const char **);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/runtime/stack.h
+++ b/src/runtime/stack.h
@@ -12,7 +12,6 @@ extern "C" {
 typedef struct Stack Stack;
 
 typedef struct {
-  TSTree *tree;
   TSStateId state;
   TSLength position;
 } StackEntry;
@@ -52,12 +51,6 @@ int ts_stack_head_count(const Stack *);
  *  returns the initial state (0).
  */
 TSStateId ts_stack_top_state(const Stack *, int head);
-
-/*
- *  Get the tree at given head of the stack. If the stack is empty, this
- *  returns NULL.
- */
-TSTree *ts_stack_top_tree(const Stack *, int head);
 
 /*
  *  Get the position of the given head of the stack. If the stack is empty, this


### PR DESCRIPTION
Fixes an issue discovered in https://github.com/tree-sitter/tree-sitter-ruby/pull/16

#### Debugging

This adds a `ts_document_print_debugging_graphs` function. When this boolean flag is set on the document, it dumps a [DOT](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) representation of the graph-structured parse stack after every parse action. This output can be piped directly to `dot`to produce a sequence of graphs and parse actions, like this:

<img width="918" alt="screen shot 2016-02-23 at 5 41 04 pm" src="https://cloud.githubusercontent.com/assets/326587/13272942/adceeea6-da54-11e5-9eb2-a6e4a03b4975.png">

#### Bug fix

This fixes a bug wherein ambiguities were merged incorrectly, producing nonsensical parse trees.