### PR TITLE
Out of bounds read in utf8proc

### DIFF
--- a/src/runtime/lexer.c
+++ b/src/runtime/lexer.c
@@ -34,7 +34,13 @@ static void ts_lexer__get_chunk(Lexer *self) {
 static void ts_lexer__get_lookahead(Lexer *self) {
   uint32_t position_in_chunk = self->current_position.bytes - self->chunk_start;
   const uint8_t *chunk = (const uint8_t *)self->chunk + position_in_chunk;
-  uint32_t size = self->chunk_size - position_in_chunk + 1;
+  uint32_t size = self->chunk_size - position_in_chunk;
+
+  if (size == 0) {
+    self->lookahead_size = 1;
+    self->data.lookahead = '\0';
+    return;
+  }
 
   if (self->input.encoding == TSInputEncodingUTF8) {
     int64_t lookahead_size = utf8proc_iterate(chunk, size, &self->data.lookahead);

--- a/src/runtime/tree.c
+++ b/src/runtime/tree.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <ctype.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <string.h>
@@ -468,13 +469,15 @@ const TSExternalTokenState *ts_tree_last_external_token_state(const Tree *tree) 
 static size_t ts_tree__write_char_to_string(char *s, size_t n, int32_t c) {
   if (c == 0)
     return snprintf(s, n, "EOF");
+  if (c == -1)
+    return snprintf(s, n, "INVALID");
   else if (c == '\n')
     return snprintf(s, n, "'\\n'");
   else if (c == '\t')
     return snprintf(s, n, "'\\t'");
   else if (c == '\r')
     return snprintf(s, n, "'\\r'");
-  else if (c < 128)
+  else if (0 < c && c < 128 && isprint(c))
     return snprintf(s, n, "'%c'", c);
   else
     return snprintf(s, n, "%d", c);

--- a/test/runtime/parser_test.cc
+++ b/test/runtime/parser_test.cc
@@ -187,6 +187,19 @@ describe("Parser", [&]() {
         AssertThat(ts_node_end_point(error), Equals<TSPoint>({2, 2}));
       });
     });
+
+    it("handles invalid UTF8 characters at EOF", [&]() {
+      char *string = (char *)malloc(1);
+      string[0] = '\xdf';
+
+      ts_document_set_language(document, load_real_language("javascript"));
+      ts_document_set_input_string_with_length(document, string, 1);
+      ts_document_parse(document);
+
+      free(string);
+
+      assert_root_node("(ERROR (UNEXPECTED INVALID))");
+    });
   });
 
   describe("handling extra tokens", [&]() {


### PR DESCRIPTION
I stumbled upon some out-of-bounds reads when fuzzing with AddressSanitizer enabled. There are two bugs, one of which was fixed upsteam in JuliaLang/utf8proc#66.

I _think_ the other bug is that the `+ 1` in the [lexer](https://github.com/tree-sitter/tree-sitter/blob/513edec7c10f776dd3a91d4ffc3a77c56b948e0c/src/runtime/lexer.c#L37) is calculating the wrong bounds:

```
uint32_t size = self->chunk_size - position_in_chunk + 1;
```

When parsing a single-byte file `\xdf` with `tree-sitter-go`, with some `printf`s added I can see the size is calculated as two:
```
ts_lexer__get_lookahead: size = 0x2 = 0x1 - 0x0 + 1
=================================================================
==7==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6020000000b1 at pc 0x00000058c1ef bp 0x7ffe57cd32b0 sp 0x7ffe57cd32a8
READ of size 1 at 0x6020000000b1 thread T0
SCARINESS: 12 (1-byte-read-heap-buffer-overflow)
    #0 0x58c1ee in utf8proc_iterate /src/tree-sitter/externals/utf8proc/utf8proc.c:131:25
    #1 0x581c92 in ts_lexer__get_lookahead /src/tree-sitter/src/runtime/lexer.c:44:30
    #2 0x5736d6 in parser__lex /src/tree-sitter/src/runtime/parser.c:260:5
    #3 0x568d32 in parser__advance /src/tree-sitter/src/runtime/parser.c:1058:21
    #4 0x567c89 in parser_parse /src/tree-sitter/src/runtime/parser.c:1256:9
    #5 0x56103b in ts_document_parse_with_options /src/tree-sitter/src/runtime/document.c:137:16
    #6 0x5152ae in LLVMFuzzerTestOneInput /src/tree-sitter/../fuzzer.cc:21:3
...

0x6020000000b1 is located 0 bytes to the right of 1-byte region [0x6020000000b0,0x6020000000b1)
allocated by thread T0 here:
    #0 0x511070 in operator new[](unsigned long) /src/llvm/projects/compiler-rt/lib/asan/asan_new_delete.cc:84
    #1 0x5b9201 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)
...
```

However, removing the `+ 1` causes an infinite loop because the main loop in `parser__lex` never advances. So, I think another change is needed somewhere in the lexer or parser to completely fix the issue 🤔 