### PR TITLE
Fix more performance problems found by fuzzing

### DIFF
--- a/.clang_complete
+++ b/.clang_complete
@@ -5,3 +5,4 @@
 -Iexternals/utf8proc
 -Iexternals/json-parser
 -Iexternals/bandit
+-Iexternals/crypto-algorithms

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "externals/json-parser"]
 	path = externals/json-parser
 	url = https://github.com/udp/json-parser.git
+[submodule "externals/crypto-algorithms"]
+	path = externals/crypto-algorithms
+	url = https://github.com/B-Con/crypto-algorithms.git

--- a/src/runtime/error_costs.c
+++ b/src/runtime/error_costs.c
@@ -2,7 +2,6 @@
 
 static const unsigned MAX_COST_DIFFERENCE = 16 * ERROR_COST_PER_SKIPPED_TREE;
 static const unsigned MAX_PUSH_COUNT_WITH_COUNT_DIFFERENCE = 24;
-static const unsigned MAX_PUSH_COUNT_TO_ALLOW_MULTIPLE = 32;
 static const unsigned MAX_DEPTH_TO_ALLOW_MULTIPLE = 12;
 
 ErrorComparison error_status_compare(ErrorStatus a, ErrorStatus b, bool are_mergeable) {
@@ -45,17 +44,11 @@ ErrorComparison error_status_compare(ErrorStatus a, ErrorStatus b, bool are_merg
   }
 
   if (a.count > 0) {
-    if (a.push_count > MAX_PUSH_COUNT_TO_ALLOW_MULTIPLE ||
-        b.push_count > MAX_PUSH_COUNT_TO_ALLOW_MULTIPLE ||
-        a.depth > MAX_DEPTH_TO_ALLOW_MULTIPLE ||
+    if (a.depth > MAX_DEPTH_TO_ALLOW_MULTIPLE ||
         b.depth > MAX_DEPTH_TO_ALLOW_MULTIPLE) {
       return a.depth <= b.depth ?
         ErrorComparisonTakeLeft :
         ErrorComparisonTakeRight;
-    } else {
-      return a.depth <= b.depth ?
-        ErrorComparisonPreferLeft :
-        ErrorComparisonPreferRight;
     }
   }
 

--- a/src/runtime/error_costs.c
+++ b/src/runtime/error_costs.c
@@ -2,6 +2,8 @@
 
 static const unsigned MAX_COST_DIFFERENCE = 16 * ERROR_COST_PER_SKIPPED_TREE;
 static const unsigned MAX_PUSH_COUNT_WITH_COUNT_DIFFERENCE = 24;
+static const unsigned MAX_PUSH_COUNT_TO_ALLOW_MULTIPLE = 32;
+static const unsigned MAX_DEPTH_TO_ALLOW_MULTIPLE = 12;
 
 ErrorComparison error_status_compare(ErrorStatus a, ErrorStatus b, bool are_mergeable) {
   if (a.count < b.count) {
@@ -39,6 +41,21 @@ ErrorComparison error_status_compare(ErrorStatus a, ErrorStatus b, bool are_merg
       return ErrorComparisonTakeRight;
     } else {
       return ErrorComparisonPreferRight;
+    }
+  }
+
+  if (a.count > 0) {
+    if (a.push_count > MAX_PUSH_COUNT_TO_ALLOW_MULTIPLE ||
+        b.push_count > MAX_PUSH_COUNT_TO_ALLOW_MULTIPLE ||
+        a.depth > MAX_DEPTH_TO_ALLOW_MULTIPLE ||
+        b.depth > MAX_DEPTH_TO_ALLOW_MULTIPLE) {
+      return a.depth <= b.depth ?
+        ErrorComparisonTakeLeft :
+        ErrorComparisonTakeRight;
+    } else {
+      return a.depth <= b.depth ?
+        ErrorComparisonPreferLeft :
+        ErrorComparisonPreferRight;
     }
   }
 

--- a/src/runtime/error_costs.h
+++ b/src/runtime/error_costs.h
@@ -16,6 +16,7 @@ typedef struct {
   unsigned count;
   unsigned cost;
   unsigned push_count;
+  unsigned depth;
 } ErrorStatus;
 
 typedef enum {

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -571,8 +571,7 @@ static StackPopResult parser__reduce(Parser *self, StackVersion version,
     // delete the rest of the tree arrays.
     while (i + 1 < pop.slices.size) {
       StackSlice next_slice = pop.slices.contents[i + 1];
-      if (next_slice.version != slice.version)
-        break;
+      if (next_slice.version != slice.version) break;
       i++;
 
       uint32_t child_count = next_slice.trees.size;

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -42,6 +42,7 @@
 
 static const uint32_t SOFT_MAX_VERSION_COUNT = 10;
 static const uint32_t HARD_MAX_VERSION_COUNT = 18;
+static const uint32_t MAX_PRECEDING_TREES_TO_SKIP = 32;
 
 typedef struct {
   Parser *parser;
@@ -963,6 +964,7 @@ static bool parser__do_potential_reductions(Parser *self, StackVersion version) 
 
 static StackIterateAction parser__skip_preceding_trees_callback(
   void *payload, TSStateId state, const TreeArray *trees, uint32_t tree_count) {
+  if (trees->size > MAX_PRECEDING_TREES_TO_SKIP) return StackIterateStop;
   if (tree_count > 0 && state != ERROR_STATE) {
     uint32_t bytes_skipped = 0;
     for (uint32_t i = 0; i < trees->size; i++) {

--- a/src/runtime/stack.c
+++ b/src/runtime/stack.c
@@ -303,8 +303,9 @@ inline StackPopResult stack__iter(Stack *self, StackVersion version,
           if (!link.tree->extra) {
             next_iterator->tree_count++;
             next_iterator->depth--;
-            if (!link.is_pending)
+            if (!link.is_pending) {
               next_iterator->is_pending = false;
+            }
           }
           array_push(&next_iterator->trees, link.tree);
           ts_tree_retain(link.tree);
@@ -561,9 +562,8 @@ void ts_stack_force_merge(Stack *self, StackVersion version1, StackVersion versi
   for (uint32_t i = 0; i < head2->node->link_count; i++) {
     stack_node_add_link(head1->node, head2->node->links[i]);
   }
-  if (head2->push_count > head1->push_count) {
-    head1->push_count = head2->push_count;
-  }
+  if (head2->push_count > head1->push_count) head1->push_count = head2->push_count;
+  if (head2->depth > head1->depth) head1->depth = head2->depth;
   ts_stack_remove_version(self, version2);
 }
 

--- a/src/runtime/stack.c
+++ b/src/runtime/stack.c
@@ -384,6 +384,7 @@ ErrorStatus ts_stack_error_status(const Stack *self, StackVersion version) {
     .cost = head->node->error_cost,
     .count = head->node->error_count,
     .push_count = head->push_count,
+    .depth = head->depth,
   };
 }
 

--- a/test/fixtures/error_corpus/javascript_errors.txt
+++ b/test/fixtures/error_corpus/javascript_errors.txt
@@ -30,9 +30,8 @@ h i j k;
 
 (program
   (if_statement
-    (ERROR (identifier))
+    (ERROR (identifier) (identifier))
     (identifier)
-    (ERROR (identifier))
     (statement_block
       (expression_statement
         (identifier)

--- a/test/fixtures/error_corpus/javascript_errors.txt
+++ b/test/fixtures/error_corpus/javascript_errors.txt
@@ -30,8 +30,9 @@ h i j k;
 
 (program
   (if_statement
-    (ERROR (identifier) (identifier))
+    (ERROR (identifier))
     (identifier)
+    (ERROR (identifier))
     (statement_block
       (expression_statement
         (identifier)

--- a/test/helpers/tree_helpers.cc
+++ b/test/helpers/tree_helpers.cc
@@ -1,4 +1,6 @@
+#include "bandit/bandit.h"
 #include "helpers/tree_helpers.h"
+#include "helpers/point_helpers.h"
 #include "runtime/document.h"
 #include "runtime/node.h"
 #include <ostream>
@@ -47,4 +49,43 @@ bool operator==(const std::vector<Tree *> &vec, const TreeArray &array) {
     if (array.contents[i] != vec[i])
       return false;
   return true;
+}
+
+void assert_consistent_tree_sizes(TSNode node) {
+  size_t child_count = ts_node_child_count(node);
+  size_t start_byte = ts_node_start_byte(node);
+  size_t end_byte = ts_node_end_byte(node);
+  TSPoint start_point = ts_node_start_point(node);
+  TSPoint end_point = ts_node_end_point(node);
+  bool some_child_has_changes = false;
+
+  AssertThat(start_byte, !IsGreaterThan(end_byte));
+  AssertThat(start_point, !IsGreaterThan(end_point));
+
+  size_t last_child_end_byte = start_byte;
+  TSPoint last_child_end_point = start_point;
+
+  for (size_t i = 0; i < child_count; i++) {
+    TSNode child = ts_node_child(node, i);
+    size_t child_start_byte = ts_node_start_byte(child);
+    TSPoint child_start_point = ts_node_start_point(child);
+
+    AssertThat(child_start_byte, !IsLessThan(last_child_end_byte));
+    AssertThat(child_start_point, !IsLessThan(last_child_end_point));
+    assert_consistent_tree_sizes(child);
+    if (ts_node_has_changes(child))
+      some_child_has_changes = true;
+
+    last_child_end_byte = ts_node_end_byte(child);
+    last_child_end_point = ts_node_end_point(child);
+  }
+
+  if (child_count > 0) {
+    AssertThat(end_byte, !IsLessThan(last_child_end_byte));
+    AssertThat(end_point, !IsLessThan(last_child_end_point));
+  }
+
+  if (some_child_has_changes) {
+    AssertThat(ts_node_has_changes(node), IsTrue());
+  }
 }

--- a/test/helpers/tree_helpers.h
+++ b/test/helpers/tree_helpers.h
@@ -13,4 +13,6 @@ std::ostream &operator<<(std::ostream &stream, const TSNode &node);
 bool operator==(const TSNode &left, const TSNode &right);
 bool operator==(const std::vector<Tree *> &right, const TreeArray &array);
 
+void assert_consistent_tree_sizes(TSNode node);
+
 #endif  // HELPERS_TREE_HELPERS_H_

--- a/test/integration/fuzzing-examples.cc
+++ b/test/integration/fuzzing-examples.cc
@@ -1,0 +1,60 @@
+#include "test_helper.h"
+#include "base64.c"
+#include "helpers/load_language.h"
+#include "helpers/tree_helpers.h"
+#include "helpers/record_alloc.h"
+
+START_TEST
+
+vector<pair<string, string>> examples({
+  {
+    "javascript",
+    "Bi0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLXGK0i0vLS0tLS0tLS0tLS0tLS0tLS0tLS0tLXGK0i0vLS0tLS0tLS0tLS0tLS0xLS0tLTYtLfpZAA=="
+  },
+});
+
+describe("examples found via fuzzing", [&]() {
+  before_each([&]() {
+    record_alloc::start();
+  });
+
+  after_each([&]() {
+    AssertThat(record_alloc::outstanding_allocation_indices(), IsEmpty());
+  });
+
+  for (unsigned i = 0, n = examples.size(); i < n; i++) {
+
+    it(("parses example number " + to_string(i)).c_str(), [&]() {
+      TSDocument *document = ts_document_new();
+      // ts_document_print_debugging_graphs(document, true);
+
+      const string &language_name = examples[i].first;
+      ts_document_set_language(document, load_real_language(language_name));
+
+      string input;
+      const string &base64_input = examples[i].second;
+      input.resize(base64_input.size());
+      input.resize(base64_decode(
+        reinterpret_cast<const unsigned char *>(base64_input.c_str()),
+        reinterpret_cast<unsigned char *>(&input[0]),
+        base64_input.size()
+      ));
+
+      ts_document_set_input_string_with_length(
+        document,
+        input.c_str(),
+        input.size()
+      );
+
+      ts_document_parse(document);
+
+      TSNode node = ts_document_root_node(document);
+      assert_consistent_tree_sizes(node);
+
+      ts_document_free(document);
+    });
+
+  }
+});
+
+END_TEST

--- a/test/runtime/stack_test.cc
+++ b/test/runtime/stack_test.cc
@@ -390,7 +390,7 @@ describe("Stack", [&]() {
 
           StackSlice slice2 = pop.slices.contents[1];
           AssertThat(slice2.version, Equals<StackVersion>(1));
-          AssertThat(slice2.trees, Equals(vector<Tree *>({ trees[4], trees[5], trees[6], trees[10] })))
+          AssertThat(slice2.trees, Equals(vector<Tree *>({ trees[4], trees[5], trees[6], trees[10] })));
 
           AssertThat(ts_stack_version_count(stack), Equals<size_t>(2));
           AssertThat(ts_stack_top_state(stack, 0), Equals(stateI));
@@ -441,15 +441,15 @@ describe("Stack", [&]() {
 
           StackSlice slice1 = pop.slices.contents[0];
           AssertThat(slice1.version, Equals<StackVersion>(1));
-          AssertThat(slice1.trees, Equals(vector<Tree *>({ trees[3], trees[10] })))
+          AssertThat(slice1.trees, Equals(vector<Tree *>({ trees[3], trees[10] })));
 
           StackSlice slice2 = pop.slices.contents[1];
           AssertThat(slice2.version, Equals<StackVersion>(2));
-          AssertThat(slice2.trees, Equals(vector<Tree *>({ trees[6], trees[10] })))
+          AssertThat(slice2.trees, Equals(vector<Tree *>({ trees[6], trees[10] })));
 
           StackSlice slice3 = pop.slices.contents[2];
           AssertThat(slice3.version, Equals<StackVersion>(3));
-          AssertThat(slice3.trees, Equals(vector<Tree *>({ trees[9], trees[10] })))
+          AssertThat(slice3.trees, Equals(vector<Tree *>({ trees[9], trees[10] })));
 
           AssertThat(ts_stack_version_count(stack), Equals<size_t>(4));
           AssertThat(ts_stack_top_state(stack, 0), Equals(stateI));

--- a/tests.gyp
+++ b/tests.gyp
@@ -12,6 +12,7 @@
         'test',
         'externals/bandit',
         'externals/utf8proc',
+        'externals/crypto-algorithms',
       ],
       'sources': [
         'test/tests.cc',


### PR DESCRIPTION
Certain inputs with repeating operator characters can lead to very deep parse stacks. For example, in JavaScript or Ruby, a string like

`------------------------------------------------------x`

though it would never occur in real code, is valid, and can be interpreted as "negative negative negative negative negative ... negative x".

When the parse stack gets abnormally deep to accommodate expressions like this, a number of unusual performance problems come up, especially when error recovery happens. This PR fixes some of the bottlenecks I identified.

I've also added a new test file that will make it easy to reproduce base64-encoded examples found using fuzzers.