### PR TITLE
Simplify treatment of rules that are always aliased one way

### DIFF
--- a/project.gyp
+++ b/project.gyp
@@ -29,6 +29,7 @@
         'src/compiler/prepare_grammar/expand_repeats.cc',
         'src/compiler/prepare_grammar/expand_tokens.cc',
         'src/compiler/prepare_grammar/extract_choices.cc',
+        'src/compiler/prepare_grammar/extract_simple_aliases.cc',
         'src/compiler/prepare_grammar/extract_tokens.cc',
         'src/compiler/prepare_grammar/flatten_grammar.cc',
         'src/compiler/prepare_grammar/intern_symbols.cc',

--- a/src/compiler/build_tables/parse_table_builder.h
+++ b/src/compiler/build_tables/parse_table_builder.h
@@ -2,6 +2,7 @@
 #define COMPILER_BUILD_TABLES_PARSE_TABLE_BUILDER_H_
 
 #include <memory>
+#include <unordered_map>
 #include "compiler/parse_table.h"
 #include "compiler/compile_error.h"
 
@@ -16,7 +17,11 @@ namespace build_tables {
 
 class ParseTableBuilder {
  public:
-  static std::unique_ptr<ParseTableBuilder> create(const SyntaxGrammar &, const LexicalGrammar &);
+  static std::unique_ptr<ParseTableBuilder> create(
+    const SyntaxGrammar &,
+    const LexicalGrammar &,
+    const std::unordered_map<rules::Symbol, rules::Alias> &
+  );
 
   struct BuildResult {
     ParseTable parse_table;

--- a/src/compiler/compile.cc
+++ b/src/compiler/compile.cc
@@ -22,8 +22,7 @@ extern "C" TSCompileResult ts_compile_grammar(const char *input, FILE *log_file)
 
   ParseGrammarResult parse_result = parse_grammar(string(input));
   if (!parse_result.error_message.empty()) {
-    return { nullptr, strdup(parse_result.error_message.c_str()),
-             TSCompileErrorTypeInvalidGrammar };
+    return {nullptr, strdup(parse_result.error_message.c_str()), TSCompileErrorTypeInvalidGrammar};
   }
 
   auto prepare_grammar_result = prepare_grammar::prepare_grammar(parse_result.grammar);
@@ -35,7 +34,11 @@ extern "C" TSCompileResult ts_compile_grammar(const char *input, FILE *log_file)
     return {nullptr, strdup(error.message.c_str()), error.type};
   }
 
-  auto builder = build_tables::ParseTableBuilder::create(syntax_grammar, lexical_grammar);
+  auto builder = build_tables::ParseTableBuilder::create(
+    syntax_grammar,
+    lexical_grammar,
+    simple_aliases
+  );
   auto build_tables_result = builder->build();
   error = build_tables_result.error;
   if (error.type != 0) {
@@ -54,7 +57,7 @@ extern "C" TSCompileResult ts_compile_grammar(const char *input, FILE *log_file)
   );
 
   set_log_file(nullptr);
-  return { strdup(code.c_str()), nullptr, TSCompileErrorTypeNone };
+  return {strdup(code.c_str()), nullptr, TSCompileErrorTypeNone};
 }
 
 }  // namespace tree_sitter

--- a/src/compiler/compile.cc
+++ b/src/compiler/compile.cc
@@ -27,9 +27,10 @@ extern "C" TSCompileResult ts_compile_grammar(const char *input, FILE *log_file)
   }
 
   auto prepare_grammar_result = prepare_grammar::prepare_grammar(parse_result.grammar);
-  SyntaxGrammar &syntax_grammar = get<0>(prepare_grammar_result);
-  LexicalGrammar &lexical_grammar = get<1>(prepare_grammar_result);
-  CompileError error = get<2>(prepare_grammar_result);
+  SyntaxGrammar &syntax_grammar = prepare_grammar_result.syntax_grammar;
+  LexicalGrammar &lexical_grammar = prepare_grammar_result.lexical_grammar;
+  auto &simple_aliases = prepare_grammar_result.simple_aliases;
+  CompileError error = prepare_grammar_result.error;
   if (error.type) {
     return {nullptr, strdup(error.message.c_str()), error.type};
   }
@@ -48,7 +49,8 @@ extern "C" TSCompileResult ts_compile_grammar(const char *input, FILE *log_file)
     move(build_tables_result.keyword_lex_table),
     build_tables_result.keyword_capture_token,
     move(syntax_grammar),
-    move(lexical_grammar)
+    move(lexical_grammar),
+    move(simple_aliases)
   );
 
   set_log_file(nullptr);

--- a/src/compiler/generate_code/c_code.h
+++ b/src/compiler/generate_code/c_code.h
@@ -2,6 +2,7 @@
 #define COMPILER_GENERATE_CODE_C_CODE_H_
 
 #include <string>
+#include <unordered_map>
 #include "compiler/rule.h"
 
 namespace tree_sitter {
@@ -20,7 +21,8 @@ std::string c_code(
   LexTable &&,
   rules::Symbol,
   SyntaxGrammar &&,
-  LexicalGrammar &&
+  LexicalGrammar &&,
+  std::unordered_map<rules::Symbol, rules::Alias> &&
 );
 
 }  // namespace generate_code

--- a/src/compiler/prepare_grammar/extract_simple_aliases.cc
+++ b/src/compiler/prepare_grammar/extract_simple_aliases.cc
@@ -1,0 +1,111 @@
+#include "compiler/prepare_grammar/extract_simple_aliases.h"
+#include "compiler/lexical_grammar.h"
+#include "compiler/syntax_grammar.h"
+#include <unordered_map>
+#include <vector>
+
+namespace tree_sitter {
+namespace prepare_grammar {
+
+using std::pair;
+using std::vector;
+using std::unordered_map;
+using rules::Alias;
+using rules::Symbol;
+
+template <typename T>
+static void apply_alias(T *variable, Alias alias) {
+  if (!alias.value.empty()) {
+    variable->name = alias.value;
+    variable->type = alias.is_named ? VariableTypeNamed : VariableTypeAnonymous;
+  }
+}
+
+std::unordered_map<rules::Symbol, rules::Alias>
+extract_simple_aliases(SyntaxGrammar *syntax_grammar, LexicalGrammar *lexical_grammar) {
+  struct SymbolStatus {
+    Alias alias;
+    bool eligible = true;
+  };
+
+  vector<SymbolStatus> terminal_status_list(lexical_grammar->variables.size());
+  vector<SymbolStatus> non_terminal_status_list(syntax_grammar->variables.size());
+  vector<SymbolStatus> external_status_list(syntax_grammar->external_tokens.size());
+
+  for (const SyntaxVariable &variable : syntax_grammar->variables) {
+    for (const Production &production : variable.productions) {
+      for (const ProductionStep &step : production.steps) {
+        SymbolStatus *status;
+        if (step.symbol.is_built_in())  {
+          continue;
+        } else if (step.symbol.is_external()) {
+          status = &external_status_list[step.symbol.index];
+        } else if (step.symbol.is_terminal()) {
+          status = &terminal_status_list[step.symbol.index];
+        } else {
+          status = &non_terminal_status_list[step.symbol.index];
+        }
+
+        if (step.alias.value.empty()) {
+          status->alias = Alias();
+          status->eligible = false;
+        }
+
+        if (status->eligible) {
+          if (status->alias.value.empty()) {
+            status->alias = step.alias;
+          } else if (status->alias != step.alias) {
+            status->alias = Alias();
+            status->eligible = false;
+          }
+        }
+      }
+    }
+  }
+
+  for (SyntaxVariable &variable : syntax_grammar->variables) {
+    for (Production &production : variable.productions) {
+      for (ProductionStep &step : production.steps) {
+        SymbolStatus *status;
+        if (step.symbol.is_built_in())  {
+          continue;
+        } else if (step.symbol.is_external()) {
+          status = &external_status_list[step.symbol.index];
+        } else if (step.symbol.is_terminal()) {
+          status = &terminal_status_list[step.symbol.index];
+        } else {
+          status = &non_terminal_status_list[step.symbol.index];
+        }
+
+        if (!status->alias.value.empty()) {
+          step.alias = Alias();
+        }
+      }
+    }
+  }
+
+  unordered_map<Symbol, Alias> result;
+
+  for (unsigned i = 0, n = terminal_status_list.size(); i < n; i++) {
+    if (!terminal_status_list[i].alias.value.empty()) {
+      result[Symbol::terminal(i)] = terminal_status_list[i].alias;
+    }
+  }
+
+  for (unsigned i = 0, n = non_terminal_status_list.size(); i < n; i++) {
+    if (!non_terminal_status_list[i].alias.value.empty()) {
+      result[Symbol::non_terminal(i)] = non_terminal_status_list[i].alias;
+    }
+  }
+
+  for (unsigned i = 0, n = external_status_list.size(); i < n; i++) {
+    if (!external_status_list[i].alias.value.empty()) {
+      result[Symbol::external(i)] = external_status_list[i].alias;
+    }
+  }
+
+  return result;
+}
+
+}  // namespace prepare_grammar
+}  // namespace tree_sitter

--- a/src/compiler/prepare_grammar/extract_simple_aliases.h
+++ b/src/compiler/prepare_grammar/extract_simple_aliases.h
@@ -1,0 +1,21 @@
+#ifndef COMPILER_PREPARE_GRAMMAR_EXTRACT_SIMPLE_ALIASES_H_
+#define COMPILER_PREPARE_GRAMMAR_EXTRACT_SIMPLE_ALIASES_H_
+
+#include "compiler/rules/symbol.h"
+#include "compiler/rules/metadata.h"
+#include <unordered_map>
+
+namespace tree_sitter {
+
+struct SyntaxGrammar;
+struct LexicalGrammar;
+
+namespace prepare_grammar {
+
+std::unordered_map<rules::Symbol, rules::Alias>
+extract_simple_aliases(SyntaxGrammar *, LexicalGrammar *);
+
+}  // namespace prepare_grammar
+}  // namespace tree_sitter
+
+#endif  // COMPILER_PREPARE_GRAMMAR_EXTRACT_SIMPLE_ALIASES_H_

--- a/src/compiler/prepare_grammar/prepare_grammar.h
+++ b/src/compiler/prepare_grammar/prepare_grammar.h
@@ -1,7 +1,7 @@
 #ifndef COMPILER_PREPARE_GRAMMAR_PREPARE_GRAMMAR_H_
 #define COMPILER_PREPARE_GRAMMAR_PREPARE_GRAMMAR_H_
 
-#include <tuple>
+#include <unordered_map>
 #include "compiler/grammar.h"
 #include "compiler/syntax_grammar.h"
 #include "compiler/lexical_grammar.h"
@@ -10,7 +10,14 @@
 namespace tree_sitter {
 namespace prepare_grammar {
 
-std::tuple<SyntaxGrammar, LexicalGrammar, CompileError> prepare_grammar(const InputGrammar &);
+struct PrepareGrammarResult {
+  SyntaxGrammar syntax_grammar;
+  LexicalGrammar lexical_grammar;
+  std::unordered_map<rules::Symbol, rules::Alias> simple_aliases;
+  CompileError error;
+};
+
+PrepareGrammarResult prepare_grammar(const InputGrammar &);
 
 }  // namespace prepare_grammar
 }  // namespace tree_sitter

--- a/src/compiler/rule.h
+++ b/src/compiler/rule.h
@@ -91,7 +91,7 @@ struct Rule {
   }
 
   template <typename ...FunctionTypes>
-  inline auto match(FunctionTypes && ...functions) const -> decltype(accept(util::make_visitor(std::forward<FunctionTypes>(functions)...))){
+  inline auto match(FunctionTypes && ...functions) const -> decltype(accept(util::make_visitor(std::forward<FunctionTypes>(functions)...))) {
     return accept(util::make_visitor(std::forward<FunctionTypes>(functions)...));
   }
 

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -36,6 +36,7 @@
 #define SYM_NAME(symbol) ts_language_symbol_name(self->language, symbol)
 
 static const unsigned MAX_VERSION_COUNT = 6;
+static const unsigned MAX_VERSION_COUNT_OVERFLOW = 4;
 static const unsigned MAX_SUMMARY_DEPTH = 16;
 static const unsigned MAX_COST_DIFFERENCE = 16 * ERROR_COST_PER_SKIPPED_TREE;
 
@@ -633,7 +634,7 @@ static StackVersion ts_parser__reduce(TSParser *self, StackVersion version, TSSy
     // Error recovery can sometimes cause lots of stack versions to merge,
     // such that a single pop operation can produce a lots of slices.
     // Avoid creating too many stack versions in that situation.
-    if (i > 0 && slice_version > MAX_VERSION_COUNT) {
+    if (i > 0 && slice_version > MAX_VERSION_COUNT + MAX_VERSION_COUNT_OVERFLOW) {
       ts_stack_remove_version(self->stack, slice_version);
       ts_subtree_array_delete(&self->tree_pool, &slice.subtrees);
       removed_version_count++;

--- a/test/fixtures/test_grammars/aliased_unit_reductions/corpus.txt
+++ b/test/fixtures/test_grammars/aliased_unit_reductions/corpus.txt
@@ -2,11 +2,12 @@
 Aliases on rules that are unit reductions
 ==========================================
 
-one two three;
+one two three four;
 
 ---
 
 (statement
   (identifier)
   (b_prime (identifier))
-  (c_prime (identifier)))
+  (c_prime (identifier))
+  (identifier))

--- a/test/fixtures/test_grammars/aliased_unit_reductions/grammar.json
+++ b/test/fixtures/test_grammars/aliased_unit_reductions/grammar.json
@@ -10,6 +10,9 @@
       "type": "SEQ",
       "members": [
         {"type": "SYMBOL", "name": "_a"},
+
+        // The `_b` rule is always aliased to `b_prime`, so it is internally treated
+        // as a simple alias.
         {
           "type": "ALIAS",
           "named": true,
@@ -19,6 +22,9 @@
             "name": "_b"
           }
         },
+
+        // The `_c` rule is used without an alias in addition to being aliased to `c_prime`,
+        // so it is not a simple alias.
         {
           "type": "ALIAS",
           "named": true,
@@ -28,6 +34,11 @@
             "name": "_c"
           }
         },
+        {
+          "type": "SYMBOL",
+          "name": "_c"
+        },
+
         {
           "type": "STRING",
           "value": ";"
@@ -57,7 +68,7 @@
 
     "_c": {
       "type": "SYMBOL",
-      "name": "_B"
+      "name": "_C"
     },
 
     "_C": {


### PR DESCRIPTION
### Problem

We're using the `alias` function a lot in grammars like [tree-sitter-html](https://github.com/tree-sitter/tree-sitter-html). It's been really useful, but it has two downsides:

1. It increases the size of the parse table somewhat because otherwise-identical REDUCE actions can have different `alias_sequence_id` values.
2. It causes tokens to have appear with different types when they occur within `ERROR` nodes, because in that case, the aliases are not applied.

The second problem came to my attention when adapting Atom's [autocomplete-html](https://github.com/atom/autocomplete-html) package to work with Tree-sitter.

### Solution

In this PR, I introduce an internal concept called *simple aliases*. A grammar symbol is considered to have a *simple* alias if the symbol is *always* used with that alias: it's never used without an alias, and it's never used with a different alias.

Simple aliases can be dealt with in a way that is, well, simpler than how we normally implement aliases :grin:. This results in a smaller parse table. More importantly though, it causes the rule to *always* appear with the same name, even when it occurs inside of an `ERROR`, which makes the syntax tree more consistent and useful overall.