### PR TITLE
Add guard to prevent infinite loops in error recovery

### DIFF
--- a/src/runtime/stack.h
+++ b/src/runtime/stack.h
@@ -79,6 +79,8 @@ unsigned ts_stack_node_count_since_error(const Stack *, StackVersion);
 
 int ts_stack_dynamic_precedence(Stack *, StackVersion);
 
+bool ts_stack_has_advanced_since_error(const Stack *, StackVersion);
+
 // Compute a summary of all the parse states near the top of the given
 // version of the stack and store the summary for later retrieval.
 void ts_stack_record_summary(Stack *, StackVersion, unsigned max_depth);


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/18342

This fixes another problem that came up when editing ERB files in Atom. When ruby is embedded within multiple ranges of an outer document (e.g. ERB), the ruby parser inserts automatic "newline" nodes at the ends of the included ranges. In certain cases, this combined with error recovery to produce an infinite loop.

This change should prevent this class of bugs from ever happening.