### PR TITLE
Add an API for parsing selected ranges of a document

### DIFF
--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -34,8 +34,10 @@ typedef struct {
 } TSPoint;
 
 typedef struct {
-  TSPoint start;
-  TSPoint end;
+  TSPoint start_point;
+  TSPoint end_point;
+  uint32_t start_byte;
+  uint32_t end_byte;
 } TSRange;
 
 typedef struct {

--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -92,6 +92,8 @@ void ts_parser_set_enabled(TSParser *, bool);
 size_t ts_parser_operation_limit(const TSParser *);
 void ts_parser_set_operation_limit(TSParser *, size_t);
 void ts_parser_reset(TSParser *);
+void ts_parser_set_included_ranges(TSParser *, const TSRange *, uint32_t);
+const TSRange *ts_parser_included_ranges(const TSParser *, uint32_t *);
 
 TSTree *ts_tree_copy(const TSTree *);
 void ts_tree_delete(TSTree *);

--- a/src/runtime/lexer.h
+++ b/src/runtime/lexer.h
@@ -16,6 +16,10 @@ typedef struct {
   Length token_start_position;
   Length token_end_position;
 
+  TSRange * included_ranges;
+  size_t included_range_count;
+  size_t current_included_range_index;
+
   const char *chunk;
   uint32_t chunk_start;
   uint32_t chunk_size;
@@ -27,10 +31,13 @@ typedef struct {
 } Lexer;
 
 void ts_lexer_init(Lexer *);
+void ts_lexer_delete(Lexer *);
 void ts_lexer_set_input(Lexer *, TSInput);
 void ts_lexer_reset(Lexer *, Length);
 void ts_lexer_start(Lexer *);
 void ts_lexer_advance_to_end(Lexer *);
+void ts_lexer_set_included_ranges(Lexer *self, const TSRange *ranges, uint32_t count);
+TSRange *ts_lexer_included_ranges(const Lexer *self, uint32_t *count);
 
 #ifdef __cplusplus
 }

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -1359,6 +1359,7 @@ void ts_parser_delete(TSParser *self) {
     ts_subtree_release(&self->tree_pool, self->old_tree);
     self->old_tree = NULL;
   }
+  ts_lexer_delete(&self->lexer);
   ts_parser__set_cached_token(self, 0, NULL, NULL);
   ts_subtree_pool_delete(&self->tree_pool);
   reusable_node_delete(&self->reusable_node);
@@ -1417,6 +1418,14 @@ size_t ts_parser_operation_limit(const TSParser *self) {
 
 void ts_parser_set_operation_limit(TSParser *self, size_t limit) {
   self->operation_limit = limit;
+}
+
+void ts_parser_set_included_ranges(TSParser *self, const TSRange *ranges, uint32_t count) {
+  ts_lexer_set_included_ranges(&self->lexer, ranges, count);
+}
+
+const TSRange *ts_parser_included_ranges(const TSParser *self, uint32_t *count) {
+  return ts_lexer_included_ranges(&self->lexer, count);
 }
 
 void ts_parser_reset(TSParser *self) {

--- a/test/helpers/point_helpers.cc
+++ b/test/helpers/point_helpers.cc
@@ -11,7 +11,12 @@ bool operator==(const TSPoint &left, const TSPoint &right) {
 }
 
 bool operator==(const TSRange &left, const TSRange &right) {
-  return left.start == right.start && left.end == right.end;
+  return (
+    left.start_byte == right.start_byte &&
+    left.end_byte == right.end_byte &&
+    left.start_point == right.start_point &&
+    left.end_point == right.end_point
+  );
 }
 
 bool operator==(const Length &left, const Length &right) {
@@ -34,7 +39,7 @@ std::ostream &operator<<(std::ostream &stream, const TSPoint &point) {
 }
 
 std::ostream &operator<<(std::ostream &stream, const TSRange &range) {
-  return stream << "{" << range.start << ", " << range.end << "}";
+  return stream << "{" << range.start_point << ", " << range.end_point << "}";
 }
 
 ostream &operator<<(ostream &stream, const Length &length) {

--- a/test/helpers/scope_sequence.cc
+++ b/test/helpers/scope_sequence.cc
@@ -73,7 +73,7 @@ void verify_changed_ranges(const ScopeSequence &old_sequence, const ScopeSequenc
       bool found_containing_range = false;
       for (size_t j = 0; j < range_count; j++) {
         TSRange range = ranges[j];
-        if (range.start <= current_position && current_position <= range.end) {
+        if (range.start_point <= current_position && current_position <= range.end_point) {
           found_containing_range = true;
           break;
         }

--- a/test/runtime/tree_test.cc
+++ b/test/runtime/tree_test.cc
@@ -131,16 +131,22 @@ describe("Tree", [&]() {
       return result;
     };
 
+    auto range_for_text = [&](string start_text, string end_text) {
+      return TSRange {
+        point(0, input->content.find(start_text)),
+        point(0, input->content.find(end_text)),
+        static_cast<uint32_t>(input->content.find(start_text)),
+        static_cast<uint32_t>(input->content.find(end_text)),
+      };
+    };
+
     it("reports changes when one token has been updated", [&]() {
       // Replace `null` with `nothing`
       auto ranges = get_changed_ranges_for_edit([&]() {
         return input->replace(input->content.find("ull"), 1, "othing");
       });
       AssertThat(ranges, Equals(vector<TSRange>({
-        TSRange{
-          point(0, input->content.find("nothing")),
-          point(0, input->content.find("}"))
-        },
+        range_for_text("nothing", "}"),
       })));
 
       // Replace `nothing` with `null` again
@@ -148,10 +154,7 @@ describe("Tree", [&]() {
         return input->undo();
       });
       AssertThat(ranges, Equals(vector<TSRange>({
-        TSRange{
-          point(0, input->content.find("null")),
-          point(0, input->content.find("}"))
-        },
+        range_for_text("null", "}"),
       })));
     });
 
@@ -192,10 +195,7 @@ describe("Tree", [&]() {
         return input->replace(input->content.find("}"), 0, ", b: false");
       });
       AssertThat(ranges, Equals(vector<TSRange>({
-        TSRange{
-          point(0, input->content.find(",")),
-          point(0, input->content.find("}"))
-        },
+        range_for_text(",", "}"),
       })));
 
       // Add a third key-value pair in between the first two
@@ -209,10 +209,7 @@ describe("Tree", [&]() {
           "(pair (property_identifier) (false)))))"
       );
       AssertThat(ranges, Equals(vector<TSRange>({
-        TSRange{
-          point(0, input->content.find(", c")),
-          point(0, input->content.find(", b"))
-        },
+        range_for_text(", c", ", b"),
       })));
 
       // Delete the middle pair.
@@ -247,10 +244,7 @@ describe("Tree", [&]() {
           "(pair (property_identifier) (binary_expression (identifier) (null))))))"
       );
       AssertThat(ranges, Equals(vector<TSRange>({
-        TSRange{
-          point(0, input->content.find("b ===")),
-          point(0, input->content.find("}"))
-        },
+        range_for_text("b ===", "}"),
       })));
     });
   });


### PR DESCRIPTION
This PR introduces a new function called `ts_parser_set_included_ranges`. It can be used to parse a subset of a document while ensuring that the resulting syntax nodes' ranges reflect their position in the overall document.

For example, we can use this to parse HTML inside of JavaScript template string literals, even if there are interpolations within the HTML:

```cpp
string source_code =
  "html `<div>Hello, ${name.toUpperCase()}, it's <b>${now()}</b>.</div>`";

ts_parser_set_language(parser, load_real_language("javascript"));
TSTree *js_tree = ts_parser_parse_string(parser, nullptr, source_code.c_str(), source_code.size());
TSNode root_node = ts_tree_root_node(js_tree);
TSNode string_node = ts_node_descendant_for_byte_range(
  root_node,
  source_code.find("<div>"),
  source_code.find("Hell")
);
TSNode open_quote_node = ts_node_child(string_node, 0);
TSNode interpolation_node1 = ts_node_child(string_node, 1);
TSNode interpolation_node2 = ts_node_child(string_node, 2);
TSNode close_quote_node = ts_node_child(string_node, 3);

TSRange included_ranges[] = {
  {
    ts_node_end_point(open_quote_node),
    ts_node_start_point(interpolation_node1),
    ts_node_end_byte(open_quote_node),
    ts_node_start_byte(interpolation_node1),
  },
  {
    ts_node_end_point(interpolation_node1),
    ts_node_start_point(interpolation_node2),
    ts_node_end_byte(interpolation_node1),
    ts_node_start_byte(interpolation_node2),
  },
  {
    ts_node_end_point(interpolation_node2),
    ts_node_start_point(close_quote_node),
    ts_node_end_byte(interpolation_node2),
    ts_node_start_byte(close_quote_node),
  }
};

ts_parser_set_included_ranges(parser, included_ranges, 3);
ts_parser_set_language(parser, load_real_language("html"));
TSTree *html_tree = ts_parser_parse_string(parser, nullptr, source_code.c_str(), source_code.size());
```

Refs https://github.com/tree-sitter/tree-sitter/issues/150
This is the first step of https://github.com/atom/atom/issues/17392

🍐 'd with @queerviolet 