### PR TITLE
OOB-read in remove_duplicate_parse_states

### DIFF
--- a/src/compiler/build_tables/build_parse_table.cc
+++ b/src/compiler/build_tables/build_parse_table.cc
@@ -394,8 +394,7 @@ class ParseTableBuilder {
       } else {
         ParseState &state = *iter;
         state.each_referenced_state([&new_state_ids](ParseStateId *state_index) {
-          if (*state_index != (ParseStateId)(-1))
-            *state_index = new_state_ids[*state_index];
+          *state_index = new_state_ids[*state_index];
         });
         ++iter;
       }

--- a/src/compiler/build_tables/build_parse_table.cc
+++ b/src/compiler/build_tables/build_parse_table.cc
@@ -394,7 +394,8 @@ class ParseTableBuilder {
       } else {
         ParseState &state = *iter;
         state.each_referenced_state([&new_state_ids](ParseStateId *state_index) {
-          *state_index = new_state_ids[*state_index];
+          if (*state_index != (ParseStateId)(-1))
+            *state_index = new_state_ids[*state_index];
         });
         ++iter;
       }

--- a/src/compiler/parse_table.cc
+++ b/src/compiler/parse_table.cc
@@ -151,7 +151,7 @@ bool ParseState::has_shift_action() const {
 void ParseState::each_referenced_state(function<void(ParseStateId *)> fn) {
   for (auto &entry : terminal_entries)
     for (ParseAction &action : entry.second.actions)
-      if (action.type == ParseActionTypeShift || ParseActionTypeRecover)
+      if (action.type == ParseActionTypeShift || action.type == ParseActionTypeRecover)
         fn(&action.state_index);
   for (auto &entry : nonterminal_entries)
     fn(&entry.second);

--- a/src/compiler/parse_table.cc
+++ b/src/compiler/parse_table.cc
@@ -151,7 +151,7 @@ bool ParseState::has_shift_action() const {
 void ParseState::each_referenced_state(function<void(ParseStateId *)> fn) {
   for (auto &entry : terminal_entries)
     for (ParseAction &action : entry.second.actions)
-      if (action.type == ParseActionTypeShift || action.type == ParseActionTypeRecover)
+      if ((action.type == ParseActionTypeShift && !action.extra) || action.type == ParseActionTypeRecover)
         fn(&action.state_index);
   for (auto &entry : nonterminal_entries)
     if (entry.second != (ParseStateId)(-1))

--- a/src/compiler/parse_table.cc
+++ b/src/compiler/parse_table.cc
@@ -154,7 +154,8 @@ void ParseState::each_referenced_state(function<void(ParseStateId *)> fn) {
       if (action.type == ParseActionTypeShift || action.type == ParseActionTypeRecover)
         fn(&action.state_index);
   for (auto &entry : nonterminal_entries)
-    fn(&entry.second);
+    if (entry.second != (ParseStateId)(-1))
+      fn(&entry.second);
 }
 
 bool ParseState::operator==(const ParseState &other) const {

--- a/src/compiler/parse_table.cc
+++ b/src/compiler/parse_table.cc
@@ -154,8 +154,7 @@ void ParseState::each_referenced_state(function<void(ParseStateId *)> fn) {
       if ((action.type == ParseActionTypeShift && !action.extra) || action.type == ParseActionTypeRecover)
         fn(&action.state_index);
   for (auto &entry : nonterminal_entries)
-    if (entry.second != (ParseStateId)(-1))
-      fn(&entry.second);
+    fn(&entry.second);
 }
 
 bool ParseState::operator==(const ParseState &other) const {


### PR DESCRIPTION
Some ParseActions have `state_id == -1` which can cause an out-of-bounds read when removing duplicated states. Also fix a think-o in `each_referenced_state`