### PR TITLE
Fix extra token ambiguity handling

### DIFF
--- a/include/tree_sitter/parser.h
+++ b/include/tree_sitter/parser.h
@@ -136,14 +136,6 @@ struct TSLanguage {
     { .type = TSParseActionTypeShift, .extra = true } \
   }
 
-#define REDUCE_EXTRA(symbol_val)                                               \
-  {                                                                            \
-    {                                                                          \
-      .type = TSParseActionTypeReduce, .symbol = symbol_val, .child_count = 1, \
-      .extra = true,                                                           \
-    }                                                                          \
-  }
-
 #define REDUCE(symbol_val, child_count_val)                  \
   {                                                          \
     {                                                        \

--- a/spec/compiler/build_tables/parse_conflict_manager_spec.cc
+++ b/spec/compiler/build_tables/parse_conflict_manager_spec.cc
@@ -66,18 +66,6 @@ describe("ParseConflictManager", []() {
       });
     });
 
-    describe("reduce-extra actions", [&]() {
-      it("favors shift-extra actions over reduce-extra actions", [&]() {
-        result = conflict_manager->resolve(ParseAction::ShiftExtra(), ParseAction::ReduceExtra(sym1));
-        AssertThat(result.first, IsTrue());
-        AssertThat(result.second, Equals(ConflictTypeNone));
-
-        result = conflict_manager->resolve(ParseAction::ReduceExtra(sym1), ParseAction::ShiftExtra());
-        AssertThat(result.first, IsFalse());
-        AssertThat(result.second, Equals(ConflictTypeNone));
-      });
-    });
-
     describe("shift/reduce conflicts", [&]() {
       describe("when the shift has higher precedence", [&]() {
         ParseAction shift = ParseAction::Shift(2, {3, 4});

--- a/spec/fixtures/error_corpus/javascript_errors.txt
+++ b/spec/fixtures/error_corpus/javascript_errors.txt
@@ -16,7 +16,8 @@ e f;
     (statement_block
       (ERROR (identifier))
       (expression_statement (identifier))))
-  (expression_statement (ERROR (identifier)) (identifier)))
+  (ERROR (identifier))
+  (expression_statement (identifier)))
 
 =======================================================
 multiple invalid tokens right after the viable prefix
@@ -52,16 +53,16 @@ if ({a: 'b'} {c: 'd'}) {
 
 (program
   (if_statement
-    (ERROR (object (pair (identifier) (string))))
     (object (pair (identifier) (string)))
+    (ERROR (object (pair (identifier) (string))))
     (statement_block
+      (ERROR (function
+        (formal_parameters (identifier))
+        (statement_block (expression_statement (identifier)))))
       (expression_statement
         (function
           (formal_parameters (identifier))
-          (statement_block (expression_statement (identifier))))
-        (ERROR (function
-          (formal_parameters (identifier))
-          (statement_block (expression_statement (identifier)))))))))
+          (statement_block (expression_statement (identifier))))))))
 
 ===================================================
 one invalid token at the end of the file
@@ -76,3 +77,24 @@ a.b =
   (trailing_expression_statement
     (member_access (identifier) (identifier)))
   (ERROR))
+
+===================================================
+Multi-line chained expressions in var declarations
+===================================================
+
+const one = two
+  .three(four)
+  .five()
+
+---
+
+(program
+  (var_declaration (var_assignment
+    (identifier)
+    (function_call
+      (member_access
+        (function_call
+          (member_access (identifier) (identifier))
+          (arguments (identifier)))
+        (identifier))
+      (arguments)))))

--- a/src/compiler/generate_code/c_code.cc
+++ b/src/compiler/generate_code/c_code.cc
@@ -340,9 +340,7 @@ class CCodeGenerator {
               }
               break;
             case ParseActionTypeReduce:
-              if (action.extra) {
-                add("REDUCE_EXTRA(" + symbol_id(action.symbol) + ")");
-              } else if (action.fragile) {
+              if (action.fragile) {
                 add("REDUCE_FRAGILE(" + symbol_id(action.symbol) + ", " +
                     to_string(action.consumed_symbol_count) + ")");
               } else {

--- a/src/compiler/parse_table.cc
+++ b/src/compiler/parse_table.cc
@@ -65,15 +65,6 @@ ParseAction ParseAction::ShiftExtra() {
   return action;
 }
 
-ParseAction ParseAction::ReduceExtra(Symbol symbol) {
-  ParseAction action;
-  action.type = ParseActionTypeReduce;
-  action.extra = true;
-  action.symbol = symbol;
-  action.consumed_symbol_count = 1;
-  return action;
-}
-
 ParseAction ParseAction::Reduce(Symbol symbol, size_t consumed_symbol_count,
                                 int precedence,
                                 rules::Associativity associativity,
@@ -132,6 +123,13 @@ bool ParseTableEntry::operator==(const ParseTableEntry &other) const {
 }
 
 ParseState::ParseState() : lex_state_id(-1) {}
+
+bool ParseState::has_shift_action() const {
+  for (const auto &pair : entries)
+    if (pair.second.actions.size() > 0 && pair.second.actions.back().type == ParseActionTypeShift)
+      return true;
+  return false;
+}
 
 set<Symbol> ParseState::expected_inputs() const {
   set<Symbol> result;

--- a/src/compiler/parse_table.h
+++ b/src/compiler/parse_table.h
@@ -38,7 +38,6 @@ class ParseAction {
                             int precedence, rules::Associativity,
                             const Production &);
   static ParseAction ShiftExtra();
-  static ParseAction ReduceExtra(rules::Symbol symbol);
   bool operator==(const ParseAction &) const;
   bool operator<(const ParseAction &) const;
 
@@ -74,6 +73,7 @@ class ParseState {
   bool operator==(const ParseState &) const;
   bool merge(const ParseState &);
   void each_advance_action(std::function<void(ParseAction *)>);
+  bool has_shift_action() const;
 
   std::map<rules::Symbol, ParseTableEntry> entries;
   LexStateId lex_state_id;

--- a/src/runtime/lexer.c
+++ b/src/runtime/lexer.c
@@ -95,9 +95,12 @@ static inline void ts_lexer__reset(TSLexer *self, TSLength position) {
   self->token_start_position = position;
   self->current_position = position;
 
-  self->chunk = 0;
-  self->chunk_start = 0;
-  self->chunk_size = 0;
+  if (self->chunk && (position.bytes < self->chunk_start || position.bytes >= self->chunk_start + self->chunk_size)) {
+    self->chunk = 0;
+    self->chunk_start = 0;
+    self->chunk_size = 0;
+  }
+
   self->lookahead_size = 0;
   self->lookahead = 0;
 }

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -170,7 +170,8 @@ static bool parser__breakdown_lookahead(Parser *self, TSTree **lookahead,
                                         ReusableNode *reusable_node) {
   bool result = false;
   while (reusable_node->tree->child_count > 0 &&
-         (reusable_node->tree->parse_state != state ||
+         (self->is_split ||
+          reusable_node->tree->parse_state != state ||
           reusable_node->tree->fragile_left ||
           reusable_node->tree->fragile_right)) {
     LOG("state_mismatch sym:%s", SYM_NAME(reusable_node->tree->symbol));

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -472,7 +472,7 @@ static bool parser__switch_children(Parser *self, TSTree *tree,
 }
 
 static Reduction parser__reduce(Parser *self, StackVersion version,
-                                TSSymbol symbol, unsigned count, bool extra,
+                                TSSymbol symbol, unsigned count,
                                 bool fragile, bool allow_skipping) {
   size_t initial_version_count = ts_stack_version_count(self->stack);
   StackPopResult pop = ts_stack_pop_count(self->stack, version, count);
@@ -531,41 +531,34 @@ static Reduction parser__reduce(Parser *self, StackVersion version,
       parent->parse_state = state;
     }
 
-    TSStateId new_state;
-    if (extra) {
-      parent->extra = true;
-      new_state = state;
-    } else {
-      const TSParseAction *action =
-        ts_language_last_action(language, state, symbol);
-      assert(action->type == TSParseActionTypeShift ||
-             action->type == TSParseActionTypeRecover);
-      new_state = action->to_state;
+    const TSParseAction *action =
+      ts_language_last_action(language, state, symbol);
+    assert(action->type == TSParseActionTypeShift ||
+           action->type == TSParseActionTypeRecover);
 
-      if (action->type == TSParseActionTypeRecover && child_count > 1 &&
-          allow_skipping) {
-        StackVersion other_version =
-          ts_stack_duplicate_version(self->stack, slice.version);
-        CHECK(other_version != STACK_VERSION_NONE);
+    if (action->type == TSParseActionTypeRecover && child_count > 1 &&
+        allow_skipping) {
+      StackVersion other_version =
+        ts_stack_duplicate_version(self->stack, slice.version);
+      CHECK(other_version != STACK_VERSION_NONE);
 
-        CHECK(ts_stack_push(self->stack, other_version, parent, false,
+      CHECK(ts_stack_push(self->stack, other_version, parent, false,
+                          TS_STATE_ERROR));
+      for (size_t j = parent->child_count; j < slice.trees.size; j++) {
+        TSTree *tree = slice.trees.contents[j];
+        CHECK(ts_stack_push(self->stack, other_version, tree, false,
                             TS_STATE_ERROR));
-        for (size_t j = parent->child_count; j < slice.trees.size; j++) {
-          TSTree *tree = slice.trees.contents[j];
-          CHECK(ts_stack_push(self->stack, other_version, tree, false,
-                              TS_STATE_ERROR));
-        }
-
-        ErrorStatus error_status = ts_stack_error_status(self->stack, other_version);
-        if (parser__better_version_exists(self, version, error_status))
-          ts_stack_remove_version(self->stack, other_version);
       }
+
+      ErrorStatus error_status = ts_stack_error_status(self->stack, other_version);
+      if (parser__better_version_exists(self, version, error_status))
+        ts_stack_remove_version(self->stack, other_version);
     }
 
-    CHECK(parser__push(self, slice.version, parent, new_state));
+    CHECK(parser__push(self, slice.version, parent, action->to_state));
     for (size_t j = parent->child_count; j < slice.trees.size; j++) {
       TSTree *tree = slice.trees.contents[j];
-      CHECK(parser__push(self, slice.version, tree, new_state));
+      CHECK(parser__push(self, slice.version, tree, action->to_state));
     }
   }
 
@@ -899,7 +892,7 @@ static PotentialReductionStatus parser__do_potential_reductions(
   for (size_t i = 0; i < self->reduce_actions.size; i++) {
     ReduceAction action = self->reduce_actions.contents[i];
     Reduction reduction = parser__reduce(self, version, action.symbol,
-                                         action.count, false, true, false);
+                                         action.count, true, false);
     switch (reduction.status) {
       case ReduceFailed:
         goto error;
@@ -1128,15 +1121,11 @@ static bool parser__advance(Parser *self, StackVersion version,
           if (reduction_stopped_at_error)
             continue;
 
-          if (action.extra) {
-            LOG("reduce_extra");
-          } else {
-            LOG("reduce sym:%s, child_count:%u", SYM_NAME(action.symbol),
-                action.child_count);
-          }
+          LOG("reduce sym:%s, child_count:%u", SYM_NAME(action.symbol),
+              action.child_count);
 
           Reduction reduction = parser__reduce(
-            self, version, action.symbol, action.child_count, action.extra,
+            self, version, action.symbol, action.child_count,
             (i < table_entry.action_count - 1), true);
 
           switch (reduction.status) {

--- a/src/runtime/stack.c
+++ b/src/runtime/stack.c
@@ -204,6 +204,7 @@ INLINE StackPopResult stack__iter(Stack *self, StackVersion version,
   array_clear(&self->iterators);
 
   StackHead *head = array_get(&self->heads, version);
+  unsigned push_count = head->push_count;
   Iterator iterator = {
     .node = head->node,
     .trees = array_new(),
@@ -233,7 +234,7 @@ INLINE StackPopResult stack__iter(Stack *self, StackVersion version,
           if (!ts_tree_array_copy(trees, &trees))
             goto error;
         array_reverse(&trees);
-        if (!ts_stack__add_slice(self, node, &trees, head->push_count + iterator->push_count))
+        if (!ts_stack__add_slice(self, node, &trees, push_count + iterator->push_count))
           goto error;
       }
 


### PR DESCRIPTION
Previously, when grammars contained tokens that could function both as 'extras' (whitespace, comments, etc) *and* as syntactically meaningful rules, the potential ambiguity was handled in a custom way, different than other grammar ambiguities. This code path existed before tree-sitter used GLR, and could thus handle ambiguity in a general way.

While using tree-sitter in Atom, I found a bug in the way newlines were treated in JavaScript in some cases. This fixes that bug by ripping out the old custom handling of extra-tokens-that-might-not-be-extra, and using the normal GLR stack-splitting mechanism for this case instead.