### PR TITLE
Remove wrong handling of \a in a regex

### DIFF
--- a/src/compiler/prepare_grammar/parse_regex.cc
+++ b/src/compiler/prepare_grammar/parse_regex.cc
@@ -190,8 +190,6 @@ class PatternParser {
 
   CharacterSet escaped_char(uint32_t value) {
     switch (value) {
-      case 'a':
-        return CharacterSet().include('a', 'z').include('A', 'Z');
       case 'w':
         return CharacterSet()
           .include('a', 'z')
@@ -210,8 +208,11 @@ class PatternParser {
       case 'D':
         return CharacterSet().include_all().exclude('0', '9');
       case 's':
-        return CharacterSet().include(' ').include('\t').include('\n').include(
-          '\r');
+        return CharacterSet()
+          .include(' ')
+          .include('\t')
+          .include('\n')
+          .include('\r');
       case 'S':
         return CharacterSet()
           .include_all()

--- a/test/fixtures/error_corpus/c_errors.txt
+++ b/test/fixtures/error_corpus/c_errors.txt
@@ -35,7 +35,7 @@ int c;
     (linkage_specification
       (string_literal)
       (declaration_list
-        (ERROR)
+        (preproc_call (preproc_directive))
         (function_definition
           (primitive_type)
           (function_declarator (identifier) (parameter_list))

--- a/test/fixtures/test_grammars/aliased_rules/grammar.json
+++ b/test/fixtures/test_grammars/aliased_rules/grammar.json
@@ -66,6 +66,6 @@
       }
     },
 
-    "identifier": {"type": "PATTERN", "value": "\\a+"}
+    "identifier": {"type": "PATTERN", "value": "[a-z]+"}
   }
 }

--- a/test/fixtures/test_grammars/conflict_in_repeat_rule/grammar.json
+++ b/test/fixtures/test_grammars/conflict_in_repeat_rule/grammar.json
@@ -71,6 +71,6 @@
       ]
     },
 
-    "identifier": {"type": "PATTERN", "value": "\\a+"}
+    "identifier": {"type": "PATTERN", "value": "[a-z]+"}
   }
 }

--- a/test/fixtures/test_grammars/external_and_internal_anonymous_tokens/grammar.json
+++ b/test/fixtures/test_grammars/external_and_internal_anonymous_tokens/grammar.json
@@ -29,7 +29,7 @@
       ]
     },
 
-    "variable": {"type": "PATTERN", "value": "\\a+"},
+    "variable": {"type": "PATTERN", "value": "[a-z]+"},
     "number": {"type": "PATTERN", "value": "\\d+"}
   }
 }

--- a/test/fixtures/test_grammars/external_and_internal_tokens/grammar.json
+++ b/test/fixtures/test_grammars/external_and_internal_tokens/grammar.json
@@ -29,7 +29,7 @@
       ]
     },
 
-    "variable": {"type": "PATTERN", "value": "\\a+"},
+    "variable": {"type": "PATTERN", "value": "[a-z]+"},
     "number": {"type": "PATTERN", "value": "\\d+"},
     "line_break": {"type": "STRING", "value": "\n"}
   }

--- a/test/fixtures/test_grammars/external_extra_tokens/grammar.json
+++ b/test/fixtures/test_grammars/external_extra_tokens/grammar.json
@@ -20,6 +20,6 @@
       ]
     },
 
-    "variable": {"type": "PATTERN", "value": "\\a+"}
+    "variable": {"type": "PATTERN", "value": "[a-z]+"}
   }
 }

--- a/test/fixtures/test_grammars/external_tokens/grammar.json
+++ b/test/fixtures/test_grammars/external_tokens/grammar.json
@@ -51,7 +51,7 @@
 
     "identifier": {
       "type": "PATTERN",
-      "value": "\\a+"
+      "value": "[a-z]+"
     }
   }
 }

--- a/test/fixtures/test_grammars/inlined_aliased_rules/grammar.json
+++ b/test/fixtures/test_grammars/inlined_aliased_rules/grammar.json
@@ -70,6 +70,6 @@
       }
     },
 
-    "identifier": {"type": "PATTERN", "value": "\\a+"}
+    "identifier": {"type": "PATTERN", "value": "[a-z]+"}
   }
 }

--- a/test/fixtures/test_grammars/inverted_external_token/grammar.json
+++ b/test/fixtures/test_grammars/inverted_external_token/grammar.json
@@ -49,7 +49,7 @@
 
     "identifier": {
       "type": "PATTERN",
-      "value": "\\a+"
+      "value": "[a-z]+"
     }
   }
 }

--- a/test/fixtures/test_grammars/partially_resolved_conflict/grammar.json
+++ b/test/fixtures/test_grammars/partially_resolved_conflict/grammar.json
@@ -52,7 +52,7 @@
 
     "identifier": {
       "type": "PATTERN",
-      "value": "\\a+"
+      "value": "[a-z]+"
     }
   }
 }


### PR DESCRIPTION
🤔  I have no idea why, but I was treating `\a` as equivalent to `[a-zA-Z]` in a regex.

Fixes #115