### PR TITLE
Add a benchmark command

### DIFF
--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -88,6 +88,7 @@ char *ts_node_string(TSNode, const TSDocument *);
 bool ts_node_eq(TSNode, TSNode);
 bool ts_node_is_named(TSNode);
 bool ts_node_has_changes(TSNode);
+bool ts_node_has_error(TSNode);
 TSNode ts_node_parent(TSNode);
 TSNode ts_node_child(TSNode, uint32_t);
 TSNode ts_node_named_child(TSNode, uint32_t);

--- a/script/benchmark
+++ b/script/benchmark
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -e
+
+mode=normal
+make -j2 benchmarks
+cmd=out/release/benchmarks
+
+while getopts "df:l:SL" option; do
+  case ${option} in
+    d)
+      mode=debug
+      ;;
+    f)
+      export TREE_SITTER_BENCHMARK_FILE_NAME=${OPTARG}
+      ;;
+    l)
+      export TREE_SITTER_BENCHMARK_LANGUAGE=${OPTARG}
+      ;;
+    L)
+      export TREE_SITTER_BENCHMARK_LOG=1
+      ;;
+    S)
+      mode=SVG
+      export TREE_SITTER_BENCHMARK_SVG=1
+      ;;
+  esac
+done
+
+case $mode in
+  debug)
+    lldb $cmd
+    ;;
+
+  SVG)
+    $cmd 2> >(grep -v 'Assertion failed' > test.dot)
+    ;;
+
+  normal)
+    exec $cmd
+    ;;
+esac

--- a/script/benchmark
+++ b/script/benchmark
@@ -59,6 +59,7 @@ while getopts "bdhf:l:SL" option; do
 done
 
 if [[ -n "$run_scan_build" ]]; then
+  . script/util/scan-build.sh
   scan_build make -j2 $target
 else
   make -j2 benchmarks

--- a/script/benchmark
+++ b/script/benchmark
@@ -60,7 +60,7 @@ done
 
 if [[ -n "$run_scan_build" ]]; then
   . script/util/scan-build.sh
-  scan_build make -j2 $target
+  scan_build make -j2 benchmarks
 else
   make -j2 benchmarks
 fi

--- a/script/benchmark
+++ b/script/benchmark
@@ -30,8 +30,8 @@ if [ "$(uname -s)" == "Darwin" ]; then
 fi
 
 mode=normal
-export BUILDTYPE=Test
-cmd=out/Test/benchmarks
+export BUILDTYPE=Release
+cmd=out/$BUILDTYPE/benchmarks
 run_scan_build=
 
 while getopts "bdhf:l:SL" option; do

--- a/script/benchmark
+++ b/script/benchmark
@@ -2,12 +2,41 @@
 
 set -e
 
-mode=normal
-make -j2 benchmarks
-cmd=out/release/benchmarks
+function usage {
+  cat <<-EOF
+USAGE
 
-while getopts "df:l:SL" option; do
+  $0  [-Ld] [-l language-name] [-f example-file-name]
+
+OPTIONS
+
+  -h  print this message
+
+  -l  run only the benchmarks for the given language
+
+  -f  run only the benchmarks that parse the file with the given name
+
+  -d  run tests in a debugger (either lldb or gdb)
+
+  -L  run benchmarks with parse logging turned on
+
+EOF
+}
+
+if [ "$(uname -s)" == "Darwin" ]; then
+  export LINK="clang++ -fsanitize=address"
+fi
+
+mode=normal
+export BUILDTYPE=Test
+cmd=out/Test/benchmarks
+
+while getopts "dhf:l:SL" option; do
   case ${option} in
+    h)
+      usage
+      exit
+      ;;
     d)
       mode=debug
       ;;
@@ -20,20 +49,14 @@ while getopts "df:l:SL" option; do
     L)
       export TREE_SITTER_BENCHMARK_LOG=1
       ;;
-    S)
-      mode=SVG
-      export TREE_SITTER_BENCHMARK_SVG=1
-      ;;
   esac
 done
+
+make -j2 benchmarks
 
 case $mode in
   debug)
     lldb $cmd
-    ;;
-
-  SVG)
-    $cmd 2> >(grep -v 'Assertion failed' > test.dot)
     ;;
 
   normal)

--- a/script/benchmark
+++ b/script/benchmark
@@ -20,6 +20,8 @@ OPTIONS
 
   -L  run benchmarks with parse logging turned on
 
+  -b  run make under the scan-build static analyzer
+
 EOF
 }
 
@@ -30,8 +32,9 @@ fi
 mode=normal
 export BUILDTYPE=Test
 cmd=out/Test/benchmarks
+run_scan_build=
 
-while getopts "dhf:l:SL" option; do
+while getopts "bdhf:l:SL" option; do
   case ${option} in
     h)
       usage
@@ -49,10 +52,17 @@ while getopts "dhf:l:SL" option; do
     L)
       export TREE_SITTER_BENCHMARK_LOG=1
       ;;
+    b)
+      run_scan_build=true
+      ;;
   esac
 done
 
-make -j2 benchmarks
+if [[ -n "$run_scan_build" ]]; then
+  scan_build make -j2 $target
+else
+  make -j2 benchmarks
+fi
 
 case $mode in
   debug)

--- a/script/ci
+++ b/script/ci
@@ -2,8 +2,6 @@
 
 set -e
 
-. script/lib.sh
-
 script/fetch-fixtures
 script/check-mallocs
 script/test -b

--- a/script/ci
+++ b/script/ci
@@ -7,4 +7,4 @@ set -e
 script/fetch-fixtures
 script/check-mallocs
 script/test -b
-script/benchmark
+script/benchmark -b

--- a/script/ci
+++ b/script/ci
@@ -7,3 +7,4 @@ set -e
 script/fetch-fixtures
 script/check-mallocs
 script/test -b
+script/benchmark

--- a/script/test
+++ b/script/test
@@ -2,8 +2,6 @@
 
 set -e
 
-. script/lib.sh
-
 function usage {
   cat <<-EOF
 USAGE
@@ -92,6 +90,7 @@ else
 fi
 
 if [[ -n "$run_scan_build" ]]; then
+  . script/util/scan-build.sh
   scan_build make -j2 $target
 else
   make -j2 $target

--- a/script/util/scan-build.sh
+++ b/script/util/scan-build.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 function scan_build {
   extra_args=()
 

--- a/src/runtime/node.c
+++ b/src/runtime/node.c
@@ -310,6 +310,10 @@ bool ts_node_has_changes(TSNode self) {
   return ts_node__tree(self)->has_changes;
 }
 
+bool ts_node_has_error(TSNode self) {
+  return ts_node__tree(self)->error_cost > 0;
+}
+
 TSNode ts_node_parent(TSNode self) {
   TSNode result = self;
   uint32_t index;

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -452,6 +452,8 @@ static bool parser__select_tree(Parser *self, Tree *left, Tree *right) {
     return false;
   }
 
+  if (left->error_cost > 0) return -1;
+
   int comparison = ts_tree_compare(left, right);
   switch (comparison) {
     case -1:

--- a/test/benchmarks.cc
+++ b/test/benchmarks.cc
@@ -1,0 +1,82 @@
+#include <cassert>
+#include <map>
+#include <vector>
+#include <ctime>
+#include <string>
+#include "tree_sitter/runtime.h"
+#include "helpers/load_language.h"
+#include "helpers/stderr_logger.h"
+#include "helpers/read_test_entries.h"
+
+using std::map;
+using std::vector;
+using std::string;
+
+vector<string> language_names({
+  "c",
+  "cpp",
+  "javascript",
+  "python",
+});
+
+int main(int argc, char *arg[]) {
+  map<string, vector<ExampleEntry>> example_entries_by_language_name;
+
+  auto document = ts_document_new();
+
+  if (getenv("TREE_SITTER_BENCHMARK_SVG")) {
+    ts_document_print_debugging_graphs(document, true);
+  } else if (getenv("TREE_SITTER_BENCHMARK_LOG")) {
+    ts_document_set_logger(document, stderr_logger_new(false));
+  }
+
+  auto language_filter = getenv("TREE_SITTER_BENCHMARK_LANGUAGE");
+  auto file_name_filter = getenv("TREE_SITTER_BENCHMARK_FILE_NAME");
+
+  for (auto &language_name : language_names) {
+    example_entries_by_language_name[language_name] = examples_for_language(language_name);
+  }
+
+  for (auto &language_name : language_names) {
+    if (language_filter && language_name != language_filter) continue;
+
+    ts_document_set_language(document, load_real_language(language_name));
+
+    printf("%s\n", language_name.c_str());
+
+    for (auto &example : example_entries_by_language_name[language_name]) {
+      if (file_name_filter && example.file_name != file_name_filter) continue;
+
+      ts_document_invalidate(document);
+      ts_document_set_input_string(document, example.input.c_str());
+
+      clock_t start_time = clock();
+      ts_document_parse(document);
+      clock_t end_time = clock();
+      unsigned duration = (end_time - start_time) * 1000 / CLOCKS_PER_SEC;
+      assert(!ts_node_has_error(ts_document_root_node(document)));
+      printf("  %-30s\t%u\n", example.file_name.c_str(), duration);
+    }
+
+    for (auto &other_language_name : language_names) {
+      if (other_language_name == language_name) continue;
+
+      for (auto &example : example_entries_by_language_name[other_language_name]) {
+        if (file_name_filter && example.file_name != file_name_filter) continue;
+
+        ts_document_invalidate(document);
+        ts_document_set_input_string(document, example.input.c_str());
+
+        clock_t start_time = clock();
+        ts_document_parse(document);
+        clock_t end_time = clock();
+        unsigned duration = (end_time - start_time) * 1000 / CLOCKS_PER_SEC;
+        printf("  %-30s\t%u\n", example.file_name.c_str(), duration);
+      }
+    }
+
+    puts("");
+  }
+
+  return 0;
+}

--- a/test/benchmarks.cc
+++ b/test/benchmarks.cc
@@ -21,17 +21,18 @@ vector<string> language_names({
 
 size_t mean(const vector<size_t> &values) {
   if (values.empty()) return 0;
-  double result = 0;
-  for (double value : values) {
+  size_t result = 0;
+  for (size_t value : values) {
     result += value;
   }
   return result / values.size();
 }
 
 size_t min(const vector<size_t> &values) {
-  double result = 0;
-  for (double value : values) {
-    if (value < result || result == 0) result = value;
+  size_t result = 0;
+  for (unsigned i = 0; i < values.size(); i++) {
+    size_t value = values[i];
+    if (i == 0 || value < result) result = value;
   }
   return result;
 }

--- a/test/benchmarks.cc
+++ b/test/benchmarks.cc
@@ -19,8 +19,27 @@ vector<string> language_names({
   "python",
 });
 
+size_t mean(const vector<size_t> &values) {
+  if (values.empty()) return 0;
+  double result = 0;
+  for (double value : values) {
+    result += value;
+  }
+  return result / values.size();
+}
+
+size_t min(const vector<size_t> &values) {
+  double result = 0;
+  for (double value : values) {
+    if (value < result || result == 0) result = value;
+  }
+  return result;
+}
+
 int main(int argc, char *arg[]) {
   map<string, vector<ExampleEntry>> example_entries_by_language_name;
+  vector<size_t> error_speeds;
+  vector<size_t> non_error_speeds;
 
   auto document = ts_document_new();
 
@@ -46,6 +65,11 @@ int main(int argc, char *arg[]) {
 
     for (auto &example : example_entries_by_language_name[language_name]) {
       if (file_name_filter && example.file_name != file_name_filter) continue;
+      if (example.input.size() < 256) continue;
+
+      ts_document_invalidate(document);
+      ts_document_set_input_string(document, "");
+      ts_document_parse(document);
 
       ts_document_invalidate(document);
       ts_document_set_input_string(document, example.input.c_str());
@@ -55,7 +79,9 @@ int main(int argc, char *arg[]) {
       clock_t end_time = clock();
       unsigned duration = (end_time - start_time) * 1000 / CLOCKS_PER_SEC;
       assert(!ts_node_has_error(ts_document_root_node(document)));
-      printf("  %-30s\t%u\n", example.file_name.c_str(), duration);
+      size_t speed = static_cast<double>(example.input.size()) / duration;
+      printf("  %-30s\t%u ms\t\t%lu bytes/ms\n", example.file_name.c_str(), duration, speed);
+      non_error_speeds.push_back(speed);
     }
 
     for (auto &other_language_name : language_names) {
@@ -63,6 +89,7 @@ int main(int argc, char *arg[]) {
 
       for (auto &example : example_entries_by_language_name[other_language_name]) {
         if (file_name_filter && example.file_name != file_name_filter) continue;
+        if (example.input.size() < 256) continue;
 
         ts_document_invalidate(document);
         ts_document_set_input_string(document, example.input.c_str());
@@ -71,12 +98,23 @@ int main(int argc, char *arg[]) {
         ts_document_parse(document);
         clock_t end_time = clock();
         unsigned duration = (end_time - start_time) * 1000 / CLOCKS_PER_SEC;
-        printf("  %-30s\t%u\n", example.file_name.c_str(), duration);
+        size_t speed = static_cast<double>(example.input.size()) / duration;
+        printf("  %-30s\t%u ms\t\t%lu bytes/ms\n", example.file_name.c_str(), duration, speed);
+        error_speeds.push_back(speed);
       }
     }
 
     puts("");
   }
+
+  puts("without errors:");
+  printf("  %-30s\t%lu bytes/ms\n", "average speed", mean(non_error_speeds));
+  printf("  %-30s\t%lu bytes/ms\n", "worst speed", min(non_error_speeds));
+  puts("");
+
+  puts("with errors:");
+  printf("  %-30s\t%lu bytes/ms\n", "average speed", mean(error_speeds));
+  printf("  %-30s\t%lu bytes/ms\n", "worst speed", min(error_speeds));
 
   return 0;
 }

--- a/test/fixtures/error_corpus/javascript_errors.txt
+++ b/test/fixtures/error_corpus/javascript_errors.txt
@@ -53,8 +53,8 @@ if ({a: 'b'} {c: 'd'}) {
 
 (program
   (if_statement
+    (ERROR (object (pair (identifier) (string))))
     (object (pair (identifier) (string)))
-    (ERROR (statement_block (labeled_statement (identifier) (expression_statement (string)))))
     (statement_block
       (expression_statement (assignment
         (identifier)

--- a/test/helpers/random_helpers.cc
+++ b/test/helpers/random_helpers.cc
@@ -1,7 +1,9 @@
 #include <string>
+#include <vector>
 #include <stdlib.h>
 
 using std::string;
+using std::vector;
 
 static string random_string(char min, char max) {
   string result;
@@ -32,4 +34,8 @@ string random_words(size_t count) {
     }
   }
   return result;
+}
+
+string select_random(const vector<string> &list) {
+  return list[random() % list.size()];
 }

--- a/test/helpers/random_helpers.h
+++ b/test/helpers/random_helpers.h
@@ -2,7 +2,9 @@
 #define HELPERS_RANDOM_HELPERS_H_
 
 #include <string>
+#include <vector>
 
 std::string random_words(size_t count);
+std::string select_random(const std::vector<std::string> &);
 
 #endif  // HELPERS_RANDOM_HELPERS_H_

--- a/test/helpers/read_test_entries.cc
+++ b/test/helpers/read_test_entries.cc
@@ -92,3 +92,15 @@ vector<TestEntry> read_test_language_corpus(string language_name) {
 
   return result;
 }
+
+vector<ExampleEntry> examples_for_language(string language_name) {
+  vector<ExampleEntry> result;
+  string examples_directory = fixtures_dir + "grammars/" + language_name + "/examples";
+  for (string &filename : list_directory(examples_directory)) {
+    result.push_back({
+      filename,
+      read_file(examples_directory + "/" + filename)
+    });
+  }
+  return result;
+}

--- a/test/helpers/read_test_entries.h
+++ b/test/helpers/read_test_entries.h
@@ -10,7 +10,13 @@ struct TestEntry {
 	std::string tree_string;
 };
 
+struct ExampleEntry {
+  std::string file_name;
+	std::string input;
+};
+
 std::vector<TestEntry> read_real_language_corpus(std::string name);
 std::vector<TestEntry> read_test_language_corpus(std::string name);
+std::vector<ExampleEntry> examples_for_language(std::string name);
 
 #endif

--- a/test/helpers/record_alloc.cc
+++ b/test/helpers/record_alloc.cc
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include <map>
 #include <set>
-#include "bandit/bandit.h"
 
 using std::map;
 using std::set;

--- a/test/integration/test_grammars.cc
+++ b/test/integration/test_grammars.cc
@@ -16,15 +16,9 @@ for (auto &language_name : test_languages) {
   describe(("test language: " + language_name).c_str(), [&]() {
     string directory_path = grammars_dir_path + "/" + language_name;
     string grammar_path = directory_path + "/grammar.json";
-    string external_scanner_path = directory_path + "/scanner.c";
-    string expected_error_path = directory_path + "/expected_error.txt";
-    string corpus_path = directory_path + "/corpus.txt";
-
-    if (!file_exists(external_scanner_path)) {
-      external_scanner_path = "";
-    }
-
     string grammar_json = read_file(grammar_path);
+    string expected_error_path = directory_path + "/expected_error.txt";
+    const TSLanguage *language = nullptr;
 
     if (file_exists(expected_error_path)) {
       it("fails with the correct error message", [&]() {
@@ -33,14 +27,15 @@ for (auto &language_name : test_languages) {
         AssertThat((void *)compile_result.error_message, !IsNull());
         AssertThat(compile_result.error_message, Equals(expected_error));
       });
-
       return;
-    } else {
-      TSDocument *document = nullptr;
-      const TSLanguage *language = nullptr;
+    }
 
-      before_each([&]() {
+    for (auto &entry : read_test_language_corpus(language_name)) {
+      it(("parses " + entry.description).c_str(), [&]() {
         if (!language) {
+          string external_scanner_path = directory_path + "/scanner.c";
+          if (!file_exists(external_scanner_path)) external_scanner_path = "";
+
           TSCompileResult compile_result = ts_compile_grammar(grammar_json.c_str());
 
           language = load_test_language(
@@ -50,29 +45,22 @@ for (auto &language_name : test_languages) {
           );
         }
 
-        document = ts_document_new();
+        TSDocument *document = ts_document_new();
         ts_document_set_language(document, language);
+        ts_document_set_input_string_with_length(document, entry.input.c_str(), entry.input.size());
 
         // ts_document_set_logger(document, stderr_logger_new(true));
         // ts_document_print_debugging_graphs(document, true);
+        ts_document_parse(document);
+
+        TSNode root_node = ts_document_root_node(document);
+        const char *node_string = ts_node_string(root_node, document);
+        string result(node_string);
+        ts_free((void *)node_string);
+        ts_document_free(document);
+
+        AssertThat(result, Equals(entry.tree_string));
       });
-
-      after_each([&]() {
-        if (document) ts_document_free(document);
-      });
-
-      for (auto &entry : read_test_language_corpus(language_name)) {
-        it(("parses " + entry.description).c_str(), [&]() {
-          ts_document_set_input_string_with_length(document, entry.input.c_str(), entry.input.size());
-          ts_document_parse(document);
-
-          TSNode root_node = ts_document_root_node(document);
-          const char *node_string = ts_node_string(root_node, document);
-          string result(node_string);
-          ts_free((void *)node_string);
-          AssertThat(result, Equals(entry.tree_string));
-        });
-      }
     }
   });
 }

--- a/test/runtime/parser_test.cc
+++ b/test/runtime/parser_test.cc
@@ -398,7 +398,8 @@ describe("Parser", [&]() {
 
         assert_root_node(
           "(program "
-            "(expression_statement (number) (ERROR (number))) "
+            "(ERROR (number)) "
+            "(expression_statement (number)) "
             "(expression_statement (math_op (number) (number))))");
       });
     });

--- a/tests.gyp
+++ b/tests.gyp
@@ -18,11 +18,8 @@
         'test/helpers/load_language.cc',
         'test/helpers/read_test_entries.cc',
         'test/helpers/stderr_logger.cc',
+        'test/helpers/record_alloc.cc',
       ],
-      'configurations': {'Test': {}, 'Release': {}},
-      'default_configuration': 'Release',
-      'xcode_settings': {'CLANG_CXX_LANGUAGE_STANDARD': 'c++11'},
-      'cflags_cc': ['-std=c++11'],
     },
     {
       'target_name': 'tests',
@@ -45,40 +42,34 @@
         '<!@(find test/integration -name "*.cc")',
         '<!@(find test/helpers -name "*.cc")',
       ],
-      'libraries': [
-        '-ldl'
-      ],
-      'default_configuration': 'Test',
-      'configurations': {'Test': {}, 'Release': {}},
-      'cflags': [
-        '-g',
-        '-O0',
+    }
+  ],
+
+  'target_defaults': {
+    'default_configuration': 'Test',
+    'configurations': {'Test': {}, 'Release': {}},
+    'cflags': [
+      '-g',
+      '-O0',
+      '-Wall',
+      '-Wextra',
+      '-Wno-unused-parameter',
+      '-Wno-unknown-pragmas',
+    ],
+    'cflags_cc': ['-std=c++14'],
+    'ldflags': ['-g'],
+    'libraries': ['-ldl'],
+    'xcode_settings': {
+      'CLANG_CXX_LANGUAGE_STANDARD': 'c++14',
+      'OTHER_LDFLAGS': ['-g'],
+      'OTHER_CPLUSPLUSFLAGS': ['-fsanitize=address'],
+      'GCC_OPTIMIZATION_LEVEL': '0',
+      'ALWAYS_SEARCH_USER_PATHS': 'NO',
+      'WARNING_CFLAGS': [
         '-Wall',
         '-Wextra',
-        '-Wno-unused-parameter',
-        '-Wno-unknown-pragmas',
+        '-Wno-unused-parameter'
       ],
-      'cflags_c': [
-        '-std=c99',
-      ],
-      'cflags_cc': [
-        '-std=c++14',
-      ],
-      'ldflags': [
-        '-g',
-      ],
-      'xcode_settings': {
-        'CLANG_CXX_LANGUAGE_STANDARD': 'c++14',
-        'OTHER_LDFLAGS': ['-g'],
-        'OTHER_CPLUSPLUSFLAGS': ['-fsanitize=address'],
-        'GCC_OPTIMIZATION_LEVEL': '0',
-        'ALWAYS_SEARCH_USER_PATHS': 'NO',
-        'WARNING_CFLAGS': [
-          '-Wall',
-          '-Wextra',
-          '-Wno-unused-parameter'
-        ],
-      },
-    }
-  ]
+    },
+  }
 }

--- a/tests.gyp
+++ b/tests.gyp
@@ -2,6 +2,7 @@
   'targets': [
     {
       'target_name': 'benchmarks',
+      'default_configuration': 'Release',
       'type': 'executable',
       'dependencies': [
         'project.gyp:runtime',
@@ -18,11 +19,11 @@
         'test/helpers/load_language.cc',
         'test/helpers/read_test_entries.cc',
         'test/helpers/stderr_logger.cc',
-        'test/helpers/record_alloc.cc',
       ],
     },
     {
       'target_name': 'tests',
+      'default_configuration': 'Test',
       'type': 'executable',
       'dependencies': [
         'project.gyp:runtime',
@@ -42,34 +43,35 @@
         '<!@(find test/integration -name "*.cc")',
         '<!@(find test/helpers -name "*.cc")',
       ],
+      'cflags': [
+        '-g',
+        '-O0',
+        '-Wall',
+        '-Wextra',
+        '-Wno-unused-parameter',
+        '-Wno-unknown-pragmas',
+      ],
+      'ldflags': ['-g'],
+      'xcode_settings': {
+        'OTHER_LDFLAGS': ['-g'],
+        'OTHER_CPLUSPLUSFLAGS': ['-fsanitize=address'],
+        'GCC_OPTIMIZATION_LEVEL': '0',
+        'WARNING_CFLAGS': [
+          '-Wall',
+          '-Wextra',
+          '-Wno-unused-parameter'
+        ],
+      },
     }
   ],
 
   'target_defaults': {
-    'default_configuration': 'Test',
     'configurations': {'Test': {}, 'Release': {}},
-    'cflags': [
-      '-g',
-      '-O0',
-      '-Wall',
-      '-Wextra',
-      '-Wno-unused-parameter',
-      '-Wno-unknown-pragmas',
-    ],
     'cflags_cc': ['-std=c++14'],
-    'ldflags': ['-g'],
     'libraries': ['-ldl'],
     'xcode_settings': {
       'CLANG_CXX_LANGUAGE_STANDARD': 'c++14',
-      'OTHER_LDFLAGS': ['-g'],
-      'OTHER_CPLUSPLUSFLAGS': ['-fsanitize=address'],
-      'GCC_OPTIMIZATION_LEVEL': '0',
       'ALWAYS_SEARCH_USER_PATHS': 'NO',
-      'WARNING_CFLAGS': [
-        '-Wall',
-        '-Wextra',
-        '-Wno-unused-parameter'
-      ],
-    },
+    }
   }
 }

--- a/tests.gyp
+++ b/tests.gyp
@@ -1,6 +1,30 @@
 {
   'targets': [
     {
+      'target_name': 'benchmarks',
+      'type': 'executable',
+      'dependencies': [
+        'project.gyp:runtime',
+        'project.gyp:compiler'
+      ],
+      'include_dirs': [
+        'src',
+        'test',
+        'externals/utf8proc',
+      ],
+      'sources': [
+        'test/benchmarks.cc',
+        'test/helpers/file_helpers.cc',
+        'test/helpers/load_language.cc',
+        'test/helpers/read_test_entries.cc',
+        'test/helpers/stderr_logger.cc',
+      ],
+      'configurations': {'Test': {}, 'Release': {}},
+      'default_configuration': 'Release',
+      'xcode_settings': {'CLANG_CXX_LANGUAGE_STANDARD': 'c++11'},
+      'cflags_cc': ['-std=c++11'],
+    },
+    {
       'target_name': 'tests',
       'type': 'executable',
       'dependencies': [


### PR DESCRIPTION
This adds a new command, `script/benchmark` that parses all of the files in the `examples` folders of the fixture grammars. It also parses the examples with the *wrong* grammars, to measure the speed of error recovery in large files with lots of errors.

```sh
c
  cluster.c                     	55 ms		3939 bytes/ms
  malloc.c                      	6 ms		2016 bytes/ms
  parser.c                      	16 ms		2779 bytes/ms
  marker-index.h                	14 ms		345 bytes/ms
  rule.cc                       	18 ms		469 bytes/ms
  jquery.js                     	230 ms		1075 bytes/ms
  python2-grammar.py            	268 ms		115 bytes/ms
  python3-grammar.py            	157 ms		196 bytes/ms

cpp
  marker-index.h                	1 ms		4832 bytes/ms
  rule.cc                       	3 ms		2816 bytes/ms
  cluster.c                     	57 ms		3801 bytes/ms
  malloc.c                      	26 ms		465 bytes/ms
  parser.c                      	21 ms		2118 bytes/ms
  jquery.js                     	228 ms		1084 bytes/ms
  python2-grammar.py            	337 ms		91 bytes/ms
  python3-grammar.py            	306 ms		100 bytes/ms

javascript
  jquery.js                     	55 ms		4497 bytes/ms
  cluster.c                     	324 ms		668 bytes/ms
  malloc.c                      	33 ms		366 bytes/ms
  parser.c                      	68 ms		654 bytes/ms
  marker-index.h                	8 ms		604 bytes/ms
  rule.cc                       	103 ms		82 bytes/ms
  python2-grammar.py            	95 ms		326 bytes/ms
  python3-grammar.py            	102 ms		301 bytes/ms

python
  python2-grammar.py            	10 ms		3098 bytes/ms
  python3-grammar.py            	10 ms		3077 bytes/ms
  cluster.c                     	1232 ms		175 bytes/ms
  malloc.c                      	105 ms		115 bytes/ms
  parser.c                      	137 ms		324 bytes/ms
  marker-index.h                	35 ms		138 bytes/ms
  rule.cc                       	41 ms		206 bytes/ms
  jquery.js                     	868 ms		284 bytes/ms

without errors:
  average speed                 	3381 bytes/ms
  worst speed                   	2016 bytes/ms

with errors:
  average speed                 	587 bytes/ms
  worst speed                   	82 bytes/ms
```