### PR TITLE
Parse table compression

### DIFF
--- a/spec/helpers/random_helpers.cc
+++ b/spec/helpers/random_helpers.cc
@@ -1,0 +1,35 @@
+#include <string>
+#include <stdlib.h>
+
+using std::string;
+
+static string random_string(char min, char max) {
+  string result;
+  size_t length = random() % 12;
+  for (size_t i = 0; i < length; i++) {
+    char inserted_char = min + (random() % (max - min));
+    result += inserted_char;
+  }
+  return result;
+}
+
+static string random_char(string characters) {
+  size_t index = random() % characters.size();
+  return string() + characters[index];
+}
+
+string random_words(size_t count) {
+  string result;
+  bool just_inserted_word = false;
+  for (size_t i = 0; i < count; i++) {
+    if (random() % 10 < 6) {
+      result += random_char("!(){}[]<>+-=");
+    } else {
+      if (just_inserted_word)
+        result += " ";
+      result += random_string('a', 'z');
+      just_inserted_word = true;
+    }
+  }
+  return result;
+}

--- a/spec/helpers/random_helpers.h
+++ b/spec/helpers/random_helpers.h
@@ -1,0 +1,8 @@
+#ifndef HELPERS_RANDOM_HELPERS_H_
+#define HELPERS_RANDOM_HELPERS_H_
+
+#include <string>
+
+std::string random_words(size_t count);
+
+#endif  // HELPERS_RANDOM_HELPERS_H_

--- a/spec/integration/corpus_specs.cc
+++ b/spec/integration/corpus_specs.cc
@@ -7,6 +7,7 @@
 #include "helpers/point_helpers.h"
 #include "helpers/encoding_helpers.h"
 #include "helpers/record_alloc.h"
+#include "helpers/random_helpers.h"
 #include <set>
 
 static void expect_the_correct_tree(TSNode node, TSDocument *document, string tree_string) {
@@ -58,37 +59,6 @@ static void expect_a_consistent_tree(TSNode node, TSDocument *document) {
 
   if (child_count > 0)
     AssertThat(has_changes, Equals(some_child_has_changes));
-}
-
-static string random_string(char min, char max) {
-  string result;
-  size_t length = random() % 12;
-  for (size_t i = 0; i < length; i++) {
-    char inserted_char = min + (random() % (max - min));
-    result += inserted_char;
-  }
-  return result;
-}
-
-static string random_char(string characters) {
-  size_t index = random() % characters.size();
-  return string() + characters[index];
-}
-
-static string random_words(size_t count) {
-  string result;
-  bool just_inserted_word = false;
-  for (size_t i = 0; i < count; i++) {
-    if (random() % 10 < 6) {
-      result += random_char("!(){}[]<>+-=");
-    } else {
-      if (just_inserted_word)
-        result += " ";
-      result += random_string('a', 'z');
-      just_inserted_word = true;
-    }
-  }
-  return result;
 }
 
 START_TEST

--- a/spec/runtime/document_spec.cc
+++ b/spec/runtime/document_spec.cc
@@ -173,7 +173,7 @@ describe("Document", [&]() {
 
       AssertThat(debugger->messages, Contains("new_parse"));
       AssertThat(debugger->messages, Contains("lookahead char:'['"));
-      AssertThat(debugger->messages, Contains("reduce sym:array, child_count:4, fragile:false"));
+      AssertThat(debugger->messages, Contains("reduce sym:array, child_count:4"));
       AssertThat(debugger->messages, Contains("accept"));
     });
 

--- a/spec/runtime/parser_spec.cc
+++ b/spec/runtime/parser_spec.cc
@@ -224,7 +224,7 @@ describe("Parser", [&]() {
               "(identifier) "
               "(math_op (number) (identifier)))))");
 
-          insert_text(strlen("x ^ (100 + abc"), ".d");
+          insert_text(strlen("x * (100 + abc"), ".d");
 
           assert_root_node(
             "(program (expression_statement (math_op "

--- a/spec/runtime/parser_spec.cc
+++ b/spec/runtime/parser_spec.cc
@@ -231,7 +231,7 @@ describe("Parser", [&]() {
               "(identifier) "
               "(math_op (number) (member_access (identifier) (identifier))))))");
 
-          AssertThat(input->strings_read, Equals(vector<string>({ " abc.d);", "" })));
+          AssertThat(input->strings_read, Equals(vector<string>({ " + abc.d)", "" })));
         });
       });
 

--- a/src/compiler/build_tables/build_lex_table.cc
+++ b/src/compiler/build_tables/build_lex_table.cc
@@ -147,7 +147,7 @@ class LexTableBuilder {
     }
 
     auto replacements =
-      remove_duplicate_states<LexState, AdvanceAction>(&lex_table.states);
+      remove_duplicate_states<LexTable, AdvanceAction>(&lex_table);
 
     for (ParseState &parse_state : parse_table->states) {
       auto replacement = replacements.find(parse_state.lex_state_id);

--- a/src/compiler/build_tables/build_parse_table.cc
+++ b/src/compiler/build_tables/build_parse_table.cc
@@ -70,6 +70,11 @@ class ParseTableBuilder {
     if (error.type != TSCompileErrorTypeNone)
       return { parse_table, error };
 
+    for (const ParseState &state : parse_table.states)
+      for (const auto &pair1 : state.entries)
+        for (const auto &pair2 : state.entries)
+          parse_table.symbols[pair1.first].compatible_symbols.insert(pair2.first);
+
     build_error_parse_state();
 
     allow_any_conflict = true;
@@ -134,8 +139,7 @@ class ParseTableBuilder {
     const ParseItemSet &item_set = recovery_states[symbol];
     if (!item_set.entries.empty()) {
       ParseStateId state = add_parse_state(item_set);
-      error_state->entries[symbol].actions.push_back(
-        ParseAction::Recover(state));
+      error_state->entries[symbol].actions.push_back(ParseAction::Recover(state));
     }
   }
 
@@ -268,7 +272,7 @@ class ParseTableBuilder {
   }
 
   void remove_duplicate_parse_states() {
-    remove_duplicate_states<ParseState, ParseAction>(&parse_table.states);
+    remove_duplicate_states<ParseTable, ParseAction>(&parse_table);
   }
 
   ParseAction *add_action(ParseStateId state_id, Symbol lookahead,

--- a/src/compiler/build_tables/build_parse_table.cc
+++ b/src/compiler/build_tables/build_parse_table.cc
@@ -115,13 +115,12 @@ class ParseTableBuilder {
   void build_error_parse_state() {
     ParseState error_state;
 
-    for (const Symbol &symbol : recovery_tokens(lexical_grammar)) {
+    for (const Symbol &symbol : recovery_tokens(lexical_grammar))
       add_out_of_context_parse_state(&error_state, symbol);
-    }
 
-    for (const Symbol &symbol : grammar.extra_tokens) {
-      error_state.entries[symbol].actions.push_back(ParseAction::ShiftExtra());
-    }
+    for (const Symbol &symbol : grammar.extra_tokens)
+      if (!error_state.entries.count(symbol))
+        error_state.entries[symbol].actions.push_back(ParseAction::ShiftExtra());
 
     for (size_t i = 0; i < grammar.variables.size(); i++) {
       Symbol symbol(i, false);
@@ -197,8 +196,13 @@ class ParseTableBuilder {
 
   void add_shift_extra_actions(ParseStateId state_id) {
     ParseAction action = ParseAction::ShiftExtra();
+    ParseState &state = parse_table.states[state_id];
     for (const Symbol &extra_symbol : grammar.extra_tokens)
-      add_action(state_id, extra_symbol, action, null_item_set);
+      if (!state.entries.count(extra_symbol) ||
+          (allow_any_conflict &&
+           state.entries[extra_symbol].actions.back().type ==
+             ParseActionTypeReduce))
+        parse_table.add_action(state_id, extra_symbol, action);
   }
 
   void add_reduce_extra_actions(ParseStateId state_id) {

--- a/src/compiler/build_tables/remove_duplicate_states.h
+++ b/src/compiler/build_tables/remove_duplicate_states.h
@@ -7,15 +7,15 @@
 namespace tree_sitter {
 namespace build_tables {
 
-template <typename StateType, typename ActionType>
-std::map<size_t, size_t> remove_duplicate_states(std::vector<StateType> *states) {
+template <typename TableType, typename ActionType>
+std::map<size_t, size_t> remove_duplicate_states(TableType *table) {
   std::map<size_t, size_t> replacements;
 
   while (true) {
     std::map<size_t, size_t> duplicates;
-    for (size_t i = 0, size = states->size(); i < size; i++)
+    for (size_t i = 0, size = table->states.size(); i < size; i++)
       for (size_t j = 0; j < i; j++)
-        if (states->at(i) == states->at(j)) {
+        if (!duplicates.count(j) && table->merge_state(j, i)) {
           duplicates.insert({ i, j });
           break;
         }
@@ -24,7 +24,7 @@ std::map<size_t, size_t> remove_duplicate_states(std::vector<StateType> *states)
       break;
 
     std::map<size_t, size_t> new_replacements;
-    for (size_t i = 0, size = states->size(); i < size; i++) {
+    for (size_t i = 0, size = table->states.size(); i < size; i++) {
       size_t new_state_index = i;
       auto duplicate = duplicates.find(i);
       if (duplicate != duplicates.end())
@@ -45,7 +45,7 @@ std::map<size_t, size_t> remove_duplicate_states(std::vector<StateType> *states)
           replacement.second = new_state_index;
     }
 
-    for (StateType &state : *states)
+    for (auto &state : table->states)
       state.each_advance_action([&new_replacements](ActionType *action) {
         auto new_replacement = new_replacements.find(action->state_index);
         if (new_replacement != new_replacements.end())
@@ -53,7 +53,7 @@ std::map<size_t, size_t> remove_duplicate_states(std::vector<StateType> *states)
       });
 
     for (auto i = duplicates.rbegin(); i != duplicates.rend(); ++i)
-      states->erase(states->begin() + i->first);
+      table->states.erase(table->states.begin() + i->first);
   }
 
   return replacements;

--- a/src/compiler/generate_code/c_code.cc
+++ b/src/compiler/generate_code/c_code.cc
@@ -165,6 +165,9 @@ class CCodeGenerator {
               line(".named = false,");
               break;
             case VariableTypeHidden:
+              line(".visible = false,");
+              line(".named = true,");
+              break;
             case VariableTypeAuxiliary:
               line(".visible = false,");
               line(".named = false,");

--- a/src/compiler/generate_code/c_code.cc
+++ b/src/compiler/generate_code/c_code.cc
@@ -211,7 +211,7 @@ class CCodeGenerator {
   }
 
   void add_parse_table() {
-    add_parse_action_list_id(ParseTableEntry{ {}, true, false });
+    add_parse_action_list_id(ParseTableEntry{ {}, false, false });
 
     size_t state_id = 0;
     line("#pragma GCC diagnostic push");

--- a/src/compiler/lex_table.cc
+++ b/src/compiler/lex_table.cc
@@ -71,4 +71,8 @@ LexState &LexTable::state(LexStateId id) {
   return states[id];
 }
 
+bool LexTable::merge_state(size_t i, size_t j) {
+  return states[i] == states[j];
+}
+
 }  // namespace tree_sitter

--- a/src/compiler/lex_table.h
+++ b/src/compiler/lex_table.h
@@ -22,7 +22,7 @@ struct AdvanceAction {
   AdvanceAction();
   AdvanceAction(size_t, PrecedenceRange, bool);
 
-  bool operator==(const AdvanceAction &action) const;
+  bool operator==(const AdvanceAction &other) const;
 
   size_t state_index;
   PrecedenceRange precedence_range;
@@ -66,6 +66,8 @@ class LexTable {
   LexStateId add_state();
   LexState &state(LexStateId state_id);
   std::vector<LexState> states;
+
+  bool merge_state(size_t i, size_t j);
 };
 
 }  // namespace tree_sitter

--- a/src/compiler/parse_table.h
+++ b/src/compiler/parse_table.h
@@ -61,6 +61,10 @@ struct ParseTableEntry {
   ParseTableEntry();
   ParseTableEntry(const std::vector<ParseAction> &, bool, bool);
   bool operator==(const ParseTableEntry &other) const;
+
+  inline bool operator!=(const ParseTableEntry &other) const {
+    return !operator==(other);
+  }
 };
 
 class ParseState {
@@ -68,6 +72,7 @@ class ParseState {
   ParseState();
   std::set<rules::Symbol> expected_inputs() const;
   bool operator==(const ParseState &) const;
+  bool merge(const ParseState &);
   void each_advance_action(std::function<void(ParseAction *)>);
 
   std::map<rules::Symbol, ParseTableEntry> entries;
@@ -77,6 +82,7 @@ class ParseState {
 struct ParseTableSymbolMetadata {
   bool extra;
   bool structural;
+  std::set<rules::Symbol> compatible_symbols;
 };
 
 class ParseTable {
@@ -87,6 +93,7 @@ class ParseTable {
                           ParseAction action);
   ParseAction &add_action(ParseStateId state_id, rules::Symbol symbol,
                           ParseAction action);
+  bool merge_state(size_t i, size_t j);
 
   std::vector<ParseState> states;
   std::map<rules::Symbol, ParseTableSymbolMetadata> symbols;

--- a/src/runtime/node.c
+++ b/src/runtime/node.c
@@ -33,7 +33,7 @@ static inline size_t ts_node__offset_row(TSNode self) {
 
 static inline bool ts_node__is_relevant(TSNode self, bool include_anonymous) {
   const TSTree *tree = ts_node__tree(self);
-  return include_anonymous ? tree->visible : tree->named;
+  return include_anonymous ? tree->visible : tree->visible && tree->named;
 }
 
 static inline size_t ts_node__relevant_child_count(TSNode self,

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -170,6 +170,7 @@ static bool ts_parser__condense_stack(TSParser *self) {
   bool result = false;
   for (StackVersion i = 0; i < ts_stack_version_count(self->stack); i++) {
     if (ts_stack_is_halted(self->stack, i)) {
+      result = true;
       ts_stack_remove_version(self->stack, i);
       i--;
       continue;

--- a/src/runtime/parser.h
+++ b/src/runtime/parser.h
@@ -10,6 +10,11 @@ extern "C" {
 #include "runtime/reduce_action.h"
 
 typedef struct {
+  TSTree *tree;
+  size_t char_index;
+} ReusableNode;
+
+typedef struct {
   TSLexer lexer;
   Stack *stack;
   const TSLanguage *language;
@@ -18,6 +23,9 @@ typedef struct {
   bool is_split;
   bool print_debugging_graphs;
   TSTree scratch_tree;
+  TSTree *cached_token;
+  size_t cached_token_char_index;
+  ReusableNode reusable_node;
 } TSParser;
 
 bool ts_parser_init(TSParser *);

--- a/src/runtime/tree.c
+++ b/src/runtime/tree.c
@@ -436,8 +436,8 @@ void ts_tree__print_dot_graph(const TSTree *self, size_t offset,
   if (self->extra)
     fprintf(f, ", fontcolor=gray");
 
-  fprintf(f, ", tooltip=\"%lu - %lu\"]\n", offset,
-          offset + ts_tree_total_chars(self));
+  fprintf(f, ", tooltip=\"range:%lu - %lu\nstate:%d\"]\n", offset,
+          offset + ts_tree_total_chars(self), self->parse_state);
   for (size_t i = 0; i < self->child_count; i++) {
     const TSTree *child = self->children[i];
     ts_tree__print_dot_graph(child, offset, language, f);


### PR DESCRIPTION
The goal here is to significantly reduce the number of states in the generated parsers. This will shrink the the static memory footprints of the parsers and make them compile faster.

The approach is to merge similar parse states by allowing reductions to take place in the presence of lookahead tokens which are invalid. This preserves the behavior that errors are detected as soon as they occur; it just means that the parser will proceed to build up more structure to the left of an error before beginning error recovery.

I held off doing this optimization for a long time because I wasn't sure how it would affect the error recovery algorithm, but now that https://github.com/tree-sitter/tree-sitter/pull/26 is mostly fleshed out, I can tell that it won't be a problem.

Currently, this makes parser generation even slower than it already is, because the states are merged in a post-processing step. It's probably possible to do this in a way that actually makes it *faster*, but it would be more complicated, and I'm less concerned about parser generation speed than I am about memory footprint and compile time, so I'm going to worry about optimizing parser generation later.