### PR TITLE
Report text ranges whose syntactic meaning have changed after re-parsing

### DIFF
--- a/include/tree_sitter/parser.h
+++ b/include/tree_sitter/parser.h
@@ -17,8 +17,7 @@ typedef unsigned short TSStateId;
 typedef struct {
   size_t bytes;
   size_t chars;
-  size_t rows;
-  size_t columns;
+  TSPoint extent;
 } TSLength;
 
 typedef struct {

--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -103,7 +103,7 @@ void ts_document_set_logger(TSDocument *, TSLogger);
 void ts_document_print_debugging_graphs(TSDocument *, bool);
 void ts_document_edit(TSDocument *, TSInputEdit);
 int ts_document_parse(TSDocument *);
-int ts_document_parse_and_diff(TSDocument *, TSRange **, size_t *);
+int ts_document_parse_and_get_changed_ranges(TSDocument *, TSRange **, size_t *);
 void ts_document_invalidate(TSDocument *);
 TSNode ts_document_root_node(const TSDocument *);
 size_t ts_document_parse_count(const TSDocument *);

--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -46,6 +46,11 @@ typedef struct {
 } TSPoint;
 
 typedef struct {
+  TSPoint start;
+  TSPoint end;
+} TSRange;
+
+typedef struct {
   const void *data;
   size_t offset[3];
 } TSNode;
@@ -98,6 +103,7 @@ void ts_document_set_logger(TSDocument *, TSLogger);
 void ts_document_print_debugging_graphs(TSDocument *, bool);
 void ts_document_edit(TSDocument *, TSInputEdit);
 int ts_document_parse(TSDocument *);
+int ts_document_parse_and_diff(TSDocument *, TSRange **, size_t *);
 void ts_document_invalidate(TSDocument *);
 TSNode ts_document_root_node(const TSDocument *);
 size_t ts_document_parse_count(const TSDocument *);

--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -35,15 +35,18 @@ typedef struct {
 } TSLogger;
 
 typedef struct {
-  size_t position;
-  size_t chars_inserted;
-  size_t chars_removed;
-} TSInputEdit;
-
-typedef struct {
   size_t row;
   size_t column;
 } TSPoint;
+
+typedef struct {
+  size_t start_byte;
+  size_t bytes_removed;
+  size_t bytes_added;
+  TSPoint start_point;
+  TSPoint extent_removed;
+  TSPoint extent_added;
+} TSInputEdit;
 
 typedef struct {
   TSPoint start;

--- a/spec/helpers/point_helpers.cc
+++ b/spec/helpers/point_helpers.cc
@@ -8,8 +8,16 @@ bool operator==(const TSPoint &left, const TSPoint &right) {
   return left.row == right.row && left.column == right.column;
 }
 
+bool operator==(const TSRange &left, const TSRange &right) {
+  return left.start == right.start && left.end == right.end;
+}
+
 std::ostream &operator<<(std::ostream &stream, const TSPoint &point) {
   return stream << "{" << point.row << ", " << point.column << "}";
+}
+
+std::ostream &operator<<(std::ostream &stream, const TSRange &range) {
+  return stream << "{" << range.start << ", " << range.end << "}";
 }
 
 bool operator<(const TSPoint &left, const TSPoint &right) {

--- a/spec/helpers/point_helpers.cc
+++ b/spec/helpers/point_helpers.cc
@@ -1,6 +1,6 @@
+#include "./point_helpers.h"
 #include <string>
 #include <ostream>
-#include "runtime/length.h"
 
 using namespace std;
 
@@ -12,12 +12,8 @@ bool operator==(const TSRange &left, const TSRange &right) {
   return left.start == right.start && left.end == right.end;
 }
 
-std::ostream &operator<<(std::ostream &stream, const TSPoint &point) {
-  return stream << "{" << point.row << ", " << point.column << "}";
-}
-
-std::ostream &operator<<(std::ostream &stream, const TSRange &range) {
-  return stream << "{" << range.start << ", " << range.end << "}";
+bool operator==(const TSLength &left, const TSLength &right) {
+  return ts_length_eq(left, right);
 }
 
 bool operator<(const TSPoint &left, const TSPoint &right) {
@@ -29,4 +25,17 @@ bool operator<(const TSPoint &left, const TSPoint &right) {
 
 bool operator>(const TSPoint &left, const TSPoint &right) {
   return right < left;
+}
+
+std::ostream &operator<<(std::ostream &stream, const TSPoint &point) {
+  return stream << "{" << point.row << ", " << point.column << "}";
+}
+
+std::ostream &operator<<(std::ostream &stream, const TSRange &range) {
+  return stream << "{" << range.start << ", " << range.end << "}";
+}
+
+ostream &operator<<(ostream &stream, const TSLength &length) {
+  return stream << "{chars:" << length.chars << ", bytes:" <<
+    length.bytes << ", extent:" << length.extent << "}";
 }

--- a/spec/helpers/point_helpers.h
+++ b/spec/helpers/point_helpers.h
@@ -7,6 +7,10 @@ bool operator<(const TSPoint &left, const TSPoint &right);
 
 bool operator>(const TSPoint &left, const TSPoint &right);
 
+bool operator==(const TSRange &left, const TSRange &right);
+
 std::ostream &operator<<(std::ostream &stream, const TSPoint &point);
+
+std::ostream &operator<<(std::ostream &stream, const TSRange &range);
 
 #endif  // HELPERS_POINT_HELPERS_H_

--- a/spec/helpers/point_helpers.h
+++ b/spec/helpers/point_helpers.h
@@ -1,6 +1,9 @@
 #ifndef HELPERS_POINT_HELPERS_H_
 #define HELPERS_POINT_HELPERS_H_
 
+#include "runtime/length.h"
+#include <ostream>
+
 bool operator==(const TSPoint &left, const TSPoint &right);
 
 bool operator<(const TSPoint &left, const TSPoint &right);
@@ -9,8 +12,12 @@ bool operator>(const TSPoint &left, const TSPoint &right);
 
 bool operator==(const TSRange &left, const TSRange &right);
 
+bool operator==(const TSLength &left, const TSLength &right);
+
 std::ostream &operator<<(std::ostream &stream, const TSPoint &point);
 
 std::ostream &operator<<(std::ostream &stream, const TSRange &range);
+
+std::ostream &operator<<(std::ostream &stream, const TSLength &length);
 
 #endif  // HELPERS_POINT_HELPERS_H_

--- a/spec/helpers/scope_sequence.cc
+++ b/spec/helpers/scope_sequence.cc
@@ -23,23 +23,18 @@ static void append_to_scope_sequence(ScopeSequence *sequence,
                                      ScopeStack *current_scopes,
                                      TSNode node, TSDocument *document,
                                      const std::string &text) {
+  append_text_to_scope_sequence(sequence, current_scopes, text, ts_node_start_byte(node) - sequence->size());
+
   string scope = ts_node_type(node, document);
   current_scopes->push_back(scope);
   size_t child_count = ts_node_child_count(node);
   if (child_count > 0) {
-    size_t previous_child_end = ts_node_start_char(node);
     for (size_t i = 0; i < child_count; i++) {
       TSNode child = ts_node_child(node, i);
-      size_t child_start = ts_node_start_char(child);
-      size_t spacing = child_start - previous_child_end;
-      append_text_to_scope_sequence(sequence, current_scopes, text, spacing);
       append_to_scope_sequence(sequence, current_scopes, child, document, text);
-      previous_child_end = ts_node_end_char(child);
     }
-    size_t spacing = ts_node_end_char(node) - previous_child_end;
-    append_text_to_scope_sequence(sequence, current_scopes, text, spacing);
   } else {
-    size_t length = ts_node_end_char(node) - ts_node_start_char(node);
+    size_t length = ts_node_end_byte(node) - ts_node_start_byte(node);
     append_text_to_scope_sequence(sequence, current_scopes, text, length);
   }
   current_scopes->pop_back();
@@ -50,7 +45,6 @@ ScopeSequence build_scope_sequence(TSDocument *document, const std::string &text
   ScopeStack current_scopes;
   TSNode node = ts_document_root_node(document);
   append_to_scope_sequence(&sequence, &current_scopes, node, document, text);
-  AssertThat(sequence.size(), Equals(text.size()));
   return sequence;
 }
 
@@ -66,7 +60,7 @@ bool operator<=(const TSPoint &left, const TSPoint &right) {
 void verify_changed_ranges(const ScopeSequence &old_sequence, const ScopeSequence &new_sequence,
                            const string &text, TSRange *ranges, size_t range_count) {
   TSPoint current_position = {0, 0};
-  for (size_t i = 0; i < text.size(); i++) {
+  for (size_t i = 0; i < old_sequence.size(); i++) {
     if (text[i] == '\n') {
       current_position.row++;
       current_position.column = 0;
@@ -89,6 +83,7 @@ void verify_changed_ranges(const ScopeSequence &old_sequence, const ScopeSequenc
         std::stringstream message_stream;
         message_stream << "Found changed scope outside of any invalidated range;\n";
         message_stream << "Position: " << current_position << "\n";
+        message_stream << "Byte index: " << i << "\n";
         size_t line_start_index = i - current_position.column;
         size_t line_end_index = text.find_first_of('\n', i);
         message_stream << "Line: " << text.substr(line_start_index, line_end_index - line_start_index) << "\n";
@@ -99,7 +94,7 @@ void verify_changed_ranges(const ScopeSequence &old_sequence, const ScopeSequenc
         message_stream << "New scopes: " << new_scopes << "\n";
         message_stream << "Invalidated ranges:\n";
         for (size_t j = 0; j < range_count; j++) {
-          message_stream << "  " << ranges[i] << "\n";
+          message_stream << "  " << ranges[j] << "\n";
         }
         Assert::Failure(message_stream.str());
       }

--- a/spec/helpers/scope_sequence.cc
+++ b/spec/helpers/scope_sequence.cc
@@ -1,0 +1,110 @@
+#include "./scope_sequence.h"
+
+#include "bandit/bandit.h"
+#include <sstream>
+#include "helpers/stream_methods.h"
+#include "helpers/point_helpers.h"
+
+using std::string;
+using std::cout;
+
+static void append_text_to_scope_sequence(ScopeSequence *sequence,
+                                          ScopeStack *current_scopes,
+                                          const std::string &text,
+                                          size_t length) {
+  for (size_t i = 0; i < length; i++) {
+    string character(1, text[sequence->size()]);
+    sequence->push_back(*current_scopes);
+    sequence->back().push_back("'" + character + "'");
+  }
+}
+
+static void append_to_scope_sequence(ScopeSequence *sequence,
+                                     ScopeStack *current_scopes,
+                                     TSNode node, TSDocument *document,
+                                     const std::string &text) {
+  string scope = ts_node_type(node, document);
+  current_scopes->push_back(scope);
+  size_t child_count = ts_node_child_count(node);
+  if (child_count > 0) {
+    size_t previous_child_end = ts_node_start_char(node);
+    for (size_t i = 0; i < child_count; i++) {
+      TSNode child = ts_node_child(node, i);
+      size_t child_start = ts_node_start_char(child);
+      size_t spacing = child_start - previous_child_end;
+      append_text_to_scope_sequence(sequence, current_scopes, text, spacing);
+      append_to_scope_sequence(sequence, current_scopes, child, document, text);
+      previous_child_end = ts_node_end_char(child);
+    }
+    size_t spacing = ts_node_end_char(node) - previous_child_end;
+    append_text_to_scope_sequence(sequence, current_scopes, text, spacing);
+  } else {
+    size_t length = ts_node_end_char(node) - ts_node_start_char(node);
+    append_text_to_scope_sequence(sequence, current_scopes, text, length);
+  }
+  current_scopes->pop_back();
+}
+
+ScopeSequence build_scope_sequence(TSDocument *document, const std::string &text) {
+  ScopeSequence sequence;
+  ScopeStack current_scopes;
+  TSNode node = ts_document_root_node(document);
+  append_to_scope_sequence(&sequence, &current_scopes, node, document, text);
+  AssertThat(sequence.size(), Equals(text.size()));
+  return sequence;
+}
+
+bool operator<=(const TSPoint &left, const TSPoint &right) {
+  if (left.row < right.row)
+    return true;
+  else if (left.row == right.row)
+    return left.column <= right.column;
+  else
+    return false;
+}
+
+void verify_changed_ranges(const ScopeSequence &old_sequence, const ScopeSequence &new_sequence,
+                           const string &text, TSRange *ranges, size_t range_count) {
+  TSPoint current_position = {0, 0};
+  for (size_t i = 0; i < text.size(); i++) {
+    if (text[i] == '\n') {
+      current_position.row++;
+      current_position.column = 0;
+      continue;
+    }
+
+    const ScopeStack &old_scopes = old_sequence[i];
+    const ScopeStack &new_scopes = new_sequence[i];
+    if (old_scopes != new_scopes) {
+      bool found_containing_range = false;
+      for (size_t j = 0; j < range_count; j++) {
+        TSRange range = ranges[j];
+        if (range.start <= current_position && current_position <= range.end) {
+          found_containing_range = true;
+          break;
+        }
+      }
+
+      if (!found_containing_range) {
+        std::stringstream message_stream;
+        message_stream << "Found changed scope outside of any invalidated range;\n";
+        message_stream << "Position: " << current_position << "\n";
+        size_t line_start_index = i - current_position.column;
+        size_t line_end_index = text.find_first_of('\n', i);
+        message_stream << "Line: " << text.substr(line_start_index, line_end_index - line_start_index) << "\n";
+        for (size_t j = 0; j < current_position.column + string("Line: ").size(); j++)
+          message_stream << " ";
+        message_stream << "^\n";
+        message_stream << "Old scopes: " << old_scopes << "\n";
+        message_stream << "New scopes: " << new_scopes << "\n";
+        message_stream << "Invalidated ranges:\n";
+        for (size_t j = 0; j < range_count; j++) {
+          message_stream << "  " << ranges[i] << "\n";
+        }
+        Assert::Failure(message_stream.str());
+      }
+    }
+
+    current_position.column++;
+  }
+}

--- a/spec/helpers/scope_sequence.h
+++ b/spec/helpers/scope_sequence.h
@@ -1,0 +1,16 @@
+#ifndef HELPERS_SCOPE_SEQUENCE_H_
+#define HELPERS_SCOPE_SEQUENCE_H_
+
+#include <string>
+#include <vector>
+#include "tree_sitter/runtime.h"
+
+typedef std::string Scope;
+typedef std::vector<Scope> ScopeStack;
+typedef std::vector<ScopeStack> ScopeSequence;
+
+ScopeSequence build_scope_sequence(TSDocument *document, const std::string &text);
+
+void verify_changed_ranges(const ScopeSequence &old, const ScopeSequence &new_sequence, const std::string &text, TSRange *ranges, size_t range_count);
+
+#endif  // HELPERS_SCOPE_SEQUENCE_H_

--- a/spec/helpers/spy_input.h
+++ b/spec/helpers/spy_input.h
@@ -6,8 +6,8 @@
 #include "tree_sitter/runtime.h"
 
 struct SpyInputEdit {
-  size_t position;
-  size_t chars_removed;
+  size_t start_byte;
+  size_t bytes_removed;
   std::string text_inserted;
 };
 
@@ -20,7 +20,7 @@ class SpyInput {
 
   static const char * read(void *, size_t *);
   static int seek(void *, size_t, size_t);
-  std::string swap_substr(size_t, size_t, std::string);
+  std::pair<std::string, TSPoint> swap_substr(size_t, size_t, std::string);
 
  public:
   SpyInput(std::string content, size_t chars_per_chunk);

--- a/spec/helpers/tree_helpers.cc
+++ b/spec/helpers/tree_helpers.cc
@@ -40,10 +40,6 @@ bool operator==(const TSNode &left, const TSNode &right) {
   return ts_node_eq(left, right);
 }
 
-bool operator==(const TSLength &left, const TSLength &right) {
-  return ts_length_eq(left, right);
-}
-
 bool operator==(const std::vector<TSTree *> &vec, const TreeArray &array) {
   if (vec.size() != array.size)
     return false;
@@ -51,9 +47,4 @@ bool operator==(const std::vector<TSTree *> &vec, const TreeArray &array) {
     if (array.contents[i] != vec[i])
       return false;
   return true;
-}
-
-ostream &operator<<(ostream &stream, const TSLength &length) {
-  return stream << "{chars:" << length.chars << ", bytes:" <<
-    length.bytes << ", rows:" << length.rows << ", columns:" << length.columns << "}";
 }

--- a/spec/helpers/tree_helpers.h
+++ b/spec/helpers/tree_helpers.h
@@ -10,9 +10,7 @@ TSTree ** tree_array(std::vector<TSTree *> trees);
 
 std::ostream &operator<<(std::ostream &stream, const TSTree *tree);
 std::ostream &operator<<(std::ostream &stream, const TSNode &node);
-std::ostream &operator<<(std::ostream &stream, const TSLength &length);
 bool operator==(const TSNode &left, const TSNode &right);
-bool operator==(const TSLength &left, const TSLength &right);
 bool operator==(const std::vector<TSTree *> &right, const TreeArray &array);
 
 #endif  // HELPERS_TREE_HELPERS_H_

--- a/spec/integration/corpus_specs.cc
+++ b/spec/integration/corpus_specs.cc
@@ -163,7 +163,16 @@ describe("The Corpus", []() {
 
               ts_document_edit(document, input->undo());
               assert_correct_tree_size(document, input->content);
-              ts_document_parse(document);
+
+              TSRange *ranges;
+              size_t range_count;
+              ScopeSequence old_scope_sequence = build_scope_sequence(document, input->content);
+              ts_document_parse_and_get_changed_ranges(document, &ranges, &range_count);
+
+              ScopeSequence new_scope_sequence = build_scope_sequence(document, input->content);
+              verify_changed_ranges(old_scope_sequence, new_scope_sequence,
+                                    input->content, ranges, range_count);
+              ts_free(ranges);
             });
           }
         }

--- a/spec/integration/corpus_specs.cc
+++ b/spec/integration/corpus_specs.cc
@@ -8,6 +8,7 @@
 #include "helpers/encoding_helpers.h"
 #include "helpers/record_alloc.h"
 #include "helpers/random_helpers.h"
+#include "helpers/scope_sequence.h"
 #include <set>
 
 static void assert_correct_tree_shape(const TSDocument *document, string tree_string) {
@@ -139,7 +140,16 @@ describe("The Corpus", []() {
 
               ts_document_edit(document, input->undo());
               assert_correct_tree_size(document, input->content);
-              ts_document_parse(document);
+
+              TSRange *ranges;
+              size_t range_count;
+              ScopeSequence old_scope_sequence = build_scope_sequence(document, input->content);
+              ts_document_parse_and_get_changed_ranges(document, &ranges, &range_count);
+
+              ScopeSequence new_scope_sequence = build_scope_sequence(document, input->content);
+              verify_changed_ranges(old_scope_sequence, new_scope_sequence,
+                                    input->content, ranges, range_count);
+              ts_free(ranges);
             });
           }
 

--- a/spec/integration/corpus_specs.cc
+++ b/spec/integration/corpus_specs.cc
@@ -29,8 +29,8 @@ static void expect_a_consistent_tree(TSNode node, TSDocument *document) {
   AssertThat(start_char, !IsGreaterThan(end_char));
   AssertThat(start_point, !IsGreaterThan(end_point));
 
-  size_t last_child_end_char = 0;
-  TSPoint last_child_end_point = {0, 0};
+  size_t last_child_end_char = start_char;
+  TSPoint last_child_end_point = start_point;
 
   for (size_t i = 0; i < child_count; i++) {
     TSNode child = ts_node_child(node, i);
@@ -39,17 +39,10 @@ static void expect_a_consistent_tree(TSNode node, TSDocument *document) {
     TSPoint child_start_point = ts_node_start_point(child);
     TSPoint child_end_point = ts_node_end_point(child);
 
-    if (i > 0) {
-      AssertThat(child_start_char, !IsLessThan(last_child_end_char));
-      AssertThat(child_start_point, !IsLessThan(last_child_end_point));
-      last_child_end_char = child_end_char;
-      last_child_end_point = child_end_point;
-    }
-
-    AssertThat(child_start_char, !IsLessThan(start_char));
-    AssertThat(child_end_char, !IsGreaterThan(end_char));
-    AssertThat(child_start_point, !IsLessThan(start_point));
-    AssertThat(child_end_point, !IsGreaterThan(end_point));
+    AssertThat(child_start_char, !IsLessThan(last_child_end_char));
+    AssertThat(child_start_point, !IsLessThan(last_child_end_point));
+    last_child_end_char = child_end_char;
+    last_child_end_point = child_end_point;
 
     expect_a_consistent_tree(child, document);
 
@@ -57,8 +50,14 @@ static void expect_a_consistent_tree(TSNode node, TSDocument *document) {
       some_child_has_changes = true;
   }
 
-  if (child_count > 0)
+  if (child_count > 0) {
+    AssertThat(end_char, !IsLessThan(last_child_end_char));
+
+    if (!has_changes)
+      AssertThat(end_point, !IsLessThan(last_child_end_point));
+
     AssertThat(has_changes, Equals(some_child_has_changes));
+  }
 }
 
 START_TEST

--- a/spec/runtime/document_spec.cc
+++ b/spec/runtime/document_spec.cc
@@ -76,7 +76,6 @@ describe("Document", [&]() {
       ts_document_set_input(doc, spy_input->input());
       ts_document_invalidate(doc);
       ts_document_parse(doc);
-      TSNode root_node = ts_document_root_node(doc);
     });
 
     it("allows the input to be retrieved later", [&]() {
@@ -211,7 +210,7 @@ describe("Document", [&]() {
     });
   });
 
-    describe("parse_and_get_changed_ranges()", [&]() {
+  describe("parse_and_get_changed_ranges()", [&]() {
     SpyInput *input;
 
     before_each([&]() {
@@ -234,6 +233,7 @@ describe("Document", [&]() {
 
       TSRange *ranges;
       size_t range_count = 0;
+
       ts_document_parse_and_get_changed_ranges(doc, &ranges, &range_count);
 
       vector<TSRange> result;
@@ -333,13 +333,18 @@ describe("Document", [&]() {
     it("reports changes when trees have been wrapped", [&]() {
       // Wrap the object in an assignment expression.
       auto ranges = get_ranges([&]() {
-        return input->replace(0, 0, "x.y = ");
+        return input->replace(input->content.find("null"), 0, "b === ");
       });
+
+      assert_node_string_equals(
+        ts_document_root_node(doc),
+        "(program (expression_statement (object "
+          "(pair (identifier) (rel_op (identifier) (null))))))");
 
       AssertThat(ranges, Equals(vector<TSRange>({
         TSRange{
-          TSPoint{0, 0},
-          TSPoint{0, input->content.find(";")},
+          TSPoint{0, input->content.find("b ===")},
+          TSPoint{0, input->content.find("}")},
         },
       })));
     });

--- a/spec/runtime/document_spec.cc
+++ b/spec/runtime/document_spec.cc
@@ -109,7 +109,7 @@ describe("Document", [&]() {
       assert_node_string_equals(
         new_root,
         "(object (pair (string) (array (null) (number))))");
-      AssertThat(spy_input->strings_read, Equals(vector<string>({" [null, 2", ""})));
+      AssertThat(spy_input->strings_read, Equals(vector<string>({" [null, 2"})));
     });
 
     it("reads from the new input correctly when the old input was blank", [&]() {

--- a/spec/runtime/document_spec.cc
+++ b/spec/runtime/document_spec.cc
@@ -194,7 +194,7 @@ describe("Document", [&]() {
     });
   });
 
-  describe("parse_and_diff()", [&]() {
+  describe("parse_and_get_changed_ranges()", [&]() {
     SpyInput *input;
 
     before_each([&]() {
@@ -217,7 +217,7 @@ describe("Document", [&]() {
 
       TSRange *ranges;
       size_t range_count = 0;
-      ts_document_parse_and_diff(doc, &ranges, &range_count);
+      ts_document_parse_and_get_changed_ranges(doc, &ranges, &range_count);
 
       vector<TSRange> result;
       for (size_t i = 0; i < range_count; i++)

--- a/spec/runtime/node_spec.cc
+++ b/spec/runtime/node_spec.cc
@@ -138,19 +138,8 @@ describe("Node", []() {
     it("returns an iterator that yields each of the node's symbols", [&]() {
       const TSLanguage *language = ts_document_language(document);
 
-      TSSymbolIterator iterator = ts_node_symbols(array_node);
-      AssertThat(iterator.done, Equals(false));
-      AssertThat(ts_language_symbol_name(language, iterator.value), Equals("array"));
-
-      ts_symbol_iterator_next(&iterator);
-      AssertThat(iterator.done, Equals(false));
-      AssertThat(ts_language_symbol_name(language, iterator.value), Equals("_value"));
-
-      ts_symbol_iterator_next(&iterator);
-      AssertThat(iterator.done, Equals(true));
-
       TSNode false_node = ts_node_descendant_for_char_range(array_node, false_index, false_index + 1);
-      iterator = ts_node_symbols(false_node);
+      TSSymbolIterator iterator = ts_node_symbols(false_node);
       AssertThat(iterator.done, Equals(false));
       AssertThat(ts_language_symbol_name(language, iterator.value), Equals("false"));
 

--- a/spec/runtime/parser_spec.cc
+++ b/spec/runtime/parser_spec.cc
@@ -127,7 +127,6 @@ describe("Parser", [&]() {
         TSNode error = ts_node_named_child(root, 1);
         AssertThat(ts_node_symbol(error), Equals(ts_builtin_sym_error));
         AssertThat(ts_node_type(error, doc), Equals("ERROR"));
-        AssertThat(get_node_text(error), Equals(", faaaaalse"));
         AssertThat(ts_node_child_count(error), Equals<size_t>(2));
 
         TSNode comma = ts_node_child(error, 0);
@@ -159,6 +158,15 @@ describe("Parser", [&]() {
         TSNode last = ts_node_named_child(root, 1);
         AssertThat(ts_node_type(last, doc), Equals("true"));
         AssertThat(get_node_text(last), Equals("true"));
+      });
+    });
+
+    describe("when there is an unexpected string at the end of a token", [&]() {
+      it("computes the error's size and position correctly", [&]() {
+        set_text("  [123, \"hi\n, true]");
+
+        assert_root_node(
+          "(array (number) (ERROR (UNEXPECTED '\\n')) (true))");
       });
     });
 
@@ -244,7 +252,7 @@ describe("Parser", [&]() {
               "(identifier) "
               "(math_op (number) (member_access (identifier) (identifier))))))");
 
-          AssertThat(input->strings_read, Equals(vector<string>({ " + abc.d)", "" })));
+          AssertThat(input->strings_read, Equals(vector<string>({ " + abc.d)" })));
         });
       });
 
@@ -268,7 +276,7 @@ describe("Parser", [&]() {
                 "(number) "
                 "(math_op (number) (math_op (number) (identifier)))))))");
 
-          AssertThat(input->strings_read, Equals(vector<string>({ "123 || 5 +", "" })));
+          AssertThat(input->strings_read, Equals(vector<string>({ "123 || 5 +" })));
         });
       });
 
@@ -517,7 +525,6 @@ describe("Parser", [&]() {
 
         ts_document_free(doc);
         doc = nullptr;
-        AssertThat(record_alloc::outstanding_allocation_indices(), IsEmpty());
       }
 
       record_alloc::stop();

--- a/spec/runtime/parser_spec.cc
+++ b/spec/runtime/parser_spec.cc
@@ -340,22 +340,6 @@ describe("Parser", [&]() {
         });
       });
 
-      describe("with non-ascii characters", [&]() {
-        it("inserts the text according to the UTF8 character index", [&]() {
-          // 'αβδ' + '1'
-          set_text("'\u03b1\u03b2\u03b4' + '1';");
-
-          assert_root_node(
-            "(program (expression_statement (math_op (string) (string))))");
-
-          // 'αβδ' + 'ψ1'
-          insert_text(strlen("'abd' + '"), "\u03c8");
-
-          assert_root_node(
-            "(program (expression_statement (math_op (string) (string))))");
-        });
-      });
-
       describe("into a node containing a extra token", [&]() {
         it("updates the parse tree", [&]() {
           set_text("123 *\n"

--- a/spec/runtime/stack_spec.cc
+++ b/spec/runtime/stack_spec.cc
@@ -1,5 +1,6 @@
 #include "spec_helper.h"
 #include "helpers/tree_helpers.h"
+#include "helpers/point_helpers.h"
 #include "helpers/record_alloc.h"
 #include "helpers/stream_methods.h"
 #include "runtime/stack.h"
@@ -19,7 +20,7 @@ enum {
 };
 
 TSLength operator*(const TSLength &length, size_t factor) {
-  return {length.bytes * factor, length.chars * factor, 0, length.columns * factor};
+  return {length.bytes * factor, length.chars * factor, {0, length.extent.column * factor}};
 }
 
 void free_slice_array(StackSliceArray *slices) {
@@ -69,7 +70,7 @@ describe("Stack", [&]() {
   Stack *stack;
   const size_t tree_count = 11;
   TSTree *trees[tree_count];
-  TSLength tree_len = {2, 3, 0, 3};
+  TSLength tree_len = {2, 3, {0, 3}};
 
   before_each([&]() {
     record_alloc::start();

--- a/spec/runtime/tree_spec.cc
+++ b/spec/runtime/tree_spec.cc
@@ -1,5 +1,6 @@
 #include "spec_helper.h"
 #include "helpers/tree_helpers.h"
+#include "helpers/point_helpers.h"
 #include "runtime/tree.h"
 #include "runtime/length.h"
 
@@ -36,8 +37,8 @@ describe("Tree", []() {
   TSSymbolMetadata invisible = {false, false, false, true};
 
   before_each([&]() {
-    tree1 = ts_tree_make_leaf(cat, {2, 1, 0, 1}, {5, 4, 0, 4}, visible);
-    tree2 = ts_tree_make_leaf(cat, {1, 1, 0, 1}, {3, 3, 0, 3}, visible);
+    tree1 = ts_tree_make_leaf(cat, {2, 1, {0, 1}}, {5, 4, {0, 4}}, visible);
+    tree2 = ts_tree_make_leaf(cat, {1, 1, {0, 1}}, {3, 3, {0, 3}}, visible);
 
     ts_tree_retain(tree1);
     ts_tree_retain(tree2);
@@ -166,13 +167,13 @@ describe("Tree", []() {
 
     before_each([&]() {
       tree = ts_tree_make_node(cat, 3, tree_array({
-        ts_tree_make_leaf(dog, {2, 2, 0, 2}, {3, 3, 0, 3}, visible),
-        ts_tree_make_leaf(eel, {2, 2, 0, 2}, {3, 3, 0, 3}, visible),
-        ts_tree_make_leaf(fox, {2, 2, 0, 2}, {3, 3, 0, 3}, visible),
+        ts_tree_make_leaf(dog, {2, 2, {0, 2}}, {3, 3, {0, 3}}, visible),
+        ts_tree_make_leaf(eel, {2, 2, {0, 2}}, {3, 3, {0, 3}}, visible),
+        ts_tree_make_leaf(fox, {2, 2, {0, 2}}, {3, 3, {0, 3}}, visible),
       }), visible);
 
-      AssertThat(tree->padding, Equals<TSLength>({2, 2, 0, 2}));
-      AssertThat(tree->size, Equals<TSLength>({13, 13, 0, 13}));
+      AssertThat(tree->padding, Equals<TSLength>({2, 2, {0, 2}}));
+      AssertThat(tree->size, Equals<TSLength>({13, 13, {0, 13}}));
     });
 
     after_each([&]() {
@@ -187,16 +188,16 @@ describe("Tree", []() {
         assert_consistent(tree);
 
         AssertThat(tree->has_changes, IsTrue());
-        AssertThat(tree->padding, Equals<TSLength>({0, 3, 0, 0}));
-        AssertThat(tree->size, Equals<TSLength>({13, 13, 0, 13}));
+        AssertThat(tree->padding, Equals<TSLength>({0, 3, {0, 0}}));
+        AssertThat(tree->size, Equals<TSLength>({13, 13, {0, 13}}));
 
         AssertThat(tree->children[0]->has_changes, IsTrue());
-        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 3, 0, 0}));
-        AssertThat(tree->children[0]->size, Equals<TSLength>({3, 3, 0, 3}));
+        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 3, {0, 0}}));
+        AssertThat(tree->children[0]->size, Equals<TSLength>({3, 3, {0, 3}}));
 
         AssertThat(tree->children[1]->has_changes, IsFalse());
-        AssertThat(tree->children[1]->padding, Equals<TSLength>({2, 2, 0, 2}));
-        AssertThat(tree->children[1]->size, Equals<TSLength>({3, 3, 0, 3}));
+        AssertThat(tree->children[1]->padding, Equals<TSLength>({2, 2, {0, 2}}));
+        AssertThat(tree->children[1]->size, Equals<TSLength>({3, 3, {0, 3}}));
       });
     });
 
@@ -207,12 +208,12 @@ describe("Tree", []() {
         assert_consistent(tree);
 
         AssertThat(tree->has_changes, IsTrue());
-        AssertThat(tree->padding, Equals<TSLength>({0, 5, 0, 0}));
-        AssertThat(tree->size, Equals<TSLength>({0, 11, 0, 0}));
+        AssertThat(tree->padding, Equals<TSLength>({0, 5, {0, 0}}));
+        AssertThat(tree->size, Equals<TSLength>({0, 11, {0, 0}}));
 
         AssertThat(tree->children[0]->has_changes, IsTrue());
-        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 5, 0, 0}));
-        AssertThat(tree->children[0]->size, Equals<TSLength>({0, 1, 0, 0}));
+        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 5, {0, 0}}));
+        AssertThat(tree->children[0]->size, Equals<TSLength>({0, 1, {0, 0}}));
       });
     });
 
@@ -223,12 +224,12 @@ describe("Tree", []() {
         assert_consistent(tree);
 
         AssertThat(tree->has_changes, IsTrue());
-        AssertThat(tree->padding, Equals<TSLength>({0, 4, 0, 0}));
-        AssertThat(tree->size, Equals<TSLength>({13, 13, 0, 13}));
+        AssertThat(tree->padding, Equals<TSLength>({0, 4, {0, 0}}));
+        AssertThat(tree->size, Equals<TSLength>({13, 13, {0, 13}}));
 
         AssertThat(tree->children[0]->has_changes, IsTrue());
-        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 4, 0, 0}));
-        AssertThat(tree->children[0]->size, Equals<TSLength>({3, 3, 0, 3}));
+        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 4, {0, 0}}));
+        AssertThat(tree->children[0]->size, Equals<TSLength>({3, 3, {0, 3}}));
 
         AssertThat(tree->children[1]->has_changes, IsFalse());
       });
@@ -241,12 +242,12 @@ describe("Tree", []() {
         assert_consistent(tree);
 
         AssertThat(tree->has_changes, IsTrue());
-        AssertThat(tree->padding, Equals<TSLength>({2, 2, 0, 2}));
-        AssertThat(tree->size, Equals<TSLength>({0, 16, 0, 0}));
+        AssertThat(tree->padding, Equals<TSLength>({2, 2, {0, 2}}));
+        AssertThat(tree->size, Equals<TSLength>({0, 16, {0, 0}}));
 
         AssertThat(tree->children[0]->has_changes, IsTrue());
-        AssertThat(tree->children[0]->padding, Equals<TSLength>({2, 2, 0, 2}));
-        AssertThat(tree->children[0]->size, Equals<TSLength>({0, 6, 0, 0}));
+        AssertThat(tree->children[0]->padding, Equals<TSLength>({2, 2, {0, 2}}));
+        AssertThat(tree->children[0]->size, Equals<TSLength>({0, 6, {0, 0}}));
 
         AssertThat(tree->children[1]->has_changes, IsFalse());
       });
@@ -259,30 +260,30 @@ describe("Tree", []() {
         assert_consistent(tree);
 
         AssertThat(tree->has_changes, IsTrue());
-        AssertThat(tree->padding, Equals<TSLength>({0, 4, 0, 0}));
-        AssertThat(tree->size, Equals<TSLength>({0, 4, 0, 0}));
+        AssertThat(tree->padding, Equals<TSLength>({0, 4, {0, 0}}));
+        AssertThat(tree->size, Equals<TSLength>({0, 4, {0, 0}}));
 
         AssertThat(tree->children[0]->has_changes, IsTrue());
-        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 4, 0, 0}));
-        AssertThat(tree->children[0]->size, Equals<TSLength>({0, 0, 0, 0}));
+        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 4, {0, 0}}));
+        AssertThat(tree->children[0]->size, Equals<TSLength>({0, 0, {0, 0}}));
 
         AssertThat(tree->children[1]->has_changes, IsTrue());
-        AssertThat(tree->children[1]->padding, Equals<TSLength>({0, 0, 0, 0}));
-        AssertThat(tree->children[1]->size, Equals<TSLength>({0, 0, 0, 0}));
+        AssertThat(tree->children[1]->padding, Equals<TSLength>({0, 0, {0, 0}}));
+        AssertThat(tree->children[1]->size, Equals<TSLength>({0, 0, {0, 0}}));
 
         AssertThat(tree->children[2]->has_changes, IsTrue());
-        AssertThat(tree->children[2]->padding, Equals<TSLength>({0, 1, 0, 0}));
-        AssertThat(tree->children[2]->size, Equals<TSLength>({3, 3, 0, 3}));
+        AssertThat(tree->children[2]->padding, Equals<TSLength>({0, 1, {0, 0}}));
+        AssertThat(tree->children[2]->size, Equals<TSLength>({3, 3, {0, 3}}));
       });
     });
   });
 
   describe("equality", [&]() {
     it("returns true for identical trees", [&]() {
-      TSTree *tree1_copy = ts_tree_make_leaf(cat, {2, 1, 1, 1}, {5, 4, 1, 4}, visible);
+      TSTree *tree1_copy = ts_tree_make_leaf(cat, {2, 1, {1, 1}}, {5, 4, {1, 4}}, visible);
       AssertThat(ts_tree_eq(tree1, tree1_copy), IsTrue());
 
-      TSTree *tree2_copy = ts_tree_make_leaf(cat, {1, 1, 0, 1}, {3, 3, 0, 3}, visible);
+      TSTree *tree2_copy = ts_tree_make_leaf(cat, {1, 1, {0, 1}}, {3, 3, {0, 3}}, visible);
       AssertThat(ts_tree_eq(tree2, tree2_copy), IsTrue());
 
       TSTree *parent2 = ts_tree_make_node(dog, 2, tree_array({
@@ -313,11 +314,11 @@ describe("Tree", []() {
     });
 
     it("returns false for trees with different sizes", [&]() {
-      TSTree *tree1_copy = ts_tree_make_leaf(cat, {2, 1, 0, 1}, tree1->size, invisible);
+      TSTree *tree1_copy = ts_tree_make_leaf(cat, {2, 1, {0, 1}}, tree1->size, invisible);
       AssertThat(ts_tree_eq(tree1, tree1_copy), IsFalse());
       ts_tree_release(tree1_copy);
 
-      tree1_copy = ts_tree_make_leaf(cat, tree1->padding, {5, 4, 1, 10}, invisible);
+      tree1_copy = ts_tree_make_leaf(cat, tree1->padding, {5, 4, {1, 10}}, invisible);
       AssertThat(ts_tree_eq(tree1, tree1_copy), IsFalse());
       ts_tree_release(tree1_copy);
     });

--- a/spec/runtime/tree_spec.cc
+++ b/spec/runtime/tree_spec.cc
@@ -183,16 +183,23 @@ describe("Tree", []() {
 
     describe("edits within a tree's padding", [&]() {
       it("resizes the padding of the tree and its leftmost descendants", [&]() {
-        ts_tree_edit(tree, {1, 1, 0});
-
+        TSInputEdit edit = {
+          .start_byte = 1,
+          .bytes_removed = 0,
+          .bytes_added = 1,
+          .start_point = {0, 1},
+          .extent_removed = {0, 0},
+          .extent_added = {0, 1},
+        };
+        ts_tree_edit(tree, &edit);
         assert_consistent(tree);
 
         AssertThat(tree->has_changes, IsTrue());
-        AssertThat(tree->padding, Equals<TSLength>({0, 3, {0, 0}}));
+        AssertThat(tree->padding, Equals<TSLength>({3, 0, {0, 3}}));
         AssertThat(tree->size, Equals<TSLength>({13, 13, {0, 13}}));
 
         AssertThat(tree->children[0]->has_changes, IsTrue());
-        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 3, {0, 0}}));
+        AssertThat(tree->children[0]->padding, Equals<TSLength>({3, 0, {0, 3}}));
         AssertThat(tree->children[0]->size, Equals<TSLength>({3, 3, {0, 3}}));
 
         AssertThat(tree->children[1]->has_changes, IsFalse());
@@ -203,32 +210,48 @@ describe("Tree", []() {
 
     describe("edits that start in a tree's padding but extend into its content", [&]() {
       it("shrinks the content to compensate for the expanded padding", [&]() {
-        ts_tree_edit(tree, {1, 4, 3});
-
+        TSInputEdit edit = {
+          .start_byte = 1,
+          .bytes_removed = 3,
+          .bytes_added = 4,
+          .start_point = {0, 1},
+          .extent_removed = {0, 3},
+          .extent_added = {0, 4},
+        };
+        ts_tree_edit(tree, &edit);
         assert_consistent(tree);
 
         AssertThat(tree->has_changes, IsTrue());
-        AssertThat(tree->padding, Equals<TSLength>({0, 5, {0, 0}}));
-        AssertThat(tree->size, Equals<TSLength>({0, 11, {0, 0}}));
+        AssertThat(tree->padding, Equals<TSLength>({5, 0, {0, 5}}));
+        AssertThat(tree->size, Equals<TSLength>({11, 0, {0, 11}}));
 
         AssertThat(tree->children[0]->has_changes, IsTrue());
-        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 5, {0, 0}}));
-        AssertThat(tree->children[0]->size, Equals<TSLength>({0, 1, {0, 0}}));
+        AssertThat(tree->children[0]->padding, Equals<TSLength>({5, 0, {0, 5}}));
+        AssertThat(tree->children[0]->size, Equals<TSLength>({1, 0, {0, 1}}));
       });
     });
 
     describe("insertions at the edge of a tree's padding", [&]() {
       it("expands the tree's padding", [&]() {
-        ts_tree_edit(tree, {2, 2, 0});
+        TSInputEdit edit = {
+          .start_byte = 2,
+          .bytes_removed = 0,
+          .bytes_added = 2,
+          .start_point = {0, 2},
+          .extent_removed = {0, 0},
+          .extent_added = {0, 2},
+        };
+        ts_tree_edit(tree, &edit);
+        assert_consistent(tree);
 
         assert_consistent(tree);
 
         AssertThat(tree->has_changes, IsTrue());
-        AssertThat(tree->padding, Equals<TSLength>({0, 4, {0, 0}}));
+        AssertThat(tree->padding, Equals<TSLength>({4, 0, {0, 4}}));
         AssertThat(tree->size, Equals<TSLength>({13, 13, {0, 13}}));
 
         AssertThat(tree->children[0]->has_changes, IsTrue());
-        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 4, {0, 0}}));
+        AssertThat(tree->children[0]->padding, Equals<TSLength>({4, 0, {0, 4}}));
         AssertThat(tree->children[0]->size, Equals<TSLength>({3, 3, {0, 3}}));
 
         AssertThat(tree->children[1]->has_changes, IsFalse());
@@ -237,17 +260,24 @@ describe("Tree", []() {
 
     describe("replacements starting at the edge of a tree's padding", [&]() {
       it("resizes the content and not the padding", [&]() {
-        ts_tree_edit(tree, {2, 5, 2});
-
+        TSInputEdit edit = {
+          .start_byte = 2,
+          .bytes_removed = 2,
+          .bytes_added = 5,
+          .start_point = {0, 2},
+          .extent_removed = {0, 2},
+          .extent_added = {0, 5},
+        };
+        ts_tree_edit(tree, &edit);
         assert_consistent(tree);
 
         AssertThat(tree->has_changes, IsTrue());
         AssertThat(tree->padding, Equals<TSLength>({2, 2, {0, 2}}));
-        AssertThat(tree->size, Equals<TSLength>({0, 16, {0, 0}}));
+        AssertThat(tree->size, Equals<TSLength>({16, 0, {0, 16}}));
 
         AssertThat(tree->children[0]->has_changes, IsTrue());
         AssertThat(tree->children[0]->padding, Equals<TSLength>({2, 2, {0, 2}}));
-        AssertThat(tree->children[0]->size, Equals<TSLength>({0, 6, {0, 0}}));
+        AssertThat(tree->children[0]->size, Equals<TSLength>({6, 0, {0, 6}}));
 
         AssertThat(tree->children[1]->has_changes, IsFalse());
       });
@@ -255,16 +285,25 @@ describe("Tree", []() {
 
     describe("deletions that span more than one child node", [&]() {
       it("shrinks subsequent child nodes", [&]() {
-        ts_tree_edit(tree, {1, 3, 10});
+        TSInputEdit edit = {
+          .start_byte = 1,
+          .bytes_removed = 10,
+          .bytes_added = 3,
+          .start_point = {0, 1},
+          .extent_removed = {0, 10},
+          .extent_added = {0, 3},
+        };
+        ts_tree_edit(tree, &edit);
+        assert_consistent(tree);
 
         assert_consistent(tree);
 
         AssertThat(tree->has_changes, IsTrue());
-        AssertThat(tree->padding, Equals<TSLength>({0, 4, {0, 0}}));
-        AssertThat(tree->size, Equals<TSLength>({0, 4, {0, 0}}));
+        AssertThat(tree->padding, Equals<TSLength>({4, 0, {0, 4}}));
+        AssertThat(tree->size, Equals<TSLength>({4, 0, {0, 4}}));
 
         AssertThat(tree->children[0]->has_changes, IsTrue());
-        AssertThat(tree->children[0]->padding, Equals<TSLength>({0, 4, {0, 0}}));
+        AssertThat(tree->children[0]->padding, Equals<TSLength>({4, 0, {0, 4}}));
         AssertThat(tree->children[0]->size, Equals<TSLength>({0, 0, {0, 0}}));
 
         AssertThat(tree->children[1]->has_changes, IsTrue());
@@ -272,7 +311,7 @@ describe("Tree", []() {
         AssertThat(tree->children[1]->size, Equals<TSLength>({0, 0, {0, 0}}));
 
         AssertThat(tree->children[2]->has_changes, IsTrue());
-        AssertThat(tree->children[2]->padding, Equals<TSLength>({0, 1, {0, 0}}));
+        AssertThat(tree->children[2]->padding, Equals<TSLength>({1, 0, {0, 1}}));
         AssertThat(tree->children[2]->size, Equals<TSLength>({3, 3, {0, 3}}));
       });
     });

--- a/src/runtime/document.c
+++ b/src/runtime/document.c
@@ -82,7 +82,7 @@ void ts_document_edit(TSDocument *self, TSInputEdit edit) {
 
   size_t max_bytes = ts_tree_total_bytes(self->tree);
   if (edit.start_byte > max_bytes)
-    edit.start_byte = max_bytes;
+    return;
   if (edit.bytes_removed > max_bytes - edit.start_byte)
     edit.bytes_removed = max_bytes - edit.start_byte;
 

--- a/src/runtime/document.c
+++ b/src/runtime/document.c
@@ -165,7 +165,10 @@ static bool ts_tree_diff(TSDocument *doc, TSTree *old, TSNode *new_node,
           PRINT("advance before diff ('%s', %lu) -> ('%s', %lu)",
             NAME(new_node->data), ts_node_start_char(*new_node), NAME(next.data),
             ts_node_start_char(next));
+
           *new_node = next;
+        } else {
+          break;
         }
       } else if (new_child_start == old_child_start) {
         if (!ts_tree_diff(doc, old_child, new_node, depth, results, extend_last_change))
@@ -196,7 +199,7 @@ static bool ts_tree_diff(TSDocument *doc, TSTree *old, TSNode *new_node,
   return true;
 }
 
-int ts_document_parse_and_diff(TSDocument *self, TSRange **ranges, size_t *range_count) {
+int ts_document_parse_and_get_changed_ranges(TSDocument *self, TSRange **ranges, size_t *range_count) {
   if (ranges) *ranges = NULL;
   if (range_count) *range_count = 0;
 
@@ -238,7 +241,7 @@ int ts_document_parse_and_diff(TSDocument *self, TSRange **ranges, size_t *range
 }
 
 int ts_document_parse(TSDocument *self) {
-  return ts_document_parse_and_diff(self, NULL, NULL);
+  return ts_document_parse_and_get_changed_ranges(self, NULL, NULL);
 }
 
 void ts_document_invalidate(TSDocument *self) {

--- a/src/runtime/document.c
+++ b/src/runtime/document.c
@@ -5,6 +5,7 @@
 #include "runtime/parser.h"
 #include "runtime/string_input.h"
 #include "runtime/document.h"
+#include "runtime/tree_path.h"
 
 TSDocument *ts_document_new() {
   TSDocument *self = ts_calloc(1, sizeof(TSDocument));
@@ -89,212 +90,10 @@ void ts_document_edit(TSDocument *self, TSInputEdit edit) {
   ts_tree_edit(self->tree, &edit);
 }
 
-typedef Array(TSRange) RangeArray;
-
-#define NAME(t)                                                                 \
-  ((t)                                                                          \
-     ? (ts_language_symbol_name(doc->parser.language, ((TSTree *)(t))->symbol)) \
-     : "<NULL>")
-
-static bool push_change(RangeArray *results, TSPoint start, TSPoint end) {
-  if (results->size > 0) {
-    TSRange *last_range = array_back(results);
-    if (ts_point_lte(start, last_range->end)) {
-      last_range->end = end;
-      return true;
-    }
-  }
-
-  if (ts_point_lt(start, end)) {
-    TSRange range = { start, end };
-    return array_push(results, range);
-  }
-
-  return true;
-}
-
-static bool tree_path_descend(TreePath *path, TSPoint position) {
-  bool did_descend;
-  do {
-    did_descend = false;
-    TreePathEntry entry = *array_back(path);
-    TSLength child_position = entry.position;
-    for (size_t i = 0; i < entry.tree->child_count; i++) {
-      TSTree *child = entry.tree->children[i];
-      TSLength child_right_position =
-        ts_length_add(child_position, ts_tree_total_size(child));
-      if (ts_point_lt(position, child_right_position.extent)) {
-        TreePathEntry child_entry = { child, child_position, i };
-        if (child->visible) {
-          array_push(path, child_entry);
-          return true;
-        } else if (child->visible_child_count > 0) {
-          array_push(path, child_entry);
-          did_descend = true;
-          break;
-        }
-      }
-      child_position = child_right_position;
-    }
-  } while (did_descend);
-  return false;
-}
-
-static size_t tree_path_advance(TreePath *path) {
-  size_t ascend_count = 0;
-  while (path->size > 0) {
-    TreePathEntry entry = array_pop(path);
-    if (path->size == 0)
-      break;
-    TreePathEntry parent_entry = *array_back(path);
-    if (parent_entry.tree->visible) {
-      ascend_count++;
-    }
-    TSLength position =
-      ts_length_add(entry.position, ts_tree_total_size(entry.tree));
-    for (size_t i = entry.child_index + 1, n = parent_entry.tree->child_count;
-         i < n; i++) {
-      TSTree *next_child = parent_entry.tree->children[i];
-      if (next_child->visible || next_child->visible_child_count > 0) {
-        if (parent_entry.tree->visible) {
-          ascend_count--;
-        }
-        array_push(path,
-                   ((TreePathEntry){
-                     .tree = next_child, .child_index = i, .position = position,
-                   }));
-        if (!next_child->visible)
-          tree_path_descend(path, (TSPoint){ 0, 0 });
-        return ascend_count;
-      }
-      position = ts_length_add(position, ts_tree_total_size(next_child));
-    }
-  }
-  return ascend_count;
-}
-
-static void tree_path_ascend(TreePath *path, size_t count) {
-  for (size_t i = 0; i < count; i++) {
-    do {
-      array_pop(path);
-    } while (path->size > 0 && !array_back(path)->tree->visible);
-  }
-}
-
-static void tree_path_init(TreePath *path, TSTree *tree) {
-  array_clear(path);
-  array_push(path,
-             ((TreePathEntry){
-               .tree = tree, .position = { 0, 0, { 0, 0 } }, .child_index = 0,
-             }));
-  if (!tree->visible)
-    tree_path_descend(path, (TSPoint){ 0, 0 });
-}
-
-static bool ts_tree_get_changes(TSDocument *doc, TreePath *old_path,
-                                TreePath *new_path, size_t depth,
-                                RangeArray *results) {
-  TSPoint position = { 0, 0 };
-
-  while (old_path->size && new_path->size) {
-    bool is_different = false;
-    TSPoint next_position = position;
-
-    TreePathEntry old_entry = *array_back(old_path);
-    TreePathEntry new_entry = *array_back(new_path);
-    TSTree *old_tree = old_entry.tree;
-    TSTree *new_tree = new_entry.tree;
-    TSSymbol old_symbol = old_tree->symbol;
-    TSSymbol new_symbol = new_tree->symbol;
-    size_t old_start_byte = old_entry.position.bytes;
-    size_t new_start_byte = new_entry.position.bytes;
-    size_t old_end_byte = old_start_byte + ts_tree_total_bytes(old_tree);
-    size_t new_end_byte = new_start_byte + ts_tree_total_bytes(new_tree);
-    TSPoint old_start_point =
-      ts_point_add(old_entry.position.extent, old_tree->padding.extent);
-    TSPoint new_start_point =
-      ts_point_add(new_entry.position.extent, new_tree->padding.extent);
-    TSPoint old_end_point = ts_point_add(old_start_point, old_tree->size.extent);
-    TSPoint new_end_point = ts_point_add(new_start_point, new_tree->size.extent);
-
-    // printf("At [%-2lu, %-2lu] Compare (%-20s\t [%-2lu, %-2lu] - [%lu, %lu])\tvs\t(%-20s\t [%lu, %lu] - [%lu, %lu])\t",
-    //   position.row, position.column, NAME(old_tree), old_start_point.row,
-    //   old_start_point.column, old_end_point.row, old_end_point.column,
-    //   NAME(new_tree), new_start_point.row, new_start_point.column,
-    //   new_end_point.row, new_end_point.column);
-
-    if (ts_point_lt(position, old_start_point)) {
-      if (ts_point_lt(position, new_start_point)) {
-        next_position = ts_point_min(old_start_point, new_start_point);
-      } else {
-        is_different = true;
-        next_position = old_start_point;
-      }
-    } else if (ts_point_lt(position, new_start_point)) {
-      is_different = true;
-      next_position = new_start_point;
-    } else {
-      if (old_tree == new_tree ||
-          (!old_tree->has_changes && old_symbol == new_symbol &&
-           old_start_byte == new_start_byte && old_end_byte == new_end_byte &&
-           old_tree->parse_state != TS_TREE_STATE_NONE &&
-           new_tree->parse_state != TS_TREE_STATE_NONE)) {
-        next_position = old_end_point;
-      } else if (old_symbol == new_symbol) {
-        bool old_descended = tree_path_descend(old_path, position);
-        bool new_descended = tree_path_descend(new_path, position);
-        if (old_descended) {
-          if (!new_descended) {
-            tree_path_ascend(old_path, 1);
-            is_different = true;
-            next_position = new_end_point;
-          }
-        } else if (new_descended) {
-          tree_path_ascend(new_path, 1);
-          is_different = true;
-          next_position = old_end_point;
-        } else {
-          next_position = ts_point_min(old_end_point, new_end_point);
-        }
-      } else {
-        is_different = true;
-        next_position = ts_point_min(old_end_point, new_end_point);
-      }
-    }
-
-    bool advance_old = ts_point_lte(old_end_point, next_position);
-    bool advance_new = ts_point_lte(new_end_point, next_position);
-
-    if (advance_new && advance_old) {
-      size_t old_ascend_count = tree_path_advance(old_path);
-      size_t new_ascend_count = tree_path_advance(new_path);
-      if (old_ascend_count > new_ascend_count) {
-        tree_path_ascend(new_path, old_ascend_count - new_ascend_count);
-      } else if (new_ascend_count > old_ascend_count) {
-        tree_path_ascend(old_path, new_ascend_count - old_ascend_count);
-      }
-    } else if (advance_new) {
-      size_t ascend_count = tree_path_advance(new_path);
-      tree_path_ascend(old_path, ascend_count);
-    } else if (advance_old) {
-      size_t ascend_count = tree_path_advance(old_path);
-      tree_path_ascend(new_path, ascend_count);
-    }
-
-    if (is_different)
-      push_change(results, position, next_position);
-    position = next_position;
-  }
-
-  return true;
-}
-
 int ts_document_parse_and_get_changed_ranges(TSDocument *self, TSRange **ranges,
                                              size_t *range_count) {
-  if (ranges)
-    *ranges = NULL;
-  if (range_count)
-    *range_count = 0;
+  if (ranges) *ranges = NULL;
+  if (range_count) *range_count = 0;
 
   if (!self->input.read || !self->parser.language)
     return -1;
@@ -312,14 +111,11 @@ int ts_document_parse_and_get_changed_ranges(TSDocument *self, TSRange **ranges,
     self->tree = tree;
 
     if (ranges && range_count) {
-      RangeArray result = { 0, 0, 0 };
       tree_path_init(&self->parser.tree_path1, old_tree);
       tree_path_init(&self->parser.tree_path2, tree);
-      if (!ts_tree_get_changes(self, &self->parser.tree_path1,
-                               &self->parser.tree_path2, 0, &result))
+      if (!tree_path_get_changes(&self->parser.tree_path1,
+                                 &self->parser.tree_path2, ranges, range_count))
         return -1;
-      *ranges = result.contents;
-      *range_count = result.size;
     }
 
     ts_tree_release(old_tree);

--- a/src/runtime/length.h
+++ b/src/runtime/length.h
@@ -12,11 +12,11 @@ typedef struct {
   TSPoint extent;
 } TSLength;
 
-static inline bool ts_length_is_unknown(TSLength self) {
+static inline bool ts_length_has_unknown_chars(TSLength self) {
   return self.bytes > 0 && self.chars == 0;
 }
 
-static inline void ts_length_set_unknown(TSLength *self) {
+static inline void ts_length_set_unknown_chars(TSLength *self) {
   self->chars = 0;
 }
 
@@ -30,7 +30,7 @@ static inline TSLength ts_length_add(TSLength len1, TSLength len2) {
   result.bytes = len1.bytes + len2.bytes;
   result.extent = ts_point_add(len1.extent, len2.extent);
 
-  if (ts_length_is_unknown(len1) || ts_length_is_unknown(len2)) {
+  if (ts_length_has_unknown_chars(len1) || ts_length_has_unknown_chars(len2)) {
     result.chars = 0;
   } else {
     result.chars = len1.chars + len2.chars;
@@ -44,7 +44,7 @@ static inline TSLength ts_length_sub(TSLength len1, TSLength len2) {
   result.bytes = len1.bytes - len2.bytes;
   result.extent = ts_point_sub(len1.extent, len2.extent);
 
-  if (ts_length_is_unknown(len1) || ts_length_is_unknown(len2)) {
+  if (ts_length_has_unknown_chars(len1) || ts_length_has_unknown_chars(len2)) {
     result.chars = 0;
   } else {
     result.chars = len1.chars - len2.chars;

--- a/src/runtime/length.h
+++ b/src/runtime/length.h
@@ -4,14 +4,27 @@
 #include "tree_sitter/parser.h"
 #include <stdbool.h>
 
+static inline TSPoint ts_point_add(TSPoint a, TSPoint b) {
+  if (b.row > 0)
+    return (TSPoint){a.row + b.row, b.column};
+  else
+    return (TSPoint){a.row, a.column + b.column};
+}
+
+static inline TSPoint ts_point_sub(TSPoint a, TSPoint b) {
+  if (a.row > b.row)
+    return (TSPoint){a.row - b.row, a.column};
+  else
+    return (TSPoint){0, a.column - b.column};
+}
+
 static inline bool ts_length_is_unknown(TSLength self) {
   return self.chars > 0 && self.bytes == 0;
 }
 
 static inline void ts_length_set_unknown(TSLength *self) {
   self->bytes = 0;
-  self->rows = 0;
-  self->columns = 0;
+  self->extent = (TSPoint){0, 0};
 }
 
 static inline TSLength ts_length_min(TSLength len1, TSLength len2) {
@@ -24,17 +37,10 @@ static inline TSLength ts_length_add(TSLength len1, TSLength len2) {
 
   if (ts_length_is_unknown(len1) || ts_length_is_unknown(len2)) {
     result.bytes = 0;
-    result.rows = 0;
-    result.columns = result.chars;
+    result.extent = (TSPoint){0, result.chars};
   } else {
     result.bytes = len1.bytes + len2.bytes;
-    if (len2.rows == 0) {
-      result.rows = len1.rows;
-      result.columns = len1.columns + len2.columns;
-    } else {
-      result.rows = len1.rows + len2.rows;
-      result.columns = len2.columns;
-    }
+    result.extent = ts_point_add(len1.extent, len2.extent);
   }
 
   return result;
@@ -46,29 +52,23 @@ static inline TSLength ts_length_sub(TSLength len1, TSLength len2) {
 
   if (ts_length_is_unknown(len1) || ts_length_is_unknown(len2)) {
     result.bytes = 0;
-    result.rows = 0;
-    result.columns = result.chars;
+    result.extent = (TSPoint){0, result.chars};
   } else {
     result.bytes = len1.bytes - len2.bytes;
-    if (len1.rows == len2.rows) {
-      result.rows = 0;
-      result.columns = len1.columns - len2.columns;
-    } else {
-      result.rows = len1.rows - len2.rows;
-      result.columns = len1.columns;
-    }
+    result.extent = ts_point_sub(len1.extent, len2.extent);
   }
 
   return result;
 }
 
 static inline TSLength ts_length_zero() {
-  return (TSLength){ 0, 0, 0, 0 };
+  return (TSLength){ 0, 0, {0, 0} };
 }
 
 static inline bool ts_length_eq(TSLength self, TSLength other) {
   return self.bytes == other.bytes && self.chars == other.chars &&
-         self.rows == other.rows && self.columns == other.columns;
+         self.extent.row == other.extent.row &&
+         self.extent.column == other.extent.column;
 }
 
 #endif

--- a/src/runtime/length.h
+++ b/src/runtime/length.h
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include <stdbool.h>
+#include "runtime/point.h"
 #include "tree_sitter/runtime.h"
 
 typedef struct {
@@ -10,46 +11,6 @@ typedef struct {
   size_t chars;
   TSPoint extent;
 } TSLength;
-
-static inline TSPoint ts_point_add(TSPoint a, TSPoint b) {
-  if (b.row > 0)
-    return (TSPoint){a.row + b.row, b.column};
-  else
-    return (TSPoint){a.row, a.column + b.column};
-}
-
-static inline TSPoint ts_point_sub(TSPoint a, TSPoint b) {
-  if (a.row > b.row)
-    return (TSPoint){a.row - b.row, a.column};
-  else
-    return (TSPoint){0, a.column - b.column};
-}
-
-static inline bool ts_point_lte(TSPoint a, TSPoint b) {
-  return (a.row < b.row) || (a.row == b.row && a.column <= b.column);
-}
-
-static inline bool ts_point_lt(TSPoint a, TSPoint b) {
-  return (a.row < b.row) || (a.row == b.row && a.column < b.column);
-}
-
-static inline bool ts_point_eq(TSPoint a, TSPoint b) {
-  return a.row == b.row && a.column == b.column;
-}
-
-static inline TSPoint ts_point_min(TSPoint a, TSPoint b) {
-  if (a.row < b.row || (a.row == b.row && a.column < b.column))
-    return a;
-  else
-    return b;
-}
-
-static inline TSPoint ts_point_max(TSPoint a, TSPoint b) {
-  if (a.row > b.row || (a.row == b.row && a.column > b.column))
-    return a;
-  else
-    return b;
-}
 
 static inline bool ts_length_is_unknown(TSLength self) {
   return self.bytes > 0 && self.chars == 0;

--- a/src/runtime/length.h
+++ b/src/runtime/length.h
@@ -18,13 +18,19 @@ static inline TSPoint ts_point_sub(TSPoint a, TSPoint b) {
     return (TSPoint){0, a.column - b.column};
 }
 
+static inline TSPoint ts_point_min(TSPoint a, TSPoint b) {
+  if (a.row < b.row || (a.row == b.row && a.column < b.column))
+    return a;
+  else
+    return b;
+}
+
 static inline bool ts_length_is_unknown(TSLength self) {
-  return self.chars > 0 && self.bytes == 0;
+  return self.bytes > 0 && self.chars == 0;
 }
 
 static inline void ts_length_set_unknown(TSLength *self) {
-  self->bytes = 0;
-  self->extent = (TSPoint){0, 0};
+  self->chars = 0;
 }
 
 static inline TSLength ts_length_min(TSLength len1, TSLength len2) {
@@ -34,13 +40,13 @@ static inline TSLength ts_length_min(TSLength len1, TSLength len2) {
 static inline TSLength ts_length_add(TSLength len1, TSLength len2) {
   TSLength result;
   result.chars = len1.chars + len2.chars;
+  result.bytes = len1.bytes + len2.bytes;
+  result.extent = ts_point_add(len1.extent, len2.extent);
 
   if (ts_length_is_unknown(len1) || ts_length_is_unknown(len2)) {
-    result.bytes = 0;
-    result.extent = (TSPoint){0, result.chars};
+    result.chars = 0;
   } else {
-    result.bytes = len1.bytes + len2.bytes;
-    result.extent = ts_point_add(len1.extent, len2.extent);
+    result.chars = len1.chars + len2.chars;
   }
 
   return result;
@@ -48,14 +54,13 @@ static inline TSLength ts_length_add(TSLength len1, TSLength len2) {
 
 static inline TSLength ts_length_sub(TSLength len1, TSLength len2) {
   TSLength result;
-  result.chars = len1.chars - len2.chars;
+  result.bytes = len1.bytes - len2.bytes;
+  result.extent = ts_point_sub(len1.extent, len2.extent);
 
   if (ts_length_is_unknown(len1) || ts_length_is_unknown(len2)) {
-    result.bytes = 0;
-    result.extent = (TSPoint){0, result.chars};
+    result.chars = 0;
   } else {
-    result.bytes = len1.bytes - len2.bytes;
-    result.extent = ts_point_sub(len1.extent, len2.extent);
+    result.chars = len1.chars - len2.chars;
   }
 
   return result;

--- a/src/runtime/length.h
+++ b/src/runtime/length.h
@@ -18,8 +18,27 @@ static inline TSPoint ts_point_sub(TSPoint a, TSPoint b) {
     return (TSPoint){0, a.column - b.column};
 }
 
+static inline bool ts_point_lte(TSPoint a, TSPoint b) {
+  return (a.row < b.row) || (a.row == b.row && a.column <= b.column);
+}
+
+static inline bool ts_point_lt(TSPoint a, TSPoint b) {
+  return (a.row < b.row) || (a.row == b.row && a.column < b.column);
+}
+
+static inline bool ts_point_eq(TSPoint a, TSPoint b) {
+  return a.row == b.row && a.column == b.column;
+}
+
 static inline TSPoint ts_point_min(TSPoint a, TSPoint b) {
   if (a.row < b.row || (a.row == b.row && a.column < b.column))
+    return a;
+  else
+    return b;
+}
+
+static inline TSPoint ts_point_max(TSPoint a, TSPoint b) {
+  if (a.row > b.row || (a.row == b.row && a.column > b.column))
     return a;
   else
     return b;

--- a/src/runtime/lexer.c
+++ b/src/runtime/lexer.c
@@ -55,10 +55,10 @@ static void ts_lexer__advance(TSLexer *self, TSStateId state, bool skip) {
     self->current_position.bytes += self->lookahead_size;
     self->current_position.chars++;
     if (self->lookahead == '\n') {
-      self->current_position.rows++;
-      self->current_position.columns = 0;
+      self->current_position.extent.row++;
+      self->current_position.extent.column = 0;
     } else {
-      self->current_position.columns++;
+      self->current_position.extent.column++;
     }
   }
 

--- a/src/runtime/node.c
+++ b/src/runtime/node.c
@@ -48,7 +48,7 @@ static inline TSNode ts_node__direct_parent(TSNode self, size_t *index) {
   return ts_node_make(tree->context.parent,
                       ts_node__offset_char(self) - tree->context.offset.chars,
                       ts_node__offset_byte(self) - tree->context.offset.bytes,
-                      ts_node__offset_row(self) - tree->context.offset.rows);
+                      ts_node__offset_row(self) - tree->context.offset.extent.row);
 }
 
 static inline TSNode ts_node__direct_child(TSNode self, size_t i) {
@@ -56,7 +56,7 @@ static inline TSNode ts_node__direct_child(TSNode self, size_t i) {
   return ts_node_make(
     child_tree, ts_node__offset_char(self) + child_tree->context.offset.chars,
     ts_node__offset_byte(self) + child_tree->context.offset.bytes,
-    ts_node__offset_row(self) + child_tree->context.offset.rows);
+    ts_node__offset_row(self) + child_tree->context.offset.extent.row);
 }
 
 static inline TSNode ts_node__child(TSNode self, size_t child_index,
@@ -246,14 +246,14 @@ size_t ts_node_end_byte(TSNode self) {
 
 TSPoint ts_node_start_point(TSNode self) {
   const TSTree *tree = ts_node__tree(self);
-  return (TSPoint){ ts_node__offset_row(self) + tree->padding.rows,
+  return (TSPoint){ ts_node__offset_row(self) + tree->padding.extent.row,
                     ts_tree_start_column(tree) };
 }
 
 TSPoint ts_node_end_point(TSNode self) {
   const TSTree *tree = ts_node__tree(self);
-  return (TSPoint){ ts_node__offset_row(self) + tree->padding.rows +
-                      tree->size.rows,
+  return (TSPoint){ ts_node__offset_row(self) + tree->padding.extent.row +
+                      tree->size.extent.row,
                     ts_tree_end_column(tree) };
 }
 

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -144,7 +144,7 @@ error:
 }
 
 static void parser__pop_reusable_node(ReusableNode *reusable_node) {
-  reusable_node->char_index += ts_tree_total_chars(reusable_node->tree);
+  reusable_node->byte_index += ts_tree_total_bytes(reusable_node->tree);
   while (reusable_node->tree) {
     TSTree *parent = reusable_node->tree->context.parent;
     size_t next_index = reusable_node->tree->context.index + 1;
@@ -270,7 +270,7 @@ static TSTree *parser__lex(Parser *self, TSStateId parse_state) {
       break;
     }
 
-    if (self->lexer.current_position.chars == position.chars) {
+    if (self->lexer.current_position.bytes == position.bytes) {
       if (!skipped_error) {
         error_start_position = self->lexer.current_position;
         first_error_character = self->lexer.lookahead;
@@ -317,15 +317,15 @@ static TSTree *parser__get_lookahead(Parser *self, StackVersion version,
   TSLength position = ts_stack_top_position(self->stack, version);
 
   while (reusable_node->tree) {
-    if (reusable_node->char_index > position.chars) {
+    if (reusable_node->byte_index > position.bytes) {
       LOG("before_reusable sym:%s, pos:%lu",
-          SYM_NAME(reusable_node->tree->symbol), reusable_node->char_index);
+          SYM_NAME(reusable_node->tree->symbol), reusable_node->byte_index);
       break;
     }
 
-    if (reusable_node->char_index < position.chars) {
+    if (reusable_node->byte_index < position.bytes) {
       LOG("past_reusable sym:%s, pos:%lu",
-          SYM_NAME(reusable_node->tree->symbol), reusable_node->char_index);
+          SYM_NAME(reusable_node->tree->symbol), reusable_node->byte_index);
       parser__pop_reusable_node(reusable_node);
       continue;
     }
@@ -333,7 +333,7 @@ static TSTree *parser__get_lookahead(Parser *self, StackVersion version,
     if (reusable_node->tree->has_changes) {
       LOG("cant_reuse_changed tree:%s, size:%lu",
           SYM_NAME(reusable_node->tree->symbol),
-          reusable_node->tree->size.chars);
+          reusable_node->tree->size.bytes);
       if (!parser__breakdown_reusable_node(reusable_node)) {
         parser__pop_reusable_node(reusable_node);
         CHECK(parser__breakdown_top_of_stack(self, version));
@@ -344,7 +344,7 @@ static TSTree *parser__get_lookahead(Parser *self, StackVersion version,
     if (reusable_node->tree->symbol == ts_builtin_sym_error) {
       LOG("cant_reuse_error tree:%s, size:%lu",
           SYM_NAME(reusable_node->tree->symbol),
-          reusable_node->tree->size.chars);
+          reusable_node->tree->size.bytes);
       if (!parser__breakdown_reusable_node(reusable_node)) {
         parser__pop_reusable_node(reusable_node);
         CHECK(parser__breakdown_top_of_stack(self, version));
@@ -357,7 +357,7 @@ static TSTree *parser__get_lookahead(Parser *self, StackVersion version,
     return result;
   }
 
-  if (self->cached_token && position.chars == self->cached_token_char_index) {
+  if (self->cached_token && position.bytes == self->cached_token_byte_index) {
     ts_tree_retain(self->cached_token);
     return self->cached_token;
   }
@@ -1073,7 +1073,7 @@ static bool parser__advance(Parser *self, StackVersion version,
 
       validated_lookahead = true;
       LOG("lookahead sym:%s, size:%lu", SYM_NAME(lookahead->symbol),
-          lookahead->size.chars);
+          lookahead->size.bytes);
     }
 
     bool reduction_stopped_at_error = false;

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -1272,8 +1272,8 @@ TSTree *parser_parse(Parser *self, TSInput input, TSTree *old_tree) {
         LOG("process version:%d, version_count:%lu, state:%d, row:%lu, col:%lu",
             version, ts_stack_version_count(self->stack),
             ts_stack_top_state(self->stack, version),
-            ts_stack_top_position(self->stack, version).rows + 1,
-            ts_stack_top_position(self->stack, version).columns + 1);
+            ts_stack_top_position(self->stack, version).extent.row + 1,
+            ts_stack_top_position(self->stack, version).extent.column + 1);
 
         CHECK(parser__advance(self, version, &reusable_node));
         LOG_STACK();

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -1226,7 +1226,8 @@ bool parser_init(Parser *self) {
   self->finished_tree = NULL;
   self->stack = NULL;
   array_init(&self->reduce_actions);
-  array_init(&self->tree_stack);
+  array_init(&self->tree_path1);
+  array_init(&self->tree_path2);
 
   self->stack = ts_stack_new();
   if (!self->stack)
@@ -1252,8 +1253,10 @@ void parser_destroy(Parser *self) {
     ts_stack_delete(self->stack);
   if (self->reduce_actions.contents)
     array_delete(&self->reduce_actions);
-  if (self->tree_stack.contents)
-    array_delete(&self->tree_stack);
+  if (self->tree_path1.contents)
+    array_delete(&self->tree_path1);
+  if (self->tree_path2.contents)
+    array_delete(&self->tree_path2);
 }
 
 TSTree *parser_parse(Parser *self, TSInput input, TSTree *old_tree) {
@@ -1299,7 +1302,7 @@ TSTree *parser_parse(Parser *self, TSInput input, TSTree *old_tree) {
   LOG_TREE();
   ts_stack_clear(self->stack);
   parser__clear_cached_token(self);
-  CHECK(ts_tree_assign_parents(self->finished_tree, &self->tree_stack));
+  CHECK(ts_tree_assign_parents(self->finished_tree, &self->tree_path1));
   return self->finished_tree;
 
 error:

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -1224,6 +1224,7 @@ bool parser_init(Parser *self) {
   self->finished_tree = NULL;
   self->stack = NULL;
   array_init(&self->reduce_actions);
+  array_init(&self->tree_stack);
 
   self->stack = ts_stack_new();
   if (!self->stack)
@@ -1249,6 +1250,8 @@ void parser_destroy(Parser *self) {
     ts_stack_delete(self->stack);
   if (self->reduce_actions.contents)
     array_delete(&self->reduce_actions);
+  if (self->tree_stack.contents)
+    array_delete(&self->tree_stack);
 }
 
 TSTree *parser_parse(Parser *self, TSInput input, TSTree *old_tree) {
@@ -1294,7 +1297,7 @@ TSTree *parser_parse(Parser *self, TSInput input, TSTree *old_tree) {
   LOG_TREE();
   ts_stack_clear(self->stack);
   parser__clear_cached_token(self);
-  ts_tree_assign_parents(self->finished_tree);
+  CHECK(ts_tree_assign_parents(self->finished_tree, &self->tree_stack));
   return self->finished_tree;
 
 error:

--- a/src/runtime/parser.h
+++ b/src/runtime/parser.h
@@ -11,7 +11,7 @@ extern "C" {
 
 typedef struct {
   TSTree *tree;
-  size_t char_index;
+  size_t byte_index;
 } ReusableNode;
 
 typedef struct {
@@ -24,7 +24,7 @@ typedef struct {
   bool print_debugging_graphs;
   TSTree scratch_tree;
   TSTree *cached_token;
-  size_t cached_token_char_index;
+  size_t cached_token_byte_index;
   ReusableNode reusable_node;
 } Parser;
 

--- a/src/runtime/parser.h
+++ b/src/runtime/parser.h
@@ -26,6 +26,7 @@ typedef struct {
   TSTree *cached_token;
   size_t cached_token_byte_index;
   ReusableNode reusable_node;
+  TreeArray tree_stack;
 } Parser;
 
 bool parser_init(Parser *);

--- a/src/runtime/parser.h
+++ b/src/runtime/parser.h
@@ -26,7 +26,8 @@ typedef struct {
   TSTree *cached_token;
   size_t cached_token_byte_index;
   ReusableNode reusable_node;
-  TreeArray tree_stack;
+  TreePath tree_path1;
+  TreePath tree_path2;
 } Parser;
 
 bool parser_init(Parser *);

--- a/src/runtime/point.h
+++ b/src/runtime/point.h
@@ -1,0 +1,46 @@
+#ifndef RUNTIME_POINT_H_
+#define RUNTIME_POINT_H_
+
+#include "tree_sitter/runtime.h"
+
+static inline TSPoint ts_point_add(TSPoint a, TSPoint b) {
+  if (b.row > 0)
+    return (TSPoint){a.row + b.row, b.column};
+  else
+    return (TSPoint){a.row, a.column + b.column};
+}
+
+static inline TSPoint ts_point_sub(TSPoint a, TSPoint b) {
+  if (a.row > b.row)
+    return (TSPoint){a.row - b.row, a.column};
+  else
+    return (TSPoint){0, a.column - b.column};
+}
+
+static inline bool ts_point_lte(TSPoint a, TSPoint b) {
+  return (a.row < b.row) || (a.row == b.row && a.column <= b.column);
+}
+
+static inline bool ts_point_lt(TSPoint a, TSPoint b) {
+  return (a.row < b.row) || (a.row == b.row && a.column < b.column);
+}
+
+static inline bool ts_point_eq(TSPoint a, TSPoint b) {
+  return a.row == b.row && a.column == b.column;
+}
+
+static inline TSPoint ts_point_min(TSPoint a, TSPoint b) {
+  if (a.row < b.row || (a.row == b.row && a.column < b.column))
+    return a;
+  else
+    return b;
+}
+
+static inline TSPoint ts_point_max(TSPoint a, TSPoint b) {
+  if (a.row > b.row || (a.row == b.row && a.column > b.column))
+    return a;
+  else
+    return b;
+}
+
+#endif

--- a/src/runtime/stack.c
+++ b/src/runtime/stack.c
@@ -126,7 +126,7 @@ static StackNode *stack_node_new(StackNode *next, TSTree *tree, bool is_pending,
                               ERROR_COST_PER_SKIPPED_CHAR *
                                 (tree->padding.chars + tree->size.chars) +
                               ERROR_COST_PER_SKIPPED_LINE *
-                                (tree->padding.rows + tree->size.rows);
+                                (tree->padding.extent.row + tree->size.extent.row);
         }
       }
     } else {
@@ -606,7 +606,7 @@ bool ts_stack_print_dot_graph(Stack *self, const char **symbol_names, FILE *f) {
 
       fprintf(f,
               " tooltip=\"position: %lu,%lu\nerror_count: %u\nerror_cost: %u\"];\n",
-              node->position.rows, node->position.columns, node->error_count,
+              node->position.extent.row, node->position.extent.column, node->error_count,
               node->error_cost);
 
       for (int j = 0; j < node->link_count; j++) {

--- a/src/runtime/tree.c
+++ b/src/runtime/tree.c
@@ -399,6 +399,12 @@ void ts_tree_edit(TSTree *self, const TSInputEdit *edit) {
 static size_t ts_tree__write_char_to_string(char *s, size_t n, int32_t c) {
   if (c == 0)
     return snprintf(s, n, "EOF");
+  else if (c == '\n')
+    return snprintf(s, n, "'\\n'");
+  else if (c == '\t')
+    return snprintf(s, n, "'\\t'");
+  else if (c == '\r')
+    return snprintf(s, n, "'\\r'");
   else if (c < 128)
     return snprintf(s, n, "'%c'", c);
   else

--- a/src/runtime/tree.c
+++ b/src/runtime/tree.c
@@ -320,14 +320,14 @@ void ts_tree_edit(TSTree *self, const TSInputEdit *edit) {
   self->has_changes = true;
 
   if (edit->start_byte < self->padding.bytes) {
-    ts_length_set_unknown(&self->padding);
+    ts_length_set_unknown_chars(&self->padding);
     if (self->padding.bytes >= old_end_byte) {
       size_t trailing_padding_bytes = self->padding.bytes - old_end_byte;
       TSPoint trailing_padding_extent = ts_point_sub(self->padding.extent, old_end_point);
       self->padding.bytes = new_end_byte + trailing_padding_bytes;
       self->padding.extent = ts_point_add(new_end_point, trailing_padding_extent);
     } else {
-      ts_length_set_unknown(&self->size);
+      ts_length_set_unknown_chars(&self->size);
       size_t removed_content_bytes = old_end_byte - self->padding.bytes;
       TSPoint removed_content_extent = ts_point_sub(old_end_point, self->padding.extent);
       self->size.bytes = self->size.bytes - removed_content_bytes;
@@ -336,11 +336,11 @@ void ts_tree_edit(TSTree *self, const TSInputEdit *edit) {
       self->padding.extent = new_end_point;
     }
   } else if (edit->start_byte == self->padding.bytes && edit->bytes_removed == 0) {
-    ts_length_set_unknown(&self->padding);
+    ts_length_set_unknown_chars(&self->padding);
     self->padding.bytes = self->padding.bytes + edit->bytes_added;
     self->padding.extent = ts_point_add(self->padding.extent, edit->extent_added);
   } else {
-    ts_length_set_unknown(&self->size);
+    ts_length_set_unknown_chars(&self->size);
     size_t trailing_content_bytes = ts_tree_total_bytes(self) - old_end_byte;
     TSPoint trailing_content_extent = ts_point_sub(ts_tree_total_extent(self), old_end_point);
     self->size.bytes = new_end_byte + trailing_content_bytes - self->padding.bytes;

--- a/src/runtime/tree.c
+++ b/src/runtime/tree.c
@@ -152,7 +152,7 @@ void ts_tree_set_children(TSTree *self, size_t child_count, TSTree **children) {
 
   if (self->symbol == ts_builtin_sym_error) {
     self->error_cost += ERROR_COST_PER_SKIPPED_CHAR * self->size.chars +
-                        ERROR_COST_PER_SKIPPED_LINE * self->size.rows;
+                        ERROR_COST_PER_SKIPPED_LINE * self->size.extent.row;
     for (size_t i = 0; i < child_count; i++)
       if (!self->children[i]->extra)
         self->error_cost += ERROR_COST_PER_SKIPPED_TREE;
@@ -233,20 +233,20 @@ recur:
 }
 
 size_t ts_tree_start_column(const TSTree *self) {
-  size_t column = self->padding.columns;
-  if (self->padding.rows > 0)
+  size_t column = self->padding.extent.column;
+  if (self->padding.extent.row > 0)
     return column;
   for (const TSTree *tree = self; tree != NULL; tree = tree->context.parent) {
-    column += tree->context.offset.columns;
-    if (tree->context.offset.rows > 0)
+    column += tree->context.offset.extent.column;
+    if (tree->context.offset.extent.row > 0)
       break;
   }
   return column;
 }
 
 size_t ts_tree_end_column(const TSTree *self) {
-  size_t result = self->size.columns;
-  if (self->size.rows == 0)
+  size_t result = self->size.extent.column;
+  if (self->size.extent.row == 0)
     result += ts_tree_start_column(self);
   return result;
 }

--- a/src/runtime/tree.h
+++ b/src/runtime/tree.h
@@ -67,7 +67,7 @@ int ts_tree_compare(const TSTree *tree1, const TSTree *tree2);
 size_t ts_tree_start_column(const TSTree *self);
 size_t ts_tree_end_column(const TSTree *self);
 void ts_tree_set_children(TSTree *, size_t, TSTree **);
-void ts_tree_assign_parents(TSTree *);
+bool ts_tree_assign_parents(TSTree *, TreeArray *);
 void ts_tree_edit(TSTree *, const TSInputEdit *edit);
 char *ts_tree_string(const TSTree *, const TSLanguage *, bool include_all);
 void ts_tree_print_dot_graph(const TSTree *, const TSLanguage *, FILE *);

--- a/src/runtime/tree.h
+++ b/src/runtime/tree.h
@@ -49,7 +49,16 @@ typedef struct TSTree {
   bool has_changes : 1;
 } TSTree;
 
+typedef struct {
+  TSTree *tree;
+  TSLength position;
+  size_t child_index;
+} TreePathEntry;
+
 typedef Array(TSTree *) TreeArray;
+
+typedef Array(TreePathEntry) TreePath;
+
 bool ts_tree_array_copy(TreeArray, TreeArray *);
 void ts_tree_array_delete(TreeArray *);
 size_t ts_tree_array_essential_count(const TreeArray *);
@@ -67,7 +76,7 @@ int ts_tree_compare(const TSTree *tree1, const TSTree *tree2);
 size_t ts_tree_start_column(const TSTree *self);
 size_t ts_tree_end_column(const TSTree *self);
 void ts_tree_set_children(TSTree *, size_t, TSTree **);
-bool ts_tree_assign_parents(TSTree *, TreeArray *);
+bool ts_tree_assign_parents(TSTree *, TreePath *);
 void ts_tree_edit(TSTree *, const TSInputEdit *edit);
 char *ts_tree_string(const TSTree *, const TSLanguage *, bool include_all);
 void ts_tree_print_dot_graph(const TSTree *, const TSLanguage *, FILE *);

--- a/src/runtime/tree.h
+++ b/src/runtime/tree.h
@@ -68,7 +68,7 @@ size_t ts_tree_start_column(const TSTree *self);
 size_t ts_tree_end_column(const TSTree *self);
 void ts_tree_set_children(TSTree *, size_t, TSTree **);
 void ts_tree_assign_parents(TSTree *);
-void ts_tree_edit(TSTree *, TSInputEdit);
+void ts_tree_edit(TSTree *, const TSInputEdit *edit);
 char *ts_tree_string(const TSTree *, const TSLanguage *, bool include_all);
 void ts_tree_print_dot_graph(const TSTree *, const TSLanguage *, FILE *);
 
@@ -76,8 +76,16 @@ static inline size_t ts_tree_total_chars(const TSTree *self) {
   return self->padding.chars + self->size.chars;
 }
 
+static inline size_t ts_tree_total_bytes(const TSTree *self) {
+  return self->padding.bytes + self->size.bytes;
+}
+
 static inline TSLength ts_tree_total_size(const TSTree *self) {
   return ts_length_add(self->padding, self->size);
+}
+
+static inline TSPoint ts_tree_total_extent(const TSTree *self) {
+  return ts_point_add(self->padding.extent, self->size.extent);
 }
 
 static inline bool ts_tree_is_fragile(const TSTree *tree) {

--- a/src/runtime/tree_path.h
+++ b/src/runtime/tree_path.h
@@ -1,0 +1,208 @@
+#ifndef RUNTIME_TREE_PATH_H_
+#define RUNTIME_TREE_PATH_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "runtime/tree.h"
+
+typedef Array(TSRange) RangeArray;
+
+static bool range_array_add(RangeArray *results, TSPoint start, TSPoint end) {
+  if (results->size > 0) {
+    TSRange *last_range = array_back(results);
+    if (ts_point_lte(start, last_range->end)) {
+      last_range->end = end;
+      return true;
+    }
+  }
+
+  if (ts_point_lt(start, end)) {
+    TSRange range = { start, end };
+    return array_push(results, range);
+  }
+
+  return true;
+}
+
+static bool tree_path_descend(TreePath *path, TSPoint position) {
+  bool did_descend;
+  do {
+    did_descend = false;
+    TreePathEntry entry = *array_back(path);
+    TSLength child_position = entry.position;
+    for (size_t i = 0; i < entry.tree->child_count; i++) {
+      TSTree *child = entry.tree->children[i];
+      TSLength child_right_position =
+        ts_length_add(child_position, ts_tree_total_size(child));
+      if (ts_point_lt(position, child_right_position.extent)) {
+        TreePathEntry child_entry = { child, child_position, i };
+        if (child->visible) {
+          array_push(path, child_entry);
+          return true;
+        } else if (child->visible_child_count > 0) {
+          array_push(path, child_entry);
+          did_descend = true;
+          break;
+        }
+      }
+      child_position = child_right_position;
+    }
+  } while (did_descend);
+  return false;
+}
+
+static size_t tree_path_advance(TreePath *path) {
+  size_t ascend_count = 0;
+  while (path->size > 0) {
+    TreePathEntry entry = array_pop(path);
+    if (path->size == 0)
+      break;
+    TreePathEntry parent_entry = *array_back(path);
+    if (parent_entry.tree->visible) ascend_count++;
+    TSLength position =
+      ts_length_add(entry.position, ts_tree_total_size(entry.tree));
+    for (size_t i = entry.child_index + 1; i < parent_entry.tree->child_count; i++) {
+      TSTree *next_child = parent_entry.tree->children[i];
+      if (next_child->visible || next_child->visible_child_count > 0) {
+        if (parent_entry.tree->visible) ascend_count--;
+        array_push(path, ((TreePathEntry){
+          .tree = next_child,
+          .child_index = i,
+          .position = position,
+        }));
+        if (!next_child->visible)
+          tree_path_descend(path, (TSPoint){ 0, 0 });
+        return ascend_count;
+      }
+      position = ts_length_add(position, ts_tree_total_size(next_child));
+    }
+  }
+  return ascend_count;
+}
+
+static void tree_path_ascend(TreePath *path, size_t count) {
+  for (size_t i = 0; i < count; i++) {
+    do {
+      array_pop(path);
+    } while (path->size > 0 && !array_back(path)->tree->visible);
+  }
+}
+
+static void tree_path_init(TreePath *path, TSTree *tree) {
+  array_clear(path);
+  array_push(path,
+             ((TreePathEntry){
+               .tree = tree, .position = { 0, 0, { 0, 0 } }, .child_index = 0,
+             }));
+  if (!tree->visible)
+    tree_path_descend(path, (TSPoint){ 0, 0 });
+}
+
+static bool tree_must_eq(TSTree *old_tree, TSTree *new_tree) {
+  return old_tree == new_tree || (
+    !old_tree->has_changes &&
+    old_tree->symbol == new_tree->symbol &&
+    old_tree->size.bytes == new_tree->size.bytes &&
+    old_tree->parse_state != TS_TREE_STATE_NONE &&
+    new_tree->parse_state != TS_TREE_STATE_NONE &&
+    (old_tree->parse_state == TS_STATE_ERROR) ==
+    (new_tree->parse_state == TS_STATE_ERROR)
+  );
+}
+
+static bool tree_path_get_changes(TreePath *old_path, TreePath *new_path,
+                                  TSRange **ranges, size_t *range_count) {
+  TSPoint position = { 0, 0 };
+  RangeArray results = array_new();
+
+  while (old_path->size && new_path->size) {
+    bool is_changed = false;
+    TSPoint next_position = position;
+
+    TreePathEntry old_entry = *array_back(old_path);
+    TreePathEntry new_entry = *array_back(new_path);
+    TSTree *old_tree = old_entry.tree;
+    TSTree *new_tree = new_entry.tree;
+    size_t old_start_byte = old_entry.position.bytes + old_tree->padding.bytes;
+    size_t new_start_byte = new_entry.position.bytes + new_tree->padding.bytes;
+    TSPoint old_start_point =
+      ts_point_add(old_entry.position.extent, old_tree->padding.extent);
+    TSPoint new_start_point =
+      ts_point_add(new_entry.position.extent, new_tree->padding.extent);
+    TSPoint old_end_point = ts_point_add(old_start_point, old_tree->size.extent);
+    TSPoint new_end_point = ts_point_add(new_start_point, new_tree->size.extent);
+
+    // #define NAME(t) (ts_language_symbol_name(language, ((TSTree *)(t))->symbol))
+    // printf("At [%-2lu, %-2lu] Compare (%-20s\t [%-2lu, %-2lu] - [%lu, %lu])\tvs\t(%-20s\t [%lu, %lu] - [%lu, %lu])\n",
+    //   position.row, position.column, NAME(old_tree), old_start_point.row,
+    //   old_start_point.column, old_end_point.row, old_end_point.column,
+    //   NAME(new_tree), new_start_point.row, new_start_point.column,
+    //   new_end_point.row, new_end_point.column);
+
+    if (ts_point_lt(position, old_start_point)) {
+      if (ts_point_lt(position, new_start_point)) {
+        next_position = ts_point_min(old_start_point, new_start_point);
+      } else {
+        is_changed = true;
+        next_position = old_start_point;
+      }
+    } else if (ts_point_lt(position, new_start_point)) {
+      is_changed = true;
+      next_position = new_start_point;
+    } else if (old_start_byte == new_start_byte &&
+               tree_must_eq(old_tree, new_tree)) {
+      next_position = old_end_point;
+    } else if (old_tree->symbol == new_tree->symbol) {
+      if (tree_path_descend(old_path, position)) {
+        if (!tree_path_descend(new_path, position)) {
+          tree_path_ascend(old_path, 1);
+          is_changed = true;
+          next_position = new_end_point;
+        }
+      } else if (tree_path_descend(new_path, position)) {
+        tree_path_ascend(new_path, 1);
+        is_changed = true;
+        next_position = old_end_point;
+      } else {
+        next_position = ts_point_min(old_end_point, new_end_point);
+      }
+    } else {
+      is_changed = true;
+      next_position = ts_point_min(old_end_point, new_end_point);
+    }
+
+    bool at_old_end = ts_point_lte(old_end_point, next_position);
+    bool at_new_end = ts_point_lte(new_end_point, next_position);
+
+    if (at_new_end && at_old_end) {
+      size_t old_ascend_count = tree_path_advance(old_path);
+      size_t new_ascend_count = tree_path_advance(new_path);
+      if (old_ascend_count > new_ascend_count) {
+        tree_path_ascend(new_path, old_ascend_count - new_ascend_count);
+      } else if (new_ascend_count > old_ascend_count) {
+        tree_path_ascend(old_path, new_ascend_count - old_ascend_count);
+      }
+    } else if (at_new_end) {
+      size_t ascend_count = tree_path_advance(new_path);
+      tree_path_ascend(old_path, ascend_count);
+    } else if (at_old_end) {
+      size_t ascend_count = tree_path_advance(old_path);
+      tree_path_ascend(new_path, ascend_count);
+    }
+
+    if (is_changed) range_array_add(&results, position, next_position);
+    position = next_position;
+  }
+
+  *ranges = results.contents;
+  *range_count = results.size;
+  return true;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RUNTIME_TREE_H_

--- a/src/runtime/tree_path.h
+++ b/src/runtime/tree_path.h
@@ -1,10 +1,6 @@
 #ifndef RUNTIME_TREE_PATH_H_
 #define RUNTIME_TREE_PATH_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "runtime/tree.h"
 #include "runtime/error_costs.h"
 
@@ -202,8 +198,4 @@ static bool tree_path_get_changes(TreePath *old_path, TreePath *new_path,
   return true;
 }
 
-#ifdef __cplusplus
-}
-#endif
-
-#endif  // RUNTIME_TREE_H_
+#endif  // RUNTIME_TREE_PATH_H_


### PR DESCRIPTION
This will allow the [`TreeSitterDecorationLayer`](https://github.com/atom/tree-sitter-syntax/blob/66695c8605a5b2872d6706b9ab4b467b6f7708a7/lib/tree-sitter-decoration-layer.js) to implement the `DisplayLayer's` [`getInvalidatedRanges()`](https://github.com/atom/text-buffer/blob/b7a82b80afd6e1b8cd9d37288849982ad2204731/src/display-layer.coffee#L244) method more intelligently, so that we can avoid recomputing every onscreen line after an edit.

Refs https://github.com/tree-sitter/tree-sitter/issues/34