### PR TITLE
Increase size of ref_counts and add assertions

### DIFF
--- a/src/runtime/stack.c
+++ b/src/runtime/stack.c
@@ -26,7 +26,7 @@ struct StackNode {
   Length position;
   StackLink links[MAX_LINK_COUNT];
   short unsigned int link_count;
-  short unsigned int ref_count;
+  uint32_t ref_count;
   unsigned error_cost;
   unsigned error_count;
 };
@@ -65,8 +65,9 @@ struct Stack {
 static void stack_node_retain(StackNode *self) {
   if (!self)
     return;
-  assert(self->ref_count != 0);
+  assert(self->ref_count > 0);
   self->ref_count++;
+  assert(self->ref_count != 0);
 }
 
 static void stack_node_release(StackNode *self, StackNodeArray *pool) {

--- a/src/runtime/tree.c
+++ b/src/runtime/tree.c
@@ -232,6 +232,7 @@ Tree *ts_tree_make_error_node(TreeArray *children) {
 void ts_tree_retain(Tree *self) {
   assert(self->ref_count > 0);
   self->ref_count++;
+  assert(self->ref_count != 0);
 }
 
 void ts_tree_release(Tree *self) {

--- a/src/runtime/tree.h
+++ b/src/runtime/tree.h
@@ -45,7 +45,7 @@ typedef struct Tree {
     TSLexMode lex_mode;
   } first_leaf;
 
-  unsigned short ref_count;
+  uint32_t ref_count;
   bool visible : 1;
   bool named : 1;
   bool extra : 1;


### PR DESCRIPTION
This bumps the size of the reference counts from 16- to 32-bit counters to make
it less likely to overflow. Also assert in the retain function that the
reference count didn't overflow.

32-bits seems big enough for non-pathological examples but a more fool-proof
fix may be to bump it to 64-bits.