### PR TITLE
s/TSDebugger/TSLogger in spec name

### DIFF
--- a/spec/runtime/document_spec.cc
+++ b/spec/runtime/document_spec.cc
@@ -144,7 +144,7 @@ describe("Document", [&]() {
     });
   });
 
-  describe("set_logger(TSDebugger)", [&]() {
+  describe("set_logger(TSLogger)", [&]() {
     SpyLogger *logger;
 
     before_each([&]() {


### PR DESCRIPTION
Really minor cosmetic fix in specs that got left behind from the API clean up in #37.

cc @maxbrunsfeld 