### PR TITLE
Enabled Fortify for libruntime.a

### DIFF
--- a/project.gyp
+++ b/project.gyp
@@ -102,7 +102,7 @@
         'externals/utf8proc/utf8proc.c',
       ],
       'cflags_c': [
-        '-std=c99'
+        '-std=c99', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=1'
       ],
       'ldflags': [
         '-g',


### PR DESCRIPTION
There is currently no code in libruntime.a that Fortify can protect so this
doesn't actually change the generated assembly. However, we may add code in the
future that Fortify can protect.

clang defines `_FORTIFY_SOURCE` by default so we need to undefine then redefine it to avoid build errors.