### PR TITLE
Be less conservative about merging parse states with external tokens

### DIFF
--- a/src/compiler/build_tables/parse_table_builder.cc
+++ b/src/compiler/build_tables/parse_table_builder.cc
@@ -478,28 +478,20 @@ class ParseTableBuilderImpl : public ParseTableBuilder {
     if (entry.actions.back().type != ParseActionTypeReduce) return false;
     if (!has_actions(state, entry)) return false;
 
-    // Do not add external tokens; they could conflict lexically with any
-    // of the state's existing lookahead tokens.
+    // Do not add external tokens; they could conflict lexically with any of the state's
+    // existing lookahead tokens.
     if (new_token.is_external()) return false;
 
+    // Do not add tokens which are both internal and external. Their validity could
+    // influence the behavior of the external scanner.
+    for (const ExternalToken &external_token : grammar.external_tokens) {
+      if (external_token.corresponding_internal_token == new_token) return false;
+    }
+
+    // Do not add a token if it conflicts with an existing token.
     if (!new_token.is_built_in()) {
-      const auto &incompatible_tokens = lex_table_builder->get_incompatible_tokens(new_token.index);
-      if (!incompatible_tokens.empty()) {
-        for (const auto &pair : state.terminal_entries) {
-          const Symbol &existing_token = pair.first;
-
-          // Do not add a token if it conflicts with any token in the follow set
-          // of an existing external token.
-          if (existing_token.is_external()) {
-            const LookaheadSet &following_tokens = following_tokens_by_token[existing_token];
-            for (auto &incompatible_token : incompatible_tokens) {
-              if (following_tokens.contains(incompatible_token)) return false;
-            }
-          }
-
-          // Do not add a token if it conflicts with an existing token.
-          if (incompatible_tokens.count(existing_token)) return false;
-        }
+      for (Symbol incompatible_token : lex_table_builder->get_incompatible_tokens(new_token.index)) {
+        if (state.terminal_entries.count(incompatible_token)) return false;
       }
     }
 

--- a/src/compiler/grammar.h
+++ b/src/compiler/grammar.h
@@ -30,7 +30,7 @@ struct InputGrammar {
   std::vector<Variable> variables;
   std::vector<rules::Rule> extra_tokens;
   std::vector<std::unordered_set<rules::NamedSymbol>> expected_conflicts;
-  std::vector<Variable> external_tokens;
+  std::vector<rules::Rule> external_tokens;
   std::unordered_set<rules::NamedSymbol> variables_to_inline;
 };
 

--- a/src/compiler/parse_grammar.cc
+++ b/src/compiler/parse_grammar.cc
@@ -354,15 +354,7 @@ ParseGrammarResult parse_grammar(const string &input) {
         error_message = "Invalid external token: " + result.error_message;
         goto error;
       }
-
-      grammar.external_tokens.push_back(result.rule.match(
-        [](rules::NamedSymbol named_symbol) {
-          return Variable{named_symbol.value, VariableTypeNamed, named_symbol};
-        },
-        [](auto rule) {
-          return Variable{"", VariableTypeAnonymous, rule};
-        }
-      ));
+      grammar.external_tokens.push_back(result.rule);
     }
   }
 

--- a/src/compiler/prepare_grammar/extract_tokens.cc
+++ b/src/compiler/prepare_grammar/extract_tokens.cc
@@ -179,10 +179,10 @@ tuple<InitialSyntaxGrammar, LexicalGrammar, CompileError> extract_tokens(
 
   vector<Variable> processed_external_tokens;
   for (const auto &external_token : grammar.external_tokens) {
-    processed_external_tokens.push_back({
+    processed_external_tokens.push_back(Variable{
       external_token.name,
       external_token.type,
-      extractor.apply(external_token.rule)
+      extractor.apply(external_token.rule),
     });
   }
 
@@ -312,13 +312,13 @@ tuple<InitialSyntaxGrammar, LexicalGrammar, CompileError> extract_tokens(
       syntax_grammar.external_tokens.push_back(ExternalToken{
         external_token.name,
         external_token.type,
-        rules::NONE()
+        rules::NONE(),
       });
     } else {
       syntax_grammar.external_tokens.push_back(ExternalToken{
         lexical_grammar.variables[symbol.index].name,
         external_token.type,
-        symbol
+        symbol,
       });
     }
   }

--- a/src/compiler/prepare_grammar/interned_grammar.h
+++ b/src/compiler/prepare_grammar/interned_grammar.h
@@ -15,6 +15,7 @@ struct InternedGrammar {
   std::vector<rules::Rule> extra_tokens;
   std::set<std::set<rules::Symbol>> expected_conflicts;
   std::vector<Variable> external_tokens;
+  std::set<rules::Symbol> blank_external_tokens;
   std::set<rules::Symbol> variables_to_inline;
 };
 

--- a/test/compiler/prepare_grammar/intern_symbols_test.cc
+++ b/test/compiler/prepare_grammar/intern_symbols_test.cc
@@ -75,16 +75,8 @@ describe("intern_symbols", []() {
       {},
       {},
       {
-        Variable{
-          "w",
-          VariableTypeNamed,
-          NamedSymbol{"w"}
-        },
-        Variable{
-          "z",
-          VariableTypeNamed,
-          NamedSymbol{"z"}
-        },
+        NamedSymbol{"w"},
+        NamedSymbol{"z"},
       },
       {}
     };
@@ -95,12 +87,12 @@ describe("intern_symbols", []() {
       Variable{
         "w",
         VariableTypeNamed,
-        Symbol::external(0)
+        Symbol::external(0),
       },
       Variable{
         "z",
         VariableTypeNamed,
-        Symbol::non_terminal(2)
+        Symbol::non_terminal(2),
       },
     }))
   });


### PR DESCRIPTION
### Problem

Tree-sitter tries to produce the smallest possible parse table for each language by *merging* parse states which are similar in certain ways (See #32). One concern when merging parse states is by adding to the set of tokens that are valid in any given state, we change the behavior of the lexer when it is run in that state. So we need to be careful not to merge states in such a way that introduces lexical conflicts.

Previously, when evaluating whether parse state merges were legal, there was an overly conservative strategy for merging parse states in which external tokens were valid.

### Solution

For some parsers with external scanners, the external scanner needs to know whether or not certain *regular* (non-external) tokens are valid in order to decide whether to return a certain external scanner. For example, in the Bash external scanner, the logic for when to return a `_concat` token depends on whether a `]` token is expected. In other words, adding the `]` token as a valid lookahead in a given state would change the behavior of the external scanner in that state.

The new logic for checking if states are mergeable takes into account these types of tokens: internal tokens which are referenced by the external scanner.