### PR TITLE
Take total dynamic precedence into account in stack version sorting

### DIFF
--- a/src/runtime/stack.h
+++ b/src/runtime/stack.h
@@ -104,6 +104,8 @@ StackPopResult ts_stack_pop_all(Stack *, StackVersion);
 
 unsigned ts_stack_depth_since_error(Stack *, StackVersion);
 
+int ts_stack_dynamic_precedence(Stack *, StackVersion);
+
 void ts_stack_record_summary(Stack *, StackVersion, unsigned max_depth);
 
 StackSummary *ts_stack_get_summary(Stack *, StackVersion);


### PR DESCRIPTION
We place a hard limit on the number of stack versions that can coexist. Currently the limit is 6. In some highly ambiguous code, this causes us to incorrectly discard the correct parse. With this change, we take into account the total *dynamic precedence* of a given stack version when we sort the versions. This way, versions that have constructs that we've marked with high dynamic precedence won't be discarded.