### PR TITLE
Perform keyword optimization using explicitly selected word token

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -32,6 +32,7 @@
               <div id="current-page-table-of-contents">
                 {% capture whitespace %}
                 {% assign min_header = 2 %}
+                {% assign max_header = 3 %}
                 {% assign nodes = content | split: "<h" %}
                 {% assign first_header = true %}
                 {% for node in nodes %}
@@ -41,7 +42,7 @@
 
                   {% assign header_level = node | replace: '"', '' | slice: 0, 1 | times: 1 %}
 
-                  {% if header_level < min_header or header_level > maxHeader %}
+                  {% if header_level < min_header or header_level > max_header %}
                     {% continue %}
                   {% endif %}
 
@@ -127,7 +128,7 @@
     }
   });
 
-  $('h1, h2, h3, h4, h5, h6').filter('[id]').each(function() {
+  $('h1, h2, h3').filter('[id]').each(function() {
     $(this).html('<a href="#'+$(this).attr('id')+'">' + $(this).text() + '</a>');
   });
 </script>

--- a/include/tree_sitter/compiler.h
+++ b/include/tree_sitter/compiler.h
@@ -19,6 +19,7 @@ typedef enum {
   TSCompileErrorTypeEpsilonRule,
   TSCompileErrorTypeInvalidTokenContents,
   TSCompileErrorTypeInvalidRuleName,
+  TSCompileErrorTypeInvalidWordRule,
 } TSCompileErrorType;
 
 typedef struct {

--- a/src/compiler/build_tables/lex_table_builder.h
+++ b/src/compiler/build_tables/lex_table_builder.h
@@ -30,19 +30,6 @@ namespace build_tables {
 
 class LookaheadSet;
 
-enum ConflictStatus {
-  DoesNotMatch = 0,
-  MatchesShorterStringWithinSeparators = 1 << 0,
-  MatchesSameString = 1 << 1,
-  MatchesLongerString = 1 << 2,
-  MatchesLongerStringWithValidNextChar = 1 << 3,
-  CannotDistinguish = (
-    MatchesShorterStringWithinSeparators |
-    MatchesSameString |
-    MatchesLongerStringWithValidNextChar
-  ),
-};
-
 struct CoincidentTokenIndex {
   std::unordered_map<
     std::pair<rules::Symbol::Index, rules::Symbol::Index>,
@@ -69,7 +56,8 @@ class LexTableBuilder {
 
   BuildResult build();
 
-  ConflictStatus get_conflict_status(rules::Symbol, rules::Symbol) const;
+  bool does_token_shadow_other(rules::Symbol, rules::Symbol) const;
+  bool does_token_match_same_string_as_other(rules::Symbol, rules::Symbol) const;
 
  protected:
   LexTableBuilder() = default;

--- a/src/compiler/grammar.h
+++ b/src/compiler/grammar.h
@@ -32,6 +32,7 @@ struct InputGrammar {
   std::vector<std::unordered_set<rules::NamedSymbol>> expected_conflicts;
   std::vector<rules::Rule> external_tokens;
   std::unordered_set<rules::NamedSymbol> variables_to_inline;
+  rules::NamedSymbol word_rule;
 };
 
 }  // namespace tree_sitter

--- a/src/compiler/log.cc
+++ b/src/compiler/log.cc
@@ -1,4 +1,5 @@
 #include "compiler/log.h"
+#include <cassert>
 
 static const char *SPACES = "                                                           ";
 
@@ -21,6 +22,7 @@ void _indent_logs() {
 }
 
 void _outdent_logs() {
+  assert(_indent_level > 0);
   _indent_level--;
 }
 

--- a/src/compiler/parse_grammar.cc
+++ b/src/compiler/parse_grammar.cc
@@ -229,7 +229,9 @@ ParseGrammarResult parse_grammar(const string &input) {
   string error_message;
   string name;
   InputGrammar grammar;
-  json_value name_json, rules_json, extras_json, conflicts_json, external_tokens_json, inline_rules_json;
+  json_value
+    name_json, rules_json, extras_json, conflicts_json, external_tokens_json,
+    inline_rules_json, word_rule_json;
 
   json_settings settings = { 0, json_enable_comments, 0, 0, 0, 0 };
   char parse_error[json_error_max];
@@ -357,6 +359,16 @@ ParseGrammarResult parse_grammar(const string &input) {
       }
       grammar.external_tokens.push_back(result.rule);
     }
+  }
+
+  word_rule_json = grammar_json->operator[]("word");
+  if (word_rule_json.type != json_none) {
+    if (word_rule_json.type != json_string) {
+      error_message = "Invalid word property";
+      goto error;
+    }
+
+    grammar.word_rule = NamedSymbol { word_rule_json.u.string.ptr };
   }
 
   json_value_free(grammar_json);

--- a/src/compiler/prepare_grammar/expand_repeats.cc
+++ b/src/compiler/prepare_grammar/expand_repeats.cc
@@ -106,6 +106,7 @@ InitialSyntaxGrammar expand_repeats(const InitialSyntaxGrammar &grammar) {
     expander.aux_rules.end()
   );
 
+  result.word_rule = grammar.word_rule;
   return result;
 }
 

--- a/src/compiler/prepare_grammar/extract_tokens.cc
+++ b/src/compiler/prepare_grammar/extract_tokens.cc
@@ -329,6 +329,18 @@ tuple<InitialSyntaxGrammar, LexicalGrammar, CompileError> extract_tokens(
     }
   }
 
+  syntax_grammar.word_rule = symbol_replacer.replace_symbol(grammar.word_rule);
+  if (syntax_grammar.word_rule.is_non_terminal()) {
+    return make_tuple(
+      syntax_grammar,
+      lexical_grammar,
+      CompileError(
+        TSCompileErrorTypeInvalidWordRule,
+        "Word rules must be tokens"
+      )
+    );
+  }
+
   return make_tuple(syntax_grammar, lexical_grammar, CompileError::none());
 }
 

--- a/src/compiler/prepare_grammar/flatten_grammar.cc
+++ b/src/compiler/prepare_grammar/flatten_grammar.cc
@@ -161,6 +161,8 @@ pair<SyntaxGrammar, CompileError> flatten_grammar(const InitialSyntaxGrammar &gr
     i++;
   }
 
+  result.word_rule = grammar.word_rule;
+  
   return {result, CompileError::none()};
 }
 

--- a/src/compiler/prepare_grammar/initial_syntax_grammar.h
+++ b/src/compiler/prepare_grammar/initial_syntax_grammar.h
@@ -17,6 +17,7 @@ struct InitialSyntaxGrammar {
   std::set<std::set<rules::Symbol>> expected_conflicts;
   std::vector<ExternalToken> external_tokens;
   std::set<rules::Symbol> variables_to_inline;
+  rules::Symbol word_rule = rules::NONE();
 };
 
 }  // namespace prepare_grammar

--- a/src/compiler/prepare_grammar/initial_syntax_grammar.h
+++ b/src/compiler/prepare_grammar/initial_syntax_grammar.h
@@ -17,7 +17,7 @@ struct InitialSyntaxGrammar {
   std::set<std::set<rules::Symbol>> expected_conflicts;
   std::vector<ExternalToken> external_tokens;
   std::set<rules::Symbol> variables_to_inline;
-  rules::Symbol word_rule = rules::NONE();
+  rules::Symbol word_rule;
 };
 
 }  // namespace prepare_grammar

--- a/src/compiler/prepare_grammar/intern_symbols.cc
+++ b/src/compiler/prepare_grammar/intern_symbols.cc
@@ -166,6 +166,8 @@ pair<InternedGrammar, CompileError> intern_symbols(const InputGrammar &grammar) 
     }
   }
 
+  result.word_rule = interner.intern_symbol(grammar.word_rule);
+
   return {result, CompileError::none()};
 }
 

--- a/src/compiler/prepare_grammar/interned_grammar.h
+++ b/src/compiler/prepare_grammar/interned_grammar.h
@@ -15,8 +15,8 @@ struct InternedGrammar {
   std::vector<rules::Rule> extra_tokens;
   std::set<std::set<rules::Symbol>> expected_conflicts;
   std::vector<Variable> external_tokens;
-  std::set<rules::Symbol> blank_external_tokens;
   std::set<rules::Symbol> variables_to_inline;
+  rules::Symbol word_rule;
 };
 
 }  // namespace prepare_grammar

--- a/src/compiler/syntax_grammar.h
+++ b/src/compiler/syntax_grammar.h
@@ -60,7 +60,7 @@ struct SyntaxGrammar {
   std::set<std::set<rules::Symbol>> expected_conflicts;
   std::vector<ExternalToken> external_tokens;
   std::set<rules::Symbol> variables_to_inline;
-  rules::Symbol word_rule = rules::NONE();
+  rules::Symbol word_rule;
 };
 
 }  // namespace tree_sitter

--- a/src/compiler/syntax_grammar.h
+++ b/src/compiler/syntax_grammar.h
@@ -60,6 +60,7 @@ struct SyntaxGrammar {
   std::set<std::set<rules::Symbol>> expected_conflicts;
   std::vector<ExternalToken> external_tokens;
   std::set<rules::Symbol> variables_to_inline;
+  rules::Symbol word_rule = rules::NONE();
 };
 
 }  // namespace tree_sitter

--- a/src/runtime/array.h
+++ b/src/runtime/array.h
@@ -110,7 +110,7 @@ static inline void array__grow(VoidArray *self, size_t element_size) {
 
 static inline void array__splice(VoidArray *self, size_t element_size,
                                  uint32_t index, uint32_t old_count,
-                                 uint32_t new_count, void *elements) {
+                                 uint32_t new_count, const void *elements) {
   uint32_t new_size = self->size + new_count - old_count;
   uint32_t old_end = index + old_count;
   uint32_t new_end = index + new_count;

--- a/src/runtime/node.c
+++ b/src/runtime/node.c
@@ -28,11 +28,11 @@ static inline TSNode ts_node__null() {
 
 // TSNode - accessors
 
-uint32_t ts_node_start_byte(const TSNode self) {
+uint32_t ts_node_start_byte(TSNode self) {
   return self.context[0];
 }
 
-TSPoint ts_node_start_point(const TSNode self) {
+TSPoint ts_node_start_point(TSNode self) {
   return (TSPoint) {self.context[1], self.context[2]};
 }
 

--- a/src/runtime/subtree.c
+++ b/src/runtime/subtree.c
@@ -59,7 +59,7 @@ bool ts_external_scanner_state_eq(const ExternalScannerState *a, const ExternalS
 // SubtreeArray
 
 bool ts_subtree_array_copy(SubtreeArray self, SubtreeArray *dest) {
-  const Subtree **contents = NULL;
+  Subtree **contents = NULL;
   if (self.capacity > 0) {
     contents = ts_calloc(self.capacity, sizeof(Subtree *));
     memcpy(contents, self.contents, self.size * sizeof(Subtree *));

--- a/test/compiler/build_tables/parse_item_set_builder_test.cc
+++ b/test/compiler/build_tables/parse_item_set_builder_test.cc
@@ -25,7 +25,8 @@ describe("ParseItemSetBuilder", []() {
   LexicalGrammar lexical_grammar{lexical_variables, {}};
 
   it("adds items at the beginnings of referenced rules", [&]() {
-    SyntaxGrammar grammar{{
+    SyntaxGrammar grammar;
+    grammar.variables = {
       SyntaxVariable{"rule0", VariableTypeNamed, {
         Production({
           {Symbol::non_terminal(1), 0, AssociativityNone, Alias{}},
@@ -47,7 +48,7 @@ describe("ParseItemSetBuilder", []() {
           {Symbol::terminal(15), 0, AssociativityNone, Alias{}},
         }, 0)
       }},
-    }, {}, {}, {}, {}};
+    };
 
     auto production = [&](int variable_index, int production_index) -> const Production & {
       return grammar.variables[variable_index].productions[production_index];
@@ -84,7 +85,8 @@ describe("ParseItemSetBuilder", []() {
   });
 
   it("handles rules with empty productions", [&]() {
-    SyntaxGrammar grammar{{
+    SyntaxGrammar grammar;
+    grammar.variables = {
       SyntaxVariable{"rule0", VariableTypeNamed, {
         Production({
           {Symbol::non_terminal(1), 0, AssociativityNone, Alias{}},
@@ -98,7 +100,7 @@ describe("ParseItemSetBuilder", []() {
         }, 0),
         Production{{}, 0}
       }},
-    }, {}, {}, {}, {}};
+    };
 
     auto production = [&](int variable_index, int production_index) -> const Production & {
       return grammar.variables[variable_index].productions[production_index];

--- a/test/compiler/prepare_grammar/expand_repeats_test.cc
+++ b/test/compiler/prepare_grammar/expand_repeats_test.cc
@@ -11,11 +11,9 @@ START_TEST
 
 describe("expand_repeats", []() {
   it("replaces repeat rules with pairs of recursive rules", [&]() {
-    InitialSyntaxGrammar grammar{
-      {
-        Variable{"rule0", VariableTypeNamed, Repeat{Symbol::terminal(0)}},
-      },
-      {}, {}, {}, {}
+    InitialSyntaxGrammar grammar;
+    grammar.variables = {
+      Variable{"rule0", VariableTypeNamed, Repeat{Symbol::terminal(0)}},
     };
 
     auto result = expand_repeats(grammar);
@@ -30,14 +28,12 @@ describe("expand_repeats", []() {
   });
 
   it("replaces repeats inside of sequences", [&]() {
-    InitialSyntaxGrammar grammar{
-      {
-        Variable{"rule0", VariableTypeNamed, Rule::seq({
-          Symbol::terminal(10),
-          Repeat{Symbol::terminal(11)},
-        })},
-      },
-      {}, {}, {}, {}
+    InitialSyntaxGrammar grammar;
+    grammar.variables = {
+      Variable{"rule0", VariableTypeNamed, Rule::seq({
+        Symbol::terminal(10),
+        Repeat{Symbol::terminal(11)},
+      })},
     };
 
     auto result = expand_repeats(grammar);
@@ -55,14 +51,12 @@ describe("expand_repeats", []() {
   });
 
   it("replaces repeats inside of choices", [&]() {
-    InitialSyntaxGrammar grammar{
-      {
-        Variable{"rule0", VariableTypeNamed, Rule::choice({
-          Symbol::terminal(10),
-          Repeat{Symbol::terminal(11)}
-        })},
-      },
-      {}, {}, {}, {}
+    InitialSyntaxGrammar grammar;
+    grammar.variables = {
+      Variable{"rule0", VariableTypeNamed, Rule::choice({
+        Symbol::terminal(10),
+        Repeat{Symbol::terminal(11)}
+      })},
     };
 
     auto result = expand_repeats(grammar);
@@ -80,18 +74,16 @@ describe("expand_repeats", []() {
   });
 
   it("does not create redundant auxiliary rules", [&]() {
-    InitialSyntaxGrammar grammar{
-      {
-        Variable{"rule0", VariableTypeNamed, Rule::choice({
-          Rule::seq({ Symbol::terminal(1), Repeat{Symbol::terminal(4)} }),
-          Rule::seq({ Symbol::terminal(2), Repeat{Symbol::terminal(4)} }),
-        })},
-        Variable{"rule1", VariableTypeNamed, Rule::seq({
-          Symbol::terminal(3),
-          Repeat{Symbol::terminal(4)}
-        })},
-      },
-      {}, {}, {}, {}
+    InitialSyntaxGrammar grammar;
+    grammar.variables = {
+      Variable{"rule0", VariableTypeNamed, Rule::choice({
+        Rule::seq({ Symbol::terminal(1), Repeat{Symbol::terminal(4)} }),
+        Rule::seq({ Symbol::terminal(2), Repeat{Symbol::terminal(4)} }),
+      })},
+      Variable{"rule1", VariableTypeNamed, Rule::seq({
+        Symbol::terminal(3),
+        Repeat{Symbol::terminal(4)}
+      })},
     };
 
     auto result = expand_repeats(grammar);
@@ -113,14 +105,14 @@ describe("expand_repeats", []() {
   });
 
   it("can replace multiple repeats in the same rule", [&]() {
-    InitialSyntaxGrammar grammar{
+    InitialSyntaxGrammar grammar;
+    grammar.variables = {
       {
         Variable{"rule0", VariableTypeNamed, Rule::seq({
           Repeat{Symbol::terminal(10)},
           Repeat{Symbol::terminal(11)},
         })},
-      },
-      {}, {}, {}, {}
+      }
     };
 
     auto result = expand_repeats(grammar);
@@ -142,12 +134,10 @@ describe("expand_repeats", []() {
   });
 
   it("can replace repeats in multiple rules", [&]() {
-    InitialSyntaxGrammar grammar{
-      {
-        Variable{"rule0", VariableTypeNamed, Repeat{Symbol::terminal(10)}},
-        Variable{"rule1", VariableTypeNamed, Repeat{Symbol::terminal(11)}},
-      },
-      {}, {}, {}, {}
+    InitialSyntaxGrammar grammar;
+    grammar.variables = {
+      Variable{"rule0", VariableTypeNamed, Repeat{Symbol::terminal(10)}},
+      Variable{"rule1", VariableTypeNamed, Repeat{Symbol::terminal(11)}},
     };
 
     auto result = expand_repeats(grammar);

--- a/test/compiler/prepare_grammar/intern_symbols_test.cc
+++ b/test/compiler/prepare_grammar/intern_symbols_test.cc
@@ -11,13 +11,11 @@ using prepare_grammar::intern_symbols;
 
 describe("intern_symbols", []() {
   it("replaces named symbols with numerically-indexed symbols", [&]() {
-    InputGrammar grammar{
-      {
-        {"x", VariableTypeNamed, Rule::choice({ NamedSymbol{"y"}, NamedSymbol{"_z"} })},
-        {"y", VariableTypeNamed, NamedSymbol{"_z"}},
-        {"_z", VariableTypeNamed, String{"stuff"}}
-      },
-      {}, {}, {}, {}
+    InputGrammar grammar;
+    grammar.variables = {
+      {"x", VariableTypeNamed, Rule::choice({ NamedSymbol{"y"}, NamedSymbol{"_z"} })},
+      {"y", VariableTypeNamed, NamedSymbol{"_z"}},
+      {"_z", VariableTypeNamed, String{"stuff"}}
     };
 
     auto result = intern_symbols(grammar);
@@ -32,11 +30,9 @@ describe("intern_symbols", []() {
 
   describe("when there are symbols that reference undefined rules", [&]() {
     it("returns an error", []() {
-      InputGrammar grammar{
-        {
-          {"x", VariableTypeNamed, NamedSymbol{"y"}},
-        },
-        {}, {}, {}, {}
+      InputGrammar grammar;
+      grammar.variables = {
+        {"x", VariableTypeNamed, NamedSymbol{"y"}},
       };
 
       auto result = intern_symbols(grammar);
@@ -46,16 +42,14 @@ describe("intern_symbols", []() {
   });
 
   it("translates the grammar's optional 'extra_tokens' to numerical symbols", [&]() {
-    InputGrammar grammar{
-      {
-        {"x", VariableTypeNamed, Rule::choice({ NamedSymbol{"y"}, NamedSymbol{"z"} })},
-        {"y", VariableTypeNamed, NamedSymbol{"z"}},
-        {"z", VariableTypeNamed, String{"stuff"}}
-      },
-      {
-        NamedSymbol{"z"}
-      },
-      {}, {}, {}
+    InputGrammar grammar;
+    grammar.variables = {
+      {"x", VariableTypeNamed, Rule::choice({ NamedSymbol{"y"}, NamedSymbol{"z"} })},
+      {"y", VariableTypeNamed, NamedSymbol{"z"}},
+      {"z", VariableTypeNamed, String{"stuff"}}
+    };
+    grammar.extra_tokens = {
+      NamedSymbol{"z"}
     };
 
     auto result = intern_symbols(grammar);
@@ -66,19 +60,15 @@ describe("intern_symbols", []() {
   });
 
   it("records any rule names that match external token names", [&]() {
-    InputGrammar grammar{
-      {
-        {"x", VariableTypeNamed, Rule::choice({ NamedSymbol{"y"}, NamedSymbol{"z"} })},
-        {"y", VariableTypeNamed, NamedSymbol{"z"}},
-        {"z", VariableTypeNamed, String{"stuff"}},
-      },
-      {},
-      {},
-      {
-        NamedSymbol{"w"},
-        NamedSymbol{"z"},
-      },
-      {}
+    InputGrammar grammar;
+    grammar.variables = {
+      {"x", VariableTypeNamed, Rule::choice({ NamedSymbol{"y"}, NamedSymbol{"z"} })},
+      {"y", VariableTypeNamed, NamedSymbol{"z"}},
+      {"z", VariableTypeNamed, String{"stuff"}},
+    };
+    grammar.external_tokens = {
+      NamedSymbol{"w"},
+      NamedSymbol{"z"},
     };
 
     auto result = intern_symbols(grammar);


### PR DESCRIPTION
See #137, #163 

Previously, Tree-sitter would try to automatically detect a 'keyword capture token' for the purposes of the keyword tokenizing optimization. I tried multiple times to refine the logic for selecting this token, but @queerviolet and I still found that an incorrect keyword capture token was selected when creating [tree-sitter-html](https://github.com/tree-sitter/tree-sitter-html).

We've decided to stop trying to infer this token automatically, and allow the Grammar author to explicitly specify it using the new `word` field on the grammar. If no `word` is specified, then keyword extraction won't be attempted.