### PR TITLE
Fix bug where missing token was inserted outside of any included range

### DIFF
--- a/src/runtime/lexer.c
+++ b/src/runtime/lexer.c
@@ -256,6 +256,10 @@ void ts_lexer_advance_to_end(Lexer *self) {
   }
 }
 
+void ts_lexer_mark_end(Lexer *self) {
+  ts_lexer__mark_end(&self->data);
+}
+
 static const TSRange DEFAULT_RANGES[] = {
   {
     .start_point = {

--- a/src/runtime/lexer.h
+++ b/src/runtime/lexer.h
@@ -36,6 +36,7 @@ void ts_lexer_set_input(Lexer *, TSInput);
 void ts_lexer_reset(Lexer *, Length);
 void ts_lexer_start(Lexer *);
 void ts_lexer_advance_to_end(Lexer *);
+void ts_lexer_mark_end(Lexer *);
 void ts_lexer_set_included_ranges(Lexer *self, const TSRange *ranges, uint32_t count);
 TSRange *ts_lexer_included_ranges(const Lexer *self, uint32_t *count);
 

--- a/src/runtime/subtree.c
+++ b/src/runtime/subtree.c
@@ -395,9 +395,9 @@ Subtree *ts_subtree_new_error_node(SubtreePool *pool, SubtreeArray *children,
   return ts_subtree_new_node(pool, ts_builtin_sym_error, children, 0, language);
 }
 
-Subtree *ts_subtree_new_missing_leaf(SubtreePool *pool, TSSymbol symbol,
+Subtree *ts_subtree_new_missing_leaf(SubtreePool *pool, TSSymbol symbol, Length padding,
                                      const TSLanguage *language) {
-  Subtree *result = ts_subtree_new_leaf(pool, symbol, length_zero(), length_zero(), language);
+  Subtree *result = ts_subtree_new_leaf(pool, symbol, padding, length_zero(), language);
   result->is_missing = true;
   result->error_cost = ERROR_COST_PER_MISSING_TREE + ERROR_COST_PER_RECOVERY;
   return result;

--- a/src/runtime/subtree.h
+++ b/src/runtime/subtree.h
@@ -94,7 +94,7 @@ Subtree *ts_subtree_new_node(SubtreePool *, TSSymbol, SubtreeArray *, unsigned, 
 Subtree *ts_subtree_new_copy(SubtreePool *, const Subtree *);
 Subtree *ts_subtree_new_error_node(SubtreePool *, SubtreeArray *, const TSLanguage *);
 Subtree *ts_subtree_new_error(SubtreePool *, Length, Length, int32_t, const TSLanguage *);
-Subtree *ts_subtree_new_missing_leaf(SubtreePool *, TSSymbol, const TSLanguage *);
+Subtree *ts_subtree_new_missing_leaf(SubtreePool *, TSSymbol, Length, const TSLanguage *);
 Subtree *ts_subtree_make_mut(SubtreePool *, const Subtree *);
 void ts_subtree_retain(const Subtree *tree);
 void ts_subtree_release(SubtreePool *, const Subtree *tree);


### PR DESCRIPTION
Fixes https://github.com/atom/language-javascript/issues/595

The parser that we use for [parsing regexes in JavaScript](https://github.com/tree-sitter/tree-sitter-regex) currently fails on certain valid regexes like `{ab`. For that particular regex, it currently tries to recover from the error by inserting a *missing* pattern character before the `{`.

There was previously a bug in the runtime where missing tokens were accidentally allowed to be inserted outside of `included_ranges`. That allowed the erroneous regex to "escape out" of its expected delimiters, causing syntax highlighting problems.

This PR adds a check to make sure that when we insert missing tokens, we position them within one of the current `included_ranges`.

/cc @t9md, @queerviolet 