### PR TITLE
Remove `-s` option from `which` in test script

### DIFF
--- a/script/test
+++ b/script/test
@@ -112,9 +112,9 @@ case ${mode} in
     ;;
 
   debug)
-    if which -s lldb; then
+    if which lldb; then
       lldb $cmd -- "${args[@]}"
-    elif which -s gdb; then
+    elif which gdb; then
       gdb $cmd -- "${args[@]}"
     else
       echo "No debugger found"

--- a/script/test
+++ b/script/test
@@ -112,9 +112,9 @@ case ${mode} in
     ;;
 
   debug)
-    if which lldb; then
+    if hash lldb &> /dev/null; then
       lldb $cmd -- "${args[@]}"
-    elif which gdb; then
+    elif hash gdb &> /dev/null; then
       gdb $cmd -- "${args[@]}"
     else
       echo "No debugger found"


### PR DESCRIPTION
When I tried running the tests with a debugger, the script failed with the following message:

    Illegal option -s
    Usage: /usr/bin/which [-a] args
    Illegal option -s
    Usage: /usr/bin/which [-a] args
    No debugger found

In case this `-s` flag is needed for other OSes than Linux (I'm working with Ubuntu 18.04), this could be based on a `uname` check (like on line 44).