### PR TITLE
Add error message for TSCompileErrorTypeInvalidTokenContents

### DIFF
--- a/src/compiler/prepare_grammar/expand_tokens.cc
+++ b/src/compiler/prepare_grammar/expand_tokens.cc
@@ -72,7 +72,7 @@ ExpandTokenResult expand_token(const rules::Rule &rule) {
       return Rule(rules::Choice{elements});
     },
 
-    [](auto) { return CompileError(TSCompileErrorTypeInvalidTokenContents, ""); }
+    [](auto) { return CompileError(TSCompileErrorTypeInvalidTokenContents, "Symbols inside tokens are not allowed."); }
   );
 };
 


### PR DESCRIPTION
I accidentally used a symbol inside a token. An error message could have saved some time.