### PR TITLE
Enable direct parsing of UTF-16 strings

### DIFF
--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -87,6 +87,7 @@ void ts_parser_print_dot_graphs(TSParser *, FILE *);
 void ts_parser_halt_on_error(TSParser *, bool);
 TSTree *ts_parser_parse(TSParser *, const TSTree *, TSInput);
 TSTree *ts_parser_parse_string(TSParser *, const TSTree *, const char *, uint32_t);
+TSTree *ts_parser_parse_string_encoding(TSParser *, const TSTree *, const void *, uint32_t, TSInputEncoding);
 bool ts_parser_enabled(const TSParser *);
 void ts_parser_set_enabled(TSParser *, bool);
 size_t ts_parser_operation_limit(const TSParser *);

--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -87,7 +87,7 @@ void ts_parser_print_dot_graphs(TSParser *, FILE *);
 void ts_parser_halt_on_error(TSParser *, bool);
 TSTree *ts_parser_parse(TSParser *, const TSTree *, TSInput);
 TSTree *ts_parser_parse_string(TSParser *, const TSTree *, const char *, uint32_t);
-TSTree *ts_parser_parse_string_encoding(TSParser *, const TSTree *, const void *, uint32_t, TSInputEncoding);
+TSTree *ts_parser_parse_string_encoding(TSParser *, const TSTree *, const char *, uint32_t, TSInputEncoding);
 bool ts_parser_enabled(const TSParser *);
 void ts_parser_set_enabled(TSParser *, bool);
 size_t ts_parser_operation_limit(const TSParser *);

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -87,7 +87,7 @@ typedef enum {
 } ErrorComparison;
 
 typedef struct {
-  const void *string;
+  const char *string;
   uint32_t length;
 } TSStringInput;
 
@@ -1647,7 +1647,7 @@ TSTree *ts_parser_parse_string(TSParser *self, const TSTree *old_tree,
 }
 
 TSTree *ts_parser_parse_string_encoding(TSParser *self, const TSTree *old_tree,
-                                        const void *string, uint32_t length, TSInputEncoding encoding) {
+                                        const char *string, uint32_t length, TSInputEncoding encoding) {
   TSStringInput input = {string, length};
   return ts_parser_parse(self, old_tree, (TSInput) {
     &input,

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -87,7 +87,7 @@ typedef enum {
 } ErrorComparison;
 
 typedef struct {
-  const char *string;
+  const void *string;
   uint32_t length;
 } TSStringInput;
 
@@ -1643,11 +1643,16 @@ TSTree *ts_parser_parse(TSParser *self, const TSTree *old_tree, TSInput input) {
 
 TSTree *ts_parser_parse_string(TSParser *self, const TSTree *old_tree,
                                const char *string, uint32_t length) {
+  return ts_parser_parse_string_encoding(self, old_tree, string, length, TSInputEncodingUTF8);
+}
+
+TSTree *ts_parser_parse_string_encoding(TSParser *self, const TSTree *old_tree,
+                                        const void *string, uint32_t length, TSInputEncoding encoding) {
   TSStringInput input = {string, length};
   return ts_parser_parse(self, old_tree, (TSInput) {
     &input,
     ts_string_input_read,
-    TSInputEncodingUTF8,
+    encoding,
   });
 }
 


### PR DESCRIPTION
This adds a new function that can accept an encoding so you can parse a UTF-16 string directly by using the `TSInputEncodingUTF16` encoding. I'm writing Swift bindings for tree-sitter and having the library provide this simplifies things quite a bit. I don't write much C, so I'm not sure if this is the best approach.