### PR TITLE
Handle changes to the included ranges set when re-parsing after an edit

### DIFF
--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -72,9 +72,9 @@ typedef struct {
 } TSNode;
 
 typedef struct {
-  uint32_t context[2];
-  const void *id;
   const void *tree;
+  const void *id;
+  uint32_t context[2];
 } TSTreeCursor;
 
 TSParser *ts_parser_new();

--- a/src/runtime/get_changed_ranges.h
+++ b/src/runtime/get_changed_ranges.h
@@ -1,13 +1,36 @@
 #ifndef RUNTIME_GET_CHANGED_RANGES_H_
 #define RUNTIME_GET_CHANGED_RANGES_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "runtime/tree_cursor.h"
 #include "runtime/subtree.h"
+
+typedef Array(TSRange) TSRangeArray;
+
+void ts_range_array_get_changed_ranges(
+  const TSRange *old_ranges, unsigned old_range_count,
+  const TSRange *new_ranges, unsigned new_range_count,
+  TSRangeArray *differences
+);
+
+bool ts_range_array_intersects(
+  const TSRangeArray *self, unsigned start_index,
+  uint32_t start_byte, uint32_t end_byte
+);
 
 unsigned ts_subtree_get_changed_ranges(
   const Subtree *old_tree, const Subtree *new_tree,
   TreeCursor *cursor1, TreeCursor *cursor2,
-  const TSLanguage *language, TSRange **ranges
+  const TSLanguage *language,
+  const TSRangeArray *included_range_differences,
+  TSRange **ranges
 );
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // RUNTIME_GET_CHANGED_RANGES_H_

--- a/src/runtime/length.h
+++ b/src/runtime/length.h
@@ -12,6 +12,7 @@ typedef struct {
 } Length;
 
 static const Length LENGTH_UNDEFINED = {0, {0, 1}};
+static const Length LENGTH_MAX = {UINT32_MAX, {UINT32_MAX, UINT32_MAX}};
 
 static inline bool length_is_undefined(Length length) {
   return length.bytes == 0 && length.extent.column != 0;

--- a/src/runtime/point.h
+++ b/src/runtime/point.h
@@ -3,6 +3,8 @@
 
 #include "tree_sitter/runtime.h"
 
+#define POINT_MAX ((TSPoint) {UINT32_MAX, UINT32_MAX})
+
 static inline TSPoint point__new(unsigned row, unsigned column) {
   TSPoint result = {row, column};
   return result;

--- a/src/runtime/subtree.c
+++ b/src/runtime/subtree.c
@@ -440,7 +440,12 @@ void ts_subtree_set_children(
     if (ts_subtree_fragile_left(first_child)) self.ptr->fragile_left = true;
     if (ts_subtree_fragile_right(last_child)) self.ptr->fragile_right = true;
 
-    if (self.ptr->child_count == 2 && !self.ptr->visible && !self.ptr->named) {
+    if (
+      self.ptr->child_count == 2 &&
+      !self.ptr->visible &&
+      !self.ptr->named &&
+      ts_subtree_symbol(first_child) == self.ptr->symbol
+    ) {
       if (ts_subtree_repeat_depth(first_child) > ts_subtree_repeat_depth(last_child)) {
         self.ptr->repeat_depth = ts_subtree_repeat_depth(first_child) + 1;
       } else {

--- a/src/runtime/tree.c
+++ b/src/runtime/tree.c
@@ -81,8 +81,8 @@ void ts_tree_edit(TSTree *self, const TSInputEdit *edit) {
 
 TSRange *ts_tree_get_changed_ranges(const TSTree *self, const TSTree *other, uint32_t *count) {
   TSRange *result;
-  TreeCursor cursor1 = {array_new(), NULL};
-  TreeCursor cursor2 = {array_new(), NULL};
+  TreeCursor cursor1 = {NULL, array_new()};
+  TreeCursor cursor2 = {NULL, array_new()};
   TSNode root = ts_tree_root_node(self);
   ts_tree_cursor_init(&cursor1, root);
   ts_tree_cursor_init(&cursor2, root);

--- a/src/runtime/tree.c
+++ b/src/runtime/tree.c
@@ -7,25 +7,32 @@
 
 static const unsigned PARENT_CACHE_CAPACITY = 32;
 
-TSTree *ts_tree_new(Subtree root, const TSLanguage *language) {
+TSTree *ts_tree_new(
+  Subtree root, const TSLanguage *language,
+  const TSRange *included_ranges, unsigned included_range_count
+) {
   TSTree *result = ts_malloc(sizeof(TSTree));
   result->root = root;
   result->language = language;
   result->parent_cache = NULL;
   result->parent_cache_start = 0;
   result->parent_cache_size = 0;
+  result->included_ranges = ts_calloc(included_range_count, sizeof(TSRange));
+  memcpy(result->included_ranges, included_ranges, included_range_count * sizeof(TSRange));
+  result->included_range_count = included_range_count;
   return result;
 }
 
 TSTree *ts_tree_copy(const TSTree *self) {
   ts_subtree_retain(self->root);
-  return ts_tree_new(self->root, self->language);
+  return ts_tree_new(self->root, self->language, self->included_ranges, self->included_range_count);
 }
 
 void ts_tree_delete(TSTree *self) {
   SubtreePool pool = ts_subtree_pool_new(0);
   ts_subtree_release(&pool, self->root);
   ts_subtree_pool_delete(&pool);
+  ts_free(self->included_ranges);
   if (self->parent_cache) ts_free(self->parent_cache);
   ts_free(self);
 }
@@ -39,6 +46,32 @@ const TSLanguage *ts_tree_language(const TSTree *self) {
 }
 
 void ts_tree_edit(TSTree *self, const TSInputEdit *edit) {
+  for (unsigned i = 0; i < self->included_range_count; i++) {
+    TSRange *range = &self->included_ranges[i];
+    if (range->end_byte >= edit->old_end_byte) {
+      range->end_byte = edit->new_end_byte + (range->end_byte - edit->old_end_byte);
+      range->end_point = point_add(
+        edit->new_end_point,
+        point_sub(range->end_point, edit->old_end_point)
+      );
+      if (range->end_byte < edit->new_end_byte) {
+        range->end_byte = UINT32_MAX;
+        range->end_point = POINT_MAX;
+      }
+      if (range->start_byte >= edit->old_end_byte) {
+        range->start_byte = edit->new_end_byte + (range->start_byte - edit->old_end_byte);
+        range->start_point = point_add(
+          edit->new_end_point,
+          point_sub(range->start_point, edit->old_end_point)
+        );
+        if (range->start_byte < edit->new_end_byte) {
+          range->start_byte = UINT32_MAX;
+          range->start_point = POINT_MAX;
+        }
+      }
+    }
+  }
+
   SubtreePool pool = ts_subtree_pool_new(0);
   self->root = ts_subtree_edit(self->root, edit, &pool);
   self->parent_cache_start = 0;
@@ -53,10 +86,20 @@ TSRange *ts_tree_get_changed_ranges(const TSTree *self, const TSTree *other, uin
   TSNode root = ts_tree_root_node(self);
   ts_tree_cursor_init(&cursor1, root);
   ts_tree_cursor_init(&cursor2, root);
+
+  TSRangeArray included_range_differences = array_new();
+  ts_range_array_get_changed_ranges(
+    self->included_ranges, self->included_range_count,
+    other->included_ranges, other->included_range_count,
+    &included_range_differences
+  );
+
   *count = ts_subtree_get_changed_ranges(
     &self->root, &other->root, &cursor1, &cursor2,
-    self->language, &result
+    self->language, &included_range_differences, &result
   );
+
+  array_delete(&included_range_differences);
   array_delete(&cursor1.stack);
   array_delete(&cursor2.stack);
   return result;

--- a/src/runtime/tree.h
+++ b/src/runtime/tree.h
@@ -18,9 +18,11 @@ struct TSTree {
   ParentCacheEntry *parent_cache;
   uint32_t parent_cache_start;
   uint32_t parent_cache_size;
+  TSRange *included_ranges;
+  unsigned included_range_count;
 };
 
-TSTree *ts_tree_new(Subtree root, const TSLanguage *language);
+TSTree *ts_tree_new(Subtree root, const TSLanguage *language, const TSRange *, unsigned);
 TSNode ts_node_new(const TSTree *, const Subtree *, Length, TSSymbol);
 TSNode ts_tree_get_cached_parent(const TSTree *, const TSNode *);
 void ts_tree_set_cached_parent(const TSTree *, const TSNode *, const TSNode *);

--- a/src/runtime/tree_cursor.c
+++ b/src/runtime/tree_cursor.c
@@ -66,7 +66,7 @@ static inline bool ts_tree_cursor_child_iterator_next(ChildIterator *self,
 // TSTreeCursor - lifecycle
 
 TSTreeCursor ts_tree_cursor_new(TSNode node) {
-  TSTreeCursor self = {{0, 0}, NULL, NULL};
+  TSTreeCursor self = {NULL, NULL, {0, 0}};
   ts_tree_cursor_init((TreeCursor *)&self, node);
   return self;
 }

--- a/src/runtime/tree_cursor.h
+++ b/src/runtime/tree_cursor.h
@@ -11,8 +11,8 @@ typedef struct {
 } TreeCursorEntry;
 
 typedef struct {
-  Array(TreeCursorEntry) stack;
   const TSTree *tree;
+  Array(TreeCursorEntry) stack;
 } TreeCursor;
 
 void ts_tree_cursor_init(TreeCursor *, TSNode);


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/18342
Specifically addresses https://github.com/atom/atom/issues/18342#issuecomment-436295896

### Background

In #180, we added the ability to parse a selected set of ranges within a document, in order to handle situations where one programming language is embedded within another. Before parsing, you can call `ts_parser_set_included_ranges(parser, ranges)` in order to specify these ranges.

One subtlety that I overlooked when adding that feature is that when you re-parse a document after it has been edited, you might *add or remove* included ranges. These kinds of changes need to  be explicitly accounted for when deciding whether to reuse nodes, and when computing which ranges have changed from an old tree to a new tree.

### Example Problem

In Atom, most parsing takes place [off of the main thread](https://github.com/atom/atom/pull/17339). After we finish parsing a document, we search that document to find if any "injected" documents were affected, and re-parse those.

So suppose this happens when editing an ERB document:

1. User pastes a line containing a code directive `<% foo %>`
1. Atom starts re-parsing the ERB template (*Parse 1*) in response to the `foo`.
1. User pastes another line containing a code directive `<% bar %>`
1. *Parse 1* finishes
1. Atom starts re-parsing the injected HTML (*Parse 2*) in response to the `foo` line
1. Atom starts re-parsing the ERB template (*Parse 3*) in response to the `bar` line.
1. *Parse 2* finishes
1. *Parse 3* finishes
1. Atom starts re-parsing the injected HTML *again* (*Parse 4*) in response to the `bar` line.

In the final step (*Parse 4*), when we re-parse the HTML code, no text has actually changed since the previous parse (*Parse 2*). The only difference is that the outer ERB syntax tree has been updated to include the new directive, so there is a new range that is *excluded* from the HTML: the range of the `<% bar %>`.

Previously, we would have produced an HTML syntax tree that incorrectly reused nodes containing the `<% bar %>`, because we did not take into account any *changes* in the included ranges.

### Solution

In this PR, I've added a new internal property to a `TSTree`: the `included_ranges` from when the tree was parsed. I maintain these ranges' logical positions when editing a tree via `ts_tree_edit`. And when using a tree as the basis for a new parse, we make sure to avoid reusing nodes of the tree in which the included ranges have changed.

### Possible Drawbacks

Currently, a tree's `included_ranges` is stored as a simple array of ranges. Each range is stored in absolute coordinates. This means that when a tree is edited, the entire array of ranges needs to be updated to reflect the edit, and the number of included ranges can be large in cases like parsing HTML or Ruby inside of an ERB document.

This is an O(N) algorithm, which we've generally avoided because the syntax tree naturally lends itself toward O(log(n)) algorithms. However, when profiling editing of large ERB documents in Atom, I'm not seeing `ts_tree_edit` as a bottleneck so far, so I think I'm ok with leaving this as it is for now.

