### PR TITLE
Fix assetion of an example program

### DIFF
--- a/docs/section-2-using-parsers.md
+++ b/docs/section-2-using-parsers.md
@@ -63,7 +63,7 @@ int main() {
 
   // Check that the nodes have the expected child counts.
   assert(ts_node_child_count(root_node) == 1);
-  assert(ts_node_child_count(array_node) == 4);
+  assert(ts_node_child_count(array_node) == 5);
   assert(ts_node_named_child_count(array_node) == 2);
   assert(ts_node_child_count(number_node) == 0);
 


### PR DESCRIPTION
In my environment, [test-json-parser in the document](http://tree-sitter.github.io/tree-sitter/using-parsers#an-example-program) failed with the following message:

```
test-json-parser.c:42: int main(): Assertion `ts_node_child_count(array_node) == 4' failed.
```

It seems that `array_node` has five nodes: `[`, `number`, `,`, `null`, `]`.