### PR TITLE
Represent byte, char and tree counts as 32 bit numbers

### DIFF
--- a/include/tree_sitter/parser.h
+++ b/include/tree_sitter/parser.h
@@ -58,8 +58,8 @@ typedef union {
 } TSParseActionEntry;
 
 typedef struct TSLanguage {
-  size_t symbol_count;
-  size_t token_count;
+  uint32_t symbol_count;
+  uint32_t token_count;
   const char **symbol_names;
   const TSSymbolMetadata *symbol_metadata;
   const unsigned short *parse_table;

--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #include <stdlib.h>
+#include <stdint.h>
 #include <stdbool.h>
 
 typedef unsigned short TSSymbol;
@@ -19,8 +20,8 @@ typedef enum {
 
 typedef struct {
   void *payload;
-  const char *(*read)(void *payload, size_t *bytes_read);
-  int (*seek)(void *payload, size_t character_index, size_t byte_index);
+  const char *(*read)(void *payload, uint32_t *bytes_read);
+  int (*seek)(void *payload, uint32_t character_index, uint32_t byte_index);
   TSInputEncoding encoding;
 } TSInput;
 
@@ -35,14 +36,14 @@ typedef struct {
 } TSLogger;
 
 typedef struct {
-  size_t row;
-  size_t column;
+  uint32_t row;
+  uint32_t column;
 } TSPoint;
 
 typedef struct {
-  size_t start_byte;
-  size_t bytes_removed;
-  size_t bytes_added;
+  uint32_t start_byte;
+  uint32_t bytes_removed;
+  uint32_t bytes_added;
   TSPoint start_point;
   TSPoint extent_removed;
   TSPoint extent_added;
@@ -55,7 +56,7 @@ typedef struct {
 
 typedef struct {
   const void *data;
-  size_t offset[3];
+  uint32_t offset[3];
 } TSNode;
 
 typedef struct {
@@ -64,11 +65,11 @@ typedef struct {
   void *data;
 } TSSymbolIterator;
 
-size_t ts_node_start_char(TSNode);
-size_t ts_node_start_byte(TSNode);
+uint32_t ts_node_start_char(TSNode);
+uint32_t ts_node_start_byte(TSNode);
 TSPoint ts_node_start_point(TSNode);
-size_t ts_node_end_char(TSNode);
-size_t ts_node_end_byte(TSNode);
+uint32_t ts_node_end_char(TSNode);
+uint32_t ts_node_end_byte(TSNode);
 TSPoint ts_node_end_point(TSNode);
 TSSymbol ts_node_symbol(TSNode);
 TSSymbolIterator ts_node_symbols(TSNode);
@@ -79,18 +80,18 @@ bool ts_node_eq(TSNode, TSNode);
 bool ts_node_is_named(TSNode);
 bool ts_node_has_changes(TSNode);
 TSNode ts_node_parent(TSNode);
-TSNode ts_node_child(TSNode, size_t);
-TSNode ts_node_named_child(TSNode, size_t);
-size_t ts_node_child_count(TSNode);
-size_t ts_node_named_child_count(TSNode);
+TSNode ts_node_child(TSNode, uint32_t);
+TSNode ts_node_named_child(TSNode, uint32_t);
+uint32_t ts_node_child_count(TSNode);
+uint32_t ts_node_named_child_count(TSNode);
 TSNode ts_node_next_sibling(TSNode);
 TSNode ts_node_next_named_sibling(TSNode);
 TSNode ts_node_prev_sibling(TSNode);
 TSNode ts_node_prev_named_sibling(TSNode);
-TSNode ts_node_descendant_for_char_range(TSNode, size_t, size_t);
-TSNode ts_node_named_descendant_for_char_range(TSNode, size_t, size_t);
-TSNode ts_node_descendant_for_byte_range(TSNode, size_t, size_t);
-TSNode ts_node_named_descendant_for_byte_range(TSNode, size_t, size_t);
+TSNode ts_node_descendant_for_char_range(TSNode, uint32_t, uint32_t);
+TSNode ts_node_named_descendant_for_char_range(TSNode, uint32_t, uint32_t);
+TSNode ts_node_descendant_for_byte_range(TSNode, uint32_t, uint32_t);
+TSNode ts_node_named_descendant_for_byte_range(TSNode, uint32_t, uint32_t);
 TSNode ts_node_descendant_for_point_range(TSNode, TSPoint, TSPoint);
 TSNode ts_node_named_descendant_for_point_range(TSNode, TSPoint, TSPoint);
 
@@ -106,12 +107,12 @@ void ts_document_set_logger(TSDocument *, TSLogger);
 void ts_document_print_debugging_graphs(TSDocument *, bool);
 void ts_document_edit(TSDocument *, TSInputEdit);
 void ts_document_parse(TSDocument *);
-void ts_document_parse_and_get_changed_ranges(TSDocument *, TSRange **, size_t *);
+void ts_document_parse_and_get_changed_ranges(TSDocument *, TSRange **, uint32_t *);
 void ts_document_invalidate(TSDocument *);
 TSNode ts_document_root_node(const TSDocument *);
-size_t ts_document_parse_count(const TSDocument *);
+uint32_t ts_document_parse_count(const TSDocument *);
 
-size_t ts_language_symbol_count(const TSLanguage *);
+uint32_t ts_language_symbol_count(const TSLanguage *);
 const char *ts_language_symbol_name(const TSLanguage *, TSSymbol);
 
 #ifdef __cplusplus

--- a/spec/helpers/spy_input.cc
+++ b/spec/helpers/spy_input.cc
@@ -22,7 +22,7 @@ SpyInput::~SpyInput() {
   delete[] buffer;
 }
 
-const char * SpyInput::read(void *payload, size_t *bytes_read) {
+const char * SpyInput::read(void *payload, uint32_t *bytes_read) {
   auto spy = static_cast<SpyInput *>(payload);
 
   if (spy->byte_offset > spy->content.size()) {
@@ -52,7 +52,7 @@ const char * SpyInput::read(void *payload, size_t *bytes_read) {
   return spy->buffer;
 }
 
-int SpyInput::seek(void *payload, size_t character, size_t byte) {
+int SpyInput::seek(void *payload, uint32_t character, uint32_t byte) {
   auto spy = static_cast<SpyInput *>(payload);
   if (spy->strings_read.size() == 0 || spy->strings_read.back().size() > 0)
     spy->strings_read.push_back("");

--- a/spec/helpers/spy_input.h
+++ b/spec/helpers/spy_input.h
@@ -12,14 +12,14 @@ struct SpyInputEdit {
 };
 
 class SpyInput {
-  size_t chars_per_chunk;
-  size_t buffer_size;
+  uint32_t chars_per_chunk;
+  uint32_t buffer_size;
   char *buffer;
-  size_t byte_offset;
+  uint32_t byte_offset;
   std::vector<SpyInputEdit> undo_stack;
 
-  static const char * read(void *, size_t *);
-  static int seek(void *, size_t, size_t);
+  static const char * read(void *, uint32_t *);
+  static int seek(void *, uint32_t, uint32_t);
   std::pair<std::string, TSPoint> swap_substr(size_t, size_t, std::string);
 
  public:

--- a/spec/integration/corpus_specs.cc
+++ b/spec/integration/corpus_specs.cc
@@ -142,7 +142,7 @@ describe("The Corpus", []() {
               assert_correct_tree_size(document, input->content);
 
               TSRange *ranges;
-              size_t range_count;
+              uint32_t range_count;
               ScopeSequence old_scope_sequence = build_scope_sequence(document, input->content);
               ts_document_parse_and_get_changed_ranges(document, &ranges, &range_count);
 
@@ -165,7 +165,7 @@ describe("The Corpus", []() {
               assert_correct_tree_size(document, input->content);
 
               TSRange *ranges;
-              size_t range_count;
+              uint32_t range_count;
               ScopeSequence old_scope_sequence = build_scope_sequence(document, input->content);
               ts_document_parse_and_get_changed_ranges(document, &ranges, &range_count);
 

--- a/spec/runtime/document_spec.cc
+++ b/spec/runtime/document_spec.cc
@@ -8,6 +8,10 @@
 #include "helpers/spy_input.h"
 #include "helpers/load_language.h"
 
+TSPoint point(size_t row, size_t column) {
+  return TSPoint{static_cast<uint32_t>(row), static_cast<uint32_t>(column)};
+}
+
 START_TEST
 
 describe("Document", [&]() {
@@ -232,7 +236,7 @@ describe("Document", [&]() {
       ts_document_edit(doc, edit);
 
       TSRange *ranges;
-      size_t range_count = 0;
+      uint32_t range_count = 0;
 
       ts_document_parse_and_get_changed_ranges(doc, &ranges, &range_count);
 
@@ -252,8 +256,8 @@ describe("Document", [&]() {
 
       AssertThat(ranges, Equals(vector<TSRange>({
         TSRange{
-          TSPoint{0, input->content.find("nothing")},
-          TSPoint{0, input->content.find("}")}
+          point(0, input->content.find("nothing")),
+          point(0, input->content.find("}"))
         },
       })));
 
@@ -264,8 +268,8 @@ describe("Document", [&]() {
 
       AssertThat(ranges, Equals(vector<TSRange>({
         TSRange{
-          TSPoint{0, input->content.find("null")},
-          TSPoint{0, input->content.find("}")}
+          point(0, input->content.find("null")),
+          point(0, input->content.find("}"))
         },
       })));
     });
@@ -278,8 +282,8 @@ describe("Document", [&]() {
 
       AssertThat(ranges, Equals(vector<TSRange>({
         TSRange{
-          TSPoint{0, input->content.find(",")},
-          TSPoint{0, input->content.find("}")},
+          point(0, input->content.find(",")),
+          point(0, input->content.find("}"))
         },
       })));
 
@@ -297,8 +301,8 @@ describe("Document", [&]() {
 
       AssertThat(ranges, Equals(vector<TSRange>({
         TSRange{
-          TSPoint{0, input->content.find(", c")},
-          TSPoint{0, input->content.find(", b")},
+          point(0, input->content.find(", c")),
+          point(0, input->content.find(", b"))
         },
       })));
 
@@ -343,8 +347,8 @@ describe("Document", [&]() {
 
       AssertThat(ranges, Equals(vector<TSRange>({
         TSRange{
-          TSPoint{0, input->content.find("b ===")},
-          TSPoint{0, input->content.find("}")},
+          point(0, input->content.find("b ===")),
+          point(0, input->content.find("}"))
         },
       })));
     });

--- a/spec/runtime/stack_spec.cc
+++ b/spec/runtime/stack_spec.cc
@@ -19,7 +19,7 @@ enum {
   symbol9, symbol10
 };
 
-Length operator*(const Length &length, size_t factor) {
+Length operator*(const Length &length, uint32_t factor) {
   return {length.bytes * factor, length.chars * factor, {0, length.extent.column * factor}};
 }
 
@@ -54,7 +54,7 @@ vector<StackEntry> get_stack_entries(Stack *stack, StackVersion version) {
   ts_stack_iterate(
     stack,
     version,
-    [](void *payload, TSStateId state, TreeArray *trees, size_t tree_count, bool is_done, bool is_pending) -> StackIterateAction {
+    [](void *payload, TSStateId state, TreeArray *trees, uint32_t tree_count, bool is_done, bool is_pending) -> StackIterateAction {
       auto entries = static_cast<vector<StackEntry> *>(payload);
       StackEntry entry = {state, tree_count};
       if (find(entries->begin(), entries->end(), entry) == entries->end())

--- a/src/runtime/array.h
+++ b/src/runtime/array.h
@@ -7,6 +7,7 @@ extern "C" {
 
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <assert.h>
 #include <stdbool.h>
 #include "runtime/alloc.h"
@@ -14,8 +15,8 @@ extern "C" {
 #define Array(T)     \
   struct {           \
     T *contents;     \
-    size_t size;     \
-    size_t capacity; \
+    uint32_t size;     \
+    uint32_t capacity; \
   }
 
 #define array_init(self) \
@@ -25,7 +26,7 @@ extern "C" {
   { NULL, 0, 0 }
 
 #define array_get(self, index) \
-  (assert((size_t)index < (self)->size), &(self)->contents[index])
+  (assert((uint32_t)index < (self)->size), &(self)->contents[index])
 
 #define array_front(self) array_get(self, 0)
 
@@ -71,7 +72,7 @@ static inline void array__delete(VoidArray *self) {
 }
 
 static inline void array__erase(VoidArray *self, size_t element_size,
-                                size_t index) {
+                                uint32_t index) {
   assert(index < self->size);
   char *contents = (char *)self->contents;
   memmove(contents + index * element_size, contents + (index + 1) * element_size,
@@ -80,7 +81,7 @@ static inline void array__erase(VoidArray *self, size_t element_size,
 }
 
 static inline void array__grow(VoidArray *self, size_t element_size,
-                               size_t new_capacity) {
+                               uint32_t new_capacity) {
   if (new_capacity > self->capacity) {
     if (new_capacity < 2 * self->capacity)
       new_capacity = 2 * self->capacity;
@@ -95,11 +96,11 @@ static inline void array__grow(VoidArray *self, size_t element_size,
 }
 
 static inline void array__splice(VoidArray *self, size_t element_size,
-                                 size_t index, size_t old_count,
-                                 size_t new_count, void *elements) {
-  size_t new_size = self->size + new_count - old_count;
-  size_t old_end = index + old_count;
-  size_t new_end = index + new_count;
+                                 uint32_t index, uint32_t old_count,
+                                 uint32_t new_count, void *elements) {
+  uint32_t new_size = self->size + new_count - old_count;
+  uint32_t old_end = index + old_count;
+  uint32_t new_end = index + new_count;
   assert(old_end <= self->size);
 
   array__grow(self, element_size, new_size);
@@ -117,7 +118,7 @@ static inline void array__splice(VoidArray *self, size_t element_size,
 static inline void array__reverse(VoidArray *self, size_t element_size) {
   char swap[element_size];
   char *contents = (char *)self->contents;
-  for (size_t i = 0, limit = self->size / 2; i < limit; i++) {
+  for (uint32_t i = 0, limit = self->size / 2; i < limit; i++) {
     size_t offset = i * element_size;
     size_t reverse_offset = (self->size - 1 - i) * element_size;
     memcpy(&swap, contents + offset, element_size);

--- a/src/runtime/document.c
+++ b/src/runtime/document.c
@@ -80,7 +80,7 @@ void ts_document_edit(TSDocument *self, TSInputEdit edit) {
   if (!self->tree)
     return;
 
-  size_t max_bytes = ts_tree_total_bytes(self->tree);
+  uint32_t max_bytes = ts_tree_total_bytes(self->tree);
   if (edit.start_byte > max_bytes)
     return;
   if (edit.bytes_removed > max_bytes - edit.start_byte)
@@ -90,7 +90,7 @@ void ts_document_edit(TSDocument *self, TSInputEdit edit) {
 }
 
 void ts_document_parse_and_get_changed_ranges(TSDocument *self, TSRange **ranges,
-                                             size_t *range_count) {
+                                              uint32_t *range_count) {
   if (ranges) *ranges = NULL;
   if (range_count) *range_count = 0;
 
@@ -137,6 +137,6 @@ TSNode ts_document_root_node(const TSDocument *self) {
   return result;
 }
 
-size_t ts_document_parse_count(const TSDocument *self) {
+uint32_t ts_document_parse_count(const TSDocument *self) {
   return self->parse_count;
 }

--- a/src/runtime/language.c
+++ b/src/runtime/language.c
@@ -8,7 +8,7 @@ static const TSParseAction ERROR_SHIFT_EXTRA = {
 
 void ts_language_table_entry(const TSLanguage *self, TSStateId state,
                              TSSymbol symbol, TableEntry *result) {
-  size_t action_index;
+  uint32_t action_index;
   if (symbol == ts_builtin_sym_error) {
     if (state == ERROR_STATE) {
       result->action_count = 1;
@@ -30,7 +30,7 @@ void ts_language_table_entry(const TSLanguage *self, TSStateId state,
   result->actions = (const TSParseAction *)(entry + 1);
 }
 
-size_t ts_language_symbol_count(const TSLanguage *language) {
+uint32_t ts_language_symbol_count(const TSLanguage *language) {
   return language->symbol_count;
 }
 

--- a/src/runtime/language.h
+++ b/src/runtime/language.h
@@ -10,7 +10,7 @@ extern "C" {
 
 typedef struct {
   const TSParseAction *actions;
-  size_t action_count;
+  uint32_t action_count;
   bool is_reusable;
   bool depends_on_lookahead;
 } TableEntry;
@@ -22,7 +22,7 @@ TSSymbolMetadata ts_language_symbol_metadata(const TSLanguage *, TSSymbol);
 static inline const TSParseAction *ts_language_actions(const TSLanguage *self,
                                                        TSStateId state,
                                                        TSSymbol symbol,
-                                                       size_t *count) {
+                                                       uint32_t *count) {
   TableEntry entry;
   ts_language_table_entry(self, state, symbol, &entry);
   *count = entry.action_count;
@@ -35,7 +35,7 @@ static inline TSStateId ts_language_next_state(const TSLanguage *self,
   if (symbol == ts_builtin_sym_error) {
     return 0;
   } else if (symbol < self->token_count) {
-    size_t count;
+    uint32_t count;
     const TSParseAction *actions = ts_language_actions(self, state, symbol, &count);
     if (count > 0) {
       TSParseAction action = actions[count - 1];

--- a/src/runtime/length.h
+++ b/src/runtime/length.h
@@ -7,8 +7,8 @@
 #include "tree_sitter/runtime.h"
 
 typedef struct {
-  size_t bytes;
-  size_t chars;
+  uint32_t bytes;
+  uint32_t chars;
   TSPoint extent;
 } Length;
 

--- a/src/runtime/lexer.c
+++ b/src/runtime/lexer.c
@@ -33,9 +33,9 @@ static void ts_lexer__get_chunk(Lexer *self) {
 }
 
 static void ts_lexer__get_lookahead(Lexer *self) {
-  size_t position_in_chunk = self->current_position.bytes - self->chunk_start;
+  uint32_t position_in_chunk = self->current_position.bytes - self->chunk_start;
   const uint8_t *chunk = (const uint8_t *)self->chunk + position_in_chunk;
-  size_t size = self->chunk_size - position_in_chunk + 1;
+  uint32_t size = self->chunk_size - position_in_chunk + 1;
 
   if (self->input.encoding == TSInputEncodingUTF8)
     self->lookahead_size =
@@ -120,7 +120,7 @@ void ts_lexer_reset(Lexer *self, Length position) {
 }
 
 void ts_lexer_start(Lexer *self, TSStateId lex_state) {
-  LOG("start_lex state:%d, pos:%lu", lex_state, self->current_position.chars);
+  LOG("start_lex state:%d, pos:%u", lex_state, self->current_position.chars);
 
   self->token_start_position = self->current_position;
   self->data.result_symbol = 0;

--- a/src/runtime/lexer.h
+++ b/src/runtime/lexer.h
@@ -17,10 +17,10 @@ typedef struct {
   Length token_start_position;
 
   const char *chunk;
-  size_t chunk_start;
-  size_t chunk_size;
+  uint32_t chunk_start;
+  uint32_t chunk_size;
 
-  size_t lookahead_size;
+  uint32_t lookahead_size;
 
   TSInput input;
   TSLogger logger;

--- a/src/runtime/node.h
+++ b/src/runtime/node.h
@@ -3,6 +3,6 @@
 
 #include "runtime/tree.h"
 
-TSNode ts_node_make(const Tree *, size_t character, size_t byte, size_t row);
+TSNode ts_node_make(const Tree *, uint32_t character, uint32_t byte, uint32_t row);
 
 #endif

--- a/src/runtime/parser.h
+++ b/src/runtime/parser.h
@@ -12,7 +12,7 @@ extern "C" {
 
 typedef struct {
   Tree *tree;
-  size_t byte_index;
+  uint32_t byte_index;
 } ReusableNode;
 
 typedef struct {
@@ -25,7 +25,7 @@ typedef struct {
   bool print_debugging_graphs;
   Tree scratch_tree;
   Tree *cached_token;
-  size_t cached_token_byte_index;
+  uint32_t cached_token_byte_index;
   ReusableNode reusable_node;
   TreePath tree_path1;
   TreePath tree_path2;

--- a/src/runtime/reduce_action.h
+++ b/src/runtime/reduce_action.h
@@ -9,15 +9,15 @@ extern "C" {
 #include "tree_sitter/runtime.h"
 
 typedef struct {
+  uint32_t count;
   TSSymbol symbol;
-  size_t count;
 } ReduceAction;
 
 typedef Array(ReduceAction) ReduceActionSet;
 
 static inline void ts_reduce_action_set_add(ReduceActionSet *self,
                                             ReduceAction new_action) {
-  for (size_t i = 0; i < self->size; i++) {
+  for (uint32_t i = 0; i < self->size; i++) {
     ReduceAction action = self->contents[i];
     if (action.symbol == new_action.symbol && action.count == new_action.count)
       return;

--- a/src/runtime/stack.c
+++ b/src/runtime/stack.c
@@ -32,14 +32,14 @@ struct StackNode {
 
 typedef struct {
   TreeArray trees;
-  size_t tree_count;
+  uint32_t tree_count;
   StackNode *node;
   bool is_pending;
   unsigned push_count;
 } Iterator;
 
 typedef struct {
-  size_t goal_tree_count;
+  uint32_t goal_tree_count;
   bool found_error;
   bool found_valid_path;
 } StackPopSession;
@@ -181,7 +181,7 @@ static StackVersion ts_stack__add_version(Stack *self, StackNode *node,
 
 static void ts_stack__add_slice(Stack *self, StackNode *node, TreeArray *trees,
                                 unsigned push_count) {
-  for (size_t i = self->slices.size - 1; i + 1 > 0; i--) {
+  for (uint32_t i = self->slices.size - 1; i + 1 > 0; i--) {
     StackVersion version = self->slices.contents[i].version;
     if (self->heads.contents[version].node == node) {
       StackSlice slice = { *trees, version };
@@ -212,7 +212,7 @@ INLINE StackPopResult stack__iter(Stack *self, StackVersion version,
   array_push(&self->iterators, iterator);
 
   while (self->iterators.size > 0) {
-    for (size_t i = 0, size = self->iterators.size; i < size; i++) {
+    for (uint32_t i = 0, size = self->iterators.size; i < size; i++) {
       Iterator *iterator = &self->iterators.contents[i];
       StackNode *node = iterator->node;
       bool is_done = node == self->base_node;
@@ -240,7 +240,7 @@ INLINE StackPopResult stack__iter(Stack *self, StackVersion version,
         continue;
       }
 
-      for (size_t j = 1; j <= node->link_count; j++) {
+      for (uint32_t j = 1; j <= node->link_count; j++) {
         Iterator *next_iterator;
         StackLink link;
         if (j == node->link_count) {
@@ -299,11 +299,11 @@ void ts_stack_delete(Stack *self) {
   if (self->iterators.contents)
     array_delete(&self->iterators);
   stack_node_release(self->base_node, &self->node_pool);
-  for (size_t i = 0; i < self->heads.size; i++)
+  for (uint32_t i = 0; i < self->heads.size; i++)
     stack_node_release(self->heads.contents[i].node, &self->node_pool);
   array_clear(&self->heads);
   if (self->node_pool.contents) {
-    for (size_t i = 0; i < self->node_pool.size; i++)
+    for (uint32_t i = 0; i < self->node_pool.size; i++)
       ts_free(self->node_pool.contents[i]);
     array_delete(&self->node_pool);
   }
@@ -311,7 +311,7 @@ void ts_stack_delete(Stack *self) {
   ts_free(self);
 }
 
-size_t ts_stack_version_count(const Stack *self) {
+uint32_t ts_stack_version_count(const Stack *self) {
   return self->heads.size;
 }
 
@@ -373,7 +373,7 @@ StackPopResult ts_stack_iterate(Stack *self, StackVersion version,
 }
 
 INLINE StackIterateAction pop_count_callback(void *payload, TSStateId state,
-                                             TreeArray *trees, size_t tree_count,
+                                             TreeArray *trees, uint32_t tree_count,
                                              bool is_done, bool is_pending) {
   StackPopSession *pop_session = (StackPopSession *)payload;
 
@@ -394,7 +394,7 @@ INLINE StackIterateAction pop_count_callback(void *payload, TSStateId state,
 }
 
 StackPopResult ts_stack_pop_count(Stack *self, StackVersion version,
-                                  size_t count) {
+                                  uint32_t count) {
   StackPopSession session = {
     .goal_tree_count = count, .found_error = false, .found_valid_path = false,
   };
@@ -418,7 +418,7 @@ StackPopResult ts_stack_pop_count(Stack *self, StackVersion version,
 
 INLINE StackIterateAction pop_pending_callback(void *payload, TSStateId state,
                                                TreeArray *trees,
-                                               size_t tree_count, bool is_done,
+                                               uint32_t tree_count, bool is_done,
                                                bool is_pending) {
   if (tree_count >= 1) {
     if (is_pending) {
@@ -441,7 +441,7 @@ StackPopResult ts_stack_pop_pending(Stack *self, StackVersion version) {
 }
 
 INLINE StackIterateAction pop_all_callback(void *payload, TSStateId state,
-                                           TreeArray *trees, size_t tree_count,
+                                           TreeArray *trees, uint32_t tree_count,
                                            bool is_done, bool is_pending) {
   return is_done ? (StackIteratePop | StackIterateStop) : StackIterateNone;
 }
@@ -458,7 +458,7 @@ void ts_stack_remove_version(Stack *self, StackVersion version) {
 
 void ts_stack_renumber_version(Stack *self, StackVersion v1, StackVersion v2) {
   assert(v2 < v1);
-  assert((size_t)v1 < self->heads.size);
+  assert((uint32_t)v1 < self->heads.size);
   stack_node_release(self->heads.contents[v2].node, &self->node_pool);
   self->heads.contents[v2] = self->heads.contents[v1];
   array_erase(&self->heads, v1);
@@ -481,7 +481,7 @@ bool ts_stack_merge(Stack *self, StackVersion version, StackVersion new_version)
       new_node->position.chars == node->position.chars &&
       new_node->error_count == node->error_count &&
       new_node->error_cost == node->error_cost) {
-    for (size_t j = 0; j < new_node->link_count; j++)
+    for (uint32_t j = 0; j < new_node->link_count; j++)
       stack_node_add_link(node, new_node->links[j]);
     if (new_head->push_count > head->push_count)
       head->push_count = new_head->push_count;
@@ -502,7 +502,7 @@ bool ts_stack_is_halted(Stack *self, StackVersion version) {
 
 void ts_stack_clear(Stack *self) {
   stack_node_retain(self->base_node);
-  for (size_t i = 0; i < self->heads.size; i++)
+  for (uint32_t i = 0; i < self->heads.size; i++)
     stack_node_release(self->heads.contents[i].node, &self->node_pool);
   array_clear(&self->heads);
   array_push(&self->heads, ((StackHead){ self->base_node, false, 0 }));
@@ -520,14 +520,14 @@ bool ts_stack_print_dot_graph(Stack *self, const char **symbol_names, FILE *f) {
   Array(StackNode *)visited_nodes = array_new();
 
   array_clear(&self->iterators);
-  for (size_t i = 0; i < self->heads.size; i++) {
+  for (uint32_t i = 0; i < self->heads.size; i++) {
     StackHead *head = &self->heads.contents[i];
     if (head->is_halted)
       continue;
-    fprintf(f, "node_head_%lu [shape=none, label=\"\"]\n", i);
+    fprintf(f, "node_head_%u [shape=none, label=\"\"]\n", i);
     fprintf(
       f,
-      "node_head_%lu -> node_%p [label=%lu, fontcolor=blue, weight=10000, "
+      "node_head_%u -> node_%p [label=%u, fontcolor=blue, weight=10000, "
       "labeltooltip=\"push_count: %u\"]\n",
       i, head->node, i, head->push_count);
     array_push(&self->iterators, ((Iterator){.node = head->node }));
@@ -537,11 +537,11 @@ bool ts_stack_print_dot_graph(Stack *self, const char **symbol_names, FILE *f) {
   while (!all_iterators_done) {
     all_iterators_done = true;
 
-    for (size_t i = 0; i < self->iterators.size; i++) {
+    for (uint32_t i = 0; i < self->iterators.size; i++) {
       Iterator *iterator = &self->iterators.contents[i];
       StackNode *node = iterator->node;
 
-      for (size_t j = 0; j < visited_nodes.size; j++) {
+      for (uint32_t j = 0; j < visited_nodes.size; j++) {
         if (visited_nodes.contents[j] == node) {
           node = NULL;
           break;
@@ -562,7 +562,7 @@ bool ts_stack_print_dot_graph(Stack *self, const char **symbol_names, FILE *f) {
         fprintf(f, "label=\"%d\"", node->state);
 
       fprintf(f,
-              " tooltip=\"position: %lu,%lu\nerror_count: %u\nerror_cost: %u\"];\n",
+              " tooltip=\"position: %u,%u\nerror_count: %u\nerror_cost: %u\"];\n",
               node->position.extent.row, node->position.extent.column, node->error_count,
               node->error_cost);
 

--- a/src/runtime/stack.h
+++ b/src/runtime/stack.h
@@ -38,7 +38,7 @@ typedef unsigned int StackIterateAction;
 
 typedef StackIterateAction (*StackIterateCallback)(void *, TSStateId state,
                                                    TreeArray *trees,
-                                                   size_t tree_count,
+                                                   uint32_t tree_count,
                                                    bool is_done,
                                                    bool is_pending);
 
@@ -55,7 +55,7 @@ void ts_stack_delete(Stack *);
 /*
  *  Get the stack's current number of versions.
  */
-size_t ts_stack_version_count(const Stack *);
+uint32_t ts_stack_version_count(const Stack *);
 
 /*
  *  Get the state at the top of the given version of the stack. If the stack is
@@ -86,7 +86,7 @@ bool ts_stack_push(Stack *, StackVersion, Tree *, bool, TSStateId);
  *  indicates the index of each revealed version and the trees removed from that
  *  version.
  */
-StackPopResult ts_stack_pop_count(Stack *, StackVersion, size_t count);
+StackPopResult ts_stack_pop_count(Stack *, StackVersion, uint32_t count);
 
 StackPopResult ts_stack_iterate(Stack *, StackVersion, StackIterateCallback,
                                 void *);

--- a/src/runtime/string_input.c
+++ b/src/runtime/string_input.c
@@ -4,23 +4,23 @@
 
 typedef struct {
   const char *string;
-  size_t position;
-  size_t length;
+  uint32_t position;
+  uint32_t length;
 } TSStringInput;
 
-const char *ts_string_input_read(void *payload, size_t *bytes_read) {
+const char *ts_string_input_read(void *payload, uint32_t *bytes_read) {
   TSStringInput *input = (TSStringInput *)payload;
   if (input->position >= input->length) {
     *bytes_read = 0;
     return "";
   }
-  size_t previous_position = input->position;
+  uint32_t previous_position = input->position;
   input->position = input->length;
   *bytes_read = input->position - previous_position;
   return input->string + previous_position;
 }
 
-int ts_string_input_seek(void *payload, size_t character, size_t byte) {
+int ts_string_input_seek(void *payload, uint32_t character, uint32_t byte) {
   TSStringInput *input = (TSStringInput *)payload;
   input->position = byte;
   return (byte < input->length);

--- a/src/runtime/tree.c
+++ b/src/runtime/tree.c
@@ -35,7 +35,7 @@ bool ts_tree_array_copy(TreeArray self, TreeArray *dest) {
   if (self.capacity > 0) {
     contents = ts_calloc(self.capacity, sizeof(Tree *));
     memcpy(contents, self.contents, self.size * sizeof(Tree *));
-    for (size_t i = 0; i < self.size; i++)
+    for (uint32_t i = 0; i < self.size; i++)
       ts_tree_retain(contents[i]);
   }
 
@@ -46,14 +46,14 @@ bool ts_tree_array_copy(TreeArray self, TreeArray *dest) {
 }
 
 void ts_tree_array_delete(TreeArray *self) {
-  for (size_t i = 0; i < self->size; i++)
+  for (uint32_t i = 0; i < self->size; i++)
     ts_tree_release(self->contents[i]);
   array_delete(self);
 }
 
-size_t ts_tree_array_essential_count(const TreeArray *self) {
-  size_t result = 0;
-  for (size_t i = 0; i < self->size; i++) {
+uint32_t ts_tree_array_essential_count(const TreeArray *self) {
+  uint32_t result = 0;
+  for (uint32_t i = 0; i < self->size; i++) {
     Tree *tree = self->contents[i];
     if (!tree->extra && tree->symbol != ts_builtin_sym_error)
       result++;
@@ -85,7 +85,7 @@ void ts_tree_assign_parents(Tree *self, TreePath *path) {
   while (path->size > 0) {
     Tree *tree = array_pop(path).tree;
     Length offset = length_zero();
-    for (size_t i = 0; i < tree->child_count; i++) {
+    for (uint32_t i = 0; i < tree->child_count; i++) {
       Tree *child = tree->children[i];
       if (child->context.parent != tree || child->context.index != i) {
         child->context.parent = tree;
@@ -99,7 +99,7 @@ void ts_tree_assign_parents(Tree *self, TreePath *path) {
 }
 
 
-void ts_tree_set_children(Tree *self, size_t child_count, Tree **children) {
+void ts_tree_set_children(Tree *self, uint32_t child_count, Tree **children) {
   if (self->child_count > 0)
     ts_free(self->children);
 
@@ -109,7 +109,7 @@ void ts_tree_set_children(Tree *self, size_t child_count, Tree **children) {
   self->visible_child_count = 0;
   self->error_cost = 0;
 
-  for (size_t i = 0; i < child_count; i++) {
+  for (uint32_t i = 0; i < child_count; i++) {
     Tree *child = children[i];
 
     if (i == 0) {
@@ -139,7 +139,7 @@ void ts_tree_set_children(Tree *self, size_t child_count, Tree **children) {
   if (self->symbol == ts_builtin_sym_error) {
     self->error_cost += ERROR_COST_PER_SKIPPED_CHAR * self->size.chars +
                         ERROR_COST_PER_SKIPPED_LINE * self->size.extent.row;
-    for (size_t i = 0; i < child_count; i++)
+    for (uint32_t i = 0; i < child_count; i++)
       if (!self->children[i]->extra)
         self->error_cost += ERROR_COST_PER_SKIPPED_TREE;
   }
@@ -153,7 +153,7 @@ void ts_tree_set_children(Tree *self, size_t child_count, Tree **children) {
   }
 }
 
-Tree *ts_tree_make_node(TSSymbol symbol, size_t child_count,
+Tree *ts_tree_make_node(TSSymbol symbol, uint32_t child_count,
                           Tree **children, TSSymbolMetadata metadata) {
   Tree *result =
     ts_tree_make_leaf(symbol, length_zero(), length_zero(), metadata);
@@ -162,12 +162,12 @@ Tree *ts_tree_make_node(TSSymbol symbol, size_t child_count,
 }
 
 Tree *ts_tree_make_error_node(TreeArray *children) {
-  for (size_t i = 0; i < children->size; i++) {
+  for (uint32_t i = 0; i < children->size; i++) {
     Tree *child = children->contents[i];
     if (child->symbol == ts_builtin_sym_error && child->child_count > 0) {
       array_splice(children, i, 1, child->child_count, child->children);
       i += child->child_count - 1;
-      for (size_t j = 0; j < child->child_count; j++)
+      for (uint32_t j = 0; j < child->child_count; j++)
         ts_tree_retain(child->children[j]);
       ts_tree_release(child);
     }
@@ -197,7 +197,7 @@ recur:
 
   if (self->ref_count == 0) {
     if (self->child_count > 0) {
-      for (size_t i = 0; i < self->child_count - 1; i++)
+      for (uint32_t i = 0; i < self->child_count - 1; i++)
         ts_tree_release(self->children[i]);
       Tree *last_child = self->children[self->child_count - 1];
       ts_free(self->children);
@@ -211,8 +211,8 @@ recur:
   }
 }
 
-size_t ts_tree_start_column(const Tree *self) {
-  size_t column = self->padding.extent.column;
+uint32_t ts_tree_start_column(const Tree *self) {
+  uint32_t column = self->padding.extent.column;
   if (self->padding.extent.row > 0)
     return column;
   for (const Tree *tree = self; tree != NULL; tree = tree->context.parent) {
@@ -223,8 +223,8 @@ size_t ts_tree_start_column(const Tree *self) {
   return column;
 }
 
-size_t ts_tree_end_column(const Tree *self) {
-  size_t result = self->size.extent.column;
+uint32_t ts_tree_end_column(const Tree *self) {
+  uint32_t result = self->size.extent.column;
   if (self->size.extent.row == 0)
     result += ts_tree_start_column(self);
   return result;
@@ -252,7 +252,7 @@ bool ts_tree_eq(const Tree *self, const Tree *other) {
     return false;
   if (self->named_child_count != other->named_child_count)
     return false;
-  for (size_t i = 0; i < self->child_count; i++)
+  for (uint32_t i = 0; i < self->child_count; i++)
     if (!ts_tree_eq(self->children[i], other->children[i]))
       return false;
   return true;
@@ -267,7 +267,7 @@ int ts_tree_compare(const Tree *left, const Tree *right) {
     return -1;
   if (right->child_count < left->child_count)
     return 1;
-  for (size_t i = 0; i < left->child_count; i++) {
+  for (uint32_t i = 0; i < left->child_count; i++) {
     Tree *left_child = left->children[i];
     Tree *right_child = right->children[i];
     switch (ts_tree_compare(left_child, right_child)) {
@@ -288,8 +288,8 @@ static inline long min(long a, long b) {
 
 
 void ts_tree_edit(Tree *self, const TSInputEdit *edit) {
-  size_t old_end_byte = edit->start_byte + edit->bytes_removed;
-  size_t new_end_byte = edit->start_byte + edit->bytes_added;
+  uint32_t old_end_byte = edit->start_byte + edit->bytes_removed;
+  uint32_t new_end_byte = edit->start_byte + edit->bytes_added;
   TSPoint old_end_point = point_add(edit->start_point, edit->extent_removed);
   TSPoint new_end_point = point_add(edit->start_point, edit->extent_added);
 
@@ -300,13 +300,13 @@ void ts_tree_edit(Tree *self, const TSInputEdit *edit) {
   if (edit->start_byte < self->padding.bytes) {
     length_set_unknown_chars(&self->padding);
     if (self->padding.bytes >= old_end_byte) {
-      size_t trailing_padding_bytes = self->padding.bytes - old_end_byte;
+      uint32_t trailing_padding_bytes = self->padding.bytes - old_end_byte;
       TSPoint trailing_padding_extent = point_sub(self->padding.extent, old_end_point);
       self->padding.bytes = new_end_byte + trailing_padding_bytes;
       self->padding.extent = point_add(new_end_point, trailing_padding_extent);
     } else {
       length_set_unknown_chars(&self->size);
-      size_t removed_content_bytes = old_end_byte - self->padding.bytes;
+      uint32_t removed_content_bytes = old_end_byte - self->padding.bytes;
       TSPoint removed_content_extent = point_sub(old_end_point, self->padding.extent);
       self->size.bytes = self->size.bytes - removed_content_bytes;
       self->size.extent = point_sub(self->size.extent, removed_content_extent);
@@ -319,7 +319,7 @@ void ts_tree_edit(Tree *self, const TSInputEdit *edit) {
     self->padding.extent = point_add(self->padding.extent, edit->extent_added);
   } else {
     length_set_unknown_chars(&self->size);
-    size_t trailing_content_bytes = ts_tree_total_bytes(self) - old_end_byte;
+    uint32_t trailing_content_bytes = ts_tree_total_bytes(self) - old_end_byte;
     TSPoint trailing_content_extent = point_sub(ts_tree_total_extent(self), old_end_point);
     self->size.bytes = new_end_byte + trailing_content_bytes - self->padding.bytes;
     self->size.extent = point_sub(point_add(new_end_point, trailing_content_extent), self->padding.extent);
@@ -329,7 +329,7 @@ void ts_tree_edit(Tree *self, const TSInputEdit *edit) {
   long remaining_bytes_to_delete = 0;
   TSPoint remaining_extent_to_delete = {0, 0};
   Length child_left, child_right = length_zero();
-  for (size_t i = 0; i < self->child_count; i++) {
+  for (uint32_t i = 0; i < self->child_count; i++) {
     Tree *child = self->children[i];
     child_left = child_right;
 
@@ -415,7 +415,7 @@ static size_t ts_tree__write_to_string(const Tree *self,
     }
   }
 
-  for (size_t i = 0; i < self->child_count; i++) {
+  for (uint32_t i = 0; i < self->child_count; i++) {
     Tree *child = self->children[i];
     cursor += ts_tree__write_to_string(child, language, *writer, limit, false,
                                        include_all);
@@ -437,7 +437,7 @@ char *ts_tree_string(const Tree *self, const TSLanguage *language,
   return result;
 }
 
-void ts_tree__print_dot_graph(const Tree *self, size_t byte_offset,
+void ts_tree__print_dot_graph(const Tree *self, uint32_t byte_offset,
                               const TSLanguage *language, FILE *f) {
   fprintf(f, "tree_%p [label=\"%s\"", self,
           ts_language_symbol_name(language, self->symbol));
@@ -447,13 +447,13 @@ void ts_tree__print_dot_graph(const Tree *self, size_t byte_offset,
   if (self->extra)
     fprintf(f, ", fontcolor=gray");
 
-  fprintf(f, ", tooltip=\"range:%lu - %lu\nstate:%d\nerror-cost:%u\"]\n",
+  fprintf(f, ", tooltip=\"range:%u - %u\nstate:%d\nerror-cost:%u\"]\n",
           byte_offset, byte_offset + ts_tree_total_bytes(self), self->parse_state,
           self->error_cost);
-  for (size_t i = 0; i < self->child_count; i++) {
+  for (uint32_t i = 0; i < self->child_count; i++) {
     const Tree *child = self->children[i];
     ts_tree__print_dot_graph(child, byte_offset, language, f);
-    fprintf(f, "tree_%p -> tree_%p [tooltip=%lu]\n", self, child, i);
+    fprintf(f, "tree_%p -> tree_%p [tooltip=%u]\n", self, child, i);
     byte_offset += ts_tree_total_bytes(child);
   }
 }

--- a/src/runtime/tree.h
+++ b/src/runtime/tree.h
@@ -17,13 +17,13 @@ extern TSStateId TS_TREE_STATE_NONE;
 typedef struct Tree {
   struct {
     struct Tree *parent;
-    size_t index;
+    uint32_t index;
     Length offset;
   } context;
 
-  size_t child_count;
-  size_t visible_child_count;
-  size_t named_child_count;
+  uint32_t child_count;
+  uint32_t visible_child_count;
+  uint32_t named_child_count;
   union {
     struct Tree **children;
     int32_t lookahead_char;
@@ -53,7 +53,7 @@ typedef struct Tree {
 typedef struct {
   Tree *tree;
   Length position;
-  size_t child_index;
+  uint32_t child_index;
 } TreePathEntry;
 
 typedef Array(Tree *) TreeArray;
@@ -62,10 +62,10 @@ typedef Array(TreePathEntry) TreePath;
 
 bool ts_tree_array_copy(TreeArray, TreeArray *);
 void ts_tree_array_delete(TreeArray *);
-size_t ts_tree_array_essential_count(const TreeArray *);
+uint32_t ts_tree_array_essential_count(const TreeArray *);
 
 Tree *ts_tree_make_leaf(TSSymbol, Length, Length, TSSymbolMetadata);
-Tree *ts_tree_make_node(TSSymbol, size_t, Tree **, TSSymbolMetadata);
+Tree *ts_tree_make_node(TSSymbol, uint32_t, Tree **, TSSymbolMetadata);
 Tree *ts_tree_make_copy(Tree *child);
 Tree *ts_tree_make_error_node(TreeArray *);
 Tree *ts_tree_make_error(Length, Length, char);
@@ -74,19 +74,15 @@ void ts_tree_release(Tree *tree);
 bool ts_tree_eq(const Tree *tree1, const Tree *tree2);
 int ts_tree_compare(const Tree *tree1, const Tree *tree2);
 
-size_t ts_tree_start_column(const Tree *self);
-size_t ts_tree_end_column(const Tree *self);
-void ts_tree_set_children(Tree *, size_t, Tree **);
+uint32_t ts_tree_start_column(const Tree *self);
+uint32_t ts_tree_end_column(const Tree *self);
+void ts_tree_set_children(Tree *, uint32_t, Tree **);
 void ts_tree_assign_parents(Tree *, TreePath *);
 void ts_tree_edit(Tree *, const TSInputEdit *edit);
 char *ts_tree_string(const Tree *, const TSLanguage *, bool include_all);
 void ts_tree_print_dot_graph(const Tree *, const TSLanguage *, FILE *);
 
-static inline size_t ts_tree_total_chars(const Tree *self) {
-  return self->padding.chars + self->size.chars;
-}
-
-static inline size_t ts_tree_total_bytes(const Tree *self) {
+static inline uint32_t ts_tree_total_bytes(const Tree *self) {
   return self->padding.bytes + self->size.bytes;
 }
 
@@ -100,7 +96,7 @@ static inline TSPoint ts_tree_total_extent(const Tree *self) {
 
 static inline bool ts_tree_is_fragile(const Tree *tree) {
   return tree->fragile_left || tree->fragile_right ||
-         ts_tree_total_chars(tree) == 0;
+         ts_tree_total_bytes(tree) == 0;
 }
 
 #ifdef __cplusplus

--- a/src/runtime/tree_path.h
+++ b/src/runtime/tree_path.h
@@ -22,13 +22,13 @@ static void range_array_add(RangeArray *results, TSPoint start, TSPoint end) {
 }
 
 static bool tree_path_descend(TreePath *path, TSPoint position) {
-  size_t original_size = path->size;
+  uint32_t original_size = path->size;
   bool did_descend;
   do {
     did_descend = false;
     TreePathEntry entry = *array_back(path);
     Length child_position = entry.position;
-    for (size_t i = 0; i < entry.tree->child_count; i++) {
+    for (uint32_t i = 0; i < entry.tree->child_count; i++) {
       Tree *child = entry.tree->children[i];
       Length child_right_position =
         length_add(child_position, ts_tree_total_size(child));
@@ -50,8 +50,8 @@ static bool tree_path_descend(TreePath *path, TSPoint position) {
   return false;
 }
 
-static size_t tree_path_advance(TreePath *path) {
-  size_t ascend_count = 0;
+static uint32_t tree_path_advance(TreePath *path) {
+  uint32_t ascend_count = 0;
   while (path->size > 0) {
     TreePathEntry entry = array_pop(path);
     if (path->size == 0)
@@ -60,7 +60,7 @@ static size_t tree_path_advance(TreePath *path) {
     if (parent_entry.tree->visible) ascend_count++;
     Length position =
       length_add(entry.position, ts_tree_total_size(entry.tree));
-    for (size_t i = entry.child_index + 1; i < parent_entry.tree->child_count; i++) {
+    for (uint32_t i = entry.child_index + 1; i < parent_entry.tree->child_count; i++) {
       Tree *next_child = parent_entry.tree->children[i];
       if (next_child->visible || next_child->visible_child_count > 0) {
         if (parent_entry.tree->visible) ascend_count--;
@@ -79,8 +79,8 @@ static size_t tree_path_advance(TreePath *path) {
   return ascend_count;
 }
 
-static void tree_path_ascend(TreePath *path, size_t count) {
-  for (size_t i = 0; i < count; i++) {
+static void tree_path_ascend(TreePath *path, uint32_t count) {
+  for (uint32_t i = 0; i < count; i++) {
     do {
       path->size--;
     } while (path->size > 0 && !array_back(path)->tree->visible);
@@ -111,7 +111,7 @@ static bool tree_must_eq(Tree *old_tree, Tree *new_tree) {
 }
 
 static void tree_path_get_changes(TreePath *old_path, TreePath *new_path,
-                                  TSRange **ranges, size_t *range_count) {
+                                  TSRange **ranges, uint32_t *range_count) {
   TSPoint position = { 0, 0 };
   RangeArray results = array_new();
 
@@ -123,8 +123,8 @@ static void tree_path_get_changes(TreePath *old_path, TreePath *new_path,
     TreePathEntry new_entry = *array_back(new_path);
     Tree *old_tree = old_entry.tree;
     Tree *new_tree = new_entry.tree;
-    size_t old_start_byte = old_entry.position.bytes + old_tree->padding.bytes;
-    size_t new_start_byte = new_entry.position.bytes + new_tree->padding.bytes;
+    uint32_t old_start_byte = old_entry.position.bytes + old_tree->padding.bytes;
+    uint32_t new_start_byte = new_entry.position.bytes + new_tree->padding.bytes;
     TSPoint old_start_point =
       point_add(old_entry.position.extent, old_tree->padding.extent);
     TSPoint new_start_point =
@@ -175,18 +175,18 @@ static void tree_path_get_changes(TreePath *old_path, TreePath *new_path,
     bool at_new_end = point_lte(new_end_point, next_position);
 
     if (at_new_end && at_old_end) {
-      size_t old_ascend_count = tree_path_advance(old_path);
-      size_t new_ascend_count = tree_path_advance(new_path);
+      uint32_t old_ascend_count = tree_path_advance(old_path);
+      uint32_t new_ascend_count = tree_path_advance(new_path);
       if (old_ascend_count > new_ascend_count) {
         tree_path_ascend(new_path, old_ascend_count - new_ascend_count);
       } else if (new_ascend_count > old_ascend_count) {
         tree_path_ascend(old_path, new_ascend_count - old_ascend_count);
       }
     } else if (at_new_end) {
-      size_t ascend_count = tree_path_advance(new_path);
+      uint32_t ascend_count = tree_path_advance(new_path);
       tree_path_ascend(old_path, ascend_count);
     } else if (at_old_end) {
-      size_t ascend_count = tree_path_advance(old_path);
+      uint32_t ascend_count = tree_path_advance(old_path);
       tree_path_ascend(new_path, ascend_count);
     }
 


### PR DESCRIPTION
The parser spends the majority of its time allocating and freeing trees and stack nodes.
Also, the memory footprint of the AST is a significant concern when using tree-sitter
with large files. This library is already unlikely to work very well with source files
larger than 4GB, so representing rows, columns, byte lengths and child indices as
unsigned 32 bit integers seems like the right choice.