### PR TITLE
Reduce the branching factor of the parse stack during error recovery

### DIFF
--- a/spec/fixtures/error_corpus/c_errors.txt
+++ b/spec/fixtures/error_corpus/c_errors.txt
@@ -127,5 +127,6 @@ int b() {
           (ERROR (identifier) (identifier))
           (identifier) (number_literal)))
       (declaration
+        (ERROR (identifier) (identifier))
         (identifier)
-        (init_declarator (ERROR (identifier) (identifier)) (identifier) (number_literal))))))
+        (init_declarator (identifier) (number_literal))))))

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -550,7 +550,7 @@ static StackPopResult parser__reduce(Parser *self, StackVersion version,
     // If this pop operation terminated at the end of an error region, then
     // create two stack versions: one in which the parent node is interpreted
     // normally, and one in which the parent node is skipped.
-    if (state == ERROR_STATE && allow_skipping) {
+    if (state == ERROR_STATE && allow_skipping && child_count > 1) {
       StackVersion other_version = ts_stack_copy_version(self->stack, slice.version);
 
       ts_stack_push(self->stack, other_version, parent, false, ERROR_STATE);


### PR DESCRIPTION
Right now, when recovering from errors, the parse stack often branches off in way too many directions. This slows down parsing, but more importantly, it makes it harder to debug the parsing process, because the parse stack becomes so complex.

This PR reduces the branching of the parse stack in one simple way. I'm going to continue to improve this in further PRs. 