### PR TITLE
Rebalance repetition trees after parsing

### DIFF
--- a/include/tree_sitter/parser.h
+++ b/include/tree_sitter/parser.h
@@ -41,6 +41,7 @@ typedef struct {
     struct {
       TSStateId state;
       bool extra : 1;
+      bool repetition : 1;
     };
     struct {
       TSSymbol symbol;
@@ -136,6 +137,17 @@ typedef struct TSLanguage {
       .type = TSParseActionTypeShift,   \
       .params = {.state = state_value}, \
     }                                   \
+  }
+
+#define SHIFT_REPEAT(state_value)     \
+  {                                   \
+    {                                 \
+      .type = TSParseActionTypeShift, \
+      .params = {                     \
+        .state = state_value,         \
+        .repetition = true            \
+      },                              \
+    }                                 \
   }
 
 #define RECOVER()                        \

--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -9,7 +9,7 @@ extern "C" {
 #include <stdint.h>
 #include <stdbool.h>
 
-#define TREE_SITTER_LANGUAGE_VERSION 4
+#define TREE_SITTER_LANGUAGE_VERSION 5
 
 typedef unsigned short TSSymbol;
 typedef struct TSLanguage TSLanguage;

--- a/src/compiler/build_tables/parse_table_builder.cc
+++ b/src/compiler/build_tables/parse_table_builder.cc
@@ -504,6 +504,20 @@ class ParseTableBuilderImpl : public ParseTableBuilder {
     }
 
     if (entry.actions.back().type == ParseActionTypeShift) {
+      Symbol symbol = conflicting_items.begin()->lhs();
+      if (symbol.is_non_terminal() && grammar.variables[symbol.index].type == VariableTypeAuxiliary) {
+        bool all_symbols_match = true;
+        for (const ParseItem &conflicting_item : conflicting_items) {
+          if (conflicting_item.lhs() != symbol) {
+            all_symbols_match = false;
+            break;
+          }
+        }
+        if (all_symbols_match) {
+          entry.actions.back().repetition = true;
+          return "";
+        }
+      }
 
       // If the shift action has higher precedence, prefer it over any of the
       // reduce actions.

--- a/src/compiler/generate_code/c_code.cc
+++ b/src/compiler/generate_code/c_code.cc
@@ -623,6 +623,8 @@ class CCodeGenerator {
             case ParseActionTypeShift:
               if (action.extra) {
                 add("SHIFT_EXTRA()");
+              } else if (action.repetition) {
+                add("SHIFT_REPEAT(" + to_string(action.state_index) + ")");
               } else {
                 add("SHIFT(" + to_string(action.state_index) + ")");
               }

--- a/src/compiler/parse_table.cc
+++ b/src/compiler/parse_table.cc
@@ -21,7 +21,8 @@ ParseAction::ParseAction() :
   associativity(rules::AssociativityNone),
   alias_sequence_id(0),
   fragile(false),
-  extra(false) {}
+  extra(false),
+  repetition(false) {}
 
 ParseAction ParseAction::Error() {
   return ParseAction();
@@ -78,7 +79,8 @@ bool ParseAction::operator==(const ParseAction &other) const {
     associativity == other.associativity &&
     alias_sequence_id == other.alias_sequence_id &&
     extra == other.extra &&
-    fragile == other.fragile;
+    fragile == other.fragile &&
+    repetition == other.repetition;
 }
 
 bool ParseAction::operator<(const ParseAction &other) const {
@@ -100,6 +102,8 @@ bool ParseAction::operator<(const ParseAction &other) const {
   if (other.extra && !extra) return false;
   if (fragile && !other.fragile) return true;
   if (other.fragile && !fragile) return false;
+  if (repetition && !other.repetition) return true;
+  if (other.repetition && !repetition) return false;
   return alias_sequence_id < other.alias_sequence_id;
 }
 

--- a/src/compiler/parse_table.h
+++ b/src/compiler/parse_table.h
@@ -45,6 +45,7 @@ struct ParseAction {
   unsigned alias_sequence_id;
   bool fragile;
   bool extra;
+  bool repetition;
 };
 
 struct ParseTableEntry {

--- a/src/compiler/prepare_grammar/expand_repeats.cc
+++ b/src/compiler/prepare_grammar/expand_repeats.cc
@@ -57,7 +57,7 @@ class ExpandRepeats {
           helper_rule_name,
           VariableTypeAuxiliary,
           rules::Choice{{
-            rules::Seq{repeat_symbol, inner_rule},
+            rules::Seq{repeat_symbol, repeat_symbol},
             inner_rule,
           }}
         });

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -1097,6 +1097,7 @@ static void parser__advance(Parser *self, StackVersion version, ReusableNode *re
 
       switch (action.type) {
         case TSParseActionTypeShift: {
+          if (action.params.repetition) break;
           TSStateId next_state;
           if (action.params.extra) {
             next_state = state;

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -1249,10 +1249,11 @@ Tree *parser_parse(Parser *self, TSInput input, Tree *old_tree, bool halt_on_err
     self->in_ambiguity = version > 1;
   } while (version != 0);
 
-  LOG("done");
-  LOG_TREE();
   ts_stack_clear(self->stack);
   parser__set_cached_token(self, 0, NULL, NULL);
   ts_tree_assign_parents(self->finished_tree, &self->tree_pool, self->language);
+
+  LOG("done");
+  LOG_TREE();
   return self->finished_tree;
 }

--- a/src/runtime/tree.c
+++ b/src/runtime/tree.c
@@ -206,15 +206,13 @@ Tree *ts_tree_make_copy(TreePool *pool, Tree *self) {
 static void ts_tree__compress(Tree *self, unsigned count, const TSLanguage *language) {
   Tree *tree = self;
   for (unsigned i = 0; i < count; i++) {
-    if (tree->child_count != 2) break;
     Tree *child = tree->children[0];
-    if (child->symbol != tree->symbol || child->child_count != 2) break;
-    if (tree->ref_count > 1) break;
-    if (child->ref_count > 1) break;
+    if (child->symbol != tree->symbol) break;
 
     Tree *grandchild = child->children[0];
-    if (grandchild->symbol != tree->symbol || grandchild->child_count != 2) break;
-    if (grandchild->ref_count > 1) break;
+    if (grandchild->symbol != tree->symbol) break;
+    if (grandchild->children[0]->symbol != tree->symbol) break;
+    if (child->ref_count > 1 || grandchild->ref_count > 1) break;
 
     tree->children[0] = grandchild;
     grandchild->context.parent = tree;

--- a/src/runtime/tree.h
+++ b/src/runtime/tree.h
@@ -50,6 +50,7 @@ typedef struct Tree {
   TSSymbol symbol;
   TSStateId parse_state;
   unsigned error_cost;
+  unsigned repeat_depth;
 
   struct {
     TSSymbol symbol;

--- a/test/compiler/prepare_grammar/expand_repeats_test.cc
+++ b/test/compiler/prepare_grammar/expand_repeats_test.cc
@@ -23,7 +23,7 @@ describe("expand_repeats", []() {
     AssertThat(result.variables, Equals(vector<Variable>{
       Variable{"rule0", VariableTypeNamed, Symbol::non_terminal(1)},
       Variable{"rule0_repeat1", VariableTypeAuxiliary, Rule::choice({
-        Rule::seq({ Symbol::non_terminal(1), Symbol::terminal(0) }),
+        Rule::seq({ Symbol::non_terminal(1), Symbol::non_terminal(1) }),
         Symbol::terminal(0),
       })},
     }));
@@ -48,7 +48,7 @@ describe("expand_repeats", []() {
         Symbol::non_terminal(1),
       })},
       Variable{"rule0_repeat1", VariableTypeAuxiliary, Rule::choice({
-        Rule::seq({ Symbol::non_terminal(1), Symbol::terminal(11) }),
+        Rule::seq({ Symbol::non_terminal(1), Symbol::non_terminal(1) }),
         Symbol::terminal(11)
       })},
     }));
@@ -73,7 +73,7 @@ describe("expand_repeats", []() {
         Symbol::non_terminal(1),
       })},
       Variable{"rule0_repeat1", VariableTypeAuxiliary, Rule::choice({
-        Rule::seq({ Symbol::non_terminal(1), Symbol::terminal(11) }),
+        Rule::seq({ Symbol::non_terminal(1), Symbol::non_terminal(1) }),
         Symbol::terminal(11),
       })},
     }));
@@ -106,7 +106,7 @@ describe("expand_repeats", []() {
         Symbol::non_terminal(2),
       })},
       Variable{"rule0_repeat1", VariableTypeAuxiliary, Rule::choice({
-        Rule::seq({ Symbol::non_terminal(2), Symbol::terminal(4) }),
+        Rule::seq({ Symbol::non_terminal(2), Symbol::non_terminal(2) }),
         Symbol::terminal(4),
       })},
     }));
@@ -131,11 +131,11 @@ describe("expand_repeats", []() {
         Symbol::non_terminal(2),
       })},
       Variable{"rule0_repeat1", VariableTypeAuxiliary, Rule::choice({
-        Rule::seq({ Symbol::non_terminal(1), Symbol::terminal(10) }),
+        Rule::seq({ Symbol::non_terminal(1), Symbol::non_terminal(1) }),
         Symbol::terminal(10),
       })},
       Variable{"rule0_repeat2", VariableTypeAuxiliary, Rule::choice({
-        Rule::seq({ Symbol::non_terminal(2), Symbol::terminal(11) }),
+        Rule::seq({ Symbol::non_terminal(2), Symbol::non_terminal(2) }),
         Symbol::terminal(11),
       })},
     }));
@@ -156,11 +156,11 @@ describe("expand_repeats", []() {
       Variable{"rule0", VariableTypeNamed, Symbol::non_terminal(2)},
       Variable{"rule1", VariableTypeNamed, Symbol::non_terminal(3)},
       Variable{"rule0_repeat1", VariableTypeAuxiliary, Rule::choice({
-        Rule::seq({ Symbol::non_terminal(2), Symbol::terminal(10) }),
+        Rule::seq({ Symbol::non_terminal(2), Symbol::non_terminal(2) }),
         Symbol::terminal(10),
       })},
       Variable{"rule1_repeat1", VariableTypeAuxiliary, Rule::choice({
-        Rule::seq({ Symbol::non_terminal(3), Symbol::terminal(11) }),
+        Rule::seq({ Symbol::non_terminal(3), Symbol::non_terminal(3) }),
         Symbol::terminal(11),
       })},
     }));

--- a/test/integration/real_grammars.cc
+++ b/test/integration/real_grammars.cc
@@ -96,6 +96,7 @@ for (auto &language_name : test_languages) {
             uint32_t range_count;
             ScopeSequence old_scope_sequence = build_scope_sequence(document, input->content);
             ts_document_parse_and_get_changed_ranges(document, &ranges, &range_count);
+            assert_correct_tree_size(document, input->content);
 
             ScopeSequence new_scope_sequence = build_scope_sequence(document, input->content);
             verify_changed_ranges(old_scope_sequence, new_scope_sequence,
@@ -119,6 +120,7 @@ for (auto &language_name : test_languages) {
             uint32_t range_count;
             ScopeSequence old_scope_sequence = build_scope_sequence(document, input->content);
             ts_document_parse_and_get_changed_ranges(document, &ranges, &range_count);
+            assert_correct_tree_size(document, input->content);
 
             ScopeSequence new_scope_sequence = build_scope_sequence(document, input->content);
             verify_changed_ranges(old_scope_sequence, new_scope_sequence,


### PR DESCRIPTION
### Motivation

Currently, editing and re-parsing a large file can be unexpectedly slow. This is because of an important optimization in the incremental parsing algorithm that I have not implemented until now: the rebalancing of regions of the syntax tree that represent *repetitions*.

### Background

Currently, a rule like this:

```js
block: $ => seq('{', repeat($.statement), '}'),
```

is internally replaced with something like this:

```js
block: $ => seq('{', optional($._block_repeat1), '}'),
_block_repeat1: $ => choice($.statement, seq($._block_repeat1, $.statement)),
```

Basically, repetition is implemented internally using recursion, and each call to the `repeat` function gets replaced with a reference to a hidden recursive rule. The problem is that due to their structure, these recursive rules produce unbalanced binary trees.

For example, consider some C code containing a long array literal:

```c
int a[25] = {
  0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
  0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
  0, 1, 2, 3, 4,
};
```

Previously, parsing this code would create a tree like this:

![parse-before](https://user-images.githubusercontent.com/326587/36084547-36cd4ef0-0f73-11e8-8273-65fbb6c630e4.png)

### Solution

During the parsing process, I continue to build a left-leaning tree just like before, because this left-recursive structure is the most powerful one in terms of recognizing the largest possible set of languages without LR(1) conflicts. But now, after parsing, during the existing post-processing step, I rebalance portions of the syntax tree using an approach based on the [Day-Stout-Warren Algorithm](https://en.wikipedia.org/wiki/Day%E2%80%93Stout%E2%80%93Warren_algorithm).

In order to support incremental parsing though, the internal nodes of the syntax tree must match the structure of the grammar. In order to preserve this invariant, I have changed the way that `repeat` is expanded internally. Now, instead of an explicitly left-leaning structure, the hidden rule has an 
 intentionally *ambiguous* structure:

```js
block: $ => seq('{', optional($._block_repeat1), '}'),
_block_repeat1: $ => choice($.statement, seq($._block_repeat1, $._block_repeat1)),
```

This allows the rebalanced tree to still match the grammar.

Now, parsing the C code from before produces a balanced tree:

![parse-after](https://user-images.githubusercontent.com/326587/36084556-4e391d30-0f73-11e8-8e65-7efe3006612b.png)
