### PR TITLE
Fix errors found by scan-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 language: cpp
 compiler:
 - gcc
@@ -9,10 +10,11 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-5
+    - clang
 
 install:
 - export CXX="g++-5"
-- script/configure
+- scan-build script/configure
 
 script:
 - script/ci

--- a/script/ci
+++ b/script/ci
@@ -2,6 +2,9 @@
 
 set -e
 
+. script/lib.sh
+
 script/fetch-fixtures
 script/check-mallocs
-script/test
+scan_build make
+script/test -b

--- a/script/ci
+++ b/script/ci
@@ -6,5 +6,4 @@ set -e
 
 script/fetch-fixtures
 script/check-mallocs
-scan_build make -j2
 script/test -b

--- a/script/ci
+++ b/script/ci
@@ -6,5 +6,5 @@ set -e
 
 script/fetch-fixtures
 script/check-mallocs
-scan_build make
+scan_build make -j2
 script/test -b

--- a/script/lib.sh
+++ b/script/lib.sh
@@ -22,5 +22,5 @@ function scan_build {
     extra_args+=("--use-c++=$CXX")
   fi
 
-  scan-build "${extra_args[@]}" --status-bugs "$@"
+  scan-build "${extra_args[@]}" --status-bugs -disable-checker deadcode.DeadStores "$@"
 }

--- a/script/lib.sh
+++ b/script/lib.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+function scan_build {
+  extra_args=()
+
+  # AFAICT, in the trusty travis container the scan-build tool is from the 3.4
+  # installation. Therefore, by default it will use clang-3.4 when analysing code
+  # which doesn't support the '-std=c++14' (it is available via '-std=c++1y').
+  # Use the system-wide installed clang instead which is 3.5 and does support
+  # '-std=c++14'.
+  extra_args+=("--use-analyzer=$(which clang)")
+
+  # scan-build will try to guess which CXX should be used to compile the actual
+  # code, which is usually g++ but we need g++5 in the CI. Explicitly pass
+  # $CC/$CXX to scan-build if they are set in the environment.
+
+  if [[ ! -z "$CC" ]]; then
+    extra_args+=("--use-cc=$CC")
+  fi
+
+  if [[ ! -z "$CXX" ]]; then
+    extra_args+=("--use-c++=$CXX")
+  fi
+
+  scan-build "${extra_args[@]}" --status-bugs "$@"
+}

--- a/script/scan-build
+++ b/script/scan-build
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-. script/lib.sh
-
-scan_build make "$@"

--- a/script/scan-build
+++ b/script/scan-build
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+. script/lib.sh
+
+scan_build make "$@"

--- a/script/test
+++ b/script/test
@@ -2,6 +2,8 @@
 
 set -e
 
+. script/lib.sh
+
 function usage {
   cat <<-EOF
 USAGE
@@ -11,6 +13,8 @@ USAGE
 OPTIONS
 
   -h  print this message
+
+  -b  run make under scan-build static analyzer
 
   -d  run tests in a debugger (either lldb or gdb)
 
@@ -26,6 +30,7 @@ OPTIONS
 
   -z  pipe tests' stderr to \`dot(1)\` to render an SVG log
 
+
 EOF
 }
 
@@ -37,8 +42,9 @@ args=()
 target=tests
 export BUILDTYPE=Test
 cmd="out/${BUILDTYPE}/${target}"
+run_scan_build=
 
-while getopts "df:s:gGhpvS" option; do
+while getopts "bdf:s:gGhpvS" option; do
   case ${option} in
     h)
       usage
@@ -69,6 +75,9 @@ while getopts "df:s:gGhpvS" option; do
     S)
       mode=SVG
       ;;
+    b)
+      run_scan_build=true
+      ;;
   esac
 done
 
@@ -78,7 +87,11 @@ else
   args+=("--reporter=singleline")
 fi
 
-make $target
+if [[ ! -z "$run_scan_build" ]]; then
+	scan_build make $target
+else
+	make $target
+fi
 args=${args:-""}
 
 if [[ -n $profile ]]; then

--- a/script/test
+++ b/script/test
@@ -87,10 +87,10 @@ else
   args+=("--reporter=singleline")
 fi
 
-if [[ ! -z "$run_scan_build" ]]; then
-	scan_build make -j2 $target
+if [[ -n "$run_scan_build" ]]; then
+  scan_build make -j2 $target
 else
-	make -j2 $target
+  make -j2 $target
 fi
 args=${args:-""}
 

--- a/script/test
+++ b/script/test
@@ -88,9 +88,9 @@ else
 fi
 
 if [[ ! -z "$run_scan_build" ]]; then
-	scan_build make $target
+	scan_build make -j2 $target
 else
-	make $target
+	make -j2 $target
 fi
 args=${args:-""}
 

--- a/src/compiler/build_tables/build_parse_table.cc
+++ b/src/compiler/build_tables/build_parse_table.cc
@@ -646,8 +646,8 @@ class ParseTableBuilder {
     if (considered_associativity) {
       description += "  " + to_string(resolution_count++) + ":  ";
       description += "Specify a left or right associativity in";
+      bool is_first = true;
       for (const ParseAction &action : entry.actions) {
-        bool is_first = true;
         if (action.type == ParseActionTypeReduce) {
           if (!is_first) description += " and";
           description += " `" + symbol_name(action.symbol) + "`";

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -839,7 +839,7 @@ static void parser__accept(Parser *self, StackVersion version,
 
     if (parser__select_tree(self, self->finished_tree, root)) {
       ts_tree_release(self->finished_tree);
-      assert(root->ref_count > 0);
+      assert((root == NULL) || (root->ref_count > 0));
       self->finished_tree = root;
     } else {
       ts_tree_release(root);

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -839,7 +839,7 @@ static void parser__accept(Parser *self, StackVersion version,
 
     if (parser__select_tree(self, self->finished_tree, root)) {
       ts_tree_release(self->finished_tree);
-      assert((root == NULL) || (root->ref_count > 0));
+      assert(root && root->ref_count > 0);
       self->finished_tree = root;
     } else {
       ts_tree_release(root);

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -656,7 +656,7 @@ static StackIterateAction parser__repair_error_callback(
   StackIterateAction result = StackIterateNone;
 
   uint32_t last_repair_count = -1;
-  uint32_t repair_reduction_count = -1;
+  uint32_t repair_reduction_count = 0;
   const TSParseAction *repair_reductions = NULL;
 
   for (uint32_t i = 0; i < repairs->size; i++) {

--- a/test/helpers/record_alloc.cc
+++ b/test/helpers/record_alloc.cc
@@ -71,8 +71,8 @@ void *ts_record_calloc(size_t count, size_t size) {
 }
 
 void ts_record_free(void *pointer) {
-  free(pointer);
   record_deallocation(pointer);
+  free(pointer);
 }
 
 bool ts_record_allocations_toggle(bool value) {

--- a/test/runtime/document_test.cc
+++ b/test/runtime/document_test.cc
@@ -374,7 +374,7 @@ describe("Document", [&]() {
       ts_document_set_language(document, load_real_language("json"));
       ts_document_set_input_string(document, input_string.c_str());
 
-      TSParseOptions options;
+      TSParseOptions options = {};
       options.changed_ranges = nullptr;
 
       options.halt_on_error = false;
@@ -402,7 +402,7 @@ describe("Document", [&]() {
       ts_document_set_language(document, load_real_language("json"));
       ts_document_set_input_string(document, input_string.c_str());
 
-      TSParseOptions options;
+      TSParseOptions options = {};
       options.changed_ranges = nullptr;
       options.halt_on_error = true;
       ts_document_parse_with_options(document, options);


### PR DESCRIPTION
It didn't find anything too scary, the worst thing is two NULL pointer derefs in `runtime/parser.c`. I haven't got enough domain knowledge to know if they would be hit in normal use, or if they are just pathological edge-cases.

The final missing part from this PR is to run `scan-build` automatically in the CI build. I have it working locally but doesn't work correctly on travis-ci.org 😢  I will update this branch once I have it properly working!