### PR TITLE
Avoid hangs during error recovery

### DIFF
--- a/src/runtime/error_costs.h
+++ b/src/runtime/error_costs.h
@@ -1,14 +1,16 @@
 #ifndef RUNTIME_ERROR_COSTS_H_
 #define RUNTIME_ERROR_COSTS_H_
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #define ERROR_STATE 0
-#define ERROR_COST_PER_SKIPPED_TREE 10
-#define ERROR_COST_PER_SKIPPED_LINE 3
-#define ERROR_COST_PER_SKIPPED_CHAR 0
+#define ERROR_COST_PER_SKIPPED_TREE 100
+#define ERROR_COST_PER_SKIPPED_LINE 30
+#define ERROR_COST_PER_SKIPPED_CHAR 1
 
 typedef struct {
   unsigned count;
@@ -16,7 +18,15 @@ typedef struct {
   unsigned push_count;
 } ErrorStatus;
 
-int error_status_compare(ErrorStatus a, ErrorStatus b);
+typedef enum {
+  ErrorComparisonTakeLeft,
+  ErrorComparisonPreferLeft,
+  ErrorComparisonNone,
+  ErrorComparisonPreferRight,
+  ErrorComparisonTakeRight,
+} ErrorComparison;
+
+ErrorComparison error_status_compare(ErrorStatus a, ErrorStatus b, bool can_merge);
 
 #ifdef __cplusplus
 }

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -634,10 +634,15 @@ static StackPopResult parser__reduce(Parser *self, StackVersion version,
   return pop;
 }
 
-static inline const TSParseAction *parser__reductions_after_sequence(
-  Parser *self, TSStateId start_state, const TreeArray *trees_below,
-  uint32_t tree_count_below, const TreeArray *trees_above,
-  TSSymbol lookahead_symbol, uint32_t *count) {
+static const TSParseAction *parser__reductions_after_sequence(
+  Parser *self,
+  TSStateId start_state,
+  const TreeArray *trees_below,
+  uint32_t tree_count_below,
+  const TreeArray *trees_above,
+  TSSymbol lookahead_symbol,
+  uint32_t *count
+) {
   TSStateId state = start_state;
   uint32_t child_count = 0;
   *count = 0;
@@ -687,11 +692,10 @@ static inline const TSParseAction *parser__reductions_after_sequence(
   return actions;
 }
 
-static StackIterateAction parser__repair_error_callback(
-  void *payload, TSStateId state, TreeArray *trees, uint32_t tree_count,
-  bool is_done, bool is_pending) {
-
-  ErrorRepairSession *session = (ErrorRepairSession *)payload;
+static StackIterateAction parser__repair_error_callback(void *payload, TSStateId state,
+                                                        const TreeArray *trees,
+                                                        uint32_t tree_count) {
+  ErrorRepairSession *session = payload;
   Parser *self = session->parser;
   TSSymbol lookahead_symbol = session->lookahead_symbol;
   ReduceActionSet *repairs = &self->reduce_actions;
@@ -957,8 +961,7 @@ static bool parser__do_potential_reductions(Parser *self, StackVersion version) 
 }
 
 static StackIterateAction parser__skip_preceding_trees_callback(
-  void *payload, TSStateId state, TreeArray *trees, uint32_t tree_count,
-  bool is_done, bool is_pending) {
+  void *payload, TSStateId state, const TreeArray *trees, uint32_t tree_count) {
   if (tree_count > 0 && state != ERROR_STATE) {
     uint32_t bytes_skipped = 0;
     for (uint32_t i = 0; i < trees->size; i++) {

--- a/src/runtime/stack.c
+++ b/src/runtime/stack.c
@@ -10,7 +10,7 @@
 #define MAX_NODE_POOL_SIZE 50
 #define MAX_ITERATOR_COUNT 64
 
-#define INLINE static inline __attribute__((always_inline))
+#define inline static inline __attribute__((always_inline))
 
 typedef struct StackNode StackNode;
 
@@ -220,7 +220,7 @@ static void ts_stack__add_slice(Stack *self, StackNode *node, TreeArray *trees,
   array_push(&self->slices, slice);
 }
 
-INLINE StackPopResult stack__iter(Stack *self, StackVersion version,
+inline StackPopResult stack__iter(Stack *self, StackVersion version,
                                   StackIterateInternalCallback callback, void *payload) {
   array_clear(&self->slices);
   array_clear(&self->iterators);
@@ -409,7 +409,7 @@ void ts_stack_push(Stack *self, StackVersion version, Tree *tree,
   head->node = new_node;
 }
 
-INLINE StackIterateAction iterate_callback(void *payload, const Iterator *iterator) {
+inline StackIterateAction iterate_callback(void *payload, const Iterator *iterator) {
   StackIterateSession *session = payload;
   return session->callback(session->payload, iterator->node->state, &iterator->trees, iterator->tree_count);
 }
@@ -420,7 +420,7 @@ StackPopResult ts_stack_iterate(Stack *self, StackVersion version,
   return stack__iter(self, version, iterate_callback, &session);
 }
 
-INLINE StackIterateAction pop_count_callback(void *payload, const Iterator *iterator) {
+inline StackIterateAction pop_count_callback(void *payload, const Iterator *iterator) {
   StackPopSession *pop_session = (StackPopSession *)payload;
 
   if (iterator->tree_count == pop_session->goal_tree_count) {
@@ -468,7 +468,7 @@ StackPopResult ts_stack_pop_count(Stack *self, StackVersion version,
   return pop;
 }
 
-INLINE StackIterateAction pop_pending_callback(void *payload, const Iterator *iterator) {
+inline StackIterateAction pop_pending_callback(void *payload, const Iterator *iterator) {
   if (iterator->tree_count >= 1) {
     if (iterator->is_pending) {
       return StackIteratePop | StackIterateStop;
@@ -489,10 +489,8 @@ StackPopResult ts_stack_pop_pending(Stack *self, StackVersion version) {
   return pop;
 }
 
-INLINE StackIterateAction pop_all_callback(void *payload, const Iterator *iterator) {
-  return iterator->node->link_count == 0 ?
-    (StackIteratePop | StackIterateStop) :
-    StackIterateNone;
+inline StackIterateAction pop_all_callback(void *payload, const Iterator *iterator) {
+  return iterator->node->link_count == 0 ? StackIteratePop : StackIterateNone;
 }
 
 StackPopResult ts_stack_pop_all(Stack *self, StackVersion version) {

--- a/src/runtime/stack.h
+++ b/src/runtime/stack.h
@@ -102,11 +102,17 @@ ErrorStatus ts_stack_error_status(const Stack *, StackVersion);
 
 bool ts_stack_merge(Stack *, StackVersion, StackVersion);
 
+bool ts_stack_can_merge(Stack *, StackVersion, StackVersion);
+
+void ts_stack_force_merge(Stack *, StackVersion, StackVersion);
+
 void ts_stack_halt(Stack *, StackVersion);
 
 bool ts_stack_is_halted(Stack *, StackVersion);
 
 void ts_stack_renumber_version(Stack *, StackVersion, StackVersion);
+
+void ts_stack_swap_versions(Stack *, StackVersion, StackVersion);
 
 StackVersion ts_stack_copy_version(Stack *, StackVersion);
 

--- a/src/runtime/stack.h
+++ b/src/runtime/stack.h
@@ -78,10 +78,9 @@ void ts_stack_set_last_external_token(Stack *, StackVersion, Tree *);
 Length ts_stack_top_position(const Stack *, StackVersion);
 
 /*
- *  Push a tree and state onto the given head of the stack. This could cause
- *  the version to merge with an existing version.
+ *  Push a tree and state onto the given head of the stack.
  */
-bool ts_stack_push(Stack *, StackVersion, Tree *, bool, TSStateId);
+void ts_stack_push(Stack *, StackVersion, Tree *, bool, TSStateId);
 
 /*
  *  Pop the given number of entries from the given version of the stack. This

--- a/src/runtime/stack.h
+++ b/src/runtime/stack.h
@@ -12,8 +12,7 @@ extern "C" {
 
 typedef struct Stack Stack;
 
-typedef unsigned int StackVersion;
-
+typedef unsigned StackVersion;
 #define STACK_VERSION_NONE ((StackVersion)-1)
 
 typedef struct {
@@ -28,19 +27,16 @@ typedef struct {
   StackSliceArray slices;
 } StackPopResult;
 
+typedef unsigned StackIterateAction;
 enum {
   StackIterateNone,
-  StackIterateStop = 1 << 0,
-  StackIteratePop = 1 << 1,
+  StackIterateStop = 1,
+  StackIteratePop = 2,
 };
 
-typedef unsigned int StackIterateAction;
-
 typedef StackIterateAction (*StackIterateCallback)(void *, TSStateId state,
-                                                   TreeArray *trees,
-                                                   uint32_t tree_count,
-                                                   bool is_done,
-                                                   bool is_pending);
+                                                   const TreeArray *trees,
+                                                   uint32_t tree_count);
 
 /*
  *  Create a parse stack.
@@ -91,8 +87,7 @@ void ts_stack_push(Stack *, StackVersion, Tree *, bool, TSStateId);
  */
 StackPopResult ts_stack_pop_count(Stack *, StackVersion, uint32_t count);
 
-StackPopResult ts_stack_iterate(Stack *, StackVersion, StackIterateCallback,
-                                void *);
+StackPopResult ts_stack_iterate(Stack *, StackVersion, StackIterateCallback, void *);
 
 StackPopResult ts_stack_pop_pending(Stack *, StackVersion);
 

--- a/src/runtime/tree.c
+++ b/src/runtime/tree.c
@@ -304,16 +304,6 @@ bool ts_tree_eq(const Tree *self, const Tree *other) {
   return true;
 }
 
-bool ts_tree_tokens_eq(const Tree *self, const Tree *other) {
-  if (self->child_count > 0 || other->child_count > 0) return false;
-  if (self->symbol != other->symbol) return false;
-  if (self->padding.bytes != other->padding.bytes) return false;
-  if (self->size.bytes != other->size.bytes) return false;
-  if (self->extra != other->extra) return false;
-  if (!ts_tree_external_token_state_eq(self, other)) return false;
-  return true;
-}
-
 int ts_tree_compare(const Tree *left, const Tree *right) {
   if (left->symbol < right->symbol)
     return -1;

--- a/src/runtime/tree.c
+++ b/src/runtime/tree.c
@@ -553,13 +553,19 @@ void ts_tree_print_dot_graph(const Tree *self, const TSLanguage *language,
   fprintf(f, "}\n");
 }
 
+TSExternalTokenState empty_state = {
+  0, 0, 0, 0,
+  0, 0, 0, 0,
+  0, 0, 0, 0,
+  0, 0, 0, 0,
+};
+
 bool ts_tree_external_token_state_eq(const Tree *self, const Tree *other) {
-  return self == other || (
-    self &&
-    other &&
-    self->has_external_tokens == other->has_external_tokens && (
-      !self->has_external_tokens ||
-      memcmp(&self->external_token_state, &other->external_token_state, sizeof(TSExternalTokenState)) == 0
-    )
-  );
+  const TSExternalTokenState *state1 = &empty_state;
+  const TSExternalTokenState *state2 = &empty_state;
+  if (self && self->has_external_tokens) state1 = &self->external_token_state;
+  if (other && other->has_external_tokens) state2 = &other->external_token_state;
+  return
+    state1 == state2 ||
+    memcmp(state1, state2, sizeof(TSExternalTokenState)) == 0;
 }

--- a/src/runtime/tree.h
+++ b/src/runtime/tree.h
@@ -79,7 +79,6 @@ Tree *ts_tree_make_error(Length, Length, int32_t);
 void ts_tree_retain(Tree *tree);
 void ts_tree_release(Tree *tree);
 bool ts_tree_eq(const Tree *tree1, const Tree *tree2);
-bool ts_tree_tokens_eq(const Tree *, const Tree *);
 int ts_tree_compare(const Tree *tree1, const Tree *tree2);
 
 uint32_t ts_tree_start_column(const Tree *self);

--- a/test/fixtures/error_corpus/c_errors.txt
+++ b/test/fixtures/error_corpus/c_errors.txt
@@ -112,10 +112,10 @@ int b() {
   (function_definition
     (identifier) (function_declarator (identifier))
     (compound_statement
-      (ERROR (struct_specifier (identifier)))
-      (expression_statement (number_literal))
-      (ERROR (struct_specifier (identifier)))
-      (expression_statement (number_literal))))
+      (struct_specifier (identifier))
+      (ERROR (number_literal))
+      (struct_specifier (identifier))
+      (ERROR (number_literal))))
 
   (function_definition
     (identifier) (function_declarator (identifier))

--- a/test/fixtures/error_corpus/javascript_errors.txt
+++ b/test/fixtures/error_corpus/javascript_errors.txt
@@ -30,15 +30,16 @@ h i j k;
 
 (program
   (if_statement
-    (ERROR (identifier) (identifier))
+    (ERROR (identifier))
     (identifier)
+    (ERROR (identifier))
     (statement_block
       (expression_statement
-        (ERROR (identifier) (jsx_attribute (identifier)) (jsx_attribute (identifier)))
-        (identifier))))
+        (identifier)
+        (ERROR (jsx_attribute (identifier)) (jsx_attribute (identifier)) (identifier)))))
   (expression_statement
-    (ERROR (identifier) (jsx_attribute (identifier)) (jsx_attribute (identifier)))
-    (identifier)))
+    (identifier)
+    (ERROR (jsx_attribute (identifier)) (jsx_attribute (identifier)) (identifier))))
 
 ===================================================
 one invalid subtree right after the viable prefix
@@ -52,8 +53,8 @@ if ({a: 'b'} {c: 'd'}) {
 
 (program
   (if_statement
-    (ERROR (object (pair (identifier) (string))))
     (object (pair (identifier) (string)))
+    (ERROR (statement_block (labeled_statement (identifier) (expression_statement (string)))))
     (statement_block
       (expression_statement (assignment
         (identifier)

--- a/test/runtime/stack_test.cc
+++ b/test/runtime/stack_test.cc
@@ -54,11 +54,12 @@ vector<StackEntry> get_stack_entries(Stack *stack, StackVersion version) {
   ts_stack_iterate(
     stack,
     version,
-    [](void *payload, TSStateId state, TreeArray *trees, uint32_t tree_count, bool is_done, bool is_pending) -> StackIterateAction {
+    [](void *payload, TSStateId state, const TreeArray *trees, uint32_t tree_count) -> StackIterateAction {
       auto entries = static_cast<vector<StackEntry> *>(payload);
       StackEntry entry = {state, tree_count};
-      if (find(entries->begin(), entries->end(), entry) == entries->end())
+      if (find(entries->begin(), entries->end(), entry) == entries->end()) {
         entries->push_back(entry);
+      }
       return StackIterateNone;
     }, &result);
   return result;

--- a/test/runtime/stack_test.cc
+++ b/test/runtime/stack_test.cc
@@ -524,8 +524,10 @@ describe("Stack", [&]() {
 
   describe("setting external token state", [&]() {
     before_each([&]() {
-      trees[1]->external_token_state[0] = 'a';
-      trees[2]->external_token_state[0] = 'b';
+      trees[1]->has_external_tokens = true;
+      trees[2]->has_external_tokens = true;
+      memset(&trees[1]->external_token_state, 0, sizeof(TSExternalTokenState));
+      memset(&trees[2]->external_token_state, 0, sizeof(TSExternalTokenState));
     });
 
     it("allows the state to be retrieved", [&]() {
@@ -535,18 +537,48 @@ describe("Stack", [&]() {
       AssertThat(ts_stack_last_external_token(stack, 0), Equals(trees[1]));
 
       ts_stack_copy_version(stack, 0);
-      AssertThat(ts_stack_last_external_token(stack, 0), Equals(trees[1]));
+      AssertThat(ts_stack_last_external_token(stack, 1), Equals(trees[1]));
+
+      ts_stack_set_last_external_token(stack, 0, trees[2]);
+      AssertThat(ts_stack_last_external_token(stack, 0), Equals(trees[2]));
     });
 
     it("does not merge stack versions with different external token states", [&]() {
+      trees[1]->external_token_state[5] = 'a';
+      trees[2]->external_token_state[5] = 'b';
+
       ts_stack_copy_version(stack, 0);
       ts_stack_push(stack, 0, trees[0], false, 5);
       ts_stack_push(stack, 1, trees[0], false, 5);
 
       ts_stack_set_last_external_token(stack, 0, trees[1]);
-      ts_stack_set_last_external_token(stack, 0, trees[1]);
+      ts_stack_set_last_external_token(stack, 1, trees[2]);
 
       AssertThat(ts_stack_merge(stack, 0, 1), IsFalse());
+    });
+
+    it("merges stack versions with identical external token states", [&]() {
+      trees[1]->external_token_state[5] = 'a';
+      trees[2]->external_token_state[5] = 'a';
+
+      ts_stack_copy_version(stack, 0);
+      ts_stack_push(stack, 0, trees[0], false, 5);
+      ts_stack_push(stack, 1, trees[0], false, 5);
+
+      ts_stack_set_last_external_token(stack, 0, trees[1]);
+      ts_stack_set_last_external_token(stack, 1, trees[2]);
+
+      AssertThat(ts_stack_merge(stack, 0, 1), IsTrue());
+    });
+
+    it("does not distinguish between an *empty* external token state and *no* external token state", [&]() {
+      ts_stack_copy_version(stack, 0);
+      ts_stack_push(stack, 0, trees[0], false, 5);
+      ts_stack_push(stack, 1, trees[0], false, 5);
+
+      ts_stack_set_last_external_token(stack, 0, trees[1]);
+
+      AssertThat(ts_stack_merge(stack, 0, 1), IsTrue());
     });
   });
 });


### PR DESCRIPTION
Previously, certain patterns of syntax errors could cause the parser to consider a huge number of possible error recoveries, resulting in very long parse times.

The goal of this PR is to ensure that parser will not consider an unreasonable number of different error recoveries.

The main changes are:

* We now allow stack versions with different error costs to be merged (by simply discarding the one with higher cost). Previously, we needed to preserve both versions in case they had skipped a different number of subtrees after the initial error, because then they would each allow for unique types of recoveries. Now, we prevent this type of undesirable merge by maintaining on each parse stack version a *depth* field, which indicates how many trees there are on the stack above the most recent error.

* We put a hard limit on the number of stack versions that can co-exist. During error recovery, we allow multiple parse versions to coexist because we yet know which version will ultimately produce the smallest errors. So we only remove a version when its error cost is substantially higher than some other version's cost. Now, even when parse versions' error costs differ only slightly, we sort the versions in order of preference and keep only the 16 best versions.

* The rules for comparing parse stack versions are now a bit more concrete.

/cc @philipturnbull I hope this will fix many hangs found by the fuzzer.

