### PR TITLE
Assertion failure in parser__advance

### DIFF
--- a/test/integration/fuzzing-examples.cc
+++ b/test/integration/fuzzing-examples.cc
@@ -11,6 +11,10 @@ vector<pair<string, string>> examples({
   //   "javascript",
   //   "Bi0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLXGK0i0vLS0tLS0tLS0tLS0tLS0tLS0tLS0tLXGK0i0vLS0tLS0tLS0tLS0tLS0xLS0tLTYtLfpZAA=="
   // },
+  {
+    "python",
+    "NWNvbogsKTMsLCwsY29uiCwqLDo1Y29uLA=="
+  },
 });
 
 describe("examples found via fuzzing", [&]() {


### PR DESCRIPTION
:wave: I found this via fuzzing. The python testcase decodes to:
```
00000000  35 63 6f 6e 88 2c 29 33  2c 2c 2c 2c 63 6f 6e 88  |5con.,)3,,,,con.|
00000010  2c 2a 2c 3a 35 63 6f 6e  2c                       |,*,:5con,|
```

which triggers:
```
Assertion failed: ((uint32_t)0 < (&reduction.slices)->size), function parser__advance, file src/runtime/parser.c, line 1202.
```

which looks like `parser__reduce` is returning a result with no slices.