### PR TITLE
Introduce rule for resolving runtime ambiguities

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/udp/json-parser.git
 [submodule "externals/crypto-algorithms"]
 	path = externals/crypto-algorithms
-	url = https://github.com/B-Con/crypto-algorithms.git
+	url = https://github.com/maxbrunsfeld/crypto-algorithms.git

--- a/doc/grammar-schema.json
+++ b/doc/grammar-schema.json
@@ -182,41 +182,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "pattern": "^PREC$"
-        },
-        "value": {
-          "type": "integer"
-        },
-        "content": {
-          "$ref": "#/definitions/rule"
-        }
-      },
-      "required": ["type", "content", "value"]
-    },
-
-    "prec-left-rule": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^PREC_LEFT$"
-        },
-        "value": {
-          "type": "integer"
-        },
-        "content": {
-          "$ref": "#/definitions/rule"
-        }
-      },
-      "required": ["type", "content", "value"]
-    },
-
-    "prec-right-rule": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^PREC_RIGHT$"
+          "pattern": "^(PREC|PREC_LEFT|PREC_RIGHT|PREC_DYNAMIC)$"
         },
         "value": {
           "type": "integer"
@@ -239,9 +205,7 @@
         { "$ref": "#/definitions/repeat1-rule" },
         { "$ref": "#/definitions/repeat-rule" },
         { "$ref": "#/definitions/token-rule" },
-        { "$ref": "#/definitions/prec-rule" },
-        { "$ref": "#/definitions/prec-left-rule" },
-        { "$ref": "#/definitions/prec-right-rule" }
+        { "$ref": "#/definitions/prec-rule" }
       ]
     }
   }

--- a/include/tree_sitter/parser.h
+++ b/include/tree_sitter/parser.h
@@ -42,6 +42,7 @@ typedef struct {
   union {
     TSStateId to_state;
     struct {
+      short dynamic_precedence;
       TSSymbol symbol;
       unsigned short child_count;
     };
@@ -145,21 +146,30 @@ typedef struct TSLanguage {
     { .type = TSParseActionTypeShift, .extra = true } \
   }
 
-#define REDUCE(symbol_val, child_count_val)                             \
+#define REDUCE(symbol_val, child_count_val, dynamic_precedence_val)     \
   {                                                                     \
     {                                                                   \
       .type = TSParseActionTypeReduce,                                  \
-      .params = {.symbol = symbol_val, .child_count = child_count_val } \
+      .params = {                                                       \
+        .symbol = symbol_val,                                           \
+        .child_count = child_count_val,                                 \
+        .dynamic_precedence = dynamic_precedence_val,                   \
+      }                                                                 \
     }                                                                   \
   }
 
-#define REDUCE_FRAGILE(symbol_val, child_count_val)                     \
-  {                                                                     \
-    {                                                                   \
-      .type = TSParseActionTypeReduce, .fragile = true,                 \
-      .params = {.symbol = symbol_val, .child_count = child_count_val } \
-    }                                                                   \
-  }
+#define REDUCE_FRAGILE(symbol_val, child_count_val, dynamic_precedence_val) \
+{                                                                           \
+  {                                                                         \
+    .type = TSParseActionTypeReduce,                                        \
+    .fragile = true,                                                        \
+    .params = {                                                             \
+      .symbol = symbol_val,                                                 \
+      .child_count = child_count_val,                                       \
+      .dynamic_precedence = dynamic_precedence_val,                         \
+    }                                                                       \
+  }                                                                         \
+}
 
 #define ACCEPT_INPUT()                  \
   {                                     \

--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -9,7 +9,7 @@ extern "C" {
 #include <stdint.h>
 #include <stdbool.h>
 
-#define TREE_SITTER_LANGUAGE_VERSION 2
+#define TREE_SITTER_LANGUAGE_VERSION 3
 
 typedef unsigned short TSSymbol;
 typedef struct TSLanguage TSLanguage;

--- a/src/compiler/build_tables/build_parse_table.cc
+++ b/src/compiler/build_tables/build_parse_table.cc
@@ -55,7 +55,8 @@ class ParseTableBuilder {
       Symbol::non_terminal(0);
 
     Production start_production{
-      ProductionStep{start_symbol, 0, rules::AssociativityNone},
+      {ProductionStep{start_symbol, 0, rules::AssociativityNone}},
+      0
     };
 
     // Placeholder for error state
@@ -281,9 +282,10 @@ class ParseTableBuilder {
 
         for (ParseAction &action : actions) {
           if (action.type == ParseActionTypeReduce) {
-            if (has_fragile_production(action.production))
+            if (has_fragile_production(action.production)) {
               action.fragile = true;
-            action.production = NULL;
+            }
+            action.production = nullptr;
           }
         }
 
@@ -586,7 +588,7 @@ class ParseTableBuilder {
         }
 
         description += "  (" + symbol_name(action.symbol);
-        for (const ProductionStep &step : *action.production) {
+        for (const ProductionStep &step : action.production->steps) {
           description += "  " + symbol_name(step.symbol);
         }
         description += ")";

--- a/src/compiler/build_tables/lex_table_builder.cc
+++ b/src/compiler/build_tables/lex_table_builder.cc
@@ -5,7 +5,7 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
-#include <cctype>
+#include <cwctype>
 #include <vector>
 #include "compiler/build_tables/lex_conflict_manager.h"
 #include "compiler/build_tables/lex_item.h"
@@ -16,6 +16,7 @@
 namespace tree_sitter {
 namespace build_tables {
 
+using std::iswalpha;
 using std::map;
 using std::pair;
 using std::set;

--- a/src/compiler/build_tables/lex_table_builder.h
+++ b/src/compiler/build_tables/lex_table_builder.h
@@ -2,6 +2,8 @@
 #define COMPILER_BUILD_TABLES_LEX_TABLE_BUILDER_H_
 
 #include <memory>
+#include <vector>
+#include <set>
 #include "compiler/lex_table.h"
 
 namespace tree_sitter {
@@ -15,7 +17,11 @@ class LexTableBuilder {
  public:
   static std::unique_ptr<LexTableBuilder> create(const LexicalGrammar &);
   LexTable build(ParseTable *);
-  bool detect_conflict(rules::Symbol::Index, rules::Symbol::Index);
+  bool detect_conflict(
+    rules::Symbol::Index,
+    rules::Symbol::Index,
+    const std::vector<std::set<rules::Symbol::Index>> &following_terminals_by_terminal_index
+  );
  protected:
   LexTableBuilder() = default;
 };

--- a/src/compiler/build_tables/parse_item.cc
+++ b/src/compiler/build_tables/parse_item.cc
@@ -97,13 +97,12 @@ size_t ParseItemSet::unfinished_item_signature() const {
   ParseItem previous_item;
   for (auto &pair : entries) {
     const ParseItem &item = pair.first;
-    if (item.step_index < item.production->size()) {
-      if (item.variable_index != previous_item.variable_index &&
-          item.step_index != previous_item.step_index) {
-        hash_combine(&result, item.variable_index);
-        hash_combine(&result, item.step_index);
-        previous_item = item;
-      }
+    if (item.step_index < item.production->size() &&
+        (item.variable_index != previous_item.variable_index ||
+         item.step_index != previous_item.step_index)) {
+      hash_combine(&result, item.variable_index);
+      hash_combine(&result, item.step_index);
+      previous_item = item;
     }
   }
   return result;

--- a/src/compiler/build_tables/parse_item.cc
+++ b/src/compiler/build_tables/parse_item.cc
@@ -60,6 +60,10 @@ int ParseItem::precedence() const {
   }
 }
 
+int ParseItem::dynamic_precedence() const {
+  return production->dynamic_precedence;
+}
+
 rules::Associativity ParseItem::associativity() const {
   if (is_done()) {
     if (production->empty()) {

--- a/src/compiler/build_tables/parse_item.h
+++ b/src/compiler/build_tables/parse_item.h
@@ -26,6 +26,7 @@ struct ParseItem {
   rules::Symbol lhs() const;
   rules::Symbol next_symbol() const;
   int precedence() const;
+  int dynamic_precedence() const;
   rules::Associativity associativity() const;
   bool is_done() const;
 

--- a/src/compiler/build_tables/parse_item_set_builder.h
+++ b/src/compiler/build_tables/parse_item_set_builder.h
@@ -20,6 +20,7 @@ class ParseItemSetBuilder {
   };
 
   std::map<rules::Symbol, LookaheadSet> first_sets;
+  std::map<rules::Symbol, LookaheadSet> last_sets;
   std::map<rules::Symbol::Index, std::vector<ParseItemSetComponent>> component_cache;
   std::vector<std::pair<ParseItem, LookaheadSet>> item_set_buffer;
 
@@ -27,6 +28,7 @@ class ParseItemSetBuilder {
   ParseItemSetBuilder(const SyntaxGrammar &, const LexicalGrammar &);
   void apply_transitive_closure(ParseItemSet *);
   LookaheadSet get_first_set(const rules::Symbol &) const;
+  LookaheadSet get_last_set(const rules::Symbol &) const;
 };
 
 }  // namespace build_tables

--- a/src/compiler/generate_code/c_code.cc
+++ b/src/compiler/generate_code/c_code.cc
@@ -490,12 +490,17 @@ class CCodeGenerator {
               break;
             case ParseActionTypeReduce:
               if (action.fragile) {
-                add("REDUCE_FRAGILE(" + symbol_id(action.symbol) + ", " +
-                    to_string(action.consumed_symbol_count) + ")");
+                add("REDUCE_FRAGILE");
               } else {
-                add("REDUCE(" + symbol_id(action.symbol) + ", " +
-                    to_string(action.consumed_symbol_count) + ")");
+                add("REDUCE");
               }
+
+              add("(");
+              add(symbol_id(action.symbol));
+              add(", ");
+              add(to_string(action.consumed_symbol_count));
+              add(", " + to_string(action.dynamic_precedence));
+              add(")");
               break;
             case ParseActionTypeRecover:
               add("RECOVER(" + to_string(action.state_index) + ")");

--- a/src/compiler/parse_grammar.cc
+++ b/src/compiler/parse_grammar.cc
@@ -184,6 +184,20 @@ ParseRuleResult parse_rule(json_value *rule_json) {
     return Rule(Metadata::prec_right(precedence_json.u.integer, result.rule));
   }
 
+  if (type == "PREC_DYNAMIC") {
+    json_value precedence_json = rule_json->operator[]("value");
+    if (precedence_json.type != json_integer) {
+      return "Precedence value must be an integer";
+    }
+
+    json_value content_json = rule_json->operator[]("content");
+    auto result = parse_rule(&content_json);
+    if (!result.error_message.empty()) {
+      return "Invalid precedence content: " + result.error_message;
+    }
+    return Rule(Metadata::prec_dynamic(precedence_json.u.integer, result.rule));
+  }
+
   return "Unknown rule type: " + type;
 }
 

--- a/src/compiler/parse_table.cc
+++ b/src/compiler/parse_table.cc
@@ -13,25 +13,14 @@ using std::vector;
 using std::function;
 using rules::Symbol;
 
-ParseAction::ParseAction(ParseActionType type, ParseStateId state_index,
-                         Symbol symbol, size_t consumed_symbol_count,
-                         const Production *production)
-    : type(type),
-      extra(false),
-      fragile(false),
-      state_index(state_index),
-      symbol(symbol),
-      consumed_symbol_count(consumed_symbol_count),
-      production(production) {}
-
 ParseAction::ParseAction()
-    : type(ParseActionTypeError),
+    : production(nullptr),
+      consumed_symbol_count(0),
+      symbol(rules::NONE()),
+      type(ParseActionTypeError),
       extra(false),
       fragile(false),
-      state_index(-1),
-      symbol(rules::NONE()),
-      consumed_symbol_count(0),
-      production(nullptr) {}
+      state_index(-1) {}
 
 ParseAction ParseAction::Error() {
   return ParseAction();
@@ -44,12 +33,17 @@ ParseAction ParseAction::Accept() {
 }
 
 ParseAction ParseAction::Shift(ParseStateId state_index) {
-  return ParseAction(ParseActionTypeShift, state_index, rules::NONE(), 0, nullptr);
+  ParseAction result;
+  result.type = ParseActionTypeShift;
+  result.state_index = state_index;
+  return result;
 }
 
 ParseAction ParseAction::Recover(ParseStateId state_index) {
-  return ParseAction(ParseActionTypeRecover, state_index, rules::NONE(), 0,
-                     nullptr);
+  ParseAction result;
+  result.type = ParseActionTypeRecover;
+  result.state_index = state_index;
+  return result;
 }
 
 ParseAction ParseAction::ShiftExtra() {
@@ -61,8 +55,13 @@ ParseAction ParseAction::ShiftExtra() {
 
 ParseAction ParseAction::Reduce(Symbol symbol, size_t consumed_symbol_count,
                                 const Production &production) {
-  return ParseAction(ParseActionTypeReduce, 0, symbol, consumed_symbol_count,
-                     &production);
+  ParseAction result;
+  result.type = ParseActionTypeReduce;
+  result.symbol = symbol;
+  result.consumed_symbol_count = consumed_symbol_count;
+  result.production = &production;
+  result.dynamic_precedence = production.dynamic_precedence;
+  return result;
 }
 
 int ParseAction::precedence() const {

--- a/src/compiler/parse_table.h
+++ b/src/compiler/parse_table.h
@@ -24,9 +24,6 @@ enum ParseActionType {
 
 struct ParseAction {
   ParseAction();
-  ParseAction(ParseActionType type, ParseStateId state_index,
-              rules::Symbol symbol, size_t consumed_symbol_count,
-              const Production *);
   static ParseAction Accept();
   static ParseAction Error();
   static ParseAction Shift(ParseStateId state_index);
@@ -39,13 +36,14 @@ struct ParseAction {
   rules::Associativity associativity() const;
   int precedence() const;
 
+  const Production *production;
+  size_t consumed_symbol_count;
+  rules::Symbol symbol;
+  int dynamic_precedence;
   ParseActionType type;
   bool extra;
   bool fragile;
   ParseStateId state_index;
-  rules::Symbol symbol;
-  size_t consumed_symbol_count;
-  const Production *production;
 };
 
 struct ParseTableEntry {

--- a/src/compiler/parse_table.h
+++ b/src/compiler/parse_table.h
@@ -69,7 +69,6 @@ struct ParseState {
   std::map<rules::Symbol, ParseTableEntry> terminal_entries;
   std::map<rules::Symbol::Index, ParseStateId> nonterminal_entries;
   LexStateId lex_state_id;
-  size_t shift_actions_signature;
 };
 
 struct ParseTableSymbolMetadata {

--- a/src/compiler/prepare_grammar/flatten_grammar.cc
+++ b/src/compiler/prepare_grammar/flatten_grammar.cc
@@ -1,6 +1,7 @@
 #include "compiler/prepare_grammar/flatten_grammar.h"
 #include <vector>
 #include <cassert>
+#include <cmath>
 #include <algorithm>
 #include "compiler/prepare_grammar/extract_choices.h"
 #include "compiler/prepare_grammar/initial_syntax_grammar.h"
@@ -42,7 +43,7 @@ class FlattenRule {
           associativity_stack.push_back(metadata.params.associativity);
         }
 
-        if (metadata.params.dynamic_precedence > production.dynamic_precedence) {
+        if (abs(metadata.params.dynamic_precedence) > abs(production.dynamic_precedence)) {
           production.dynamic_precedence = metadata.params.dynamic_precedence;
         }
 

--- a/src/compiler/prepare_grammar/flatten_grammar.cc
+++ b/src/compiler/prepare_grammar/flatten_grammar.cc
@@ -26,7 +26,7 @@ class FlattenRule {
   void apply(const Rule &rule) {
     rule.match(
       [&](const rules::Symbol &symbol) {
-        production.push_back(ProductionStep{
+        production.steps.push_back(ProductionStep{
           symbol,
           precedence_stack.back(),
           associativity_stack.back()
@@ -40,6 +40,10 @@ class FlattenRule {
 
         if (metadata.params.has_associativity) {
           associativity_stack.push_back(metadata.params.associativity);
+        }
+
+        if (metadata.params.dynamic_precedence > production.dynamic_precedence) {
+          production.dynamic_precedence = metadata.params.dynamic_precedence;
         }
 
         apply(*metadata.rule);

--- a/src/compiler/rules/metadata.cc
+++ b/src/compiler/rules/metadata.cc
@@ -51,6 +51,12 @@ Metadata Metadata::prec_right(int precedence, const Rule &rule) {
   return Metadata{rule, params};
 }
 
+Metadata Metadata::prec_dynamic(int dynamic_precedence, const Rule &rule) {
+  MetadataParams params;
+  params.dynamic_precedence = dynamic_precedence;
+  return Metadata{rule, params};
+}
+
 Metadata Metadata::separator(const Rule &rule) {
   MetadataParams params;
   params.has_precedence = true;

--- a/src/compiler/rules/metadata.h
+++ b/src/compiler/rules/metadata.h
@@ -14,6 +14,7 @@ enum Associativity {
 
 struct MetadataParams {
   int precedence;
+  int dynamic_precedence;
   Associativity associativity;
   bool has_precedence;
   bool has_associativity;
@@ -23,8 +24,8 @@ struct MetadataParams {
   bool is_main_token;
 
   inline MetadataParams() :
-    precedence{0}, associativity{AssociativityNone}, has_precedence{false},
-    has_associativity{false}, is_token{false}, is_string{false},
+    precedence{0}, dynamic_precedence{0}, associativity{AssociativityNone},
+    has_precedence{false}, has_associativity{false}, is_token{false}, is_string{false},
     is_active{false}, is_main_token{false} {}
 
   inline bool operator==(const MetadataParams &other) const {
@@ -33,6 +34,7 @@ struct MetadataParams {
       associativity == other.associativity &&
       has_precedence == other.has_precedence &&
       has_associativity == other.has_associativity &&
+      dynamic_precedence == other.dynamic_precedence &&
       is_token == other.is_token &&
       is_string == other.is_string &&
       is_active == other.is_active &&
@@ -54,6 +56,7 @@ struct Metadata {
   static Metadata prec(int precedence, const Rule &rule);
   static Metadata prec_left(int precedence, const Rule &rule);
   static Metadata prec_right(int precedence, const Rule &rule);
+  static Metadata prec_dynamic(int precedence, const Rule &rule);
   static Metadata separator(const Rule &rule);
   static Metadata main_token(const Rule &rule);
 

--- a/src/compiler/syntax_grammar.h
+++ b/src/compiler/syntax_grammar.h
@@ -11,8 +11,9 @@ namespace tree_sitter {
 
 struct ProductionStep {
   inline bool operator==(const ProductionStep &other) const {
-    return symbol == other.symbol && precedence == other.precedence &&
-           associativity == other.associativity;
+    return symbol == other.symbol &&
+      precedence == other.precedence &&
+      associativity == other.associativity;
   }
 
   rules::Symbol symbol;
@@ -20,7 +21,21 @@ struct ProductionStep {
   rules::Associativity associativity;
 };
 
-typedef std::vector<ProductionStep> Production;
+struct Production {
+  std::vector<ProductionStep> steps;
+  int dynamic_precedence = 0;
+
+  inline bool operator==(const Production &other) const {
+    return steps == other.steps && dynamic_precedence == other.dynamic_precedence;
+  }
+
+  inline ProductionStep &back() { return steps.back(); }
+  inline const ProductionStep &back() const { return steps.back(); }
+  inline bool empty() const { return steps.empty(); }
+  inline size_t size() const { return steps.size(); }
+  inline const ProductionStep &operator[](int i) const { return steps[i]; }
+  inline const ProductionStep &at(int i) const { return steps[i]; }
+};
 
 struct SyntaxVariable {
   std::string name;

--- a/src/runtime/reduce_action.h
+++ b/src/runtime/reduce_action.h
@@ -11,6 +11,7 @@ extern "C" {
 typedef struct {
   uint32_t count;
   TSSymbol symbol;
+  int dynamic_precedence;
 } ReduceAction;
 
 typedef Array(ReduceAction) ReduceActionSet;

--- a/src/runtime/tree.c
+++ b/src/runtime/tree.c
@@ -150,6 +150,7 @@ void ts_tree_set_children(Tree *self, uint32_t child_count, Tree **children) {
   self->visible_child_count = 0;
   self->error_cost = 0;
   self->has_external_tokens = false;
+  self->dynamic_precedence = 0;
 
   for (uint32_t i = 0; i < child_count; i++) {
     Tree *child = children[i];
@@ -165,6 +166,7 @@ void ts_tree_set_children(Tree *self, uint32_t child_count, Tree **children) {
     }
 
     self->error_cost += child->error_cost;
+    self->dynamic_precedence += child->dynamic_precedence;
 
     if (child->visible) {
       self->visible_child_count++;

--- a/src/runtime/tree.h
+++ b/src/runtime/tree.h
@@ -46,6 +46,7 @@ typedef struct Tree {
   } first_leaf;
 
   uint32_t ref_count;
+  int dynamic_precedence;
   bool visible : 1;
   bool named : 1;
   bool extra : 1;

--- a/test/compiler/build_tables/parse_item_set_builder_test.cc
+++ b/test/compiler/build_tables/parse_item_set_builder_test.cc
@@ -25,25 +25,25 @@ describe("ParseItemSetBuilder", []() {
   it("adds items at the beginnings of referenced rules", [&]() {
     SyntaxGrammar grammar{{
       SyntaxVariable{"rule0", VariableTypeNamed, {
-        Production({
+        Production{{
           {Symbol::non_terminal(1), 0, AssociativityNone},
           {Symbol::terminal(11), 0, AssociativityNone},
-        }),
+        }, 0},
       }},
       SyntaxVariable{"rule1", VariableTypeNamed, {
-        Production({
+        Production{{
           {Symbol::terminal(12), 0, AssociativityNone},
           {Symbol::terminal(13), 0, AssociativityNone},
-        }),
-        Production({
+        }, 0},
+        Production{{
           {Symbol::non_terminal(2), 0, AssociativityNone},
-        })
+        }, 0}
       }},
       SyntaxVariable{"rule2", VariableTypeNamed, {
-        Production({
+        Production{{
           {Symbol::terminal(14), 0, AssociativityNone},
           {Symbol::terminal(15), 0, AssociativityNone},
-        })
+        }, 0}
       }},
     }, {}, {}, {}};
 
@@ -84,17 +84,17 @@ describe("ParseItemSetBuilder", []() {
   it("handles rules with empty productions", [&]() {
     SyntaxGrammar grammar{{
       SyntaxVariable{"rule0", VariableTypeNamed, {
-        Production({
+        Production{{
           {Symbol::non_terminal(1), 0, AssociativityNone},
           {Symbol::terminal(11), 0, AssociativityNone},
-        }),
+        }, 0},
       }},
       SyntaxVariable{"rule1", VariableTypeNamed, {
-        Production({
+        Production{{
           {Symbol::terminal(12), 0, AssociativityNone},
           {Symbol::terminal(13), 0, AssociativityNone},
-        }),
-        Production({})
+        }, 0},
+        Production{{}, 0}
       }},
     }, {}, {}, {}};
 

--- a/test/compiler/prepare_grammar/flatten_grammar_test.cc
+++ b/test/compiler/prepare_grammar/flatten_grammar_test.cc
@@ -49,7 +49,7 @@ describe("flatten_grammar", []() {
         {Symbol::non_terminal(6), 0, AssociativityNone},
         {Symbol::non_terminal(7), 0, AssociativityNone},
       })
-    })))
+    })));
   });
 
   it("uses the last assigned precedence", [&]() {
@@ -67,7 +67,7 @@ describe("flatten_grammar", []() {
         {Symbol::non_terminal(1), 101, AssociativityLeft},
         {Symbol::non_terminal(2), 101, AssociativityLeft},
       })
-    })))
+    })));
 
     result = flatten_rule({
       "test2",
@@ -81,7 +81,7 @@ describe("flatten_grammar", []() {
       Production({
         {Symbol::non_terminal(1), 101, AssociativityLeft},
       })
-    })))
+    })));
   });
 });
 

--- a/test/compiler/prepare_grammar/flatten_grammar_test.cc
+++ b/test/compiler/prepare_grammar/flatten_grammar_test.cc
@@ -34,21 +34,63 @@ describe("flatten_grammar", []() {
     AssertThat(result.name, Equals("test"));
     AssertThat(result.type, Equals(VariableTypeNamed));
     AssertThat(result.productions, Equals(vector<Production>({
-      Production({
+      Production{{
         {Symbol::non_terminal(1), 0, AssociativityNone},
         {Symbol::non_terminal(2), 101, AssociativityLeft},
         {Symbol::non_terminal(3), 102, AssociativityRight},
         {Symbol::non_terminal(4), 101, AssociativityLeft},
         {Symbol::non_terminal(6), 0, AssociativityNone},
         {Symbol::non_terminal(7), 0, AssociativityNone},
-      }),
-      Production({
+      }, 0},
+      Production{{
         {Symbol::non_terminal(1), 0, AssociativityNone},
         {Symbol::non_terminal(2), 101, AssociativityLeft},
         {Symbol::non_terminal(5), 101, AssociativityLeft},
         {Symbol::non_terminal(6), 0, AssociativityNone},
         {Symbol::non_terminal(7), 0, AssociativityNone},
+      }, 0}
+    })));
+  });
+
+  it("stores the maximum dynamic precedence specified in each production", [&]() {
+    SyntaxVariable result = flatten_rule({
+      "test",
+      VariableTypeNamed,
+      Rule::seq({
+        Symbol::non_terminal(1),
+        Metadata::prec_dynamic(101, Rule::seq({
+          Symbol::non_terminal(2),
+          Rule::choice({
+            Metadata::prec_dynamic(102, Rule::seq({
+              Symbol::non_terminal(3),
+              Symbol::non_terminal(4)
+            })),
+            Symbol::non_terminal(5),
+          }),
+          Symbol::non_terminal(6),
+        })),
+        Symbol::non_terminal(7),
       })
+    });
+
+    AssertThat(result.name, Equals("test"));
+    AssertThat(result.type, Equals(VariableTypeNamed));
+    AssertThat(result.productions, Equals(vector<Production>({
+      Production{{
+        {Symbol::non_terminal(1), 0, AssociativityNone},
+        {Symbol::non_terminal(2), 0, AssociativityNone},
+        {Symbol::non_terminal(3), 0, AssociativityNone},
+        {Symbol::non_terminal(4), 0, AssociativityNone},
+        {Symbol::non_terminal(6), 0, AssociativityNone},
+        {Symbol::non_terminal(7), 0, AssociativityNone},
+      }, 102},
+      Production{{
+        {Symbol::non_terminal(1), 0, AssociativityNone},
+        {Symbol::non_terminal(2), 0, AssociativityNone},
+        {Symbol::non_terminal(5), 0, AssociativityNone},
+        {Symbol::non_terminal(6), 0, AssociativityNone},
+        {Symbol::non_terminal(7), 0, AssociativityNone},
+      }, 101}
     })));
   });
 
@@ -63,10 +105,10 @@ describe("flatten_grammar", []() {
     });
 
     AssertThat(result.productions, Equals(vector<Production>({
-      Production({
+      Production{{
         {Symbol::non_terminal(1), 101, AssociativityLeft},
-        {Symbol::non_terminal(2), 101, AssociativityLeft},
-      })
+        {Symbol::non_terminal(2), 101,  AssociativityLeft},
+      }, 0}
     })));
 
     result = flatten_rule({
@@ -78,9 +120,9 @@ describe("flatten_grammar", []() {
     });
 
     AssertThat(result.productions, Equals(vector<Production>({
-      Production({
+      Production{{
         {Symbol::non_terminal(1), 101, AssociativityLeft},
-      })
+      }, 0}
     })));
   });
 });

--- a/test/compiler/rules/character_set_test.cc
+++ b/test/compiler/rules/character_set_test.cc
@@ -305,29 +305,17 @@ describe("CharacterSet", []() {
   });
 
   describe("::included_ranges", [&]() {
-    it("consolidates sequences of 3 or more consecutive characters into ranges", [&]() {
+    it("consolidates consecutive sequences of characters into ranges", [&]() {
       CharacterSet set1 = CharacterSet()
         .include('a', 'c')
-        .include('g')
+        .include('e', 'j')
+        .include('m')
         .include('z');
 
       AssertThat(set1.included_ranges(), Equals(vector<CharacterRange>({
         CharacterRange{'a', 'c'},
-        CharacterRange('g'),
-        CharacterRange('z'),
-      })));
-    });
-
-    it("doesn't consolidate sequences of 2 consecutive characters", [&]() {
-      CharacterSet set1 = CharacterSet()
-        .include('a', 'b')
-        .include('g')
-        .include('z');
-
-      AssertThat(set1.included_ranges(), Equals(vector<CharacterRange>({
-        CharacterRange('a'),
-        CharacterRange('b'),
-        CharacterRange('g'),
+        CharacterRange{'e', 'j'},
+        CharacterRange('m'),
         CharacterRange('z'),
       })));
     });

--- a/test/fixtures/test_grammars/dynamic_precedence/corpus.txt
+++ b/test/fixtures/test_grammars/dynamic_precedence/corpus.txt
@@ -1,0 +1,25 @@
+===============================
+Declarations
+===============================
+
+int * x
+
+---
+
+(program (declaration
+  (type (identifier))
+  (declarator (identifier))))
+
+===============================
+Expressions
+===============================
+
+int * x * y
+
+---
+
+(program (expression
+  (expression
+    (expression (identifier))
+    (expression (identifier)))
+  (expression (identifier))))

--- a/test/fixtures/test_grammars/dynamic_precedence/grammar.json
+++ b/test/fixtures/test_grammars/dynamic_precedence/grammar.json
@@ -1,0 +1,73 @@
+{
+  "name": "dynamic_precedence",
+
+  "conflicts": [
+    ["expression", "type"]
+  ],
+
+  "extras": [
+    {"type": "PATTERN", "value": "\\s"}
+  ],
+
+  "rules": {
+    "program": {
+      "type": "CHOICE",
+      "members": [
+        {"type": "SYMBOL", "name": "declaration"},
+        {"type": "SYMBOL", "name": "expression"},
+      ]
+    },
+
+    "expression": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {"type": "SYMBOL", "name": "expression"},
+              {"type": "STRING", "value": "*"},
+              {"type": "SYMBOL", "name": "expression"}
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        ]
+      }
+    },
+
+    "declaration": {
+      "type": "SEQ",
+      "members": [
+        {"type": "SYMBOL", "name": "type"},
+        {"type": "SYMBOL", "name": "declarator"}
+      ]
+    },
+
+    "declarator": {
+      "type": "PREC_DYNAMIC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {"type": "STRING", "value": "*"},
+          {"type": "SYMBOL", "name": "identifier"}
+        ]
+      }
+    },
+
+    "type": {
+      "type": "SYMBOL",
+      "name": "identifier"
+    },
+
+    "identifier": {
+      "type": "PATTERN",
+      "value": "[a-zA-Z]+"
+    }
+  }
+}

--- a/test/fixtures/test_grammars/dynamic_precedence/readme.md
+++ b/test/fixtures/test_grammars/dynamic_precedence/readme.md
@@ -1,0 +1,1 @@
+This grammar contains a conflict that is resolved at runtime. The PREC_DYNAMIC rule is used to indicate that the `declarator` rule should be preferred to the `expression` rule at runtime.

--- a/test/fixtures/test_grammars/precedence_on_single_child_missing/expected_error.txt
+++ b/test/fixtures/test_grammars/precedence_on_single_child_missing/expected_error.txt
@@ -1,11 +1,11 @@
 Unresolved conflict for symbol sequence:
 
-  identifier  •  '{'  …
+  identifier  identifier  •  '{'  …
 
 Possible interpretations:
 
-  1:  (expression  identifier)  •  '{'  …
-  2:  (function_call  identifier  •  block)
+  1:  identifier  (expression  identifier)  •  '{'  …
+  2:  identifier  (function_call  identifier  •  block)
 
 Possible resolutions:
 

--- a/test/helpers/stream_methods.cc
+++ b/test/helpers/stream_methods.cc
@@ -136,9 +136,14 @@ ostream &operator<<(ostream &stream, const Variable &variable) {
   return stream << "(Variable " << variable.name << " " << variable.rule << ")";
 }
 
+ostream &operator<<(ostream &stream, const Production &production) {
+  return stream << "(Production " << production.steps << " " <<
+    to_string(production.dynamic_precedence) << ")";
+}
+
 ostream &operator<<(ostream &stream, const SyntaxVariable &variable) {
   return stream << "(Variable " << variable.name << " " << variable.productions <<
-    " " << to_string(variable.type) << "}";
+    " " << to_string(variable.type) << ")";
 }
 
 ostream &operator<<(ostream &stream, const LexicalVariable &variable) {

--- a/test/helpers/stream_methods.h
+++ b/test/helpers/stream_methods.h
@@ -110,6 +110,7 @@ ostream &operator<<(ostream &, const InputGrammar &);
 ostream &operator<<(ostream &, const CompileError &);
 ostream &operator<<(ostream &, const ExternalToken &);
 ostream &operator<<(ostream &, const ProductionStep &);
+ostream &operator<<(ostream &, const Production &);
 ostream &operator<<(ostream &, const PrecedenceRange &);
 ostream &operator<<(ostream &, const Variable &);
 ostream &operator<<(ostream &, const LexicalVariable &);

--- a/test/integration/test_grammars.cc
+++ b/test/integration/test_grammars.cc
@@ -13,7 +13,7 @@ vector<string> test_languages = list_directory(grammars_dir_path);
 for (auto &language_name : test_languages) {
   if (language_name == "readme.md") continue;
 
-  describe(("test language: " + language_name).c_str(), [&]() {
+  describe(("test grammar: " + language_name).c_str(), [&]() {
     string directory_path = grammars_dir_path + "/" + language_name;
     string grammar_path = directory_path + "/grammar.json";
     string grammar_json = read_file(grammar_path);


### PR DESCRIPTION
This adds to the grammar JSON schema a new rule type: `PREC_DYNAMIC`. This rule is meant to be used on conjunction with `conflicts`, and can be used to indicate which rule to select in the event of a true ambiguity. This differs from `PREC` in that it does not make a compile-time decision based on one token of lookahead. Rather, it allows the parser to explore both sides of a conflict at runtime, but in the even that both interpretations are valid, it will select one tree or the other based on which has higher dynamic precedence.

/cc @nathansobo