### PR TITLE
Update JavaScript test

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This allows it to generate a fast parser for any context-free grammar.
 ```sh
 script/configure # Generate a Makefile
 make             # Build static libraries for the compiler and runtime
+script/test      # Run the tests
 ```
 
 ### Overview

--- a/spec/fixtures/error_corpus/javascript_errors.txt
+++ b/spec/fixtures/error_corpus/javascript_errors.txt
@@ -53,7 +53,7 @@ if ({a: 'b'} {c: 'd'}) {
     (object (pair (identifier) (string)))
     (ERROR (object (pair (identifier) (string))))
     (statement_block
-      (ERROR (function
+      (function
         (formal_parameters (identifier))
         (statement_block (expression_statement (identifier)))))
       (expression_statement

--- a/spec/fixtures/error_corpus/javascript_errors.txt
+++ b/spec/fixtures/error_corpus/javascript_errors.txt
@@ -59,7 +59,7 @@ if ({a: 'b'} {c: 'd'}) {
       (expression_statement
         (function
           (formal_parameters (identifier))
-          (statement_block (expression_statement (identifier))))))))
+          (statement_block (expression_statement (identifier)))))))
 
 ===================================================
 one invalid token at the end of the file


### PR DESCRIPTION
After updating behavior in `tree-sitter-javascript`, a JavaScript test case failed.

This updates the spec fixture so that the no longer failure node in the tree is removed.

Additionally this adds an instruction on how to run the tests.

/cc @maxbrunsfeld 