### PR TITLE
runtime: make ts_language_symbol_for_name work for alias symbols

### DIFF
--- a/src/runtime/language.c
+++ b/src/runtime/language.c
@@ -50,7 +50,8 @@ const char *ts_language_symbol_name(const TSLanguage *language, TSSymbol symbol)
 TSSymbol ts_language_symbol_for_name(const TSLanguage *self, const char *name) {
   if (!strcmp(name, "ERROR")) return ts_builtin_sym_error;
 
-  for (TSSymbol i = 0; i < self->symbol_count; i++) {
+  uint32_t count = ts_language_symbol_count(self);
+  for (TSSymbol i = 0; i < count; i++) {
     if (!strcmp(self->symbol_names[i], name)) {
       return i;
     }

--- a/test/runtime/language_test.cc
+++ b/test/runtime/language_test.cc
@@ -69,6 +69,15 @@ describe("Language", []() {
         Equals("ERROR")
       );
       AssertThat(ts_language_symbol_for_name(language, "non_existent_symbol"), Equals(0u));
+
+      TSSymbol last = ts_language_symbol_count(language)-1;
+      AssertThat(
+        ts_language_symbol_for_name(
+          language,
+          ts_language_symbol_name(language, last)
+        ),
+        Equals(last)
+      );
     });
   });
 });


### PR DESCRIPTION
I noticed `ts_language_symbol_for_name(c_lang, "type_identifier")` didn't work, even if `ts_node_symbol()` works for such a node, and then `ts_language_symbol_name(c_lang, symbol)` returns `"type_identifier"`.

Is this an oversight or does alias symbols need to be treated differently somehow? The patch seems to work for my usecase. The test fails on master. I simply check the last node, but I could hardcode some node name instead, if we know of a symbol that always will be a alias symbol.