### PR TITLE
Add an option to immediately halt on syntax error

### DIFF
--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -117,6 +117,15 @@ void ts_document_print_debugging_graphs(TSDocument *, bool);
 void ts_document_edit(TSDocument *, TSInputEdit);
 void ts_document_parse(TSDocument *);
 void ts_document_parse_and_get_changed_ranges(TSDocument *, TSRange **, uint32_t *);
+
+typedef struct {
+  TSRange **changed_ranges;
+  uint32_t *changed_range_count;
+  bool halt_on_error;
+} TSParseOptions;
+
+void ts_document_parse_with_options(TSDocument *, TSParseOptions);
+
 void ts_document_invalidate(TSDocument *);
 TSNode ts_document_root_node(const TSDocument *);
 uint32_t ts_document_parse_count(const TSDocument *);

--- a/src/runtime/lexer.c
+++ b/src/runtime/lexer.c
@@ -145,3 +145,7 @@ void ts_lexer_start(Lexer *self) {
   if (!self->lookahead_size)
     ts_lexer__get_lookahead(self);
 }
+
+void ts_lexer_advance_to_end(Lexer *self) {
+  while (self->data.lookahead != 0) ts_lexer__advance(self, false);
+}

--- a/src/runtime/lexer.h
+++ b/src/runtime/lexer.h
@@ -32,6 +32,7 @@ void ts_lexer_init(Lexer *);
 void ts_lexer_set_input(Lexer *, TSInput);
 void ts_lexer_reset(Lexer *, Length);
 void ts_lexer_start(Lexer *);
+void ts_lexer_advance_to_end(Lexer *);
 
 #ifdef __cplusplus
 }

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -194,7 +194,10 @@ static CondenseResult parser__condense_stack(Parser *self) {
     }
   }
 
-  if (!has_version_without_errors) result |= CondenseResultAllVersionsHadError;
+  if (!has_version_without_errors && ts_stack_version_count(self->stack) > 0) {
+    result |= CondenseResultAllVersionsHadError;
+  }
+
   return result;
 }
 
@@ -1225,6 +1228,7 @@ Tree *parser_parse(Parser *self, TSInput input, Tree *old_tree, bool halt_on_err
     CondenseResult condense_result = parser__condense_stack(self);
     if (halt_on_error && (condense_result & CondenseResultAllVersionsHadError)) {
       LOG("halting_parse");
+      LOG_STACK();
 
       ts_lexer_advance_to_end(&self->lexer);
       Length remaining_length = length_sub(

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -151,21 +151,28 @@ static bool parser__can_reuse(Parser *self, TSStateId state, Tree *tree,
   return tree->child_count > 1 && tree->error_cost == 0;
 }
 
-static bool parser__condense_stack(Parser *self) {
-  bool result = false;
+typedef int CondenseResult;
+static int CondenseResultMadeChange = 1;
+static int CondenseResultAllVersionsHadError = 2;
+
+static CondenseResult parser__condense_stack(Parser *self) {
+  CondenseResult result = 0;
+  bool has_version_without_errors = false;
+
   for (StackVersion i = 0; i < ts_stack_version_count(self->stack); i++) {
     if (ts_stack_is_halted(self->stack, i)) {
       ts_stack_remove_version(self->stack, i);
-      result = true;
+      result |= CondenseResultMadeChange;
       i--;
       continue;
     }
 
     ErrorStatus error_status = ts_stack_error_status(self->stack, i);
+    if (error_status.count == 0) has_version_without_errors = true;
 
     for (StackVersion j = 0; j < i; j++) {
       if (ts_stack_merge(self->stack, j, i)) {
-        result = true;
+        result |= CondenseResultMadeChange;
         i--;
         break;
       }
@@ -174,18 +181,20 @@ static bool parser__condense_stack(Parser *self) {
                                    ts_stack_error_status(self->stack, j))) {
         case -1:
           ts_stack_remove_version(self->stack, j);
-          result = true;
+          result |= CondenseResultMadeChange;
           i--;
           j--;
           break;
         case 1:
           ts_stack_remove_version(self->stack, i);
-          result = true;
+          result |= CondenseResultMadeChange;
           i--;
           break;
       }
     }
   }
+
+  if (!has_version_without_errors) result |= CondenseResultAllVersionsHadError;
   return result;
 }
 
@@ -1183,7 +1192,7 @@ void parser_destroy(Parser *self) {
   parser_set_language(self, NULL);
 }
 
-Tree *parser_parse(Parser *self, TSInput input, Tree *old_tree) {
+Tree *parser_parse(Parser *self, TSInput input, Tree *old_tree, bool halt_on_error) {
   parser__start(self, input, old_tree);
 
   StackVersion version = STACK_VERSION_NONE;
@@ -1213,7 +1222,32 @@ Tree *parser_parse(Parser *self, TSInput input, Tree *old_tree) {
 
     self->reusable_node = reusable_node;
 
-    if (parser__condense_stack(self)) {
+    CondenseResult condense_result = parser__condense_stack(self);
+    if (halt_on_error && (condense_result & CondenseResultAllVersionsHadError)) {
+      LOG("halting_parse");
+
+      ts_lexer_advance_to_end(&self->lexer);
+      Length remaining_length = length_sub(
+        self->lexer.current_position,
+        ts_stack_top_position(self->stack, 0)
+      );
+
+      Tree *filler_node = ts_tree_make_error(remaining_length, length_zero(), 0);
+      filler_node->visible = false;
+      parser__push(self, 0, filler_node, 0);
+
+      TreeArray children = array_new();
+      Tree *root_error = ts_tree_make_error_node(&children);
+      parser__push(self, 0, root_error, 0);
+
+      TSSymbolMetadata metadata = ts_language_symbol_metadata(self->language, ts_builtin_sym_end);
+      Tree *eof = ts_tree_make_leaf(ts_builtin_sym_end, length_zero(), length_zero(), metadata);
+      parser__accept(self, 0, eof);
+      ts_tree_release(eof);
+      break;
+    }
+
+    if (condense_result & CondenseResultMadeChange) {
       LOG("condense");
       LOG_STACK();
     }

--- a/src/runtime/parser.h
+++ b/src/runtime/parser.h
@@ -31,7 +31,7 @@ typedef struct {
 
 bool parser_init(Parser *);
 void parser_destroy(Parser *);
-Tree *parser_parse(Parser *, TSInput, Tree *);
+Tree *parser_parse(Parser *, TSInput, Tree *, bool halt_on_error);
 void parser_set_language(Parser *, const TSLanguage *);
 
 #ifdef __cplusplus

--- a/test/runtime/document_test.cc
+++ b/test/runtime/document_test.cc
@@ -396,6 +396,21 @@ describe("Document", [&]() {
       AssertThat(ts_node_end_char(root), Equals(input_string.size()));
       AssertThat(ts_node_end_byte(root), Equals(input_string.size()));
     });
+
+    it("can parse valid code with the halt_on_error flag set", [&]() {
+      string input_string = "[1, null, 3]";
+      ts_document_set_language(document, load_real_language("json"));
+      ts_document_set_input_string(document, input_string.c_str());
+
+      TSParseOptions options;
+      options.changed_ranges = nullptr;
+      options.halt_on_error = true;
+      ts_document_parse_with_options(document, options);
+      root = ts_document_root_node(document);
+      assert_node_string_equals(
+        root,
+        "(array (number) (null) (number))");
+    });
   });
 });
 


### PR DESCRIPTION
Currently, there are some performance bugs in the error recovery algorithm that can cause it to take a very very long time in some cases. This PR adds a new API `ts_document_parse_with_options` which allows us to opt out of error recovery altogether.

🍐 'd with @tclem