### PR TITLE
Allow fuzzer CFLAGS to be overridden by environment

### DIFF
--- a/project.gyp
+++ b/project.gyp
@@ -136,8 +136,8 @@
         },
       },
       'Fuzz': {
-        'cflags': [ '-g', '-fsanitize=address,undefined', '-fsanitize-coverage=trace-pc-guard' ],
-        'ldflags': [ '-g', '-fsanitize=address,undefined', '-fsanitize-coverage=trace-pc-guard' ],
+        'cflags': ['<!@(echo $CFLAGS)'],
+        'ldflags': ['<!@(echo $CXXFLAGS)'],
       },
       'Release': {
         'cflags': [ '-O2', '-fno-strict-aliasing' ],

--- a/project.gyp
+++ b/project.gyp
@@ -137,7 +137,7 @@
       },
       'Fuzz': {
         'cflags': ['<!@(echo $CFLAGS)'],
-        'ldflags': ['<!@(echo $CXXFLAGS)'],
+        'ldflags': ['<!@(echo $CFLAGS)'],
       },
       'Release': {
         'cflags': [ '-O2', '-fno-strict-aliasing' ],

--- a/script/build-fuzzers
+++ b/script/build-fuzzers
@@ -15,13 +15,16 @@ CC=${CC:-clang}
 CXX=${CXX:-clang++}
 LINK=${LINK:-clang++}
 
-CC=$CC CXX=$CXX LINK=$LINK ./script/configure
+default_fuzz_flags="-fsanitize=address,undefined -fsanitize-coverage=trace-pc-guard"
+
+CFLAGS=${CFLAGS:-"$default_fuzz_flags"}
+CXXFLAGS=${CXXFLAGS:-"$default_fuzz_flags"}
+
+CC=$CC CXX=$CXX LINK=$LINK CFLAGS=$CFLAGS CXXFLAGS=$CXXFLAGS ./script/configure
 
 export BUILDTYPE=Fuzz
 make runtime
 
-CFLAGS="-fsanitize=address,undefined -fsanitize-coverage=trace-pc-guard"
-CXXFLAGS="-fsanitize=address,undefined -fsanitize-coverage=trace-pc-guard"
 
 if [ -z "$@" ]; then
   languages=$(ls test/fixtures/grammars)


### PR DESCRIPTION
The fixed `CFLAGS` used when fuzzing is a good default but very brittle. Allow it to be overridden by the environment so 1) it's easier to experiment with the flags and 2) allow other tools to control the flags.

Using env vars also ensures that the flags in `build-fuzzers` and `project.gyp` are always in sync 