### PR TITLE
Add an API for cancelling the current parse

### DIFF
--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -86,6 +86,8 @@ void ts_parser_print_dot_graphs(TSParser *, FILE *);
 void ts_parser_halt_on_error(TSParser *, bool);
 TSTree *ts_parser_parse(TSParser *, const TSTree *, TSInput);
 TSTree *ts_parser_parse_string(TSParser *, const TSTree *, const char *, uint32_t);
+bool ts_parser_enabled(TSParser *);
+void ts_parser_set_enabled(TSParser *, bool);
 
 TSTree *ts_tree_copy(const TSTree *);
 void ts_tree_delete(TSTree *);


### PR DESCRIPTION
### Overview

It's called `ts_parser_set_enabled`, and it  works like this:

```cpp
void test() {
  TSParser *parser = ts_parser_new();
  ts_parser_set_language(parser, ts_language_javascript());

  // On another thread, disable the parser.
  auto future = std::async([parser]() {
    usleep(100 * 1000);
    ts_parser_set_enabled(parser, false);
  });

  // Parse some input that could take a while.
  TSTree *tree = ts_parser_parse(parser, NULL, some_very_long_input);

  // Get back NULL, because the parse was cancelled.
  assert(tree == NULL);
  assert(!ts_parser_enabled(parser));
  future.wait();
}
```

### Implementation

I kept it super simple. I just check the value of a `volatile bool` on every single iteration of the main parse loop. I didn't observe any slowdown due to that added conditional.

### Next Steps

Before we can use this from Haskell, we'll need to update `haskell-tree-sitter` to use the new Tree-sitter API that @rewinfrey and I set up in https://github.com/tree-sitter/tree-sitter/pull/165.

/cc @tclem @robrix @charliesome @rewinfrey 