### PR TITLE
Disallow syntax rules that match the empty string (for now)

### DIFF
--- a/include/tree_sitter/compiler.h
+++ b/include/tree_sitter/compiler.h
@@ -13,6 +13,7 @@ typedef enum {
   TSCompileErrorTypeInvalidUbiquitousToken,
   TSCompileErrorTypeLexConflict,
   TSCompileErrorTypeParseConflict,
+  TSCompileErrorTypeEpsilonRule,
 } TSCompileErrorType;
 
 typedef struct {

--- a/spec/integration/compile_grammar_spec.cc
+++ b/spec/integration/compile_grammar_spec.cc
@@ -326,6 +326,33 @@ describe("compile_grammar", []() {
     });
   });
 
+  describe("when the grammar contains rules that match the empty string", [&]() {
+    it("reports an error", [&]() {
+      TSCompileResult result = ts_compile_grammar(R"JSON(
+        {
+          "name": "empty_rules",
+
+          "rules": {
+            "rule_1": {"type": "SYMBOL", "name": "rule_2"},
+
+            "rule_2": {
+              "type": "CHOICE",
+              "members": [
+                {"type": "SYMBOL", "name": "rule_1"},
+                {"type": "BLANK"}
+              ]
+            }
+          }
+        }
+      )JSON");
+
+      AssertThat(result.error_message, Equals(dedent(R"MESSAGE(
+        The rule `rule_2` matches the empty string.
+        Tree-sitter currently does not support syntactic rules that match the empty string.
+      )MESSAGE")));
+    });
+  });
+
   describe("when the grammar's start symbol is a token", [&]() {
     it("parses the token", [&]() {
       TSCompileResult result = ts_compile_grammar(R"JSON(

--- a/src/compiler/build_tables/build_parse_table.cc
+++ b/src/compiler/build_tables/build_parse_table.cc
@@ -177,7 +177,7 @@ class ParseTableBuilder {
             parse_table.add_terminal_action(state_id, lookahead, action);
           } else {
             ParseAction &existing_action = entry.actions[0];
-            if (allow_any_conflict) {
+            if (existing_action.type == ParseActionTypeAccept || allow_any_conflict) {
               entry.actions.push_back(action);
             } else {
               int existing_precedence = existing_action.precedence();

--- a/src/compiler/prepare_grammar/flatten_grammar.h
+++ b/src/compiler/prepare_grammar/flatten_grammar.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include "tree_sitter/compiler.h"
+#include "compiler/compile_error.h"
 #include "compiler/syntax_grammar.h"
 
 namespace tree_sitter {
@@ -11,7 +12,7 @@ namespace prepare_grammar {
 struct InitialSyntaxGrammar;
 
 SyntaxVariable flatten_rule(const Variable &variable);
-SyntaxGrammar flatten_grammar(const InitialSyntaxGrammar &);
+std::pair<SyntaxGrammar, CompileError> flatten_grammar(const InitialSyntaxGrammar &);
 
 }  // namespace prepare_grammar
 }  // namespace tree_sitter

--- a/src/compiler/prepare_grammar/prepare_grammar.cc
+++ b/src/compiler/prepare_grammar/prepare_grammar.cc
@@ -51,7 +51,11 @@ tuple<SyntaxGrammar, LexicalGrammar, CompileError> prepare_grammar(
   /*
    * Flatten syntax rules into lists of productions.
    */
-  SyntaxGrammar syntax_grammar = flatten_grammar(syntax_grammar1);
+  auto flatten_result = flatten_grammar(syntax_grammar1);
+  SyntaxGrammar syntax_grammar = flatten_result.first;
+  error = flatten_result.second;
+  if (error.type)
+    return make_tuple(SyntaxGrammar(), LexicalGrammar(), error);
 
   /*
    * Ensure all lexical rules are in a consistent format.


### PR DESCRIPTION
These *epsilon rules* are actually somewhat complicated to handle; they've never worked 100% correctly. For now, I'm just going to disallow them.