### PR TITLE
Updated links in References

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,6 @@ clang \
 
 - [Context Aware Scanning for Parsing Extensible Languages](http://www.umsec.umn.edu/publications/Context-Aware-Scanning-Parsing-Extensible)
 - [Efficient and Flexible Incremental Parsing](http://ftp.cs.berkeley.edu/sggs/toplas-parsing.ps)
-- [Incremental Analysis of Real Programming Languages](https://dl.acm.org/citation.cfm?id=258920)
+- [Incremental Analysis of Real Programming Languages](https://pdfs.semanticscholar.org/ca69/018c29cc415820ed207d7e1d391e2da1656f.pdf)
 - [Error Detection and Recovery in LR Parsers](http://what-when-how.com/compiler-writing/bottom-up-parsing-compiler-writing-part-13)
 - [Error Recovery for LR Parsers](http://www.dtic.mil/dtic/tr/fulltext/u2/a043470.pdf)

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ clang \
 ### References
 
 - [Context Aware Scanning for Parsing Extensible Languages](http://www.umsec.umn.edu/publications/Context-Aware-Scanning-Parsing-Extensible)
-- [Efficient and Flexible Incremental Parsing](http://harmonia.cs.berkeley.edu/papers/twagner-parsing.ps.gz)
-- [Incremental Analysis of Real Programming Languages](http://harmonia.cs.berkeley.edu/papers/twagner-glr.pdf)
+- [Efficient and Flexible Incremental Parsing](http://ftp.cs.berkeley.edu/sggs/toplas-parsing.ps)
+- [Incremental Analysis of Real Programming Languages](https://dl.acm.org/citation.cfm?id=258920)
 - [Error Detection and Recovery in LR Parsers](http://what-when-how.com/compiler-writing/bottom-up-parsing-compiler-writing-part-13)
 - [Error Recovery for LR Parsers](http://www.dtic.mil/dtic/tr/fulltext/u2/a043470.pdf)


### PR DESCRIPTION
I have updated "Efficient and Flexible Incremental Parsing" to point to the ftp location on berkeley.edu. The only hosted reference to "Incremental Analysis of Real Programming Languages" is at ACM Digital Library, I pointed that link here.

Fixes #107 