### PR TITLE
Use address sanitizer when running tests on mac, fix newly discovered bugs

### DIFF
--- a/project.gyp
+++ b/project.gyp
@@ -132,6 +132,7 @@
         'xcode_settings': {
           'OTHER_LDFLAGS': ['-g'],
           'GCC_OPTIMIZATION_LEVEL': '0',
+          'OTHER_CPLUSPLUSFLAGS': ['-fsanitize=address'],
         },
       },
       'Release': {

--- a/script/test
+++ b/script/test
@@ -44,6 +44,10 @@ export BUILDTYPE=Test
 cmd="out/${BUILDTYPE}/${target}"
 run_scan_build=
 
+if [ "$(uname -s)" == "Darwin" ]; then
+  export LINK="clang++ -fsanitize=address"
+fi
+
 while getopts "bdf:s:gGhpvS" option; do
   case ${option} in
     h)

--- a/src/runtime/document.c
+++ b/src/runtime/document.c
@@ -24,8 +24,7 @@ error:
 
 void ts_document_free(TSDocument *self) {
   parser_destroy(&self->parser);
-  if (self->tree)
-    ts_tree_release(self->tree);
+  if (self->tree) ts_tree_release(self->tree);
   ts_document_set_input(self, (TSInput){
     NULL,
     NULL,

--- a/src/runtime/lexer.c
+++ b/src/runtime/lexer.c
@@ -110,7 +110,7 @@ void ts_lexer_init(Lexer *self) {
       .payload = NULL,
       .log = NULL
     },
-    .last_external_token_state = NULL,
+    .last_external_token = NULL,
   };
   ts_lexer_reset(self, length_zero());
 }
@@ -134,7 +134,7 @@ static inline void ts_lexer__reset(Lexer *self, Length position) {
 void ts_lexer_set_input(Lexer *self, TSInput input) {
   self->input = input;
   ts_lexer__reset(self, length_zero());
-  self->last_external_token_state = NULL;
+  ts_lexer_set_last_external_token(self, NULL);
 }
 
 void ts_lexer_reset(Lexer *self, Length position) {
@@ -156,4 +156,10 @@ void ts_lexer_start(Lexer *self) {
 
 void ts_lexer_advance_to_end(Lexer *self) {
   while (self->data.lookahead != 0) ts_lexer__advance(self, false);
+}
+
+void ts_lexer_set_last_external_token(Lexer *self, Tree *token) {
+  if (token) ts_tree_retain(token);
+  if (self->last_external_token) ts_tree_release(self->last_external_token);
+  self->last_external_token = token;
 }

--- a/src/runtime/lexer.h
+++ b/src/runtime/lexer.h
@@ -8,6 +8,7 @@ extern "C" {
 #include "tree_sitter/parser.h"
 #include "tree_sitter/runtime.h"
 #include "runtime/length.h"
+#include "runtime/tree.h"
 
 #define TS_DEBUG_BUFFER_SIZE 512
 
@@ -25,7 +26,7 @@ typedef struct {
   TSInput input;
   TSLogger logger;
   char debug_buffer[TS_DEBUG_BUFFER_SIZE];
-  const TSExternalTokenState *last_external_token_state;
+  Tree *last_external_token;
 } Lexer;
 
 void ts_lexer_init(Lexer *);
@@ -33,6 +34,7 @@ void ts_lexer_set_input(Lexer *, TSInput);
 void ts_lexer_reset(Lexer *, Length);
 void ts_lexer_start(Lexer *);
 void ts_lexer_advance_to_end(Lexer *);
+void ts_lexer_set_last_external_token(Lexer *, Tree *);
 
 #ifdef __cplusplus
 }

--- a/src/runtime/reusable_node.h
+++ b/src/runtime/reusable_node.h
@@ -3,24 +3,21 @@
 typedef struct {
   Tree *tree;
   uint32_t byte_index;
-  bool has_preceding_external_token;
-  const TSExternalTokenState *preceding_external_token_state;
+  Tree *preceding_external_token;
 } ReusableNode;
 
 static inline ReusableNode reusable_node_new(Tree *tree) {
   return (ReusableNode){
     .tree = tree,
     .byte_index = 0,
-    .has_preceding_external_token = false,
-    .preceding_external_token_state = NULL,
+    .preceding_external_token = NULL,
   };
 }
 
 static inline void reusable_node_pop(ReusableNode *self) {
   self->byte_index += ts_tree_total_bytes(self->tree);
   if (self->tree->has_external_tokens) {
-    self->has_preceding_external_token = true;
-    self->preceding_external_token_state = ts_tree_last_external_token_state(self->tree);
+    self->preceding_external_token = ts_tree_last_external_token(self->tree);
   }
 
   while (self->tree) {

--- a/src/runtime/stack.c
+++ b/src/runtime/stack.c
@@ -258,7 +258,8 @@ INLINE StackPopResult stack__iter(Stack *self, StackVersion version,
         } else {
           if (self->iterators.size >= MAX_ITERATOR_COUNT) continue;
           link = node->links[j];
-          array_push(&self->iterators, self->iterators.contents[i]);
+          Iterator current_iterator = self->iterators.contents[i];
+          array_push(&self->iterators, current_iterator);
           next_iterator = array_back(&self->iterators);
           ts_tree_array_copy(next_iterator->trees, &next_iterator->trees);
         }
@@ -546,7 +547,7 @@ bool ts_stack_print_dot_graph(Stack *self, const char **symbol_names, FILE *f) {
   fprintf(f, "rankdir=\"RL\";\n");
   fprintf(f, "edge [arrowhead=none]\n");
 
-  Array(StackNode *)visited_nodes = array_new();
+  Array(StackNode *) visited_nodes = array_new();
 
   array_clear(&self->iterators);
   for (uint32_t i = 0; i < self->heads.size; i++) {
@@ -579,8 +580,8 @@ bool ts_stack_print_dot_graph(Stack *self, const char **symbol_names, FILE *f) {
     all_iterators_done = true;
 
     for (uint32_t i = 0; i < self->iterators.size; i++) {
-      Iterator *iterator = &self->iterators.contents[i];
-      StackNode *node = iterator->node;
+      Iterator iterator = self->iterators.contents[i];
+      StackNode *node = iterator.node;
 
       for (uint32_t j = 0; j < visited_nodes.size; j++) {
         if (visited_nodes.contents[j] == node) {
@@ -637,13 +638,14 @@ bool ts_stack_print_dot_graph(Stack *self, const char **symbol_names, FILE *f) {
 
         fprintf(f, "];\n");
 
+        Iterator *next_iterator;
         if (j == 0) {
-          iterator->node = link.node;
+          next_iterator = &self->iterators.contents[i];
         } else {
-          array_push(&self->iterators, *iterator);
-          Iterator *next_iterator = array_back(&self->iterators);
-          next_iterator->node = link.node;
+          array_push(&self->iterators, iterator);
+          next_iterator = array_back(&self->iterators);
         }
+        next_iterator->node = link.node;
       }
 
       array_push(&visited_nodes, node);

--- a/src/runtime/stack.h
+++ b/src/runtime/stack.h
@@ -67,9 +67,9 @@ unsigned ts_stack_push_count(const Stack *, StackVersion);
 
 void ts_stack_decrease_push_count(Stack *, StackVersion, unsigned);
 
-const TSExternalTokenState *ts_stack_external_token_state(const Stack *, StackVersion);
+Tree *ts_stack_last_external_token(const Stack *, StackVersion);
 
-void ts_stack_set_external_token_state(Stack *, StackVersion, const TSExternalTokenState *);
+void ts_stack_set_last_external_token(Stack *, StackVersion, Tree *);
 
 /*
  *  Get the position at the top of the given version of the stack. If the stack

--- a/src/runtime/tree.h
+++ b/src/runtime/tree.h
@@ -53,7 +53,6 @@ typedef struct Tree {
   bool fragile_right : 1;
   bool has_changes : 1;
   bool has_external_tokens : 1;
-  bool has_external_token_state : 1;
 } Tree;
 
 typedef struct {
@@ -90,7 +89,8 @@ void ts_tree_assign_parents(Tree *, TreePath *);
 void ts_tree_edit(Tree *, const TSInputEdit *edit);
 char *ts_tree_string(const Tree *, const TSLanguage *, bool include_all);
 void ts_tree_print_dot_graph(const Tree *, const TSLanguage *, FILE *);
-const TSExternalTokenState *ts_tree_last_external_token_state(const Tree *);
+Tree *ts_tree_last_external_token(Tree *);
+bool ts_tree_external_token_state_eq(const Tree *, const Tree *);
 
 static inline uint32_t ts_tree_total_bytes(const Tree *self) {
   return self->padding.bytes + self->size.bytes;
@@ -108,8 +108,6 @@ static inline bool ts_tree_is_fragile(const Tree *tree) {
   return tree->fragile_left || tree->fragile_right ||
          ts_tree_total_bytes(tree) == 0;
 }
-
-bool ts_external_token_state_eq(const TSExternalTokenState *, const TSExternalTokenState *);
 
 #ifdef __cplusplus
 }

--- a/test/helpers/record_alloc.cc
+++ b/test/helpers/record_alloc.cc
@@ -48,9 +48,6 @@ static void *record_allocation(void *result) {
 }
 
 static void record_deallocation(void *pointer) {
-  if (!_enabled)
-    return;
-
   auto entry = _outstanding_allocations.find(pointer);
   if (entry != _outstanding_allocations.end()) {
     _outstanding_allocations.erase(entry);

--- a/test/runtime/stack_test.cc
+++ b/test/runtime/stack_test.cc
@@ -523,16 +523,19 @@ describe("Stack", [&]() {
   });
 
   describe("setting external token state", [&]() {
-    TSExternalTokenState external_token_state1, external_token_state2;
+    before_each([&]() {
+      trees[1]->external_token_state[0] = 'a';
+      trees[2]->external_token_state[0] = 'b';
+    });
 
     it("allows the state to be retrieved", [&]() {
-      AssertThat(ts_stack_external_token_state(stack, 0), Equals(nullptr));
+      AssertThat(ts_stack_last_external_token(stack, 0), Equals(nullptr));
 
-      ts_stack_set_external_token_state(stack, 0, &external_token_state1);
-      AssertThat(ts_stack_external_token_state(stack, 0), Equals(&external_token_state1));
+      ts_stack_set_last_external_token(stack, 0, trees[1]);
+      AssertThat(ts_stack_last_external_token(stack, 0), Equals(trees[1]));
 
       ts_stack_copy_version(stack, 0);
-      AssertThat(ts_stack_external_token_state(stack, 0), Equals(&external_token_state1));
+      AssertThat(ts_stack_last_external_token(stack, 0), Equals(trees[1]));
     });
 
     it("does not merge stack versions with different external token states", [&]() {
@@ -540,8 +543,8 @@ describe("Stack", [&]() {
       ts_stack_push(stack, 0, trees[0], false, 5);
       ts_stack_push(stack, 1, trees[0], false, 5);
 
-      ts_stack_set_external_token_state(stack, 0, &external_token_state1);
-      ts_stack_set_external_token_state(stack, 0, &external_token_state2);
+      ts_stack_set_last_external_token(stack, 0, trees[1]);
+      ts_stack_set_last_external_token(stack, 0, trees[1]);
 
       AssertThat(ts_stack_merge(stack, 0, 1), IsFalse());
     });

--- a/test/runtime/tree_test.cc
+++ b/test/runtime/tree_test.cc
@@ -421,13 +421,12 @@ describe("Tree", []() {
     });
   });
 
-  describe("last_external_token_state", [&]() {
+  describe("last_external_token", [&]() {
     Length padding = {1, 1, {0, 1}};
     Length size = {2, 2, {0, 2}};
 
     auto make_external = [](Tree *tree) {
       tree->has_external_tokens = true;
-      tree->has_external_token_state = true;
       return tree;
     };
 
@@ -448,8 +447,8 @@ describe("Tree", []() {
         }), visible)),
       }), visible);
 
-      auto state = ts_tree_last_external_token_state(tree1);
-      AssertThat(state, Equals(&tree3->external_token_state));
+      auto token = ts_tree_last_external_token(tree1);
+      AssertThat(token, Equals(tree3));
     });
   });
 });

--- a/tests.gyp
+++ b/tests.gyp
@@ -45,6 +45,7 @@
       'xcode_settings': {
         'CLANG_CXX_LANGUAGE_STANDARD': 'c++14',
         'OTHER_LDFLAGS': ['-g'],
+        'OTHER_CPLUSPLUSFLAGS': ['-fsanitize=address'],
         'GCC_OPTIMIZATION_LEVEL': '0',
         'ALWAYS_SEARCH_USER_PATHS': 'NO',
         'WARNING_CFLAGS': [


### PR DESCRIPTION
This PR enables the [Address Sanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) when running the tests on macOS, and fixes two important bugs that the address sanitizer reported.

Refs https://github.com/tree-sitter/tree-sitter/issues/81

/cc @philipturnbull