### PR TITLE
Mergeable symbols

### DIFF
--- a/spec/compiler/build_tables/distinctive_tokens_spec.cc
+++ b/spec/compiler/build_tables/distinctive_tokens_spec.cc
@@ -27,7 +27,7 @@ describe("recovery_tokens(rule)", []() {
       })),
     };
 
-    AssertThat(recovery_tokens(grammar), Equals<vector<Symbol>>({
+    AssertThat(recovery_tokens(grammar), Equals<set<Symbol>>({
       Symbol(1, true),
     }));
   });

--- a/src/compiler/build_tables/build_parse_table.cc
+++ b/src/compiler/build_tables/build_parse_table.cc
@@ -112,7 +112,11 @@ class ParseTableBuilder {
   void build_error_parse_state() {
     ParseState error_state;
 
-    for (const Symbol &symbol : recovery_tokens(lexical_grammar))
+    auto recovery_symbols = recovery_tokens(lexical_grammar);
+
+    parse_table.mergeable_symbols.insert(recovery_symbols.begin(), recovery_symbols.end());
+
+    for (const Symbol &symbol : recovery_symbols)
       add_out_of_context_parse_state(&error_state, symbol);
 
     for (const Symbol &symbol : grammar.extra_tokens)

--- a/src/compiler/build_tables/build_parse_table.cc
+++ b/src/compiler/build_tables/build_parse_table.cc
@@ -75,6 +75,8 @@ class ParseTableBuilder {
         for (const auto &pair2 : state.entries)
           parse_table.symbols[pair1.first].compatible_symbols.insert(pair2.first);
 
+    parse_table.mergeable_symbols = recovery_tokens(lexical_grammar);
+
     build_error_parse_state();
 
     allow_any_conflict = true;
@@ -112,11 +114,7 @@ class ParseTableBuilder {
   void build_error_parse_state() {
     ParseState error_state;
 
-    auto recovery_symbols = recovery_tokens(lexical_grammar);
-
-    parse_table.mergeable_symbols.insert(recovery_symbols.begin(), recovery_symbols.end());
-
-    for (const Symbol &symbol : recovery_symbols)
+    for (auto &symbol : parse_table.mergeable_symbols)
       add_out_of_context_parse_state(&error_state, symbol);
 
     for (const Symbol &symbol : grammar.extra_tokens)

--- a/src/compiler/build_tables/recovery_tokens.cc
+++ b/src/compiler/build_tables/recovery_tokens.cc
@@ -11,7 +11,7 @@ namespace tree_sitter {
 namespace build_tables {
 
 using rules::Symbol;
-using std::vector;
+using std::set;
 
 template <bool left, bool right>
 class CharacterAggregator : public rules::RuleFn<void> {
@@ -47,8 +47,8 @@ class FirstCharacters : public CharacterAggregator<true, false> {};
 class LastCharacters : public CharacterAggregator<false, true> {};
 class AllCharacters : public CharacterAggregator<true, true> {};
 
-vector<Symbol> recovery_tokens(const LexicalGrammar &grammar) {
-  vector<Symbol> result;
+set<Symbol> recovery_tokens(const LexicalGrammar &grammar) {
+  set<Symbol> result;
 
   AllCharacters all_separator_characters;
   for (const rule_ptr &separator : grammar.separators)
@@ -79,7 +79,7 @@ vector<Symbol> recovery_tokens(const LexicalGrammar &grammar) {
       !all_characters.result.intersects(all_separator_characters.result);
 
     if ((has_distinct_start && has_distinct_end) || has_no_separators)
-      result.push_back(Symbol(i, true));
+      result.insert(Symbol(i, true));
   }
 
   return result;

--- a/src/compiler/build_tables/recovery_tokens.h
+++ b/src/compiler/build_tables/recovery_tokens.h
@@ -3,7 +3,7 @@
 
 #include "compiler/rule.h"
 #include "compiler/rules/symbol.h"
-#include <vector>
+#include <set>
 
 namespace tree_sitter {
 
@@ -11,7 +11,7 @@ struct LexicalGrammar;
 
 namespace build_tables {
 
-std::vector<rules::Symbol> recovery_tokens(const LexicalGrammar &);
+std::set<rules::Symbol> recovery_tokens(const LexicalGrammar &);
 
 }  // namespace build_tables
 }  // namespace tree_sitter

--- a/src/compiler/parse_table.cc
+++ b/src/compiler/parse_table.cc
@@ -206,6 +206,8 @@ bool ParseTable::merge_state(size_t i, size_t j) {
 
     const auto &other_entry = other.entries.find(symbol);
     if (other_entry == other.entries.end()) {
+      if (mergeable_symbols.count(symbol) == 0)
+        return false;
       if (actions.back().type != ParseActionTypeReduce)
         return false;
       if (!has_entry(other, entry.second))
@@ -222,6 +224,8 @@ bool ParseTable::merge_state(size_t i, size_t j) {
     const vector<ParseAction> &actions = entry.second.actions;
 
     if (!state.entries.count(symbol)) {
+      if (mergeable_symbols.count(symbol) == 0)
+        return false;
       if (actions.back().type != ParseActionTypeReduce)
         return false;
       if (!has_entry(state, entry.second))

--- a/src/compiler/parse_table.h
+++ b/src/compiler/parse_table.h
@@ -97,6 +97,8 @@ class ParseTable {
 
   std::vector<ParseState> states;
   std::map<rules::Symbol, ParseTableSymbolMetadata> symbols;
+
+  std::set<rules::Symbol> mergeable_symbols;
 };
 
 }  // namespace tree_sitter


### PR DESCRIPTION
In getting https://github.com/tree-sitter/tree-sitter-ruby to build and pass tests again we discovered that one of the parse table optimizations is being overly aggressive in collapsing up states. This adds one additional check to skip merging states unless the symbol on either side is in our set of recovery symbols.

🎩  @maxbrunsfeld for 🍐 ing with me and writing the first pass at this code.