### PR TITLE
Do not insert missing tokens if halt_on_error option is passed

### DIFF
--- a/test/runtime/document_test.cc
+++ b/test/runtime/document_test.cc
@@ -439,6 +439,33 @@ describe("Document", [&]() {
       AssertThat(ts_node_end_byte(root), Equals(input_string.size()));
     });
 
+    it("does not insert missing tokens if the halt_on_error flag is set", [&]() {
+      string input_string = "[1, null, 3";
+      ts_document_set_language(document, load_real_language("json"));
+      ts_document_set_input_string(document, input_string.c_str());
+
+      TSParseOptions options = {};
+      options.changed_ranges = nullptr;
+
+      options.halt_on_error = false;
+      ts_document_parse_with_options(document, options);
+      root = ts_document_root_node(document);
+      assert_node_string_equals(
+        root,
+        "(value (array (number) (null) (number) (MISSING)))");
+
+      ts_document_invalidate(document);
+
+      options.halt_on_error = true;
+      ts_document_parse_with_options(document, options);
+      root = ts_document_root_node(document);
+      assert_node_string_equals(
+        root,
+        "(ERROR (number) (null) (number))");
+
+      AssertThat(ts_node_end_byte(root), Equals(input_string.size()));
+    });
+
     it("can parse valid code with the halt_on_error flag set", [&]() {
       string input_string = "[1, null, 3]";
       ts_document_set_language(document, load_real_language("json"));


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-ruby/issues/63