### PR TITLE
Don't allow an epsilon start rule if it is used in other rules

### DIFF
--- a/test/fixtures/test_grammars/epsilon_rules/expected_error.txt
+++ b/test/fixtures/test_grammars/epsilon_rules/expected_error.txt
@@ -1,2 +1,4 @@
 The rule `rule_2` matches the empty string.
-Tree-sitter currently does not support syntactic rules that match the empty string.
+
+Tree-sitter does not support syntactic rules that match the empty string
+unless they are used only as the grammar's start rule.


### PR DESCRIPTION
Tree-sitter does not support syntax rules that match the empty string. Previously, the start rule was exempt from this rule, because it is ok for the root of the syntax tree to be empty. But the start rule can also be used elsewhere in the grammar, which will cause problems if it matches the empty string. This PR fixes the check for non-empty rules.

Closes https://github.com/tree-sitter/tree-sitter/pull/120