### PR TITLE
Add APIs for pausing a parse after N operations and resuming later

### DIFF
--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -86,8 +86,11 @@ void ts_parser_print_dot_graphs(TSParser *, FILE *);
 void ts_parser_halt_on_error(TSParser *, bool);
 TSTree *ts_parser_parse(TSParser *, const TSTree *, TSInput);
 TSTree *ts_parser_parse_string(TSParser *, const TSTree *, const char *, uint32_t);
-bool ts_parser_enabled(TSParser *);
+bool ts_parser_enabled(const TSParser *);
 void ts_parser_set_enabled(TSParser *, bool);
+size_t ts_parser_operation_limit(const TSParser *);
+void ts_parser_set_operation_limit(TSParser *, size_t);
+TSTree *ts_parser_resume(TSParser *);
 
 TSTree *ts_tree_copy(const TSTree *);
 void ts_tree_delete(TSTree *);


### PR DESCRIPTION
This will allow Atom to do something like this:

```c++
ts_parser_set_operation_limit(parser, A_VERY_SMALL_AMOUNT);
TSTree *new_tree = ts_parser_parse(parser, old_tree, input);

if (new_tree) {

  // This parse completed. It only had to do A Very Small Amount of work.
  call_javascript_callback(new_tree);

} else {

  // This parse is going to take more work. Let's do it in the background.
  on_a_background_thread([parser]() {
    ts_parser_set_operation_limit(parser, SIZE_MAX);
    TSTree *new_tree = ts_parser_resume(parser);
    call_javascript_callback(new_tree);
  });

}
```

If the parser performs more parsing operations than was specified in the preceding call to `ts_parser_set_operation_limit`, it will return `NULL` and allow the caller to decide when to resume parsing using `ts_parser_resume`. The default operation limit is `SIZE_MAX` which can never be exceeded, because the operation count itself is represented as a `size_t`.

The notion of 'operation count' is totally opaque to the caller, but operations should correspond to a fairly stable unit of time given fixed hardware conditions.