### PR TITLE
Update fuzzer to new API

### DIFF
--- a/test/fuzz/fuzzer.cc
+++ b/test/fuzz/fuzzer.cc
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <cassert>
 #include "tree_sitter/runtime.h"
 
 void test_log(void *payload, TSLogType type, const char *string) { }
@@ -13,7 +14,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   const char *str = reinterpret_cast<const char *>(data);
 
   TSParser *parser = ts_parser_new();
-  ts_parser_set_language(parser, TS_LANG());
+
+  // This can fail if the language version doesn't match the runtime version
+  bool language_ok = ts_parser_set_language(parser, TS_LANG());
+  assert(language_ok);
+
   ts_parser_halt_on_error(parser, TS_HALT_ON_ERROR);
 
   TSTree *tree = ts_parser_parse_string(parser, NULL, str, size);

--- a/test/fuzz/fuzzer.cc
+++ b/test/fuzz/fuzzer.cc
@@ -1,4 +1,3 @@
-#include <string.h>
 #include <cassert>
 #include "tree_sitter/runtime.h"
 

--- a/test/fuzz/fuzzer.cc
+++ b/test/fuzz/fuzzer.cc
@@ -17,7 +17,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   ts_parser_halt_on_error(parser, TS_HALT_ON_ERROR);
 
   TSTree *tree = ts_parser_parse_string(parser, NULL, str, size);
-  TSNode root_node = ts_document_root_node(tree);
+  TSNode root_node = ts_tree_root_node(tree);
 
   ts_tree_delete(tree);
   ts_parser_delete(parser);

--- a/test/fuzz/fuzzer.cc
+++ b/test/fuzz/fuzzer.cc
@@ -1,12 +1,6 @@
 #include <cassert>
 #include "tree_sitter/runtime.h"
 
-void test_log(void *payload, TSLogType type, const char *string) { }
-
-TSLogger logger = {
-  .log = test_log,
-};
-
 extern "C" const TSLanguage *TS_LANG();
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {


### PR DESCRIPTION
A small typo from the changes in #165. I tested that `script/build-fuzzers` and `script/run-fuzzer` works locally.

I also noticed some dead code and that we aren't checking that `ts_parser_set_language` succeeds.