### PR TITLE
Allow lexer to look ahead in order to find the actual longest match

### DIFF
--- a/include/tree_sitter/parser.h
+++ b/include/tree_sitter/parser.h
@@ -26,6 +26,7 @@ typedef struct {
 
 typedef struct {
   void (*advance)(void *, bool);
+  void (*mark_end)(void *);
   int32_t lookahead;
   TSSymbol result_symbol;
 } TSLexer;
@@ -91,32 +92,32 @@ typedef struct TSLanguage {
  *  Lexer Macros
  */
 
-#define START_LEXER() \
-  int32_t lookahead;  \
-  next_state:         \
+#define START_LEXER()           \
+  bool result = false;          \
+  int32_t lookahead;            \
+  next_state:                   \
   lookahead = lexer->lookahead;
 
-#define ADVANCE(state_value)                   \
-  {                                            \
+#define ADVANCE(state_value)      \
+  {                               \
     lexer->advance(lexer, false); \
-    state = state_value;                       \
-    goto next_state;                           \
+    state = state_value;          \
+    goto next_state;              \
   }
 
-#define SKIP(state_value)                     \
-  {                                           \
+#define SKIP(state_value)        \
+  {                              \
     lexer->advance(lexer, true); \
-    state = state_value;                      \
-    goto next_state;                          \
+    state = state_value;         \
+    goto next_state;             \
   }
 
-#define ACCEPT_TOKEN(symbol_value)       \
-  {                                      \
-    lexer->result_symbol = symbol_value; \
-    return true;                         \
-  }
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
 
-#define LEX_ERROR() return false
+#define END_STATE() return result;
 
 /*
  *  Parse Table Macros

--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -9,7 +9,7 @@ extern "C" {
 #include <stdint.h>
 #include <stdbool.h>
 
-#define TREE_SITTER_LANGUAGE_VERSION 1
+#define TREE_SITTER_LANGUAGE_VERSION 2
 
 typedef unsigned short TSSymbol;
 typedef struct TSLanguage TSLanguage;

--- a/src/compiler/lex_table.cc
+++ b/src/compiler/lex_table.cc
@@ -42,12 +42,9 @@ bool AcceptTokenAction::operator==(const AcceptTokenAction &other) const {
          (is_string == other.is_string);
 }
 
-LexState::LexState() : is_token_start(false) {}
-
 bool LexState::operator==(const LexState &other) const {
   return advance_actions == other.advance_actions &&
-         accept_action == other.accept_action &&
-         is_token_start == other.is_token_start;
+         accept_action == other.accept_action;
 }
 
 }  // namespace tree_sitter

--- a/src/compiler/lex_table.h
+++ b/src/compiler/lex_table.h
@@ -35,12 +35,10 @@ struct AcceptTokenAction {
 };
 
 struct LexState {
-  LexState();
   bool operator==(const LexState &) const;
 
   std::map<rules::CharacterSet, AdvanceAction> advance_actions;
   AcceptTokenAction accept_action;
-  bool is_token_start;
 };
 
 struct LexTable {

--- a/src/runtime/lexer.h
+++ b/src/runtime/lexer.h
@@ -15,11 +15,11 @@ typedef struct {
   TSLexer data;
   Length current_position;
   Length token_start_position;
+  Length token_end_position;
 
   const char *chunk;
   uint32_t chunk_start;
   uint32_t chunk_size;
-
   uint32_t lookahead_size;
 
   TSInput input;

--- a/src/runtime/tree.h
+++ b/src/runtime/tree.h
@@ -34,6 +34,7 @@ typedef struct Tree {
 
   Length padding;
   Length size;
+  uint32_t bytes_scanned;
 
   TSSymbol symbol;
   TSStateId parse_state;

--- a/test/compiler/build_tables/lex_conflict_manager_test.cc
+++ b/test/compiler/build_tables/lex_conflict_manager_test.cc
@@ -69,18 +69,15 @@ describe("LexConflictManager::resolve(new_action, old_action)", []() {
   describe("advance/accept-token conflicts", [&]() {
     describe("when the token to accept has higher precedence", [&]() {
       it("prefers the accept-token action", [&]() {
-        AssertThat(conflict_manager.possible_extensions, IsEmpty());
         update = conflict_manager.resolve(item_set, AdvanceAction(1, { 1, 2 }, true), AcceptTokenAction(sym3, 3, true));
         AssertThat(update, IsFalse());
-        AssertThat(conflict_manager.possible_extensions, IsEmpty());
       });
     });
 
     describe("when the token to accept does not have a higher precedence", [&]() {
-      it("favors the advance action and adds the in-progress tokens as possible extensions of the discarded token", [&]() {
+      it("favors the advance action", [&]() {
         update = conflict_manager.resolve(item_set, AdvanceAction(1, { 1, 2 }, true), AcceptTokenAction(sym3, 2, true));
         AssertThat(update, IsTrue());
-        AssertThat(conflict_manager.possible_extensions[sym3.index], Contains(sym4.index));
       });
     });
   });

--- a/test/runtime/parser_test.cc
+++ b/test/runtime/parser_test.cc
@@ -164,7 +164,7 @@ describe("Parser", [&]() {
     describe("when there is an unterminated error", [&]() {
       it("maintains a consistent tree", [&]() {
         ts_document_set_language(document, load_real_language("javascript"));
-        set_text("a; /* b");
+        set_text("a; ' this string never ends");
         assert_root_node(
           "(ERROR (program (expression_statement (identifier))) (UNEXPECTED EOF))");
       });

--- a/test/runtime/tree_test.cc
+++ b/test/runtime/tree_test.cc
@@ -312,6 +312,24 @@ describe("Tree", []() {
         AssertThat(tree->children[2]->size, Equals<Length>({3, 3, {0, 3}}));
       });
     });
+
+    describe("edits within a tree's range of scanned bytes", [&]() {
+      it("marks preceding trees as changed", [&]() {
+        tree->children[0]->bytes_scanned = 7;
+
+        TSInputEdit edit;
+        edit.start_byte = 6;
+        edit.bytes_removed = 1;
+        edit.bytes_added = 1;
+        edit.start_point = {0, 6};
+        edit.extent_removed = {0, 1};
+        edit.extent_added = {0, 1};
+        ts_tree_edit(tree, &edit);
+        assert_consistent(tree);
+
+        AssertThat(tree->children[0]->has_changes, IsTrue());
+      });
+    });
   });
 
   describe("eq", [&]() {


### PR DESCRIPTION
This PR addresses a long-standing bug in the tokenizing algorithm that caused the lexer to sometimes error out when trying to find the longest matching token, even though it *should* have successfully found a shorter token.

### Example

In Ruby, the code `100.class` parses as `(call (integer) (identifier))`. Meanwhile, the code `100.25` parses as `(float)`. So after a sequence of digits, the `.` character may or may not be part of the same token, depending on what character comes *next*. If a digit comes next, the lexer should proceed to consume any remaining digits and produce a `float`. If not, the lexer should consume only the digits *before* the dot, and produce an `integer`.

The natural way to model all of this logic would be with the following (simplified) rules:

```js
expression: $ => choice(
  $.call,
  $.integer,
  $.float
  // ...
),

call: $ => seq(
  $.expression,
  '.',
  $.identifier
),

integer: $ => /\d+/,

float: $ => /\d+\.\d+/,

identifier: $ => /\a+/
```

### The problem

Previously, with this grammar, the lexer tree-sitter generated would *error out* in the presence of code like `100.class`, because it would *commit* to trying to parse a `float` as soon as it saw the dot character.

### The solution

Now, the lexer carries an additional piece of state called `token_end_position`, which the most recent position that corresponded to a valid token. So in the example above, after consuming the `100`, the lexer will record that it has found a valid token. It will then advance past the dot. If it sees a digit, it will update its `token_end_position` and continue to advance. If not, it will still yield a valid `integer` token, backtracking by one character (the dot).

### Incremental parsing considerations

Because the computation of a given token can now be influenced by the text to the *right* of the token, an edit to the document can cause trees that *precede* the edit to become invalid. To keep track of this interaction, each `Tree` struct now has an additional field: `bytes_scanned`, which represents the total number of bytes that were *considered* when creating that tree. This field is used in the `ts_tree_edit` routine for marking additional trees as invalid.
