### PR TITLE
Cache parent nodes to speed up `ts_node_parent` in common cases

### DIFF
--- a/src/runtime/tree.h
+++ b/src/runtime/tree.h
@@ -5,13 +5,25 @@
 extern "C" {
 #endif
 
+typedef struct {
+  const Subtree *child;
+  const Subtree *parent;
+  Length position;
+  TSSymbol alias_symbol;
+} ParentCacheEntry;
+
 struct TSTree {
   const Subtree *root;
   const TSLanguage *language;
+  ParentCacheEntry *parent_cache;
+  uint32_t parent_cache_start;
+  uint32_t parent_cache_size;
 };
 
 TSTree *ts_tree_new(const Subtree *root, const TSLanguage *language);
 TSNode ts_node_new(const TSTree *, const Subtree *, Length, TSSymbol);
+TSNode ts_tree_get_cached_parent(const TSTree *, const TSNode *);
+void ts_tree_set_cached_parent(const TSTree *, const TSNode *, const TSNode *);
 
 #ifdef __cplusplus
 }

--- a/test/runtime/node_test.cc
+++ b/test/runtime/node_test.cc
@@ -438,6 +438,13 @@ describe("Node", [&]() {
         AssertThat(ts_node_end_byte(leaf), Equals(number_end_index));
         AssertThat(ts_node_start_point(leaf), Equals<TSPoint>({ 3, 2 }));
         AssertThat(ts_node_end_point(leaf), Equals<TSPoint>({ 3, 5 }));
+
+        TSNode parent = ts_node_parent(leaf);
+        AssertThat(ts_node_type(parent), Equals("array"));
+        AssertThat(ts_node_start_byte(parent), Equals(array_index));
+        parent = ts_node_parent(parent);
+        AssertThat(ts_node_type(parent), Equals("value"));
+        AssertThat(ts_node_start_byte(parent), Equals(array_index));
       });
     });
 
@@ -495,6 +502,8 @@ describe("Node", [&]() {
       AssertThat(ts_node_end_byte(node2), Equals(null_end_index));
       AssertThat(ts_node_start_point(node2), Equals<TSPoint>({ 6, 4 }));
       AssertThat(ts_node_end_point(node2), Equals<TSPoint>({ 6, 13 }));
+
+      AssertThat(ts_node_parent(node1), Equals(node2));
     });
 
     it("works in the presence of multi-byte characters", [&]() {
@@ -530,6 +539,8 @@ describe("Node", [&]() {
       AssertThat(ts_node_end_byte(node2), Equals(null_end_index));
       AssertThat(ts_node_start_point(node2), Equals<TSPoint>({ 6, 4 }));
       AssertThat(ts_node_end_point(node2), Equals<TSPoint>({ 6, 13 }));
+
+      AssertThat(ts_node_parent(node1), Equals(node2));
     });
   });
 });


### PR DESCRIPTION
### Background

In #165, we removed parent pointers from syntax nodes in order to make syntax nodes immutable. This change was crucial for allowing syntax trees to be cheaply copied, which is needed for multi-threaded use-cases. The downside to removing parent pointers is that traversing the syntax tree *upwards* (e.g. with the `ts_node_parent` or `ts_node_next_sibling`) functions becomes more expensive. Since, these APIs aren't used *too* extensively in Atom, I wasn't sure how significant the slowdown would be in practice.

### Problem

It turns out that there are still code paths in Atom which currently make heavy use of `ts_node_parent`. One example is [`TreeSitterLanguageMode.scopeDescriptorForPosition`](https://github.com/atom/atom/blob/master/src/tree-sitter-language-mode.js#L353-L371), which gets called frequently by [this code path in `bracket-matcher`](https://github.com/atom/bracket-matcher/blob/0b0f925ffe6a84b9b2a23df1b914066c6fb68bb5/lib/bracket-matcher-view.coffee#L148-L157).

This method could certainly be restructured to avoid referencing `Node.parent` so much, but if we want to expose the syntax tree in public APIs, we should try to make the syntax tree APIs fast enough so that packages don't need to worry about their performance.

### Solution

This PR introduces a layer of caching so that for the most recently accessed nodes, `ts_node_parent` will be fast. The cache is implemented as a simple ring buffer of `(child, parent)` structs.

To read from the cache, we scan through it linearly, doing pointer comparisons. Because the list is so short (currently 32 elements max), and the equality check is so simple, this doesn't seem to take significant time.

To write to the cache, we simply append to the ring buffer. Notably, we don't even check if the value being written is already present. This is to minimize the overhead of *populating* the cache. In many cases, we won't end up calling `ts_node_parent`, so it would be bad to burden these code paths with overly-complicated caching logic.

### Results

Here is a flame graph of all of the Tree-sitter API calls during a particular editing sequence that causes the `bracket-matcher` package to do an expensive scan, calling `scopeDescriptorForPosition` hundreds of times:

![node-parent-before](https://user-images.githubusercontent.com/326587/40691305-2727d25e-6360-11e8-8a7b-5d3bd82a346e.png)

Here is a flame graph of the same actions after this optimization. The `ts_node_parent` call still takes *some* time, but it's a pretty negligible amount compared to other work that we're doing.

![node-parent-after](https://user-images.githubusercontent.com/326587/40691310-2e90d3ec-6360-11e8-9bc3-fcf8afb1be71.png)

### Alternatives

We could make the logic for writing to the cache more sophisticated. Possibilities:

1. Keep the simple list, but avoid writing duplicate entries.
2. Keep the cache entries sorted by key so that we can binary search them when reading.
3. Use a hash table.

All of these options would improve our cache hit rate (so that `ts_node_parent` would be fast in more cases) at the cost of making normal tree operations slightly slower.

From some initial testing, it seems like we don't need anything too fancy. In most cases, when referencing a node's parent, you *just* got the node using some other API which warms the cache. We're only going to see `ts_node_parent` be slow when an application stores a reference to one node, then performs *other* tree operations, and then accesses the parent of that node from earlier, all in a very tight loop.

### Other Observations

Converting `TSNode` structs to JavaScript objects is the single most expensive operation when using Tree-sitter in Atom. I'm going to consider optimizing that at some point.

/cc @rewinfrey since you paired on #165
/cc @nathansobo since you helped strategize about this whole approach