### PR TITLE
Consolidate TSInput interface down to one function

### DIFF
--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -40,8 +40,7 @@ typedef struct {
 
 typedef struct {
   void *payload;
-  const char *(*read)(void *payload, uint32_t *bytes_read);
-  int (*seek)(void *payload, uint32_t byte_index, TSPoint position);
+  const char *(*read)(void *payload, uint32_t byte_index, TSPoint position, uint32_t *bytes_read);
   TSInputEncoding encoding;
 } TSInput;
 

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -62,6 +62,7 @@ struct TSParser {
   size_t operation_limit;
   volatile bool enabled;
   bool halt_on_error;
+
 };
 
 typedef struct {
@@ -1461,7 +1462,7 @@ TSTree *ts_parser_resume(TSParser *self) {
   self->finished_tree = NULL;
   ts_stack_clear(self->stack);
   ts_parser__set_cached_token(self, 0, NULL, NULL);
-  ts_lexer_set_input(&self->lexer, (TSInput) { NULL, NULL, NULL, 0 });
+  ts_lexer_set_input(&self->lexer, (TSInput) { NULL, NULL, 0 });
   return result;
 }
 
@@ -1475,5 +1476,5 @@ TSTree *ts_parser_parse_string(TSParser *self, const TSTree *old_tree,
                                const char *string, uint32_t length) {
   TSStringInput input;
   ts_string_input_init(&input, string, length);
-  return ts_parser_parse(self, old_tree, input.input);
+  return ts_parser_parse(self, old_tree, ts_string_input_get(&input));
 }

--- a/src/runtime/string_input.c
+++ b/src/runtime/string_input.c
@@ -2,32 +2,27 @@
 #include "runtime/string_input.h"
 #include <string.h>
 
-static const char *ts_string_input__read(void *payload, uint32_t *bytes_read) {
+static const char *ts_string_input__read(void *payload, uint32_t byte_offset,
+                                         TSPoint _, uint32_t *bytes_read) {
   TSStringInput *input = (TSStringInput *)payload;
-  if (input->position >= input->length) {
+  if (byte_offset >= input->length) {
     *bytes_read = 0;
     return "";
+  } else {
+    *bytes_read = input->length - byte_offset;
+    return input->string + byte_offset;
   }
-  uint32_t previous_position = input->position;
-  input->position = input->length;
-  *bytes_read = input->position - previous_position;
-  return input->string + previous_position;
-}
-
-static int ts_string_input__seek(void *payload, uint32_t byte, TSPoint _) {
-  TSStringInput *input = (TSStringInput *)payload;
-  input->position = byte;
-  return (byte < input->length);
 }
 
 void ts_string_input_init(TSStringInput *self, const char *string, uint32_t length) {
   self->string = string;
-  self->position = 0;
   self->length = length;
-  self->input = (TSInput) {
+}
+
+TSInput ts_string_input_get(TSStringInput *self) {
+  return (TSInput) {
     .payload = self,
     .read = ts_string_input__read,
-    .seek = ts_string_input__seek,
     .encoding = TSInputEncodingUTF8,
   };
 }

--- a/src/runtime/string_input.h
+++ b/src/runtime/string_input.h
@@ -9,12 +9,11 @@ extern "C" {
 
 typedef struct {
   const char *string;
-  uint32_t position;
   uint32_t length;
-  TSInput input;
 } TSStringInput;
 
 void ts_string_input_init(TSStringInput *, const char *, uint32_t);
+TSInput ts_string_input_get(TSStringInput *);
 
 #ifdef __cplusplus
 }

--- a/test/helpers/spy_input.h
+++ b/test/helpers/spy_input.h
@@ -13,11 +13,9 @@ struct SpyInputEdit {
 
 class SpyInput {
   char *buffer;
-  uint32_t byte_offset;
   std::vector<SpyInputEdit> undo_stack;
 
-  static const char * read(void *, uint32_t *);
-  static int seek(void *, uint32_t, TSPoint);
+  static const char *read(void *, uint32_t, TSPoint, uint32_t *);
   std::pair<std::string, TSPoint> swap_substr(size_t, size_t, std::string);
 
  public:

--- a/test/runtime/parser_test.cc
+++ b/test/runtime/parser_test.cc
@@ -630,14 +630,11 @@ describe("Parser", [&]() {
         size_t read_count = 0;
         TSInput infinite_input = {
           &read_count,
-          [](void *payload, uint32_t *bytes_read) {
+          [](void *payload, uint32_t byte, TSPoint position, uint32_t *bytes_read) {
             size_t *read_count = static_cast<size_t *>(payload);
             assert((*read_count)++ < 100000);
             *bytes_read = 1;
             return "[";
-          },
-          [](void *payload, unsigned byte, TSPoint position) -> int {
-            return true;
           },
           TSInputEncodingUTF8
         };
@@ -681,14 +678,11 @@ describe("Parser", [&]() {
       // it has been read.
       TSInput infinite_input = {
         &state,
-        [](void *payload, uint32_t *bytes_read) {
+        [](void *payload, uint32_t byte, TSPoint position, uint32_t *bytes_read) {
           InputState *state = static_cast<InputState *>(payload);
           assert(state->read_count++ <= 10);
           *bytes_read = strlen(state->string);
           return state->string;
-        },
-        [](void *payload, unsigned byte, TSPoint position) -> int {
-          return true;
         },
         TSInputEncodingUTF8
       };


### PR DESCRIPTION
I've realized that it's unnecessary to have the two separate `read` and `seek` methods on `TSInput`. This design was originally influenced by Go's [`ReadSeeker`](https://golang.org/pkg/io/#ReadSeeker) interface, which seemed to tell the story of how the dominant access pattern is sequential. But after stepping back, I think it's simpler to just pass the positional information on every call to `read`. Implementations of `TSInput` can still optimize for the sequential case internally.

This will simplify Tree-sitter's interface in languages with closures like [JavaScript](https://github.com/tree-sitter/node-tree-sitter) and [Rust](https://github.com/tree-sitter/rust-tree-sitter), because the input can be provided as a single closure.