### PR TITLE
Add an API for renaming nodes based on their context

### DIFF
--- a/doc/grammar-schema.json
+++ b/doc/grammar-schema.json
@@ -135,6 +135,23 @@
       "required": ["type", "members"]
     },
 
+    "rename-rule": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "^RENAME$"
+        },
+        "value": {
+          "type": "string"
+        },
+        "content": {
+          "$ref": "#/definitions/rule"
+        }
+      },
+      "required": ["type", "content", "value"]
+    },
+
     "repeat-rule": {
       "type": "object",
       "properties": {
@@ -202,6 +219,7 @@
         { "$ref": "#/definitions/symbol-rule" },
         { "$ref": "#/definitions/seq-rule" },
         { "$ref": "#/definitions/choice-rule" },
+        { "$ref": "#/definitions/rename-rule" },
         { "$ref": "#/definitions/repeat1-rule" },
         { "$ref": "#/definitions/repeat-rule" },
         { "$ref": "#/definitions/token-rule" },

--- a/doc/grammar-schema.json
+++ b/doc/grammar-schema.json
@@ -38,6 +38,14 @@
       }
     },
 
+    "inline": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-zA-Z_]\\w*$"
+      }
+    },
+
     "conflicts": {
       "type": "array",
       "items": {

--- a/include/tree_sitter/parser.h
+++ b/include/tree_sitter/parser.h
@@ -9,9 +9,8 @@ extern "C" {
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef unsigned short TSSymbol;
-typedef unsigned short TSStateId;
-
+typedef uint16_t TSSymbol;
+typedef uint16_t TSStateId;
 typedef uint8_t TSExternalTokenState[16];
 
 #define ts_builtin_sym_error ((TSSymbol)-1)
@@ -40,16 +39,19 @@ typedef enum {
 
 typedef struct {
   union {
-    TSStateId to_state;
     struct {
-      short dynamic_precedence;
-      TSSymbol symbol;
-      unsigned short child_count;
+      TSStateId to_state;
+      bool extra : 1;
     };
-  } params;
+    struct {
+      TSSymbol symbol;
+      uint16_t dynamic_precedence;
+      uint8_t child_count;
+      uint8_t rename_sequence_id : 7;
+      bool fragile : 1;
+    };
+  };
   TSParseActionType type : 4;
-  bool extra : 1;
-  bool fragile : 1;
 } TSParseAction;
 
 typedef struct {
@@ -60,7 +62,7 @@ typedef struct {
 typedef union {
   TSParseAction action;
   struct {
-    unsigned short count;
+    uint8_t count;
     bool reusable : 1;
     bool depends_on_lookahead : 1;
   };
@@ -73,9 +75,11 @@ typedef struct TSLanguage {
   uint32_t external_token_count;
   const char **symbol_names;
   const TSSymbolMetadata *symbol_metadata;
-  const unsigned short *parse_table;
+  const uint16_t *parse_table;
   const TSParseActionEntry *parse_actions;
   const TSLexMode *lex_modes;
+  const TSSymbol *rename_sequences;
+  uint16_t max_rename_sequence_length;
   bool (*lex_fn)(TSLexer *, TSStateId);
   struct {
     const bool *states;
@@ -127,70 +131,62 @@ typedef struct TSLanguage {
 #define STATE(id) id
 #define ACTIONS(id) id
 
-#define SHIFT(to_state_value)                                                 \
-  {                                                                           \
-    {                                                                         \
-      .type = TSParseActionTypeShift, .params = {.to_state = to_state_value } \
-    }                                                                         \
+#define SHIFT(to_state_value)         \
+  {                                   \
+    {                                 \
+      .type = TSParseActionTypeShift, \
+      .to_state = to_state_value,     \
+    }                                 \
   }
 
-#define RECOVER(to_state_value)                                                 \
-  {                                                                             \
-    {                                                                           \
-      .type = TSParseActionTypeRecover, .params = {.to_state = to_state_value } \
-    }                                                                           \
+#define RECOVER(to_state_value)         \
+  {                                     \
+    {                                   \
+      .type = TSParseActionTypeRecover, \
+      .to_state = to_state_value        \
+    }                                   \
   }
 
-#define SHIFT_EXTRA()                                 \
-  {                                                   \
-    { .type = TSParseActionTypeShift, .extra = true } \
+#define SHIFT_EXTRA()                 \
+  {                                   \
+    {                                 \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
+    }                                 \
   }
 
-#define REDUCE(symbol_val, child_count_val, dynamic_precedence_val)     \
-  {                                                                     \
-    {                                                                   \
-      .type = TSParseActionTypeReduce,                                  \
-      .params = {                                                       \
-        .symbol = symbol_val,                                           \
-        .child_count = child_count_val,                                 \
-        .dynamic_precedence = dynamic_precedence_val,                   \
-      }                                                                 \
-    }                                                                   \
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {                                              \
+    {                                            \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    }                                            \
   }
-
-#define REDUCE_FRAGILE(symbol_val, child_count_val, dynamic_precedence_val) \
-{                                                                           \
-  {                                                                         \
-    .type = TSParseActionTypeReduce,                                        \
-    .fragile = true,                                                        \
-    .params = {                                                             \
-      .symbol = symbol_val,                                                 \
-      .child_count = child_count_val,                                       \
-      .dynamic_precedence = dynamic_precedence_val,                         \
-    }                                                                       \
-  }                                                                         \
-}
 
 #define ACCEPT_INPUT()                  \
   {                                     \
     { .type = TSParseActionTypeAccept } \
   }
 
-#define GET_LANGUAGE(...)                                          \
-  static TSLanguage language = {                                   \
-    .version = LANGUAGE_VERSION,                                   \
-    .symbol_count = SYMBOL_COUNT,                                  \
-    .token_count = TOKEN_COUNT,                                    \
-    .symbol_metadata = ts_symbol_metadata,                         \
-    .parse_table = (const unsigned short *)ts_parse_table,         \
-    .parse_actions = ts_parse_actions,                             \
-    .lex_modes = ts_lex_modes,                                     \
-    .symbol_names = ts_symbol_names,                               \
-    .lex_fn = ts_lex,                                              \
-    .external_token_count = EXTERNAL_TOKEN_COUNT,                  \
-    .external_scanner = {__VA_ARGS__}                              \
-  };                                                               \
-  return &language                                                 \
+#define GET_LANGUAGE(...)                                      \
+  static TSLanguage language = {                               \
+    .version = LANGUAGE_VERSION,                               \
+    .symbol_count = SYMBOL_COUNT,                              \
+    .token_count = TOKEN_COUNT,                                \
+    .symbol_metadata = ts_symbol_metadata,                     \
+    .parse_table = (const unsigned short *)ts_parse_table,     \
+    .parse_actions = ts_parse_actions,                         \
+    .lex_modes = ts_lex_modes,                                 \
+    .symbol_names = ts_symbol_names,                           \
+    .rename_sequences = (const TSSymbol *)ts_rename_sequences, \
+    .max_rename_sequence_length = MAX_RENAME_SEQUENCE_LENGTH,  \
+    .lex_fn = ts_lex,                                          \
+    .external_token_count = EXTERNAL_TOKEN_COUNT,              \
+    .external_scanner = {__VA_ARGS__}                          \
+  };                                                           \
+  return &language                                             \
 
 #ifdef __cplusplus
 }

--- a/project.gyp
+++ b/project.gyp
@@ -38,6 +38,7 @@
         'src/compiler/prepare_grammar/prepare_grammar.cc',
         'src/compiler/prepare_grammar/token_description.cc',
         'src/compiler/rule.cc',
+        'src/compiler/syntax_grammar.cc',
         'src/compiler/rules/character_set.cc',
         'src/compiler/rules/choice.cc',
         'src/compiler/rules/metadata.cc',

--- a/src/compiler/build_tables/build_parse_table.cc
+++ b/src/compiler/build_tables/build_parse_table.cc
@@ -208,7 +208,7 @@ class ParseTableBuilder {
             if (existing_action.type == ParseActionTypeAccept || processing_recovery_states) {
               entry.actions.push_back(action);
             } else {
-              int existing_precedence = existing_action.precedence();
+              int existing_precedence = existing_action.production->back().precedence;
               if (precedence > existing_precedence) {
                 for (const ParseAction &old_action : entry.actions)
                   fragile_productions.insert(old_action.production);
@@ -472,7 +472,7 @@ class ParseTableBuilder {
   string handle_conflict(const ParseItemSet &item_set, const SymbolSequence &preceding_symbols,
                          ParseStateId state_id, Symbol lookahead) {
     ParseTableEntry &entry = parse_table.states[state_id].terminal_entries[lookahead];
-    int reduction_precedence = entry.actions.front().precedence();
+    int reduction_precedence = entry.actions.front().production->back().precedence;
     set<ParseItem> shift_items;
     bool considered_associativity = false;
 
@@ -524,7 +524,7 @@ class ParseTableBuilder {
         bool has_right_associative_reductions = false;
         for (const ParseAction &action : entry.actions) {
           if (action.type != ParseActionTypeReduce) break;
-          switch (action.associativity()) {
+          switch (action.production->back().associativity) {
             case rules::AssociativityLeft:
               has_left_associative_reductions = true;
               break;

--- a/src/compiler/build_tables/parse_item.cc
+++ b/src/compiler/build_tables/parse_item.cc
@@ -27,6 +27,11 @@ bool ParseItem::operator==(const ParseItem &other) const {
   if (step_index != other.step_index) return false;
   if (variable_index != other.variable_index) return false;
   if (production->size() != other.production->size()) return false;
+  for (size_t i = 0; i < step_index; i++) {
+    if (production->at(i).name_replacement != other.production->at(i).name_replacement) {
+      return false;
+    }
+  }
   if (is_done()) {
     if (!production->empty()) {
       if (production->back().precedence != other.production->back().precedence) return false;
@@ -47,6 +52,10 @@ bool ParseItem::operator<(const ParseItem &other) const {
   if (other.variable_index < variable_index) return false;
   if (production->size() < other.production->size()) return true;
   if (other.production->size() < production->size()) return false;
+  for (size_t i = 0; i < step_index; i++) {
+    if (production->at(i).name_replacement < other.production->at(i).name_replacement) return true;
+    if (other.production->at(i).name_replacement < production->at(i).name_replacement) return false;
+  }
   if (is_done()) {
     if (!production->empty()) {
       if (production->back().precedence < other.production->back().precedence) return true;
@@ -106,11 +115,6 @@ Symbol ParseItem::next_symbol() const {
     return production->at(step_index).symbol;
 }
 
-ParseItemSet::ParseItemSet() {}
-
-ParseItemSet::ParseItemSet(const map<ParseItem, LookaheadSet> &entries)
-    : entries(entries) {}
-
 bool ParseItemSet::operator==(const ParseItemSet &other) const {
   return entries == other.entries;
 }
@@ -153,6 +157,9 @@ struct hash<ParseItem> {
     hash_combine(&result, item.step_index);
     hash_combine(&result, item.production->dynamic_precedence);
     hash_combine(&result, item.production->size());
+    for (size_t i = 0; i < item.step_index; i++) {
+      hash_combine(&result, item.production->at(i).name_replacement);
+    }
     if (item.is_done()) {
       if (!item.production->empty()) {
         hash_combine(&result, item.production->back().precedence);

--- a/src/compiler/build_tables/parse_item.cc
+++ b/src/compiler/build_tables/parse_item.cc
@@ -159,7 +159,7 @@ struct hash<ParseItem> {
         hash_combine<unsigned>(&result, item.production->back().associativity);
       }
     } else {
-      for (size_t i = 0, n = item.production->size(); i < n; i++) {
+      for (size_t i = item.step_index, n = item.production->size(); i < n; i++) {
         auto &step = item.production->at(i);
         hash_combine(&result, step.symbol);
         hash_combine(&result, step.precedence);

--- a/src/compiler/build_tables/parse_item.h
+++ b/src/compiler/build_tables/parse_item.h
@@ -36,9 +36,6 @@ struct ParseItem {
 };
 
 struct ParseItemSet {
-  ParseItemSet();
-  explicit ParseItemSet(const std::map<ParseItem, LookaheadSet> &);
-
   bool operator==(const ParseItemSet &) const;
   void add(const ParseItemSet &);
   size_t unfinished_item_signature() const;

--- a/src/compiler/parse_grammar.cc
+++ b/src/compiler/parse_grammar.cc
@@ -198,6 +198,20 @@ ParseRuleResult parse_rule(json_value *rule_json) {
     return Rule(Metadata::prec_dynamic(precedence_json.u.integer, result.rule));
   }
 
+  if (type == "RENAME") {
+    json_value name_json = rule_json->operator[]("value");
+    if (name_json.type != json_string) {
+      return "Rename value must be a string";
+    }
+
+    json_value content_json = rule_json->operator[]("content");
+    auto result = parse_rule(&content_json);
+    if (!result.error_message.empty()) {
+      return "Invalid rename content: " + result.error_message;
+    }
+    return Rule(Metadata::rename(string(name_json.u.string.ptr), result.rule));
+  }
+
   return "Unknown rule type: " + type;
 }
 

--- a/src/compiler/parse_table.cc
+++ b/src/compiler/parse_table.cc
@@ -64,30 +64,6 @@ ParseAction ParseAction::Reduce(Symbol symbol, size_t consumed_symbol_count,
   return result;
 }
 
-int ParseAction::precedence() const {
-  if (consumed_symbol_count >= production->size()) {
-    if (production->empty()) {
-      return 0;
-    } else {
-      return production->back().precedence;
-    }
-  } else {
-    return production->at(consumed_symbol_count).precedence;
-  }
-}
-
-rules::Associativity ParseAction::associativity() const {
-  if (consumed_symbol_count >= production->size()) {
-    if (production->empty()) {
-      return rules::AssociativityNone;
-    } else {
-      return production->back().associativity;
-    }
-  } else {
-    return production->at(consumed_symbol_count).associativity;
-  }
-}
-
 bool ParseAction::operator==(const ParseAction &other) const {
   return (type == other.type && extra == other.extra &&
           fragile == other.fragile && symbol == other.symbol &&

--- a/src/compiler/parse_table.cc
+++ b/src/compiler/parse_table.cc
@@ -6,21 +6,20 @@
 namespace tree_sitter {
 
 using std::string;
-using std::ostream;
 using std::to_string;
-using std::set;
 using std::vector;
 using std::function;
 using rules::Symbol;
 
 ParseAction::ParseAction()
-    : production(nullptr),
-      consumed_symbol_count(0),
-      symbol(rules::NONE()),
-      type(ParseActionTypeError),
-      extra(false),
-      fragile(false),
-      state_index(-1) {}
+  : production(nullptr),
+    consumed_symbol_count(0),
+    symbol(rules::NONE()),
+    type(ParseActionTypeError),
+    extra(false),
+    fragile(false),
+    state_index(-1),
+    rename_sequence_id(0) {}
 
 ParseAction ParseAction::Error() {
   return ParseAction();
@@ -65,52 +64,49 @@ ParseAction ParseAction::Reduce(Symbol symbol, size_t consumed_symbol_count,
 }
 
 bool ParseAction::operator==(const ParseAction &other) const {
-  return (type == other.type && extra == other.extra &&
-          fragile == other.fragile && symbol == other.symbol &&
-          state_index == other.state_index && production == other.production &&
-          consumed_symbol_count == other.consumed_symbol_count);
+  return
+    type == other.type &&
+    extra == other.extra &&
+    fragile == other.fragile &&
+    symbol == other.symbol &&
+    state_index == other.state_index &&
+    production == other.production &&
+    consumed_symbol_count == other.consumed_symbol_count &&
+    rename_sequence_id == other.rename_sequence_id;
 }
 
 bool ParseAction::operator<(const ParseAction &other) const {
-  if (type < other.type)
-    return true;
-  if (other.type < type)
-    return false;
-  if (extra && !other.extra)
-    return true;
-  if (other.extra && !extra)
-    return false;
-  if (fragile && !other.fragile)
-    return true;
-  if (other.fragile && !fragile)
-    return false;
-  if (symbol < other.symbol)
-    return true;
-  if (other.symbol < symbol)
-    return false;
-  if (state_index < other.state_index)
-    return true;
-  if (other.state_index < state_index)
-    return false;
-  if (production < other.production)
-    return true;
-  if (other.production < production)
-    return false;
-  return consumed_symbol_count < other.consumed_symbol_count;
+  if (type < other.type) return true;
+  if (other.type < type) return false;
+  if (extra && !other.extra) return true;
+  if (other.extra && !extra) return false;
+  if (fragile && !other.fragile) return true;
+  if (other.fragile && !fragile) return false;
+  if (symbol < other.symbol) return true;
+  if (other.symbol < symbol) return false;
+  if (state_index < other.state_index) return true;
+  if (other.state_index < state_index) return false;
+  if (production < other.production) return true;
+  if (other.production < production) return false;
+  if (consumed_symbol_count < other.consumed_symbol_count) return true;
+  if (other.consumed_symbol_count < consumed_symbol_count) return false;
+  return rename_sequence_id < other.rename_sequence_id;
 }
 
 ParseTableEntry::ParseTableEntry()
-    : reusable(true), depends_on_lookahead(false) {}
+  : reusable(true), depends_on_lookahead(false) {}
 
 ParseTableEntry::ParseTableEntry(const vector<ParseAction> &actions,
                                  bool reusable, bool depends_on_lookahead)
-    : actions(actions),
-      reusable(reusable),
-      depends_on_lookahead(depends_on_lookahead) {}
+  : actions(actions),
+    reusable(reusable),
+    depends_on_lookahead(depends_on_lookahead) {}
 
 bool ParseTableEntry::operator==(const ParseTableEntry &other) const {
-  return actions == other.actions && reusable == other.reusable &&
-         depends_on_lookahead == other.depends_on_lookahead;
+  return
+    actions == other.actions &&
+    reusable == other.reusable &&
+    depends_on_lookahead == other.depends_on_lookahead;
 }
 
 ParseState::ParseState() : lex_state_id(-1) {}

--- a/src/compiler/parse_table.h
+++ b/src/compiler/parse_table.h
@@ -41,6 +41,7 @@ struct ParseAction {
   bool extra;
   bool fragile;
   ParseStateId state_index;
+  unsigned rename_sequence_id;
 };
 
 struct ParseTableEntry {
@@ -73,12 +74,15 @@ struct ParseTableSymbolMetadata {
   bool structural;
 };
 
+using RenameSequence = std::vector<std::string>;
+
 struct ParseTable {
   ParseAction &add_terminal_action(ParseStateId state_id, rules::Symbol, ParseAction);
   void set_nonterminal_action(ParseStateId, rules::Symbol::Index, ParseStateId);
 
   std::vector<ParseState> states;
   std::map<rules::Symbol, ParseTableSymbolMetadata> symbols;
+  std::vector<RenameSequence> rename_sequences;
 };
 
 }  // namespace tree_sitter

--- a/src/compiler/parse_table.h
+++ b/src/compiler/parse_table.h
@@ -28,13 +28,10 @@ struct ParseAction {
   static ParseAction Error();
   static ParseAction Shift(ParseStateId state_index);
   static ParseAction Recover(ParseStateId state_index);
-  static ParseAction Reduce(rules::Symbol symbol, size_t consumed_symbol_count,
-                            const Production &);
+  static ParseAction Reduce(rules::Symbol symbol, size_t child_count, const Production &);
   static ParseAction ShiftExtra();
   bool operator==(const ParseAction &) const;
   bool operator<(const ParseAction &) const;
-  rules::Associativity associativity() const;
-  int precedence() const;
 
   const Production *production;
   size_t consumed_symbol_count;

--- a/src/compiler/rules/metadata.cc
+++ b/src/compiler/rules/metadata.cc
@@ -1,9 +1,13 @@
 #include "compiler/rules/metadata.h"
 #include <climits>
+#include <string>
 #include "compiler/rule.h"
 
 namespace tree_sitter {
 namespace rules {
+
+using std::move;
+using std::string;
 
 Metadata::Metadata(const Rule &rule, MetadataParams params) :
   rule(std::make_shared<Rule>(rule)), params(params) {}
@@ -70,6 +74,12 @@ Metadata Metadata::main_token(const Rule &rule) {
   params.has_precedence = true;
   params.precedence = 0;
   params.is_main_token = true;
+  return Metadata{rule, params};
+}
+
+Metadata Metadata::rename(string &&name, const Rule &rule) {
+  MetadataParams params;
+  params.name_replacement = move(name);
   return Metadata{rule, params};
 }
 

--- a/src/compiler/rules/metadata.h
+++ b/src/compiler/rules/metadata.h
@@ -1,6 +1,7 @@
 #ifndef COMPILER_RULES_METADATA_H_
 #define COMPILER_RULES_METADATA_H_
 
+#include <string>
 #include <memory>
 
 namespace tree_sitter {
@@ -22,6 +23,7 @@ struct MetadataParams {
   bool is_string;
   bool is_active;
   bool is_main_token;
+  std::string name_replacement;
 
   inline MetadataParams() :
     precedence{0}, dynamic_precedence{0}, associativity{AssociativityNone},
@@ -38,7 +40,8 @@ struct MetadataParams {
       is_token == other.is_token &&
       is_string == other.is_string &&
       is_active == other.is_active &&
-      is_main_token == other.is_main_token
+      is_main_token == other.is_main_token &&
+      name_replacement == other.name_replacement
     );
   }
 };
@@ -59,6 +62,7 @@ struct Metadata {
   static Metadata prec_dynamic(int precedence, const Rule &rule);
   static Metadata separator(const Rule &rule);
   static Metadata main_token(const Rule &rule);
+  static Metadata rename(std::string &&name, const Rule &rule);
 
   bool operator==(const Metadata &other) const;
 };

--- a/src/compiler/syntax_grammar.cc
+++ b/src/compiler/syntax_grammar.cc
@@ -1,0 +1,36 @@
+#include "compiler/syntax_grammar.h"
+
+namespace tree_sitter {
+
+bool ProductionStep::operator==(const ProductionStep &other) const {
+  return symbol == other.symbol &&
+    precedence == other.precedence &&
+    associativity == other.associativity &&
+    name_replacement == other.name_replacement;
+}
+
+bool ProductionStep::operator!=(const ProductionStep &other) const {
+  return !operator==(other);
+}
+
+bool ProductionStep::operator<(const ProductionStep &other) const {
+ if (symbol < other.symbol) return true;
+ if (other.symbol < symbol) return false;
+ if (precedence < other.precedence) return true;
+ if (other.precedence < precedence) return false;
+ if (associativity < other.associativity) return true;
+ if (other.associativity < associativity) return false;
+ return name_replacement < other.name_replacement;
+}
+
+bool Production::operator==(const Production &other) const {
+  return steps == other.steps && dynamic_precedence == other.dynamic_precedence;
+}
+
+bool ExternalToken::operator==(const ExternalToken &other) const {
+  return name == other.name &&
+    type == other.type &&
+    corresponding_internal_token == other.corresponding_internal_token;
+}
+
+}  // namespace tree_sitter

--- a/src/compiler/syntax_grammar.h
+++ b/src/compiler/syntax_grammar.h
@@ -10,43 +10,29 @@
 namespace tree_sitter {
 
 struct ProductionStep {
-  inline bool operator==(const ProductionStep &other) const {
-    return symbol == other.symbol &&
-      precedence == other.precedence &&
-      associativity == other.associativity;
-  }
-
-  inline bool operator!=(const ProductionStep &other) const {
-    return !operator==(other);
-  }
-
-  inline bool operator<(const ProductionStep &other) const {
-    if (symbol < other.symbol) return true;
-    if (other.symbol < symbol) return false;
-    if (precedence < other.precedence) return true;
-    if (other.precedence < precedence) return false;
-    return associativity < other.associativity;
-  }
-
   rules::Symbol symbol;
   int precedence;
   rules::Associativity associativity;
+  std::string name_replacement;
+
+  bool operator==(const ProductionStep &) const;
+  bool operator!=(const ProductionStep &) const;
+  bool operator<(const ProductionStep &) const;
 };
 
 struct Production {
   std::vector<ProductionStep> steps;
   int dynamic_precedence = 0;
 
-  inline bool operator==(const Production &other) const {
-    return steps == other.steps && dynamic_precedence == other.dynamic_precedence;
-  }
-
+  bool operator==(const Production &) const;
   inline ProductionStep &back() { return steps.back(); }
   inline const ProductionStep &back() const { return steps.back(); }
   inline bool empty() const { return steps.empty(); }
   inline size_t size() const { return steps.size(); }
   inline const ProductionStep &operator[](int i) const { return steps[i]; }
   inline const ProductionStep &at(int i) const { return steps[i]; }
+  inline std::vector<ProductionStep>::const_iterator begin() const { return steps.begin(); }
+  inline std::vector<ProductionStep>::const_iterator end() const { return steps.end(); }
 };
 
 struct SyntaxVariable {
@@ -55,24 +41,18 @@ struct SyntaxVariable {
   std::vector<Production> productions;
 };
 
-using ConflictSet = std::set<rules::Symbol>;
-
 struct ExternalToken {
   std::string name;
   VariableType type;
   rules::Symbol corresponding_internal_token;
 
-  inline bool operator==(const ExternalToken &other) const {
-    return name == other.name &&
-      type == other.type &&
-      corresponding_internal_token == other.corresponding_internal_token;
-  }
+  bool operator==(const ExternalToken &) const;
 };
 
 struct SyntaxGrammar {
   std::vector<SyntaxVariable> variables;
   std::set<rules::Symbol> extra_tokens;
-  std::set<ConflictSet> expected_conflicts;
+  std::set<std::set<rules::Symbol>> expected_conflicts;
   std::vector<ExternalToken> external_tokens;
   std::set<rules::Symbol> variables_to_inline;
 };

--- a/src/runtime/language.c
+++ b/src/runtime/language.c
@@ -3,7 +3,8 @@
 #include "runtime/error_costs.h"
 
 static const TSParseAction SHIFT_ERROR = {
-  .type = TSParseActionTypeShift, .params = {.to_state = ERROR_STATE}
+  .type = TSParseActionTypeShift,
+  .to_state = ERROR_STATE,
 };
 
 void ts_language_table_entry(const TSLanguage *self, TSStateId state,

--- a/src/runtime/language.h
+++ b/src/runtime/language.h
@@ -44,7 +44,7 @@ static inline TSStateId ts_language_next_state(const TSLanguage *self,
     if (count > 0) {
       TSParseAction action = actions[count - 1];
       if (action.type == TSParseActionTypeShift || action.type == TSParseActionTypeRecover) {
-        return action.params.to_state;
+        return action.to_state;
       }
     }
     return 0;

--- a/src/runtime/language.h
+++ b/src/runtime/language.h
@@ -63,6 +63,13 @@ ts_language_enabled_external_tokens(const TSLanguage *self,
   }
 }
 
+static inline const TSSymbol *
+ts_language_rename_sequence(const TSLanguage *self, unsigned id) {
+  return id > 0 ?
+    self->rename_sequences + id * self->max_rename_sequence_length :
+    NULL;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/runtime/node.c
+++ b/src/runtime/node.c
@@ -304,7 +304,8 @@ bool ts_node_eq(TSNode self, TSNode other) {
 }
 
 bool ts_node_is_named(TSNode self) {
-  return ts_node__tree(self)->named;
+  const Tree *tree = ts_node__tree(self);
+  return tree->named || tree->context.rename_symbol != 0;
 }
 
 bool ts_node_has_changes(TSNode self) {

--- a/src/runtime/node.c
+++ b/src/runtime/node.c
@@ -288,7 +288,8 @@ void ts_symbol_iterator_next(TSSymbolIterator *self) {
 }
 
 const char *ts_node_type(TSNode self, const TSDocument *document) {
-  TSSymbol symbol = ts_node__tree(self)->symbol;
+  const Tree *tree = ts_node__tree(self);
+  TSSymbol symbol = tree->context.rename_symbol ? tree->context.rename_symbol : tree->symbol;
   return ts_language_symbol_name(document->parser.language, symbol);
 }
 

--- a/src/runtime/reduce_action.h
+++ b/src/runtime/reduce_action.h
@@ -12,6 +12,7 @@ typedef struct {
   uint32_t count;
   TSSymbol symbol;
   int dynamic_precedence;
+  unsigned short rename_sequence_id;
 } ReduceAction;
 
 typedef Array(ReduceAction) ReduceActionSet;

--- a/src/runtime/tree.h
+++ b/src/runtime/tree.h
@@ -75,7 +75,7 @@ TreeArray ts_tree_array_remove_last_n(TreeArray *, uint32_t);
 TreeArray ts_tree_array_remove_trailing_extras(TreeArray *);
 
 Tree *ts_tree_make_leaf(TSSymbol, Length, Length, TSSymbolMetadata);
-Tree *ts_tree_make_node(TSSymbol, uint32_t, Tree **, TSSymbolMetadata);
+Tree *ts_tree_make_node(TSSymbol, uint32_t, Tree **, TSSymbolMetadata, const TSSymbol *);
 Tree *ts_tree_make_copy(Tree *child);
 Tree *ts_tree_make_error_node(TreeArray *);
 Tree *ts_tree_make_error(Length, Length, int32_t);
@@ -86,7 +86,7 @@ int ts_tree_compare(const Tree *tree1, const Tree *tree2);
 
 uint32_t ts_tree_start_column(const Tree *self);
 uint32_t ts_tree_end_column(const Tree *self);
-void ts_tree_set_children(Tree *, uint32_t, Tree **);
+void ts_tree_set_children(Tree *, uint32_t, Tree **, const TSSymbol *);
 void ts_tree_assign_parents(Tree *, TreePath *, const TSLanguage *);
 void ts_tree_edit(Tree *, const TSInputEdit *edit);
 char *ts_tree_string(const Tree *, const TSLanguage *, bool include_all);

--- a/src/runtime/tree.h
+++ b/src/runtime/tree.h
@@ -19,6 +19,7 @@ typedef struct Tree {
     struct Tree *parent;
     uint32_t index;
     Length offset;
+    TSSymbol rename_symbol;
   } context;
 
   uint32_t child_count;
@@ -26,6 +27,7 @@ typedef struct Tree {
     struct {
       uint32_t visible_child_count;
       uint32_t named_child_count;
+      unsigned short rename_sequence_id;
       struct Tree **children;
     };
     TSExternalTokenState external_token_state;
@@ -85,7 +87,7 @@ int ts_tree_compare(const Tree *tree1, const Tree *tree2);
 uint32_t ts_tree_start_column(const Tree *self);
 uint32_t ts_tree_end_column(const Tree *self);
 void ts_tree_set_children(Tree *, uint32_t, Tree **);
-void ts_tree_assign_parents(Tree *, TreePath *);
+void ts_tree_assign_parents(Tree *, TreePath *, const TSLanguage *);
 void ts_tree_edit(Tree *, const TSInputEdit *edit);
 char *ts_tree_string(const Tree *, const TSLanguage *, bool include_all);
 void ts_tree_print_dot_graph(const Tree *, const TSLanguage *, FILE *);

--- a/test/compiler/build_tables/parse_item_set_builder_test.cc
+++ b/test/compiler/build_tables/parse_item_set_builder_test.cc
@@ -12,6 +12,7 @@ START_TEST
 
 describe("ParseItemSetBuilder", []() {
   vector<LexicalVariable> lexical_variables;
+
   for (size_t i = 0; i < 20; i++) {
     lexical_variables.push_back({
       "token_" + to_string(i),
@@ -27,23 +28,23 @@ describe("ParseItemSetBuilder", []() {
     SyntaxGrammar grammar{{
       SyntaxVariable{"rule0", VariableTypeNamed, {
         Production{{
-          {Symbol::non_terminal(1), 0, AssociativityNone},
-          {Symbol::terminal(11), 0, AssociativityNone},
+          {Symbol::non_terminal(1), 0, AssociativityNone, ""},
+          {Symbol::terminal(11), 0, AssociativityNone, ""},
         }, 0},
       }},
       SyntaxVariable{"rule1", VariableTypeNamed, {
         Production{{
-          {Symbol::terminal(12), 0, AssociativityNone},
-          {Symbol::terminal(13), 0, AssociativityNone},
+          {Symbol::terminal(12), 0, AssociativityNone, ""},
+          {Symbol::terminal(13), 0, AssociativityNone, ""},
         }, 0},
         Production{{
-          {Symbol::non_terminal(2), 0, AssociativityNone},
+          {Symbol::non_terminal(2), 0, AssociativityNone, ""},
         }, 0}
       }},
       SyntaxVariable{"rule2", VariableTypeNamed, {
         Production{{
-          {Symbol::terminal(14), 0, AssociativityNone},
-          {Symbol::terminal(15), 0, AssociativityNone},
+          {Symbol::terminal(14), 0, AssociativityNone, ""},
+          {Symbol::terminal(15), 0, AssociativityNone, ""},
         }, 0}
       }},
     }, {}, {}, {}, {}};
@@ -52,21 +53,21 @@ describe("ParseItemSetBuilder", []() {
       return grammar.variables[variable_index].productions[production_index];
     };
 
-    ParseItemSet item_set({
+    ParseItemSet item_set{{
       {
         ParseItem(rules::START(), production(0, 0), 0),
         LookaheadSet({ Symbol::terminal(10) }),
       }
-    });
+    }};
 
     ParseItemSetBuilder item_set_builder(grammar, lexical_grammar);
     item_set_builder.apply_transitive_closure(&item_set);
 
-    AssertThat(item_set, Equals(ParseItemSet({
+    AssertThat(item_set, Equals(ParseItemSet{{
       {
         ParseItem(rules::START(), production(0, 0), 0),
         LookaheadSet({ Symbol::terminal(10) })
-        },
+      },
       {
         ParseItem(Symbol::non_terminal(1), production(1, 0), 0),
         LookaheadSet({ Symbol::terminal(11) })
@@ -79,21 +80,21 @@ describe("ParseItemSetBuilder", []() {
         ParseItem(Symbol::non_terminal(2), production(2, 0), 0),
         LookaheadSet({ Symbol::terminal(11) })
       },
-    })));
+    }}));
   });
 
   it("handles rules with empty productions", [&]() {
     SyntaxGrammar grammar{{
       SyntaxVariable{"rule0", VariableTypeNamed, {
         Production{{
-          {Symbol::non_terminal(1), 0, AssociativityNone},
-          {Symbol::terminal(11), 0, AssociativityNone},
+          {Symbol::non_terminal(1), 0, AssociativityNone, ""},
+          {Symbol::terminal(11), 0, AssociativityNone, ""},
         }, 0},
       }},
       SyntaxVariable{"rule1", VariableTypeNamed, {
         Production{{
-          {Symbol::terminal(12), 0, AssociativityNone},
-          {Symbol::terminal(13), 0, AssociativityNone},
+          {Symbol::terminal(12), 0, AssociativityNone, ""},
+          {Symbol::terminal(13), 0, AssociativityNone, ""},
         }, 0},
         Production{{}, 0}
       }},
@@ -103,17 +104,17 @@ describe("ParseItemSetBuilder", []() {
       return grammar.variables[variable_index].productions[production_index];
     };
 
-    ParseItemSet item_set({
+    ParseItemSet item_set{{
       {
         ParseItem(rules::START(), production(0, 0), 0),
         LookaheadSet({ Symbol::terminal(10) }),
       }
-    });
+    }};
 
     ParseItemSetBuilder item_set_builder(grammar, lexical_grammar);
     item_set_builder.apply_transitive_closure(&item_set);
 
-    AssertThat(item_set, Equals(ParseItemSet({
+    AssertThat(item_set, Equals(ParseItemSet{{
       {
         ParseItem(rules::START(), production(0, 0), 0),
         LookaheadSet({ Symbol::terminal(10) })
@@ -126,7 +127,7 @@ describe("ParseItemSetBuilder", []() {
         ParseItem(Symbol::non_terminal(1), production(1, 1), 0),
         LookaheadSet({ Symbol::terminal(11) })
       },
-    })));
+    }}));
   });
 });
 

--- a/test/compiler/prepare_grammar/flatten_grammar_test.cc
+++ b/test/compiler/prepare_grammar/flatten_grammar_test.cc
@@ -35,19 +35,19 @@ describe("flatten_grammar", []() {
     AssertThat(result.type, Equals(VariableTypeNamed));
     AssertThat(result.productions, Equals(vector<Production>({
       Production{{
-        {Symbol::non_terminal(1), 0, AssociativityNone},
-        {Symbol::non_terminal(2), 101, AssociativityLeft},
-        {Symbol::non_terminal(3), 102, AssociativityRight},
-        {Symbol::non_terminal(4), 101, AssociativityLeft},
-        {Symbol::non_terminal(6), 0, AssociativityNone},
-        {Symbol::non_terminal(7), 0, AssociativityNone},
+        {Symbol::non_terminal(1), 0, AssociativityNone, ""},
+        {Symbol::non_terminal(2), 101, AssociativityLeft, ""},
+        {Symbol::non_terminal(3), 102, AssociativityRight, ""},
+        {Symbol::non_terminal(4), 101, AssociativityLeft, ""},
+        {Symbol::non_terminal(6), 0, AssociativityNone, ""},
+        {Symbol::non_terminal(7), 0, AssociativityNone, ""},
       }, 0},
       Production{{
-        {Symbol::non_terminal(1), 0, AssociativityNone},
-        {Symbol::non_terminal(2), 101, AssociativityLeft},
-        {Symbol::non_terminal(5), 101, AssociativityLeft},
-        {Symbol::non_terminal(6), 0, AssociativityNone},
-        {Symbol::non_terminal(7), 0, AssociativityNone},
+        {Symbol::non_terminal(1), 0, AssociativityNone, ""},
+        {Symbol::non_terminal(2), 101, AssociativityLeft, ""},
+        {Symbol::non_terminal(5), 101, AssociativityLeft, ""},
+        {Symbol::non_terminal(6), 0, AssociativityNone, ""},
+        {Symbol::non_terminal(7), 0, AssociativityNone, ""},
       }, 0}
     })));
   });
@@ -77,19 +77,19 @@ describe("flatten_grammar", []() {
     AssertThat(result.type, Equals(VariableTypeNamed));
     AssertThat(result.productions, Equals(vector<Production>({
       Production{{
-        {Symbol::non_terminal(1), 0, AssociativityNone},
-        {Symbol::non_terminal(2), 0, AssociativityNone},
-        {Symbol::non_terminal(3), 0, AssociativityNone},
-        {Symbol::non_terminal(4), 0, AssociativityNone},
-        {Symbol::non_terminal(6), 0, AssociativityNone},
-        {Symbol::non_terminal(7), 0, AssociativityNone},
+        {Symbol::non_terminal(1), 0, AssociativityNone, ""},
+        {Symbol::non_terminal(2), 0, AssociativityNone, ""},
+        {Symbol::non_terminal(3), 0, AssociativityNone, ""},
+        {Symbol::non_terminal(4), 0, AssociativityNone, ""},
+        {Symbol::non_terminal(6), 0, AssociativityNone, ""},
+        {Symbol::non_terminal(7), 0, AssociativityNone, ""},
       }, 102},
       Production{{
-        {Symbol::non_terminal(1), 0, AssociativityNone},
-        {Symbol::non_terminal(2), 0, AssociativityNone},
-        {Symbol::non_terminal(5), 0, AssociativityNone},
-        {Symbol::non_terminal(6), 0, AssociativityNone},
-        {Symbol::non_terminal(7), 0, AssociativityNone},
+        {Symbol::non_terminal(1), 0, AssociativityNone, ""},
+        {Symbol::non_terminal(2), 0, AssociativityNone, ""},
+        {Symbol::non_terminal(5), 0, AssociativityNone, ""},
+        {Symbol::non_terminal(6), 0, AssociativityNone, ""},
+        {Symbol::non_terminal(7), 0, AssociativityNone, ""},
       }, 101}
     })));
   });
@@ -106,8 +106,8 @@ describe("flatten_grammar", []() {
 
     AssertThat(result.productions, Equals(vector<Production>({
       Production{{
-        {Symbol::non_terminal(1), 101, AssociativityLeft},
-        {Symbol::non_terminal(2), 101,  AssociativityLeft},
+        {Symbol::non_terminal(1), 101, AssociativityLeft, ""},
+        {Symbol::non_terminal(2), 101,  AssociativityLeft, ""},
       }, 0}
     })));
 
@@ -121,7 +121,7 @@ describe("flatten_grammar", []() {
 
     AssertThat(result.productions, Equals(vector<Production>({
       Production{{
-        {Symbol::non_terminal(1), 101, AssociativityLeft},
+        {Symbol::non_terminal(1), 101, AssociativityLeft, ""},
       }, 0}
     })));
   });

--- a/test/fixtures/test_grammars/inlined_renamed_rules/corpus.txt
+++ b/test/fixtures/test_grammars/inlined_renamed_rules/corpus.txt
@@ -1,0 +1,18 @@
+======================================
+Method calls
+======================================
+
+a.b(c(d.e));
+
+---
+
+(statement
+  (call_expression
+    (member_expression
+      (variable_name)
+      (property_name))
+    (call_expression
+      (variable_name)
+      (member_expression
+        (variable_name)
+        (property_name)))))

--- a/test/fixtures/test_grammars/inlined_renamed_rules/grammar.json
+++ b/test/fixtures/test_grammars/inlined_renamed_rules/grammar.json
@@ -1,0 +1,73 @@
+{
+  "name": "inlined_renamed_rules",
+
+  "extras": [
+    {"type": "PATTERN", "value": "\\s"}
+  ],
+
+  "inline": [
+    "expression"
+  ],
+
+  "rules": {
+    "statement": {
+      "type": "SEQ",
+      "members": [
+        {"type": "SYMBOL", "name": "expression"},
+        {"type": "STRING", "value": ";"}
+      ]
+    },
+
+    "expression": {
+      "type": "CHOICE",
+      "members": [
+        {"type": "SYMBOL", "name": "call_expression"},
+        {"type": "SYMBOL", "name": "member_expression"},
+        {
+          "type": "RENAME",
+          "value": "variable_name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        }
+      ]
+    },
+
+    "call_expression": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {"type": "SYMBOL", "name": "expression"},
+          {"type": "STRING", "value": "("},
+          {"type": "SYMBOL", "name": "expression"},
+          {"type": "STRING", "value": ")"},
+        ]
+      }
+    },
+
+    "member_expression": {
+      "type": "PREC_LEFT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {"type": "SYMBOL", "name": "expression"},
+          {"type": "STRING", "value": "."},
+          {
+            "type": "RENAME",
+            "value": "property_name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "identifier"
+            }
+          }
+        ]
+      }
+    },
+
+    "identifier": {"type": "PATTERN", "value": "\\a+"}
+  }
+}

--- a/test/fixtures/test_grammars/inlined_renamed_rules/readme.md
+++ b/test/fixtures/test_grammars/inlined_renamed_rules/readme.md
@@ -1,0 +1,1 @@
+This grammar shows that a rule marked as `inline` can *contain* a `RENAME` rule.

--- a/test/fixtures/test_grammars/renamed_inlined_rules/corpus.txt
+++ b/test/fixtures/test_grammars/renamed_inlined_rules/corpus.txt
@@ -1,0 +1,13 @@
+=========================
+OK
+=========================
+
+a.b.c
+
+---
+
+(expression (member_expression
+  (expression (member_expression
+    (expression (variable_name))
+    (property_name)))
+  (property_name)))

--- a/test/fixtures/test_grammars/renamed_inlined_rules/grammar.json
+++ b/test/fixtures/test_grammars/renamed_inlined_rules/grammar.json
@@ -1,0 +1,57 @@
+{
+  "name": "renamed_inlined_rules",
+
+  "extras": [
+    {"type": "PATTERN", "value": "\\s"}
+  ],
+
+  "inline": [
+    "identifier"
+  ],
+
+  "rules": {
+    "expression": {
+      "type": "CHOICE",
+      "members": [
+        {"type": "SYMBOL", "name": "member_expression"},
+        {
+          "type": "RENAME",
+          "value": "variable_name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        }
+      ]
+    },
+
+    "member_expression": {
+      "type": "PREC_LEFT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {"type": "SYMBOL", "name": "expression"},
+          {"type": "STRING", "value": "."},
+          {
+            "type": "RENAME",
+            "value": "property_name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "identifier"
+            }
+          }
+        ]
+      }
+    },
+
+    "identifier": {
+      "type": "CHOICE",
+      "members": [
+        {"type": "STRING", "value": "a"},
+        {"type": "STRING", "value": "b"},
+        {"type": "STRING", "value": "c"}
+      ]
+    }
+  }
+}

--- a/test/fixtures/test_grammars/renamed_inlined_rules/readme.md
+++ b/test/fixtures/test_grammars/renamed_inlined_rules/readme.md
@@ -1,0 +1,1 @@
+This grammar shows that `RENAME` rules can *contain* a rule that is marked as `inline`. It also shows that you can rename a rule that would otherwise be anonymous, and it will then appear as a named node.

--- a/test/fixtures/test_grammars/renamed_rules/corpus.txt
+++ b/test/fixtures/test_grammars/renamed_rules/corpus.txt
@@ -1,0 +1,18 @@
+======================================
+Method calls
+======================================
+
+a.b(c(d.e));
+
+---
+
+(statement
+  (call_expression
+    (member_expression
+      (variable_name)
+      (property_name))
+    (call_expression
+      (variable_name)
+      (member_expression
+        (variable_name)
+        (property_name)))))

--- a/test/fixtures/test_grammars/renamed_rules/grammar.json
+++ b/test/fixtures/test_grammars/renamed_rules/grammar.json
@@ -1,0 +1,69 @@
+{
+  "name": "renamed_rules",
+
+  "extras": [
+    {"type": "PATTERN", "value": "\\s"}
+  ],
+
+  "rules": {
+    "statement": {
+      "type": "SEQ",
+      "members": [
+        {"type": "SYMBOL", "name": "_expression"},
+        {"type": "STRING", "value": ";"}
+      ]
+    },
+
+    "_expression": {
+      "type": "CHOICE",
+      "members": [
+        {"type": "SYMBOL", "name": "call_expression"},
+        {"type": "SYMBOL", "name": "member_expression"},
+        {
+          "type": "RENAME",
+          "value": "variable_name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        }
+      ]
+    },
+
+    "call_expression": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {"type": "SYMBOL", "name": "_expression"},
+          {"type": "STRING", "value": "("},
+          {"type": "SYMBOL", "name": "_expression"},
+          {"type": "STRING", "value": ")"},
+        ]
+      }
+    },
+
+    "member_expression": {
+      "type": "PREC_LEFT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {"type": "SYMBOL", "name": "_expression"},
+          {"type": "STRING", "value": "."},
+          {
+            "type": "RENAME",
+            "value": "property_name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "identifier"
+            }
+          }
+        ]
+      }
+    },
+
+    "identifier": {"type": "PATTERN", "value": "\\a+"}
+  }
+}

--- a/test/integration/test_grammars.cc
+++ b/test/integration/test_grammars.cc
@@ -3,6 +3,7 @@
 #include "helpers/load_language.h"
 #include "helpers/stderr_logger.h"
 #include "helpers/file_helpers.h"
+#include "helpers/tree_helpers.h"
 #include "runtime/alloc.h"
 
 START_TEST
@@ -54,6 +55,7 @@ for (auto &language_name : test_languages) {
         ts_document_parse(document);
 
         TSNode root_node = ts_document_root_node(document);
+        assert_consistent_tree_sizes(root_node);
         const char *node_string = ts_node_string(root_node, document);
         string result(node_string);
         ts_free((void *)node_string);

--- a/test/runtime/tree_test.cc
+++ b/test/runtime/tree_test.cc
@@ -72,7 +72,7 @@ describe("Tree", []() {
       parent1 = ts_tree_make_node(symbol3, 2, tree_array({
         tree1,
         tree2,
-      }), visible);
+      }), visible, nullptr);
     });
 
     after_each([&]() {
@@ -103,7 +103,7 @@ describe("Tree", []() {
         parent = ts_tree_make_node(symbol3, 2, tree_array({
           tree1,
           tree2,
-        }), visible);
+        }), visible, nullptr);
       });
 
       after_each([&]() {
@@ -127,7 +127,7 @@ describe("Tree", []() {
         parent = ts_tree_make_node(symbol3, 2, tree_array({
           tree1,
           tree2,
-        }), visible);
+        }), visible, nullptr);
       });
 
       after_each([&]() {
@@ -151,7 +151,7 @@ describe("Tree", []() {
         parent = ts_tree_make_node(symbol3, 2, tree_array({
           tree1,
           tree2,
-        }), visible);
+        }), visible, nullptr);
       });
 
       after_each([&]() {
@@ -173,7 +173,7 @@ describe("Tree", []() {
         ts_tree_make_leaf(symbol2, {2, 2, {0, 2}}, {3, 3, {0, 3}}, visible),
         ts_tree_make_leaf(symbol3, {2, 2, {0, 2}}, {3, 3, {0, 3}}, visible),
         ts_tree_make_leaf(symbol4, {2, 2, {0, 2}}, {3, 3, {0, 3}}, visible),
-      }), visible);
+      }), visible, nullptr);
 
       AssertThat(tree->padding, Equals<Length>({2, 2, {0, 2}}));
       AssertThat(tree->size, Equals<Length>({13, 13, {0, 13}}));
@@ -350,14 +350,14 @@ describe("Tree", []() {
       Tree *parent = ts_tree_make_node(symbol2, 2, tree_array({
         leaf,
         leaf_copy,
-      }), visible);
+      }), visible, nullptr);
       ts_tree_retain(leaf);
       ts_tree_retain(leaf_copy);
 
       Tree *parent_copy = ts_tree_make_node(symbol2, 2, tree_array({
         leaf,
         leaf_copy,
-      }), visible);
+      }), visible, nullptr);
       ts_tree_retain(leaf);
       ts_tree_retain(leaf_copy);
 
@@ -401,14 +401,14 @@ describe("Tree", []() {
       Tree *parent = ts_tree_make_node(symbol2, 2, tree_array({
         leaf,
         leaf2,
-      }), visible);
+      }), visible, nullptr);
       ts_tree_retain(leaf);
       ts_tree_retain(leaf2);
 
       Tree *different_parent = ts_tree_make_node(symbol2, 2, tree_array({
         leaf2,
         leaf,
-      }), visible);
+      }), visible, nullptr);
       ts_tree_retain(leaf2);
       ts_tree_retain(leaf);
 
@@ -438,14 +438,14 @@ describe("Tree", []() {
           (tree3 = make_external(ts_tree_make_leaf(symbol3, padding, size, visible))),
           (tree4 = ts_tree_make_leaf(symbol4, padding, size, visible)),
           (tree5 = ts_tree_make_leaf(symbol5, padding, size, visible)),
-        }), visible)),
+        }), visible, nullptr)),
         (tree6 = ts_tree_make_node(symbol6, 2, tree_array({
           (tree7 = ts_tree_make_node(symbol7, 1, tree_array({
             (tree8 = ts_tree_make_leaf(symbol8, padding, size, visible)),
-          }), visible)),
+          }), visible, nullptr)),
           (tree9 = ts_tree_make_leaf(symbol9, padding, size, visible)),
-        }), visible)),
-      }), visible);
+        }), visible, nullptr)),
+      }), visible, nullptr);
 
       auto token = ts_tree_last_external_token(tree1);
       AssertThat(token, Equals(tree3));


### PR DESCRIPTION
#### Motivation

Currently, most tree-sitter grammars have some kind of `identifier` token that is used to represent several different constructs in the language: references to variables, introductions of new variables, references to types, introductions of new types, object fields, etc. Using the current syntax tree, It isn't as easy as I would like to distinguish between these different meanings of `identifier`.

#### Solution

This PR adds a new type of rule called `rename`, which can be used like this:

```js
expression: $ => choice(
  $.call_expression,
  $.binary_expression,
  $.number,
  // ...
  rename($.identifier, 'variable_reference')
),

type: $ => choice(
  $.array_type,
  rename($.identifier, 'type_reference')
),

member_expression: $ => seq(
  $.expression,
  '.',
  rename($.identifier, 'property_name')
)
```

Unlike *wrapping* the `identifier` token in a `variable_reference` *parent* token, which increases the size of the syntax tree significantly, the `rename` rule has pretty much zero runtime cost.

/cc @nathansobo 