### PR TITLE
Don't reuse nodes within ambiguities

### DIFF
--- a/src/runtime/reusable_node.h
+++ b/src/runtime/reusable_node.h
@@ -22,6 +22,7 @@ static inline void reusable_node_reset(ReusableNode *self, const Subtree *tree) 
     .child_index = 0,
     .byte_offset = 0,
   }));
+  self->last_external_token = NULL;
 }
 
 static inline const Subtree *reusable_node_tree(ReusableNode *self) {
@@ -38,10 +39,6 @@ static inline uint32_t reusable_node_byte_offset(ReusableNode *self) {
 
 static inline void reusable_node_delete(ReusableNode *self) {
   array_delete(&self->stack);
-}
-
-static inline void reusable_node_assign(ReusableNode *self, const ReusableNode *other) {
-  array_assign(&self->stack, &other->stack);
 }
 
 static inline void reusable_node_advance(ReusableNode *self) {


### PR DESCRIPTION
This fixes a hang that @joefitzgerald found.

### Background

Tree-sitter's error recovery algorithm involves forking the parse stack into several different versions in order to try multiple ways of fixing the error. There are often infinitely many ways of recovering from errors, so for performance reasons we need to limit the number of stack versions that can coexist.

This limit is enforced via a procedure called [`ts_parser__condense_stack`](https://github.com/tree-sitter/tree-sitter/blob/95fbc23fd66d043ba7a2d72901b6a8794411d586/src/runtime/parser.c#L1201), which sorts the versions according to how "good" they appear so far and then truncates the list of versions to a reasonable number. This 'condense' function is called at the end of each iteration of the [main parsing loop](https://github.com/tree-sitter/tree-sitter/blob/95fbc23fd66d043ba7a2d72901b6a8794411d586/src/runtime/parser.c#L1364), after each stack version has been advanced by at least one token, and each version has "caught up" to its predecessor in terms of how many bytes of the source code it has processed.

### Problem

Occasionally, when re-parsing a file after editing it, it's possible that one stack version may be able to reuse a large chunk of the old syntax tree, but other stack versions may *not* be able to. This causes the different stack versions to significantly diverge in terms of their location in the source code. This means that the stack versions that are further *behind* will need to be advanced many times before `ts_parser__condense_stack` gets called, since it only gets called when all of the versions have caught up to each other. During this time, a very large number of stack versions can be created, slowing down the parse to a crawl.