### PR TITLE
Eliminate non-user-visible unit reductions from parse tables

### DIFF
--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -67,19 +67,11 @@ typedef struct {
   uint32_t offset[2];
 } TSNode;
 
-typedef struct {
-  TSSymbol value;
-  bool done;
-  void *data;
-} TSSymbolIterator;
-
 uint32_t ts_node_start_byte(TSNode);
 TSPoint ts_node_start_point(TSNode);
 uint32_t ts_node_end_byte(TSNode);
 TSPoint ts_node_end_point(TSNode);
 TSSymbol ts_node_symbol(TSNode);
-TSSymbolIterator ts_node_symbols(TSNode);
-void ts_symbol_iterator_next(TSSymbolIterator *);
 const char *ts_node_type(TSNode, const TSDocument *);
 char *ts_node_string(TSNode, const TSDocument *);
 bool ts_node_eq(TSNode, TSNode);

--- a/src/compiler/parse_table.cc
+++ b/src/compiler/parse_table.cc
@@ -146,7 +146,6 @@ bool ParseState::operator==(const ParseState &other) const {
 ParseAction &ParseTable::add_terminal_action(ParseStateId state_id,
                                              Symbol lookahead,
                                              ParseAction action) {
-  symbols.insert(lookahead);
   ParseTableEntry &entry = states[state_id].terminal_entries[lookahead];
   entry.actions.push_back(action);
   return *entry.actions.rbegin();

--- a/src/runtime/node.c
+++ b/src/runtime/node.c
@@ -263,26 +263,6 @@ TSSymbol ts_node_symbol(TSNode self) {
   return tree->context.alias_symbol ? tree->context.alias_symbol : tree->symbol;
 }
 
-TSSymbolIterator ts_node_symbols(TSNode self) {
-  const Tree *tree = ts_node__tree(self);
-  return (TSSymbolIterator){
-    .value = tree->symbol, .done = false, .data = (void *)tree,
-  };
-}
-
-void ts_symbol_iterator_next(TSSymbolIterator *self) {
-  const Tree *tree = (const Tree *)self->data;
-  const Tree *parent = tree->context.parent;
-  if (!self->done && parent) {
-    if (parent->child_count == 1 && !parent->visible) {
-      self->value = parent->symbol;
-      self->data = (void *)parent;
-      return;
-    }
-  }
-  self->done = true;
-}
-
 const char *ts_node_type(TSNode self, const TSDocument *document) {
   return ts_language_symbol_name(document->parser.language, ts_node_symbol(self));
 }

--- a/test/fixtures/error_corpus/c_errors.txt
+++ b/test/fixtures/error_corpus/c_errors.txt
@@ -141,30 +141,3 @@ int y = 5;
 (translation_unit
   (declaration (primitive_type) (ERROR (identifier)) (identifier))
   (declaration (primitive_type) (init_declarator (identifier) (number_literal))))
-
-==========================================
-Declarations with missing variable names
-==========================================
-
-int a() {
-  struct x = 1;
-  int = 2;
-}
-
----
-
-(translation_unit
-  (function_definition
-    (primitive_type)
-    (function_declarator (identifier) (parameter_list))
-    (compound_statement
-      (declaration
-        (struct_specifier (type_identifier))
-        (init_declarator
-          (MISSING)
-          (number_literal)))
-      (declaration
-        (primitive_type)
-        (init_declarator
-          (MISSING)
-          (number_literal))))))

--- a/test/runtime/node_test.cc
+++ b/test/runtime/node_test.cc
@@ -255,32 +255,6 @@ describe("Node", [&]() {
     });
   });
 
-  describe("symbols()", [&]() {
-    it("returns an iterator that yields each of the node's symbols", [&]() {
-      const TSLanguage *language = ts_document_language(document);
-
-      TSNode false_node = ts_node_descendant_for_byte_range(root_node, false_index, false_index + 1);
-      TSSymbolIterator iterator = ts_node_symbols(false_node);
-      AssertThat(iterator.done, Equals(false));
-      AssertThat(ts_language_symbol_name(language, iterator.value), Equals("false"));
-
-      ts_symbol_iterator_next(&iterator);
-      AssertThat(iterator.done, Equals(false));
-      AssertThat(ts_language_symbol_name(language, iterator.value), Equals("_value"));
-
-      ts_symbol_iterator_next(&iterator);
-      AssertThat(iterator.done, Equals(true));
-
-      TSNode comma_node = ts_node_descendant_for_byte_range(root_node, number_end_index, number_end_index);
-      iterator = ts_node_symbols(comma_node);
-      AssertThat(iterator.done, Equals(false));
-      AssertThat(ts_language_symbol_name(language, iterator.value), Equals(","));
-
-      ts_symbol_iterator_next(&iterator);
-      AssertThat(iterator.done, Equals(true));
-    });
-  });
-
   describe("child_count(), child(i)", [&]() {
     it("returns the child node at the given index, including anonymous nodes", [&]() {
       AssertThat(ts_node_child_count(root_node), Equals<size_t>(7));


### PR DESCRIPTION
### Problem

Most Tree-sitter syntax trees contain a number of ['hidden' rules](http://tree-sitter.github.io/tree-sitter/creating-parsers.html#hiding-rules), which are required for the purposes of parsing but aren't useful in the output. While necessary, these rules have a cost. They affect
1. The one-time memory footprint of the parser library (due to the extra entries in the parse table)
2. The memory footprint of each syntax tree (due to the extra nodes which must be allocated)
3. The speed of parsing (due to the extra push/pop operations on the stack)

### Improvement

This PR implements a classic optimization for LR parsers: [Unit Production Elimination](https://link.springer.com/chapter/10.1007/978-3-662-21545-6_17). Basically, in many cases we can skip the intermediate step of creating hidden nodes like `_expression` and `_type` and instead use the child expression directly.

This will shrink parse tables, reduce syntax trees' memory usage, and speed up parsing. This optimization is much simpler than some of the parse table optimizations I've already done like #32, #89, #99, and #137. I'm not sure why I didn't do it earlier. Should have spent more time reading the dragon book...

This is another step towards fixing #114.