### PR TITLE
Introduce an EXCLUDE rule

### DIFF
--- a/cli/src/generate/build_tables/build_lex_table.rs
+++ b/cli/src/generate/build_tables/build_lex_table.rs
@@ -32,15 +32,17 @@ pub(crate) fn build_lex_table(
         let tokens = state
             .terminal_entries
             .keys()
+            .copied()
+            .chain(state.exclusions.iter())
             .filter_map(|token| {
                 if token.is_terminal() {
                     if keywords.contains(&token) {
                         syntax_grammar.word_token
                     } else {
-                        Some(*token)
+                        Some(token)
                     }
                 } else if token.is_eof() {
-                    Some(*token)
+                    Some(token)
                 } else {
                     None
                 }

--- a/cli/src/generate/build_tables/build_lex_table.rs
+++ b/cli/src/generate/build_tables/build_lex_table.rs
@@ -33,7 +33,7 @@ pub(crate) fn build_lex_table(
             .terminal_entries
             .keys()
             .copied()
-            .chain(state.exclusions.iter())
+            .chain(state.keywords.iter())
             .filter_map(|token| {
                 if token.is_terminal() {
                     if keywords.contains(&token) {

--- a/cli/src/generate/build_tables/build_parse_table.rs
+++ b/cli/src/generate/build_tables/build_parse_table.rs
@@ -163,6 +163,7 @@ impl<'a> ParseTableBuilder<'a> {
                     external_lex_state_id: 0,
                     terminal_entries: IndexMap::default(),
                     nonterminal_entries: IndexMap::default(),
+                    exclusions: TokenSet::new(),
                     core_id,
                 });
                 self.parse_state_queue.push_back(ParseStateQueueEntry {
@@ -355,7 +356,7 @@ impl<'a> ParseTableBuilder<'a> {
             )?;
         }
 
-        // Finally, add actions for the grammar's `extra` symbols.
+        // Add actions for the grammar's `extra` symbols.
         let state = &mut self.parse_table.states[state_id];
         let is_end_of_non_terminal_extra = state.is_end_of_non_terminal_extra();
 
@@ -421,6 +422,12 @@ impl<'a> ParseTableBuilder<'a> {
             }
         }
 
+        for exclusion in item_set.exclusions() {
+            if !state.terminal_entries.contains_key(&exclusion) {
+                state.exclusions.insert(exclusion);
+            }
+        }
+
         Ok(())
     }
 
@@ -452,7 +459,7 @@ impl<'a> ParseTableBuilder<'a> {
                 if item.step_index > 0 {
                     if self
                         .item_set_builder
-                        .first_set(&step.symbol)
+                        .first_set_without_excluded(&step.symbol)
                         .contains(&conflicting_lookahead)
                     {
                         if item.variable_index != u32::MAX {
@@ -939,8 +946,8 @@ fn populate_following_tokens(
         .collect::<TokenSet>();
     for production in productions {
         for i in 1..production.steps.len() {
-            let left_tokens = builder.last_set(&production.steps[i - 1].symbol);
-            let right_tokens = builder.first_set(&production.steps[i].symbol);
+            let left_tokens = builder.last_set_with_excluded(&production.steps[i - 1].symbol);
+            let right_tokens = builder.first_set_with_excluded(&production.steps[i].symbol);
             for left_token in left_tokens.iter() {
                 if left_token.is_terminal() {
                     result[left_token.index].insert_all_terminals(right_tokens);

--- a/cli/src/generate/build_tables/build_parse_table.rs
+++ b/cli/src/generate/build_tables/build_parse_table.rs
@@ -163,7 +163,7 @@ impl<'a> ParseTableBuilder<'a> {
                     external_lex_state_id: 0,
                     terminal_entries: IndexMap::default(),
                     nonterminal_entries: IndexMap::default(),
-                    exclusions: TokenSet::new(),
+                    keywords: TokenSet::new(),
                     core_id,
                 });
                 self.parse_state_queue.push_back(ParseStateQueueEntry {
@@ -422,9 +422,9 @@ impl<'a> ParseTableBuilder<'a> {
             }
         }
 
-        for exclusion in item_set.exclusions() {
-            if !state.terminal_entries.contains_key(&exclusion) {
-                state.exclusions.insert(exclusion);
+        for keyword in item_set.keywords() {
+            if !state.terminal_entries.contains_key(&keyword) {
+                state.keywords.insert(keyword);
             }
         }
 
@@ -459,7 +459,7 @@ impl<'a> ParseTableBuilder<'a> {
                 if item.step_index > 0 {
                     if self
                         .item_set_builder
-                        .first_set_without_excluded(&step.symbol)
+                        .first_set(&step.symbol)
                         .contains(&conflicting_lookahead)
                     {
                         if item.variable_index != u32::MAX {
@@ -946,8 +946,8 @@ fn populate_following_tokens(
         .collect::<TokenSet>();
     for production in productions {
         for i in 1..production.steps.len() {
-            let left_tokens = builder.last_set_with_excluded(&production.steps[i - 1].symbol);
-            let right_tokens = builder.first_set_with_excluded(&production.steps[i].symbol);
+            let left_tokens = builder.last_set_with_keywords(&production.steps[i - 1].symbol);
+            let right_tokens = builder.first_set_with_keywords(&production.steps[i].symbol);
             for left_token in left_tokens.iter() {
                 if left_token.is_terminal() {
                     result[left_token.index].insert_all_terminals(right_tokens);

--- a/cli/src/generate/build_tables/item.rs
+++ b/cli/src/generate/build_tables/item.rs
@@ -18,6 +18,7 @@ lazy_static! {
             associativity: None,
             alias: None,
             field_name: None,
+            exclusions: None,
         }],
     };
 }
@@ -170,6 +171,13 @@ impl<'a> ParseItemSet<'a> {
             entries: self.entries.iter().map(|e| e.0).collect(),
         }
     }
+
+    pub fn exclusions(&self) -> impl Iterator<Item = Symbol> + '_ {
+        self.entries
+            .iter()
+            .filter_map(|(entry, _)| entry.step().and_then(|step| step.exclusions.as_ref()))
+            .flat_map(|exclusions| exclusions.iter())
+    }
 }
 
 impl<'a> Default for ParseItemSet<'a> {
@@ -296,7 +304,7 @@ impl<'a> Hash for ParseItem<'a> {
         // this item, unless any of the following are true:
         //   * the children have fields
         //   * the children have aliases
-        //   * the children are hidden and
+        //   * the children are hidden and represent rules that have fields.
         // See the docs for `has_preceding_inherited_fields`.
         for step in &self.production.steps[0..self.step_index as usize] {
             step.alias.hash(hasher);

--- a/cli/src/generate/build_tables/item.rs
+++ b/cli/src/generate/build_tables/item.rs
@@ -18,7 +18,7 @@ lazy_static! {
             associativity: None,
             alias: None,
             field_name: None,
-            exclusions: None,
+            keywords: None,
         }],
     };
 }
@@ -172,11 +172,11 @@ impl<'a> ParseItemSet<'a> {
         }
     }
 
-    pub fn exclusions(&self) -> impl Iterator<Item = Symbol> + '_ {
+    pub fn keywords(&self) -> impl Iterator<Item = Symbol> + '_ {
         self.entries
             .iter()
-            .filter_map(|(entry, _)| entry.step().and_then(|step| step.exclusions.as_ref()))
-            .flat_map(|exclusions| exclusions.iter())
+            .filter_map(|(entry, _)| entry.step().and_then(|step| step.keywords.as_ref()))
+            .flat_map(|keywords| keywords.iter())
     }
 }
 

--- a/cli/src/generate/build_tables/item_set_builder.rs
+++ b/cli/src/generate/build_tables/item_set_builder.rs
@@ -19,9 +19,9 @@ struct FollowSetInfo {
 pub(crate) struct ParseItemSetBuilder<'a> {
     syntax_grammar: &'a SyntaxGrammar,
     lexical_grammar: &'a LexicalGrammar,
-    first_sets_without_excluded: HashMap<Symbol, TokenSet>,
-    first_sets_with_excluded: HashMap<Symbol, TokenSet>,
-    last_sets_with_excluded: HashMap<Symbol, TokenSet>,
+    first_sets: HashMap<Symbol, TokenSet>,
+    first_sets_with_keywords: HashMap<Symbol, TokenSet>,
+    last_sets: HashMap<Symbol, TokenSet>,
     inlines: &'a InlinedProductionMap,
     transitive_closure_additions: Vec<Vec<TransitiveClosureAddition<'a>>>,
 }
@@ -41,9 +41,9 @@ impl<'a> ParseItemSetBuilder<'a> {
         let mut result = Self {
             syntax_grammar,
             lexical_grammar,
-            first_sets_without_excluded: HashMap::new(),
-            first_sets_with_excluded: HashMap::new(),
-            last_sets_with_excluded: HashMap::new(),
+            first_sets: HashMap::new(),
+            first_sets_with_keywords: HashMap::new(),
+            last_sets: HashMap::new(),
             inlines,
             transitive_closure_additions: vec![Vec::new(); syntax_grammar.variables.len()],
         };
@@ -58,25 +58,19 @@ impl<'a> ParseItemSetBuilder<'a> {
             let symbol = Symbol::terminal(i);
             let mut set = TokenSet::new();
             set.insert(symbol);
-            result
-                .first_sets_without_excluded
-                .insert(symbol, set.clone());
-            result.first_sets_with_excluded.insert(symbol, set.clone());
-            result
-                .first_sets_without_excluded
-                .insert(symbol, set.clone());
-            result.last_sets_with_excluded.insert(symbol, set);
+            result.first_sets.insert(symbol, set.clone());
+            result.first_sets_with_keywords.insert(symbol, set.clone());
+            result.first_sets.insert(symbol, set.clone());
+            result.last_sets.insert(symbol, set);
         }
 
         for i in 0..syntax_grammar.external_tokens.len() {
             let symbol = Symbol::external(i);
             let mut set = TokenSet::new();
             set.insert(symbol);
-            result.first_sets_with_excluded.insert(symbol, set.clone());
-            result
-                .first_sets_without_excluded
-                .insert(symbol, set.clone());
-            result.last_sets_with_excluded.insert(symbol, set);
+            result.first_sets_with_keywords.insert(symbol, set.clone());
+            result.first_sets.insert(symbol, set.clone());
+            result.last_sets.insert(symbol, set);
         }
 
         // The FIRST set of a non-terminal `i` is the union of all of the the FIRST
@@ -89,12 +83,9 @@ impl<'a> ParseItemSetBuilder<'a> {
         for i in 0..syntax_grammar.variables.len() {
             let symbol = Symbol::non_terminal(i);
 
-            let first_set = &mut result
-                .first_sets_without_excluded
-                .entry(symbol)
-                .or_insert(TokenSet::new());
-            let first_set_with_excluded = &mut result
-                .first_sets_with_excluded
+            let first_set = &mut result.first_sets.entry(symbol).or_insert(TokenSet::new());
+            let first_set_with_keywords = &mut result
+                .first_sets_with_keywords
                 .entry(symbol)
                 .or_insert(TokenSet::new());
             processed_non_terminals.clear();
@@ -103,12 +94,12 @@ impl<'a> ParseItemSetBuilder<'a> {
             while let Some(sym) = symbols_to_process.pop() {
                 for production in &syntax_grammar.variables[sym.index].productions {
                     if let Some(step) = production.steps.first() {
-                        if let Some(exclusions) = &step.exclusions {
-                            first_set_with_excluded.insert_all(exclusions);
+                        if let Some(keywords) = &step.keywords {
+                            first_set_with_keywords.insert_all(keywords);
                         }
                         if step.symbol.is_terminal() || step.symbol.is_external() {
                             first_set.insert(step.symbol);
-                            first_set_with_excluded.insert(step.symbol);
+                            first_set_with_keywords.insert(step.symbol);
                         } else if processed_non_terminals.insert(step.symbol) {
                             symbols_to_process.push(step.symbol);
                         }
@@ -117,18 +108,15 @@ impl<'a> ParseItemSetBuilder<'a> {
             }
 
             // The LAST set is defined in a similar way to the FIRST set.
-            let last_set = &mut result
-                .last_sets_with_excluded
-                .entry(symbol)
-                .or_insert(TokenSet::new());
+            let last_set = &mut result.last_sets.entry(symbol).or_insert(TokenSet::new());
             processed_non_terminals.clear();
             symbols_to_process.clear();
             symbols_to_process.push(symbol);
             while let Some(sym) = symbols_to_process.pop() {
                 for production in &syntax_grammar.variables[sym.index].productions {
                     if let Some(step) = production.steps.last() {
-                        if let Some(exclusions) = &step.exclusions {
-                            last_set.insert_all(exclusions);
+                        if let Some(keywords) = &step.keywords {
+                            last_set.insert_all(keywords);
                         }
                         if step.symbol.is_terminal() || step.symbol.is_external() {
                             last_set.insert(step.symbol);
@@ -199,7 +187,7 @@ impl<'a> ParseItemSetBuilder<'a> {
                                 } else {
                                     entries_to_process.push((
                                         symbol.index,
-                                        &result.first_sets_with_excluded
+                                        &result.first_sets_with_keywords
                                             [&production.steps[1].symbol],
                                         false,
                                     ));
@@ -277,16 +265,16 @@ impl<'a> ParseItemSetBuilder<'a> {
         result
     }
 
-    pub fn first_set_without_excluded(&self, symbol: &Symbol) -> &TokenSet {
-        &self.first_sets_without_excluded[symbol]
+    pub fn first_set(&self, symbol: &Symbol) -> &TokenSet {
+        &self.first_sets[symbol]
     }
 
-    pub fn first_set_with_excluded(&self, symbol: &Symbol) -> &TokenSet {
-        &self.first_sets_with_excluded[symbol]
+    pub fn first_set_with_keywords(&self, symbol: &Symbol) -> &TokenSet {
+        &self.first_sets_with_keywords[symbol]
     }
 
-    pub fn last_set_with_excluded(&self, symbol: &Symbol) -> &TokenSet {
-        &self.last_sets_with_excluded[symbol]
+    pub fn last_set_with_keywords(&self, symbol: &Symbol) -> &TokenSet {
+        &self.last_sets[symbol]
     }
 
     fn add_item(&self, set: &mut ParseItemSet<'a>, item: ParseItem<'a>, lookaheads: &TokenSet) {
@@ -296,7 +284,7 @@ impl<'a> ParseItemSetBuilder<'a> {
 
                 // Determine which tokens can follow this non-terminal.
                 let following_tokens = if let Some(next_step) = next_step {
-                    self.first_sets_with_excluded
+                    self.first_sets_with_keywords
                         .get(&next_step.symbol)
                         .unwrap()
                 } else {
@@ -321,7 +309,7 @@ impl<'a> fmt::Debug for ParseItemSetBuilder<'a> {
         write!(f, "ParseItemSetBuilder {{\n")?;
 
         write!(f, "  first_sets: {{\n")?;
-        for (symbol, first_set) in &self.first_sets_without_excluded {
+        for (symbol, first_set) in &self.first_sets {
             let name = match symbol.kind {
                 SymbolType::NonTerminal => &self.syntax_grammar.variables[symbol.index].name,
                 SymbolType::External => &self.syntax_grammar.external_tokens[symbol.index].name,
@@ -338,7 +326,7 @@ impl<'a> fmt::Debug for ParseItemSetBuilder<'a> {
         write!(f, "  }}\n")?;
 
         write!(f, "  last_sets: {{\n")?;
-        for (symbol, last_set) in &self.last_sets_with_excluded {
+        for (symbol, last_set) in &self.last_sets {
             let name = match symbol.kind {
                 SymbolType::NonTerminal => &self.syntax_grammar.variables[symbol.index].name,
                 SymbolType::External => &self.syntax_grammar.external_tokens[symbol.index].name,

--- a/cli/src/generate/build_tables/minimize_parse_table.rs
+++ b/cli/src/generate/build_tables/minimize_parse_table.rs
@@ -166,24 +166,24 @@ impl<'a> Minimizer<'a> {
         let mut new_states = Vec::with_capacity(state_ids_by_group_id.len());
         for state_ids in &state_ids_by_group_id {
             // Initialize the new state based on the first old state in the group.
-            let mut parse_state = ParseState::default();
-            mem::swap(&mut parse_state, &mut self.parse_table.states[state_ids[0]]);
+            let mut parse_state = mem::take(&mut self.parse_table.states[state_ids[0]]);
 
             // Extend the new state with all of the actions from the other old states
             // in the group.
             for state_id in &state_ids[1..] {
-                let mut other_parse_state = ParseState::default();
-                mem::swap(
-                    &mut other_parse_state,
-                    &mut self.parse_table.states[*state_id],
-                );
-
+                let other_parse_state = mem::take(&mut self.parse_table.states[*state_id]);
                 parse_state
                     .terminal_entries
                     .extend(other_parse_state.terminal_entries);
                 parse_state
                     .nonterminal_entries
                     .extend(other_parse_state.nonterminal_entries);
+                parse_state
+                    .exclusions
+                    .insert_all(&other_parse_state.exclusions);
+                for symbol in parse_state.terminal_entries.keys() {
+                    parse_state.exclusions.remove(symbol);
+                }
             }
 
             // Update the new state's outgoing references using the new grouping.
@@ -212,24 +212,14 @@ impl<'a> Minimizer<'a> {
                 ) {
                     return true;
                 }
-            } else if self.token_conflicts(
-                left_state.id,
-                right_state.id,
-                right_state.terminal_entries.keys(),
-                *token,
-            ) {
+            } else if self.token_conflicts(left_state.id, right_state.id, right_state, *token) {
                 return true;
             }
         }
 
         for token in right_state.terminal_entries.keys() {
             if !left_state.terminal_entries.contains_key(token) {
-                if self.token_conflicts(
-                    left_state.id,
-                    right_state.id,
-                    left_state.terminal_entries.keys(),
-                    *token,
-                ) {
+                if self.token_conflicts(left_state.id, right_state.id, left_state, *token) {
                     return true;
                 }
             }
@@ -359,11 +349,11 @@ impl<'a> Minimizer<'a> {
         false
     }
 
-    fn token_conflicts<'b>(
+    fn token_conflicts(
         &self,
         left_id: ParseStateId,
         right_id: ParseStateId,
-        existing_tokens: impl Iterator<Item = &'b Symbol>,
+        right_state: &ParseState,
         new_token: Symbol,
     ) -> bool {
         if new_token == Symbol::end_of_nonterminal_extra() {
@@ -386,6 +376,10 @@ impl<'a> Minimizer<'a> {
             return true;
         }
 
+        if right_state.exclusions.contains(&new_token) {
+            return false;
+        }
+
         // Do not add tokens which are both internal and external. Their validity could
         // influence the behavior of the external scanner.
         if self
@@ -404,28 +398,32 @@ impl<'a> Minimizer<'a> {
         }
 
         // Do not add a token if it conflicts with an existing token.
-        for token in existing_tokens {
-            if token.is_terminal() {
-                if !(self.syntax_grammar.word_token == Some(*token)
-                    && self.keywords.contains(&new_token))
-                    && !(self.syntax_grammar.word_token == Some(new_token)
-                        && self.keywords.contains(token))
-                    && (self
-                        .token_conflict_map
-                        .does_conflict(new_token.index, token.index)
-                        || self
-                            .token_conflict_map
-                            .does_match_same_string(new_token.index, token.index))
-                {
-                    info!(
-                        "split states {} {} - token {} conflicts with {}",
-                        left_id,
-                        right_id,
-                        self.symbol_name(&new_token),
-                        self.symbol_name(token),
-                    );
-                    return true;
-                }
+        for token in right_state.terminal_entries.keys().copied() {
+            if !token.is_terminal() {
+                continue;
+            }
+            if self.syntax_grammar.word_token == Some(token) && self.keywords.contains(&new_token) {
+                continue;
+            }
+            if self.syntax_grammar.word_token == Some(new_token) && self.keywords.contains(&token) {
+                continue;
+            }
+
+            if self
+                .token_conflict_map
+                .does_conflict(new_token.index, token.index)
+                || self
+                    .token_conflict_map
+                    .does_match_same_string(new_token.index, token.index)
+            {
+                info!(
+                    "split states {} {} - token {} conflicts with {}",
+                    left_id,
+                    right_id,
+                    self.symbol_name(&new_token),
+                    self.symbol_name(&token),
+                );
+                return true;
             }
         }
 

--- a/cli/src/generate/build_tables/minimize_parse_table.rs
+++ b/cli/src/generate/build_tables/minimize_parse_table.rs
@@ -178,11 +178,9 @@ impl<'a> Minimizer<'a> {
                 parse_state
                     .nonterminal_entries
                     .extend(other_parse_state.nonterminal_entries);
-                parse_state
-                    .exclusions
-                    .insert_all(&other_parse_state.exclusions);
+                parse_state.keywords.insert_all(&other_parse_state.keywords);
                 for symbol in parse_state.terminal_entries.keys() {
-                    parse_state.exclusions.remove(symbol);
+                    parse_state.keywords.remove(symbol);
                 }
             }
 
@@ -376,7 +374,7 @@ impl<'a> Minimizer<'a> {
             return true;
         }
 
-        if right_state.exclusions.contains(&new_token) {
+        if right_state.keywords.contains(&new_token) {
             return false;
         }
 

--- a/cli/src/generate/dedup.rs
+++ b/cli/src/generate/dedup.rs
@@ -3,7 +3,7 @@ pub(crate) fn split_state_id_groups<S>(
     state_ids_by_group_id: &mut Vec<Vec<usize>>,
     group_ids_by_state_id: &mut Vec<usize>,
     start_group_id: usize,
-    mut f: impl FnMut(&S, &S, &Vec<usize>) -> bool,
+    mut should_split: impl FnMut(&S, &S, &Vec<usize>) -> bool,
 ) -> bool {
     let mut result = false;
 
@@ -33,7 +33,7 @@ pub(crate) fn split_state_id_groups<S>(
                 }
                 let right_state = &states[right_state_id];
 
-                if f(left_state, right_state, &group_ids_by_state_id) {
+                if should_split(left_state, right_state, &group_ids_by_state_id) {
                     split_state_ids.push(right_state_id);
                 }
 

--- a/cli/src/generate/dsl.js
+++ b/cli/src/generate/dsl.js
@@ -16,6 +16,7 @@ function alias(rule, value) {
       result.value = value.symbol.name;
       return result;
     case Object:
+    case GrammarSymbol:
       if (typeof value.type === 'string' && value.type === 'SYMBOL') {
         result.named = true;
         result.value = value.name;
@@ -149,11 +150,23 @@ function seq(...elements) {
   };
 }
 
+class GrammarSymbol {
+  constructor(name) {
+    this.type = "SYMBOL";
+    this.name = name;    
+  }
+
+  exclude(...exclusions) {
+    return {
+      type: "EXCLUDE",
+      content: this,
+      exclusions: exclusions.map(normalize),
+    }
+  }
+}
+
 function sym(name) {
-  return {
-    type: "SYMBOL",
-    name: name
-  };
+  return new GrammarSymbol(name);
 }
 
 function token(value) {

--- a/cli/src/generate/dsl.js
+++ b/cli/src/generate/dsl.js
@@ -3,7 +3,7 @@ function alias(rule, value) {
     type: "ALIAS",
     content: normalize(rule),
     named: false,
-    value: null
+    value: null,
   };
 
   switch (value.constructor) {
@@ -17,19 +17,19 @@ function alias(rule, value) {
       return result;
     case Object:
     case GrammarSymbol:
-      if (typeof value.type === 'string' && value.type === 'SYMBOL') {
+      if (typeof value.type === "string" && value.type === "SYMBOL") {
         result.named = true;
         result.value = value.name;
         return result;
       }
   }
 
-  throw new Error('Invalid alias value ' + value);
+  throw new Error("Invalid alias value " + value);
 }
 
 function blank() {
   return {
-    type: "BLANK"
+    type: "BLANK",
   };
 }
 
@@ -37,19 +37,19 @@ function field(name, rule) {
   return {
     type: "FIELD",
     name: name,
-    content: normalize(rule)
-  }
+    content: normalize(rule),
+  };
 }
 
 function choice(...elements) {
   return {
     type: "CHOICE",
-    members: elements.map(normalize)
+    members: elements.map(normalize),
   };
 }
 
 function optional(value) {
-  checkArguments(arguments.length, optional, 'optional');
+  checkArguments(arguments.length, optional, "optional");
   return choice(value, blank());
 }
 
@@ -58,18 +58,18 @@ function prec(number, rule) {
   checkArguments(
     arguments.length - 1,
     prec,
-    'prec',
-    ' and a precedence argument'
+    "prec",
+    " and a precedence argument",
   );
 
   return {
     type: "PREC",
     value: number,
-    content: normalize(rule)
+    content: normalize(rule),
   };
 }
 
-prec.left = function(number, rule) {
+prec.left = function (number, rule) {
   if (rule == null) {
     rule = number;
     number = 0;
@@ -79,18 +79,18 @@ prec.left = function(number, rule) {
   checkArguments(
     arguments.length - 1,
     prec.left,
-    'prec.left',
-    ' and an optional precedence argument'
+    "prec.left",
+    " and an optional precedence argument",
   );
 
   return {
     type: "PREC_LEFT",
     value: number,
-    content: normalize(rule)
+    content: normalize(rule),
   };
-}
+};
 
-prec.right = function(number, rule) {
+prec.right = function (number, rule) {
   if (rule == null) {
     rule = number;
     number = 0;
@@ -100,69 +100,69 @@ prec.right = function(number, rule) {
   checkArguments(
     arguments.length - 1,
     prec.right,
-    'prec.right',
-    ' and an optional precedence argument'
+    "prec.right",
+    " and an optional precedence argument",
   );
 
   return {
     type: "PREC_RIGHT",
     value: number,
-    content: normalize(rule)
+    content: normalize(rule),
   };
-}
+};
 
-prec.dynamic = function(number, rule) {
+prec.dynamic = function (number, rule) {
   checkPrecedence(number);
   checkArguments(
     arguments.length - 1,
     prec.dynamic,
-    'prec.dynamic',
-    ' and a precedence argument'
+    "prec.dynamic",
+    " and a precedence argument",
   );
 
   return {
     type: "PREC_DYNAMIC",
     value: number,
-    content: normalize(rule)
+    content: normalize(rule),
   };
-}
+};
 
 function repeat(rule) {
-  checkArguments(arguments.length, repeat, 'repeat');
+  checkArguments(arguments.length, repeat, "repeat");
   return {
     type: "REPEAT",
-    content: normalize(rule)
+    content: normalize(rule),
   };
 }
 
 function repeat1(rule) {
-  checkArguments(arguments.length, repeat1, 'repeat1');
+  checkArguments(arguments.length, repeat1, "repeat1");
   return {
     type: "REPEAT1",
-    content: normalize(rule)
+    content: normalize(rule),
   };
 }
 
 function seq(...elements) {
   return {
     type: "SEQ",
-    members: elements.map(normalize)
+    members: elements.map(normalize),
   };
 }
 
 class GrammarSymbol {
   constructor(name) {
     this.type = "SYMBOL";
-    this.name = name;    
+    this.name = name;
   }
+}
 
-  exclude(...exclusions) {
-    return {
-      type: "EXCLUDE",
-      content: this,
-      exclusions: exclusions.map(normalize),
-    }
-  }
+function keywords(keywords, rule) {
+  return {
+    type: "KEYWORDS",
+    content: rule,
+    keywords: keywords.map(normalize),
+  };
 }
 
 function sym(name) {
@@ -172,36 +172,35 @@ function sym(name) {
 function token(value) {
   return {
     type: "TOKEN",
-    content: normalize(value)
+    content: normalize(value),
   };
 }
 
-token.immediate = function(value) {
+token.immediate = function (value) {
   return {
     type: "IMMEDIATE_TOKEN",
-    content: normalize(value)
+    content: normalize(value),
   };
-}
+};
 
 function normalize(value) {
-  if (typeof value == "undefined")
-    throw new Error("Undefined symbol");
+  if (typeof value == "undefined") throw new Error("Undefined symbol");
 
   switch (value.constructor) {
     case String:
       return {
-        type: 'STRING',
-        value
+        type: "STRING",
+        value,
       };
     case RegExp:
       return {
-        type: 'PATTERN',
-        value: value.source
+        type: "PATTERN",
+        value: value.source,
       };
     case ReferenceError:
-      throw value
+      throw value;
     default:
-      if (typeof value.type === 'string') {
+      if (typeof value.type === "string") {
         return value;
       } else {
         throw new TypeError("Invalid rule: " + value.toString());
@@ -210,19 +209,24 @@ function normalize(value) {
 }
 
 function RuleBuilder(ruleMap) {
-  return new Proxy({}, {
-    get(target, propertyName) {
-      const symbol = sym(propertyName);
+  return new Proxy(
+    {},
+    {
+      get(target, propertyName) {
+        const symbol = sym(propertyName);
 
-      if (!ruleMap || ruleMap.hasOwnProperty(propertyName)) {
-        return symbol;
-      } else {
-        const error = new ReferenceError(`Undefined symbol '${propertyName}'`);
-        error.symbol = symbol;
-        return error;
-      }
-    }
-  })
+        if (!ruleMap || ruleMap.hasOwnProperty(propertyName)) {
+          return symbol;
+        } else {
+          const error = new ReferenceError(
+            `Undefined symbol '${propertyName}'`,
+          );
+          error.symbol = symbol;
+          return error;
+        }
+      },
+    },
+  );
 }
 
 function grammar(baseGrammar, options) {
@@ -246,11 +250,17 @@ function grammar(baseGrammar, options) {
       throw new Error("Grammar's 'externals' property must be a function.");
     }
 
-    const externalsRuleBuilder = RuleBuilder(null)
-    const externalRules = options.externals.call(externalsRuleBuilder, externalsRuleBuilder, baseGrammar.externals);
+    const externalsRuleBuilder = RuleBuilder(null);
+    const externalRules = options.externals.call(
+      externalsRuleBuilder,
+      externalsRuleBuilder,
+      baseGrammar.externals,
+    );
 
     if (!Array.isArray(externalRules)) {
-      throw new Error("Grammar's 'externals' property must return an array of rules.");
+      throw new Error(
+        "Grammar's 'externals' property must return an array of rules.",
+      );
     }
 
     externals = externalRules.map(normalize);
@@ -264,7 +274,7 @@ function grammar(baseGrammar, options) {
     ruleMap[key] = true;
   }
   for (const external of externals) {
-    if (typeof external.name === 'string') {
+    if (typeof external.name === "string") {
       ruleMap[external.name] = true;
     }
   }
@@ -277,7 +287,9 @@ function grammar(baseGrammar, options) {
   }
 
   if (!/^[a-zA-Z_]\w*$/.test(name)) {
-    throw new Error("Grammar's 'name' property must not start with a digit and cannot contain non-word characters.");
+    throw new Error(
+      "Grammar's 'name' property must not start with a digit and cannot contain non-word characters.",
+    );
   }
 
   let rules = Object.assign({}, baseGrammar.rules);
@@ -289,9 +301,15 @@ function grammar(baseGrammar, options) {
     for (const ruleName in options.rules) {
       const ruleFn = options.rules[ruleName];
       if (typeof ruleFn !== "function") {
-        throw new Error("Grammar rules must all be functions. '" + ruleName + "' rule is not.");
+        throw new Error(
+          "Grammar rules must all be functions. '" +
+            ruleName +
+            "' rule is not.",
+        );
       }
-      rules[ruleName] = normalize(ruleFn.call(ruleBuilder, ruleBuilder, baseGrammar.rules[ruleName]));
+      rules[ruleName] = normalize(
+        ruleFn.call(ruleBuilder, ruleBuilder, baseGrammar.rules[ruleName]),
+      );
     }
   }
 
@@ -301,11 +319,10 @@ function grammar(baseGrammar, options) {
       throw new Error("Grammar's 'extras' property must be a function.");
     }
 
-    extras = options.extras
-      .call(ruleBuilder, ruleBuilder, baseGrammar.extras)
+    extras = options.extras.call(ruleBuilder, ruleBuilder, baseGrammar.extras);
 
     if (!Array.isArray(extras)) {
-      throw new Error("Grammar's 'extras' function must return an array.")
+      throw new Error("Grammar's 'extras' function must return an array.");
     }
 
     extras = extras.map(normalize);
@@ -314,7 +331,7 @@ function grammar(baseGrammar, options) {
   let word = baseGrammar.word;
   if (options.word) {
     word = options.word.call(ruleBuilder, ruleBuilder).name;
-    if (typeof word != 'string') {
+    if (typeof word != "string") {
       throw new Error("Grammar's 'word' property must be a named rule.");
     }
   }
@@ -325,16 +342,26 @@ function grammar(baseGrammar, options) {
       throw new Error("Grammar's 'conflicts' property must be a function.");
     }
 
-    const baseConflictRules = baseGrammar.conflicts.map(conflict => conflict.map(sym));
-    const conflictRules = options.conflicts.call(ruleBuilder, ruleBuilder, baseConflictRules);
+    const baseConflictRules = baseGrammar.conflicts.map(conflict =>
+      conflict.map(sym),
+    );
+    const conflictRules = options.conflicts.call(
+      ruleBuilder,
+      ruleBuilder,
+      baseConflictRules,
+    );
 
     if (!Array.isArray(conflictRules)) {
-      throw new Error("Grammar's conflicts must be an array of arrays of rules.");
+      throw new Error(
+        "Grammar's conflicts must be an array of arrays of rules.",
+      );
     }
 
     conflicts = conflictRules.map(conflictSet => {
       if (!Array.isArray(conflictSet)) {
-        throw new Error("Grammar's conflicts must be an array of arrays of rules.");
+        throw new Error(
+          "Grammar's conflicts must be an array of arrays of rules.",
+        );
       }
 
       return conflictSet.map(symbol => normalize(symbol).name);
@@ -348,7 +375,11 @@ function grammar(baseGrammar, options) {
     }
 
     const baseInlineRules = baseGrammar.inline.map(sym);
-    const inlineRules = options.inline.call(ruleBuilder, ruleBuilder, baseInlineRules);
+    const inlineRules = options.inline.call(
+      ruleBuilder,
+      ruleBuilder,
+      baseInlineRules,
+    );
 
     if (!Array.isArray(inlineRules)) {
       throw new Error("Grammar's inline must be an array of rules.");
@@ -364,7 +395,11 @@ function grammar(baseGrammar, options) {
     }
 
     const baseSupertypeRules = baseGrammar.supertypes.map(sym);
-    const supertypeRules = options.supertypes.call(ruleBuilder, ruleBuilder, baseSupertypeRules);
+    const supertypeRules = options.supertypes.call(
+      ruleBuilder,
+      ruleBuilder,
+      baseSupertypeRules,
+    );
 
     if (!Array.isArray(supertypeRules)) {
       throw new Error("Grammar's supertypes must be an array of rules.");
@@ -378,13 +413,21 @@ function grammar(baseGrammar, options) {
     if (typeof options.precedences !== "function") {
       throw new Error("Grammar's 'precedences' property must be a function");
     }
-    precedences = options.precedences.call(ruleBuilder, ruleBuilder, baseGrammar.precedences);
+    precedences = options.precedences.call(
+      ruleBuilder,
+      ruleBuilder,
+      baseGrammar.precedences,
+    );
     if (!Array.isArray(precedences)) {
-      throw new Error("Grammar's precedences must be an array of arrays of rules.");
+      throw new Error(
+        "Grammar's precedences must be an array of arrays of rules.",
+      );
     }
     precedences = precedences.map(list => {
       if (!Array.isArray(list)) {
-        throw new Error("Grammar's precedences must be an array of arrays of rules.");
+        throw new Error(
+          "Grammar's precedences must be an array of arrays of rules.",
+        );
       }
       return list.map(normalize);
     });
@@ -394,29 +437,42 @@ function grammar(baseGrammar, options) {
     throw new Error("Grammar must have at least one rule.");
   }
 
-  return {name, word, rules, extras, conflicts, precedences, externals, inline, supertypes};
+  return {
+    name,
+    word,
+    rules,
+    extras,
+    conflicts,
+    precedences,
+    externals,
+    inline,
+    supertypes,
+  };
 }
 
-function checkArguments(ruleCount, caller, callerName, suffix = '') {
+function checkArguments(ruleCount, caller, callerName, suffix = "") {
   if (ruleCount > 1) {
-    const error = new Error([
-      `The \`${callerName}\` function only takes one rule argument${suffix}.`,
-      'You passed multiple rules. Did you mean to call `seq`?\n'
-    ].join('\n'));
+    const error = new Error(
+      [
+        `The \`${callerName}\` function only takes one rule argument${suffix}.`,
+        "You passed multiple rules. Did you mean to call `seq`?\n",
+      ].join("\n"),
+    );
     Error.captureStackTrace(error, caller);
-    throw error
+    throw error;
   }
 }
 
 function checkPrecedence(value) {
   if (value == null) {
-    throw new Error('Missing precedence value');
+    throw new Error("Missing precedence value");
   }
 }
 
 global.alias = alias;
 global.blank = blank;
 global.choice = choice;
+global.keywords = keywords;
 global.optional = optional;
 global.prec = prec;
 global.repeat = repeat;

--- a/cli/src/generate/grammars.rs
+++ b/cli/src/generate/grammars.rs
@@ -1,5 +1,5 @@
 use super::nfa::Nfa;
-use super::rules::{Alias, Associativity, Precedence, Rule, Symbol};
+use super::rules::{Alias, Associativity, Precedence, Rule, Symbol, TokenSet};
 use std::collections::HashMap;
 use std::fmt;
 
@@ -64,6 +64,7 @@ pub(crate) struct ProductionStep {
     pub associativity: Option<Associativity>,
     pub alias: Option<Alias>,
     pub field_name: Option<String>,
+    pub exclusions: Option<Box<TokenSet>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -113,43 +114,30 @@ impl ProductionStep {
             associativity: None,
             alias: None,
             field_name: None,
+            exclusions: None,
         }
     }
 
     pub(crate) fn with_prec(
-        self,
+        mut self,
         precedence: Precedence,
         associativity: Option<Associativity>,
     ) -> Self {
-        Self {
-            symbol: self.symbol,
-            precedence,
-            associativity,
-            alias: self.alias,
-            field_name: self.field_name,
-        }
+        self.precedence = precedence;
+        self.associativity = associativity;
+        self
     }
 
-    pub(crate) fn with_alias(self, value: &str, is_named: bool) -> Self {
-        Self {
-            symbol: self.symbol,
-            precedence: self.precedence,
-            associativity: self.associativity,
-            alias: Some(Alias {
-                value: value.to_string(),
-                is_named,
-            }),
-            field_name: self.field_name,
-        }
+    pub(crate) fn with_alias(mut self, value: &str, is_named: bool) -> Self {
+        self.alias = Some(Alias {
+            value: value.to_string(),
+            is_named,
+        });
+        self
     }
-    pub(crate) fn with_field_name(self, name: &str) -> Self {
-        Self {
-            symbol: self.symbol,
-            precedence: self.precedence,
-            associativity: self.associativity,
-            alias: self.alias,
-            field_name: Some(name.to_string()),
-        }
+    pub(crate) fn with_field_name(mut self, name: &str) -> Self {
+        self.field_name = Some(name.to_string());
+        self
     }
 }
 

--- a/cli/src/generate/grammars.rs
+++ b/cli/src/generate/grammars.rs
@@ -64,7 +64,7 @@ pub(crate) struct ProductionStep {
     pub associativity: Option<Associativity>,
     pub alias: Option<Alias>,
     pub field_name: Option<String>,
-    pub exclusions: Option<Box<TokenSet>>,
+    pub keywords: Option<Box<TokenSet>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -114,7 +114,7 @@ impl ProductionStep {
             associativity: None,
             alias: None,
             field_name: None,
-            exclusions: None,
+            keywords: None,
         }
     }
 

--- a/cli/src/generate/parse_grammar.rs
+++ b/cli/src/generate/parse_grammar.rs
@@ -61,6 +61,10 @@ enum RuleJSON {
     IMMEDIATE_TOKEN {
         content: Box<RuleJSON>,
     },
+    EXCLUDE {
+        content: Box<RuleJSON>,
+        exclusions: Vec<RuleJSON>,
+    },
 }
 
 #[derive(Deserialize)]
@@ -162,6 +166,13 @@ fn parse_rule(json: RuleJSON) -> Rule {
         RuleJSON::PREC_DYNAMIC { value, content } => {
             Rule::prec_dynamic(value, parse_rule(*content))
         }
+        RuleJSON::EXCLUDE {
+            content,
+            exclusions,
+        } => Rule::Exclude {
+            rule: Box::new(parse_rule(*content)),
+            exclusions: exclusions.into_iter().map(parse_rule).collect(),
+        },
         RuleJSON::TOKEN { content } => Rule::token(parse_rule(*content)),
         RuleJSON::IMMEDIATE_TOKEN { content } => Rule::immediate_token(parse_rule(*content)),
     }

--- a/cli/src/generate/parse_grammar.rs
+++ b/cli/src/generate/parse_grammar.rs
@@ -61,9 +61,9 @@ enum RuleJSON {
     IMMEDIATE_TOKEN {
         content: Box<RuleJSON>,
     },
-    EXCLUDE {
+    KEYWORDS {
         content: Box<RuleJSON>,
-        exclusions: Vec<RuleJSON>,
+        keywords: Vec<RuleJSON>,
     },
 }
 
@@ -166,12 +166,9 @@ fn parse_rule(json: RuleJSON) -> Rule {
         RuleJSON::PREC_DYNAMIC { value, content } => {
             Rule::prec_dynamic(value, parse_rule(*content))
         }
-        RuleJSON::EXCLUDE {
-            content,
-            exclusions,
-        } => Rule::Exclude {
+        RuleJSON::KEYWORDS { content, keywords } => Rule::Keywords {
             rule: Box::new(parse_rule(*content)),
-            exclusions: exclusions.into_iter().map(parse_rule).collect(),
+            keywords: keywords.into_iter().map(parse_rule).collect(),
         },
         RuleJSON::TOKEN { content } => Rule::token(parse_rule(*content)),
         RuleJSON::IMMEDIATE_TOKEN { content } => Rule::immediate_token(parse_rule(*content)),

--- a/cli/src/generate/prepare_grammar/extract_tokens.rs
+++ b/cli/src/generate/prepare_grammar/extract_tokens.rs
@@ -1,9 +1,10 @@
-use super::{ExtractedLexicalGrammar, ExtractedSyntaxGrammar, InternedGrammar};
-use crate::generate::grammars::{ExternalToken, Variable, VariableType};
-use crate::generate::rules::{MetadataParams, Rule, Symbol, SymbolType};
+use crate::generate::{
+    grammars::{ExternalToken, Variable, VariableType},
+    prepare_grammar::{ExtractedLexicalGrammar, ExtractedSyntaxGrammar, InternedGrammar},
+    rules::{MetadataParams, Rule, Symbol, SymbolType},
+};
 use anyhow::{anyhow, Result};
 use std::collections::HashMap;
-use std::mem;
 
 pub(super) fn extract_tokens(
     mut grammar: InternedGrammar,
@@ -180,9 +181,7 @@ impl TokenExtractor {
         self.current_variable_name.clear();
         self.current_variable_name.push_str(&variable.name);
         self.current_variable_token_count = 0;
-        let mut rule = Rule::Blank;
-        mem::swap(&mut rule, &mut variable.rule);
-        variable.rule = self.extract_tokens_in_rule(&rule);
+        variable.rule = self.extract_tokens_in_rule(&variable.rule);
     }
 
     fn extract_tokens_in_rule(&mut self, input: &Rule) -> Rule {
@@ -226,6 +225,13 @@ impl TokenExtractor {
                     .map(|e| self.extract_tokens_in_rule(e))
                     .collect(),
             ),
+            Rule::Exclude { rule, exclusions } => Rule::Exclude {
+                rule: Box::new(self.extract_tokens_in_rule(rule)),
+                exclusions: exclusions
+                    .into_iter()
+                    .map(|exclusion| self.extract_tokens_in_rule(&exclusion))
+                    .collect(),
+            },
             _ => input.clone(),
         }
     }
@@ -283,6 +289,13 @@ impl SymbolReplacer {
             Rule::Metadata { rule, params } => Rule::Metadata {
                 params: params.clone(),
                 rule: Box::new(self.replace_symbols_in_rule(rule)),
+            },
+            Rule::Exclude { rule, exclusions } => Rule::Exclude {
+                rule: Box::new(self.replace_symbols_in_rule(rule)),
+                exclusions: exclusions
+                    .into_iter()
+                    .map(|exclusion| self.replace_symbols_in_rule(exclusion))
+                    .collect(),
             },
             _ => rule.clone(),
         }

--- a/cli/src/generate/prepare_grammar/extract_tokens.rs
+++ b/cli/src/generate/prepare_grammar/extract_tokens.rs
@@ -225,11 +225,11 @@ impl TokenExtractor {
                     .map(|e| self.extract_tokens_in_rule(e))
                     .collect(),
             ),
-            Rule::Exclude { rule, exclusions } => Rule::Exclude {
+            Rule::Keywords { rule, keywords } => Rule::Keywords {
                 rule: Box::new(self.extract_tokens_in_rule(rule)),
-                exclusions: exclusions
+                keywords: keywords
                     .into_iter()
-                    .map(|exclusion| self.extract_tokens_in_rule(&exclusion))
+                    .map(|keyword| self.extract_tokens_in_rule(&keyword))
                     .collect(),
             },
             _ => input.clone(),
@@ -290,11 +290,11 @@ impl SymbolReplacer {
                 params: params.clone(),
                 rule: Box::new(self.replace_symbols_in_rule(rule)),
             },
-            Rule::Exclude { rule, exclusions } => Rule::Exclude {
+            Rule::Keywords { rule, keywords } => Rule::Keywords {
                 rule: Box::new(self.replace_symbols_in_rule(rule)),
-                exclusions: exclusions
+                keywords: keywords
                     .into_iter()
-                    .map(|exclusion| self.replace_symbols_in_rule(exclusion))
+                    .map(|keyword| self.replace_symbols_in_rule(keyword))
                     .collect(),
             },
             _ => rule.clone(),

--- a/cli/src/generate/prepare_grammar/flatten_grammar.rs
+++ b/cli/src/generate/prepare_grammar/flatten_grammar.rs
@@ -1,14 +1,15 @@
-use super::ExtractedSyntaxGrammar;
-use crate::generate::grammars::{
-    Production, ProductionStep, SyntaxGrammar, SyntaxVariable, Variable,
+use crate::generate::{
+    grammars::{Production, ProductionStep, SyntaxGrammar, SyntaxVariable, Variable},
+    prepare_grammar::ExtractedSyntaxGrammar,
+    rules::{Alias, Associativity, Precedence, Rule, Symbol, TokenSet},
 };
-use crate::generate::rules::{Alias, Associativity, Precedence, Rule, Symbol};
 use anyhow::{anyhow, Result};
 
 struct RuleFlattener {
     production: Production,
     precedence_stack: Vec<Precedence>,
     associativity_stack: Vec<Associativity>,
+    exclusions_stack: Vec<TokenSet>,
     alias_stack: Vec<Alias>,
     field_name_stack: Vec<String>,
 }
@@ -22,6 +23,7 @@ impl RuleFlattener {
             },
             precedence_stack: Vec::new(),
             associativity_stack: Vec::new(),
+            exclusions_stack: Vec::new(),
             alias_stack: Vec::new(),
             field_name_stack: Vec::new(),
         }
@@ -102,6 +104,12 @@ impl RuleFlattener {
 
                 did_push
             }
+            Rule::Exclude { rule, exclusions } => {
+                self.exclusions_stack.push(rules_to_token_set(exclusions));
+                let did_push = self.apply(*rule, at_end);
+                self.exclusions_stack.pop();
+                did_push
+            }
             Rule::Symbol(symbol) => {
                 self.production.steps.push(ProductionStep {
                     symbol,
@@ -111,6 +119,7 @@ impl RuleFlattener {
                         .cloned()
                         .unwrap_or(Precedence::None),
                     associativity: self.associativity_stack.last().cloned(),
+                    exclusions: self.exclusions_stack.last().cloned().map(Box::new),
                     alias: self.alias_stack.last().cloned(),
                     field_name: self.field_name_stack.last().cloned(),
                 });
@@ -119,6 +128,19 @@ impl RuleFlattener {
             _ => false,
         }
     }
+}
+
+fn rules_to_token_set(rules: Vec<Rule>) -> TokenSet {
+    rules
+        .into_iter()
+        .filter_map(|rule| {
+            if let Rule::Symbol(s) = rule {
+                Some(s)
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 fn extract_choices(rule: Rule) -> Vec<Rule> {
@@ -151,6 +173,13 @@ fn extract_choices(rule: Rule) -> Vec<Rule> {
             .map(|rule| Rule::Metadata {
                 rule: Box::new(rule),
                 params: params.clone(),
+            })
+            .collect(),
+        Rule::Exclude { rule, exclusions } => extract_choices(*rule)
+            .into_iter()
+            .map(|rule| Rule::Exclude {
+                rule: Box::new(rule),
+                exclusions: exclusions.clone(),
             })
             .collect(),
         _ => vec![rule],

--- a/cli/src/generate/prepare_grammar/flatten_grammar.rs
+++ b/cli/src/generate/prepare_grammar/flatten_grammar.rs
@@ -9,7 +9,7 @@ struct RuleFlattener {
     production: Production,
     precedence_stack: Vec<Precedence>,
     associativity_stack: Vec<Associativity>,
-    exclusions_stack: Vec<TokenSet>,
+    keywords_stack: Vec<TokenSet>,
     alias_stack: Vec<Alias>,
     field_name_stack: Vec<String>,
 }
@@ -23,7 +23,7 @@ impl RuleFlattener {
             },
             precedence_stack: Vec::new(),
             associativity_stack: Vec::new(),
-            exclusions_stack: Vec::new(),
+            keywords_stack: Vec::new(),
             alias_stack: Vec::new(),
             field_name_stack: Vec::new(),
         }
@@ -104,10 +104,10 @@ impl RuleFlattener {
 
                 did_push
             }
-            Rule::Exclude { rule, exclusions } => {
-                self.exclusions_stack.push(rules_to_token_set(exclusions));
+            Rule::Keywords { rule, keywords } => {
+                self.keywords_stack.push(rules_to_token_set(keywords));
                 let did_push = self.apply(*rule, at_end);
-                self.exclusions_stack.pop();
+                self.keywords_stack.pop();
                 did_push
             }
             Rule::Symbol(symbol) => {
@@ -119,7 +119,7 @@ impl RuleFlattener {
                         .cloned()
                         .unwrap_or(Precedence::None),
                     associativity: self.associativity_stack.last().cloned(),
-                    exclusions: self.exclusions_stack.last().cloned().map(Box::new),
+                    keywords: self.keywords_stack.last().cloned().map(Box::new),
                     alias: self.alias_stack.last().cloned(),
                     field_name: self.field_name_stack.last().cloned(),
                 });
@@ -175,11 +175,11 @@ fn extract_choices(rule: Rule) -> Vec<Rule> {
                 params: params.clone(),
             })
             .collect(),
-        Rule::Exclude { rule, exclusions } => extract_choices(*rule)
+        Rule::Keywords { rule, keywords } => extract_choices(*rule)
             .into_iter()
-            .map(|rule| Rule::Exclude {
+            .map(|rule| Rule::Keywords {
                 rule: Box::new(rule),
-                exclusions: exclusions.clone(),
+                keywords: keywords.clone(),
             })
             .collect(),
         _ => vec![rule],

--- a/cli/src/generate/prepare_grammar/intern_symbols.rs
+++ b/cli/src/generate/prepare_grammar/intern_symbols.rs
@@ -115,9 +115,9 @@ impl<'a> Interner<'a> {
                 rule: Box::new(self.intern_rule(rule)?),
                 params: params.clone(),
             }),
-            Rule::Exclude { rule, exclusions } => Ok(Rule::Exclude {
+            Rule::Keywords { rule, keywords } => Ok(Rule::Keywords {
                 rule: Box::new(self.intern_rule(rule)?),
-                exclusions: exclusions
+                keywords: keywords
                     .into_iter()
                     .map(|r| self.intern_rule(r))
                     .collect::<Result<Vec<_>>>()?,

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -1081,7 +1081,7 @@ impl Generator {
     fn add_parse_table(&mut self) {
         // Reserve two special parse action lists:
         // * zero is for the default value, when a symbol is not valid
-        // * one is a second empty list of actions for tokens that have been excluded.
+        // * one is a second empty list of actions for keywords which are not valid.
         //   This second value allows the parser to detect when a given token is
         //   valid for the purpose of tokenization, but invalid syntactically.
         let mut next_parse_action_list_index = 2;
@@ -1148,7 +1148,7 @@ impl Generator {
                 );
             }
 
-            for token in state.exclusions.iter() {
+            for token in state.keywords.iter() {
                 add_line!(self, "[{}] = EXCLUDE,", self.symbol_ids[&token]);
             }
 
@@ -1201,13 +1201,13 @@ impl Generator {
                         .push(*symbol);
                 }
 
-                let exclusion_count = state.exclusions.len();
+                let keyword_count = state.keywords.len();
                 let mut values_with_symbols = symbols_by_value.drain().collect::<Vec<_>>();
                 values_with_symbols.sort_unstable_by_key(|((value, kind), symbols)| {
                     (symbols.len(), *kind, *value, symbols[0])
                 });
                 let mut value_count = values_with_symbols.len();
-                if exclusion_count > 0 {
+                if keyword_count > 0 {
                     value_count += 1;
                 }
 
@@ -1232,12 +1232,12 @@ impl Generator {
                     dedent!(self);
                 }
 
-                if exclusion_count > 0 {
-                    next_table_index += 2 + exclusion_count;
+                if keyword_count > 0 {
+                    next_table_index += 2 + keyword_count;
 
-                    add_line!(self, "EXCLUDE, {},", exclusion_count);
+                    add_line!(self, "KEYWORD, {},", keyword_count);
                     indent!(self);
-                    for symbol in state.exclusions.iter() {
+                    for symbol in state.keywords.iter() {
                         add_line!(self, "{},", self.symbol_ids[&symbol]);
                     }
                     dedent!(self);

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -1079,16 +1079,19 @@ impl Generator {
     }
 
     fn add_parse_table(&mut self) {
+        // Reserve two special parse action lists:
+        // * zero is for the default value, when a symbol is not valid
+        // * one is a second empty list of actions for tokens that have been excluded.
+        //   This second value allows the parser to detect when a given token is
+        //   valid for the purpose of tokenization, but invalid syntactically.
+        let mut next_parse_action_list_index = 2;
         let mut parse_table_entries = HashMap::new();
-        let mut next_parse_action_list_index = 0;
-
-        self.get_parse_action_list_id(
-            &ParseTableEntry {
-                actions: Vec::new(),
+        parse_table_entries.insert(
+            ParseTableEntry {
                 reusable: false,
+                actions: Vec::new(),
             },
-            &mut parse_table_entries,
-            &mut next_parse_action_list_index,
+            0,
         );
 
         add_line!(
@@ -1107,7 +1110,7 @@ impl Generator {
             .enumerate()
             .take(self.large_state_count)
         {
-            add_line!(self, "[{}] = {{", i);
+            add_line!(self, "[STATE({})] = {{", i);
             indent!(self);
 
             // Ensure the entries are in a deterministic order, since they are
@@ -1144,6 +1147,11 @@ impl Generator {
                     entry_id
                 );
             }
+
+            for token in state.exclusions.iter() {
+                add_line!(self, "[{}] = EXCLUDE,", self.symbol_ids[&token]);
+            }
+
             dedent!(self);
             add_line!(self, "}},");
         }
@@ -1155,11 +1163,11 @@ impl Generator {
             add_line!(self, "static const uint16_t ts_small_parse_table[] = {{");
             indent!(self);
 
-            let mut index = 0;
+            let mut next_table_index = 0;
             let mut small_state_indices = Vec::new();
             let mut symbols_by_value: HashMap<(usize, SymbolType), Vec<Symbol>> = HashMap::new();
             for state in self.parse_table.states.iter().skip(self.large_state_count) {
-                small_state_indices.push(index);
+                small_state_indices.push(next_table_index);
                 symbols_by_value.clear();
 
                 terminal_entries.clear();
@@ -1193,15 +1201,23 @@ impl Generator {
                         .push(*symbol);
                 }
 
+                let exclusion_count = state.exclusions.len();
                 let mut values_with_symbols = symbols_by_value.drain().collect::<Vec<_>>();
                 values_with_symbols.sort_unstable_by_key(|((value, kind), symbols)| {
                     (symbols.len(), *kind, *value, symbols[0])
                 });
+                let mut value_count = values_with_symbols.len();
+                if exclusion_count > 0 {
+                    value_count += 1;
+                }
 
-                add_line!(self, "[{}] = {},", index, values_with_symbols.len());
+                add_line!(self, "[{}] = {},", next_table_index, value_count);
                 indent!(self);
+                next_table_index += 1;
 
                 for ((value, kind), symbols) in values_with_symbols.iter_mut() {
+                    next_table_index += 2 + symbols.len();
+
                     if *kind == SymbolType::NonTerminal {
                         add_line!(self, "STATE({}), {},", value, symbols.len());
                     } else {
@@ -1216,12 +1232,18 @@ impl Generator {
                     dedent!(self);
                 }
 
-                dedent!(self);
+                if exclusion_count > 0 {
+                    next_table_index += 2 + exclusion_count;
 
-                index += 1 + values_with_symbols
-                    .iter()
-                    .map(|(_, symbols)| 2 + symbols.len())
-                    .sum::<usize>();
+                    add_line!(self, "EXCLUDE, {},", exclusion_count);
+                    indent!(self);
+                    for symbol in state.exclusions.iter() {
+                        add_line!(self, "{},", self.symbol_ids[&symbol]);
+                    }
+                    dedent!(self);
+                }
+
+                dedent!(self);
             }
 
             dedent!(self);

--- a/cli/src/generate/rules.rs
+++ b/cli/src/generate/rules.rs
@@ -64,9 +64,9 @@ pub(crate) enum Rule {
         params: MetadataParams,
         rule: Box<Rule>,
     },
-    Exclude {
+    Keywords {
         rule: Box<Rule>,
-        exclusions: Vec<Rule>,
+        keywords: Vec<Rule>,
     },
     Repeat(Box<Rule>),
     Seq(Vec<Rule>),

--- a/cli/src/generate/tables.rs
+++ b/cli/src/generate/tables.rs
@@ -44,6 +44,7 @@ pub(crate) struct ParseState {
     pub id: ParseStateId,
     pub terminal_entries: IndexMap<Symbol, ParseTableEntry, BuildHasherDefault<FxHasher>>,
     pub nonterminal_entries: IndexMap<Symbol, GotoAction, BuildHasherDefault<FxHasher>>,
+    pub exclusions: TokenSet,
     pub lex_state_id: usize,
     pub external_lex_state_id: usize,
     pub core_id: usize,

--- a/cli/src/generate/tables.rs
+++ b/cli/src/generate/tables.rs
@@ -44,7 +44,7 @@ pub(crate) struct ParseState {
     pub id: ParseStateId,
     pub terminal_entries: IndexMap<Symbol, ParseTableEntry, BuildHasherDefault<FxHasher>>,
     pub nonterminal_entries: IndexMap<Symbol, GotoAction, BuildHasherDefault<FxHasher>>,
-    pub exclusions: TokenSet,
+    pub keywords: TokenSet,
     pub lex_state_id: usize,
     pub external_lex_state_id: usize,
     pub core_id: usize,

--- a/lib/include/tree_sitter/parser.h
+++ b/lib/include/tree_sitter/parser.h
@@ -172,6 +172,8 @@ struct TSLanguage {
 
 #define ACTIONS(id) id
 
+#define EXCLUDE 1
+
 #define SHIFT(state_value)            \
   {{                                  \
     .shift = {                        \

--- a/lib/include/tree_sitter/parser.h
+++ b/lib/include/tree_sitter/parser.h
@@ -172,7 +172,7 @@ struct TSLanguage {
 
 #define ACTIONS(id) id
 
-#define EXCLUDE 1
+#define KEYWORD 1
 
 #define SHIFT(state_value)            \
   {{                                  \

--- a/lib/src/get_changed_ranges.c
+++ b/lib/src/get_changed_ranges.c
@@ -7,7 +7,11 @@
 
 // #define DEBUG_GET_CHANGED_RANGES
 
-static void ts_range_array_add(TSRangeArray *self, Length start, Length end) {
+static void ts_range_array_add(
+  TSRangeArray *self,
+  Length start,
+  Length end
+) {
   if (self->size > 0) {
     TSRange *last_range = array_back(self);
     if (start.bytes <= last_range->end_byte) {
@@ -23,8 +27,12 @@ static void ts_range_array_add(TSRangeArray *self, Length start, Length end) {
   }
 }
 
-bool ts_range_array_intersects(const TSRangeArray *self, unsigned start_index,
-                               uint32_t start_byte, uint32_t end_byte) {
+bool ts_range_array_intersects(
+  const TSRangeArray *self,
+  unsigned start_index,
+  uint32_t start_byte,
+  uint32_t end_byte
+) {
   for (unsigned i = start_index; i < self->size; i++) {
     TSRange *range = &self->contents[i];
     if (range->end_byte > start_byte) {
@@ -102,9 +110,13 @@ typedef struct {
   bool in_padding;
 } Iterator;
 
-static Iterator iterator_new(TreeCursor *cursor, const Subtree *tree, const TSLanguage *language) {
+static Iterator iterator_new(
+  TreeCursor *cursor,
+  const Subtree *tree,
+  const TSLanguage *language
+) {
   array_clear(&cursor->stack);
-  array_push(&cursor->stack, ((TreeCursorEntry){
+  array_push(&cursor->stack, ((TreeCursorEntry) {
     .subtree = tree,
     .position = length_zero(),
     .child_index = 0,
@@ -210,7 +222,7 @@ static bool iterator_descend(Iterator *self, uint32_t goal_position) {
       Length child_right = length_add(child_left, ts_subtree_size(*child));
 
       if (child_right.bytes > goal_position) {
-        array_push(&self->cursor.stack, ((TreeCursorEntry){
+        array_push(&self->cursor.stack, ((TreeCursorEntry) {
           .subtree = child,
           .position = position,
           .child_index = i,
@@ -262,7 +274,7 @@ static void iterator_advance(Iterator *self) {
       if (!ts_subtree_extra(*entry.subtree)) structural_child_index++;
       const Subtree *next_child = &ts_subtree_children(*parent)[child_index];
 
-      array_push(&self->cursor.stack, ((TreeCursorEntry){
+      array_push(&self->cursor.stack, ((TreeCursorEntry) {
         .subtree = next_child,
         .position = position,
         .child_index = child_index,
@@ -289,7 +301,10 @@ typedef enum {
   IteratorMatches,
 } IteratorComparison;
 
-static IteratorComparison iterator_compare(const Iterator *old_iter, const Iterator *new_iter) {
+static IteratorComparison iterator_compare(
+  const Iterator *old_iter,
+  const Iterator *new_iter
+) {
   Subtree old_tree = NULL_SUBTREE;
   Subtree new_tree = NULL_SUBTREE;
   uint32_t old_start = 0;
@@ -339,11 +354,13 @@ static inline void iterator_print_state(Iterator *self) {
 }
 #endif
 
-unsigned ts_subtree_get_changed_ranges(const Subtree *old_tree, const Subtree *new_tree,
-                                       TreeCursor *cursor1, TreeCursor *cursor2,
-                                       const TSLanguage *language,
-                                       const TSRangeArray *included_range_differences,
-                                       TSRange **ranges) {
+unsigned ts_subtree_get_changed_ranges(
+  const Subtree *old_tree, const Subtree *new_tree,
+  TreeCursor *cursor1, TreeCursor *cursor2,
+  const TSLanguage *language,
+  const TSRangeArray *included_range_differences,
+  TSRange **ranges
+) {
   TSRangeArray results = array_new();
 
   Iterator old_iter = iterator_new(cursor1, old_tree, language);

--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -24,6 +24,7 @@ void ts_language_table_entry(
   if (symbol == ts_builtin_sym_error || symbol == ts_builtin_sym_error_repeat) {
     result->action_count = 0;
     result->is_reusable = false;
+    result->is_valid_lookahead = false;
     result->actions = NULL;
   } else {
     assert(symbol < self->token_count);
@@ -31,6 +32,7 @@ void ts_language_table_entry(
     const TSParseActionEntry *entry = &self->parse_actions[action_index];
     result->action_count = entry->entry.count;
     result->is_reusable = entry->entry.reusable;
+    result->is_valid_lookahead = action_index > 0;
     result->actions = (const TSParseAction *)(entry + 1);
   }
 }

--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -42,9 +42,9 @@ TSSymbolMetadata ts_language_symbol_metadata(
   TSSymbol symbol
 ) {
   if (symbol == ts_builtin_sym_error)  {
-    return (TSSymbolMetadata){.visible = true, .named = true};
+    return (TSSymbolMetadata) {.visible = true, .named = true};
   } else if (symbol == ts_builtin_sym_error_repeat) {
-    return (TSSymbolMetadata){.visible = false, .named = false};
+    return (TSSymbolMetadata) {.visible = false, .named = false};
   } else {
     return self->symbol_metadata[symbol];
   }

--- a/lib/src/language.h
+++ b/lib/src/language.h
@@ -14,6 +14,7 @@ typedef struct {
   const TSParseAction *actions;
   uint32_t action_count;
   bool is_reusable;
+  bool is_valid_lookahead;
 } TableEntry;
 
 typedef struct {
@@ -93,12 +94,20 @@ static inline uint16_t ts_language_lookup(
   }
 }
 
-static inline bool ts_language_has_actions(
+static inline bool ts_language_is_valid_lookahead(
   const TSLanguage *self,
   TSStateId state,
   TSSymbol symbol
 ) {
   return ts_language_lookup(self, state, symbol) != 0;
+}
+
+static inline bool ts_language_has_actions(
+  const TSLanguage *self,
+  TSStateId state,
+  TSSymbol symbol
+) {
+  return ts_language_lookup(self, state, symbol) > 1;
 }
 
 // Iterate over all of the symbols that are valid in the given state.

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -1017,7 +1017,7 @@ static bool ts_parser__do_all_potential_reductions(
             break;
           case TSParseActionTypeReduce:
             if (action.reduce.child_count > 0)
-              ts_reduce_action_set_add(&self->reduce_actions, (ReduceAction){
+              ts_reduce_action_set_add(&self->reduce_actions, (ReduceAction) {
                 .symbol = action.reduce.symbol,
                 .count = action.reduce.child_count,
                 .dynamic_precedence = action.reduce.dynamic_precedence,

--- a/lib/src/stack.c
+++ b/lib/src/stack.c
@@ -43,11 +43,6 @@ typedef struct {
   bool is_pending;
 } StackIterator;
 
-typedef struct {
-  void *payload;
-  StackIterateCallback callback;
-} StackIterateSession;
-
 typedef Array(StackNode *) StackNodeArray;
 
 typedef enum {
@@ -91,7 +86,11 @@ static void stack_node_retain(StackNode *self) {
   assert(self->ref_count != 0);
 }
 
-static void stack_node_release(StackNode *self, StackNodeArray *pool, SubtreePool *subtree_pool) {
+static void stack_node_release(
+  StackNode *self,
+  StackNodeArray *pool,
+  SubtreePool *subtree_pool
+) {
 recur:
   assert(self->ref_count != 0);
   self->ref_count--;
@@ -121,16 +120,25 @@ recur:
   }
 }
 
-static StackNode *stack_node_new(StackNode *previous_node, Subtree subtree,
-                                 bool is_pending, TSStateId state, StackNodeArray *pool) {
-  StackNode *node = pool->size > 0 ?
-    array_pop(pool) :
-    ts_malloc(sizeof(StackNode));
-  *node = (StackNode){.ref_count = 1, .link_count = 0, .state = state};
+static StackNode *stack_node_new(
+  StackNode *previous_node,
+  Subtree subtree,
+  bool is_pending,
+  TSStateId state,
+  StackNodeArray *pool
+) {
+  StackNode *node = pool->size > 0
+    ? array_pop(pool)
+    : ts_malloc(sizeof(StackNode));
+  *node = (StackNode) {
+    .ref_count = 1,
+    .link_count = 0,
+    .state = state
+  };
 
   if (previous_node) {
     node->link_count = 1;
-    node->links[0] = (StackLink){
+    node->links[0] = (StackLink) {
       .node = previous_node,
       .subtree = subtree,
       .is_pending = is_pending,
@@ -156,19 +164,29 @@ static StackNode *stack_node_new(StackNode *previous_node, Subtree subtree,
 }
 
 static bool stack__subtree_is_equivalent(Subtree left, Subtree right) {
-  return
-    left.ptr == right.ptr ||
-    (left.ptr && right.ptr &&
-     ts_subtree_symbol(left) == ts_subtree_symbol(right) &&
-     ((ts_subtree_error_cost(left) > 0 && ts_subtree_error_cost(right) > 0) ||
-      (ts_subtree_padding(left).bytes == ts_subtree_padding(right).bytes &&
-       ts_subtree_size(left).bytes == ts_subtree_size(right).bytes &&
-       ts_subtree_child_count(left) == ts_subtree_child_count(right) &&
-       ts_subtree_extra(left) == ts_subtree_extra(right) &&
-       ts_subtree_external_scanner_state_eq(left, right))));
+  if (left.ptr == right.ptr) return true;
+  if (!left.ptr || !right.ptr) return false;
+
+  // Symbols must match
+  if (ts_subtree_symbol(left) != ts_subtree_symbol(right)) return false;
+
+  // If both have errors, don't bother keeping both.
+  if (ts_subtree_error_cost(left) > 0 && ts_subtree_error_cost(right) > 0) return true;
+
+  return (
+    ts_subtree_padding(left).bytes == ts_subtree_padding(right).bytes &&
+    ts_subtree_size(left).bytes == ts_subtree_size(right).bytes &&
+    ts_subtree_child_count(left) == ts_subtree_child_count(right) &&
+    ts_subtree_extra(left) == ts_subtree_extra(right) &&
+    ts_subtree_external_scanner_state_eq(left, right)
+  );
 }
 
-static void stack_node_add_link(StackNode *self, StackLink link, SubtreePool *subtree_pool) {
+static void stack_node_add_link(
+  StackNode *self,
+  StackLink link,
+  SubtreePool *subtree_pool
+) {
   if (link.node == self) return;
 
   for (int i = 0; i < self->link_count; i++) {
@@ -193,8 +211,10 @@ static void stack_node_add_link(StackNode *self, StackLink link, SubtreePool *su
       }
 
       // If the previous nodes are mergeable, merge them recursively.
-      if (existing_link->node->state == link.node->state &&
-          existing_link->node->position.bytes == link.node->position.bytes) {
+      if (
+        existing_link->node->state == link.node->state &&
+        existing_link->node->position.bytes == link.node->position.bytes
+      ) {
         for (int j = 0; j < link.node->link_count; j++) {
           stack_node_add_link(existing_link->node, link.node->links[j], subtree_pool);
         }
@@ -227,7 +247,11 @@ static void stack_node_add_link(StackNode *self, StackLink link, SubtreePool *su
   if (dynamic_precedence > self->dynamic_precedence) self->dynamic_precedence = dynamic_precedence;
 }
 
-static void stack_head_delete(StackHead *self, StackNodeArray *pool, SubtreePool *subtree_pool) {
+static void stack_head_delete(
+  StackHead *self,
+  StackNodeArray *pool,
+  SubtreePool *subtree_pool
+) {
   if (self->node) {
     if (self->last_external_token.ptr) {
       ts_subtree_release(subtree_pool, self->last_external_token);
@@ -240,8 +264,11 @@ static void stack_head_delete(StackHead *self, StackNodeArray *pool, SubtreePool
   }
 }
 
-static StackVersion ts_stack__add_version(Stack *self, StackVersion original_version,
-                                          StackNode *node) {
+static StackVersion ts_stack__add_version(
+  Stack *self,
+  StackVersion original_version,
+  StackNode *node
+) {
   StackHead head = {
     .node = node,
     .node_count_at_last_error = self->heads.contents[original_version].node_count_at_last_error,
@@ -255,8 +282,12 @@ static StackVersion ts_stack__add_version(Stack *self, StackVersion original_ver
   return (StackVersion)(self->heads.size - 1);
 }
 
-static void ts_stack__add_slice(Stack *self, StackVersion original_version,
-                                StackNode *node, SubtreeArray *subtrees) {
+static void ts_stack__add_slice(
+  Stack *self,
+  StackVersion original_version,
+  StackNode *node,
+  SubtreeArray *subtrees
+) {
   for (uint32_t i = self->slices.size - 1; i + 1 > 0; i--) {
     StackVersion version = self->slices.contents[i].version;
     if (self->heads.contents[version].node == node) {
@@ -271,9 +302,13 @@ static void ts_stack__add_slice(Stack *self, StackVersion original_version,
   array_push(&self->slices, slice);
 }
 
-inline StackSliceArray stack__iter(Stack *self, StackVersion version,
-                                   StackCallback callback, void *payload,
-                                   int goal_subtree_count) {
+inline StackSliceArray stack__iter(
+  Stack *self,
+  StackVersion version,
+  StackCallback callback,
+  void *payload,
+  int goal_subtree_count
+) {
   array_clear(&self->slices);
   array_clear(&self->iterators);
 
@@ -317,8 +352,9 @@ inline StackSliceArray stack__iter(Stack *self, StackVersion version,
       }
 
       if (should_stop) {
-        if (!should_pop)
+        if (!should_pop) {
           ts_subtree_array_delete(self->subtree_pool, &iterator->subtrees);
+        }
         array_erase(&self->iterators, i);
         i--, size--;
         continue;
@@ -443,28 +479,17 @@ unsigned ts_stack_node_count_since_error(const Stack *self, StackVersion version
   return head->node->node_count - head->node_count_at_last_error;
 }
 
-void ts_stack_push(Stack *self, StackVersion version, Subtree subtree,
-                   bool pending, TSStateId state) {
+void ts_stack_push(
+  Stack *self,
+  StackVersion version,
+  Subtree subtree,
+  bool pending,
+  TSStateId state
+) {
   StackHead *head = array_get(&self->heads, version);
   StackNode *new_node = stack_node_new(head->node, subtree, pending, state, &self->node_pool);
   if (!subtree.ptr) head->node_count_at_last_error = new_node->node_count;
   head->node = new_node;
-}
-
-inline StackAction iterate_callback(void *payload, const StackIterator *iterator) {
-  StackIterateSession *session = payload;
-  session->callback(
-    session->payload,
-    iterator->node->state,
-    iterator->subtree_count
-  );
-  return StackActionNone;
-}
-
-void ts_stack_iterate(Stack *self, StackVersion version,
-                      StackIterateCallback callback, void *payload) {
-  StackIterateSession session = {payload, callback};
-  stack__iter(self, version, iterate_callback, &session, -1);
 }
 
 inline StackAction pop_count_callback(void *payload, const StackIterator *iterator) {
@@ -530,7 +555,7 @@ SubtreeArray ts_stack_pop_error(Stack *self, StackVersion version) {
       break;
     }
   }
-  return (SubtreeArray){.size = 0};
+  return (SubtreeArray) {.size = 0};
 }
 
 inline StackAction pop_all_callback(void *payload, const StackIterator *iterator) {
@@ -557,7 +582,7 @@ inline StackAction summarize_stack_callback(void *payload, const StackIterator *
     if (entry.depth < depth) break;
     if (entry.depth == depth && entry.state == state) return StackActionNone;
   }
-  array_push(session->summary, ((StackSummaryEntry){
+  array_push(session->summary, ((StackSummaryEntry) {
     .position = iterator->node->position,
     .depth = depth,
     .state = state,
@@ -712,7 +737,7 @@ void ts_stack_clear(Stack *self) {
     stack_head_delete(&self->heads.contents[i], &self->node_pool, self->subtree_pool);
   }
   array_clear(&self->heads);
-  array_push(&self->heads, ((StackHead){
+  array_push(&self->heads, ((StackHead) {
     .node = self->base_node,
     .last_external_token = NULL_SUBTREE,
     .status = StackStatusActive,
@@ -760,7 +785,9 @@ bool ts_stack_print_dot_graph(Stack *self, const TSLanguage *language, FILE *f) 
     }
 
     fprintf(f, "\"]\n");
-    array_push(&self->iterators, ((StackIterator){.node = head->node }));
+    array_push(&self->iterators, ((StackIterator) {
+      .node = head->node
+    }));
   }
 
   bool all_iterators_done = false;

--- a/lib/src/stack.h
+++ b/lib/src/stack.h
@@ -126,8 +126,6 @@ bool ts_stack_print_dot_graph(Stack *, const TSLanguage *, FILE *);
 
 typedef void (*StackIterateCallback)(void *, TSStateId, uint32_t);
 
-void ts_stack_iterate(Stack *, StackVersion, StackIterateCallback, void *);
-
 #ifdef __cplusplus
 }
 #endif

--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -409,14 +409,19 @@ void ts_subtree_summarize_children(
       self.ptr->padding.bytes +
       self.ptr->size.bytes +
       ts_subtree_lookahead_bytes(child);
-    if (child_lookahead_end_byte > lookahead_end_byte) lookahead_end_byte = child_lookahead_end_byte;
+    if (child_lookahead_end_byte > lookahead_end_byte) {
+      lookahead_end_byte = child_lookahead_end_byte;
+    }
 
     if (ts_subtree_symbol(child) != ts_builtin_sym_error_repeat) {
       self.ptr->error_cost += ts_subtree_error_cost(child);
     }
 
     uint32_t grandchild_count = ts_subtree_child_count(child);
-    if (self.ptr->symbol == ts_builtin_sym_error || self.ptr->symbol == ts_builtin_sym_error_repeat) {
+    if (
+      self.ptr->symbol == ts_builtin_sym_error ||
+      self.ptr->symbol == ts_builtin_sym_error_repeat
+    ) {
       if (!ts_subtree_extra(child) && !(ts_subtree_is_error(child) && grandchild_count == 0)) {
         if (ts_subtree_visible(child)) {
           self.ptr->error_cost += ERROR_COST_PER_SKIPPED_TREE;
@@ -454,7 +459,10 @@ void ts_subtree_summarize_children(
 
   self.ptr->lookahead_bytes = lookahead_end_byte - self.ptr->size.bytes - self.ptr->padding.bytes;
 
-  if (self.ptr->symbol == ts_builtin_sym_error || self.ptr->symbol == ts_builtin_sym_error_repeat) {
+  if (
+    self.ptr->symbol == ts_builtin_sym_error ||
+    self.ptr->symbol == ts_builtin_sym_error_repeat
+  ) {
     self.ptr->error_cost +=
       ERROR_COST_PER_RECOVERY +
       ERROR_COST_PER_SKIPPED_CHAR * self.ptr->size.bytes +
@@ -601,37 +609,6 @@ void ts_subtree_release(SubtreePool *pool, Subtree self) {
       ts_subtree_pool_free(pool, tree.ptr);
     }
   }
-}
-
-bool ts_subtree_eq(Subtree self, Subtree other) {
-  if (self.data.is_inline || other.data.is_inline) {
-    return memcmp(&self, &other, sizeof(SubtreeInlineData)) == 0;
-  }
-
-  if (self.ptr) {
-    if (!other.ptr) return false;
-  } else {
-    return !other.ptr;
-  }
-
-  if (self.ptr->symbol != other.ptr->symbol) return false;
-  if (self.ptr->visible != other.ptr->visible) return false;
-  if (self.ptr->named != other.ptr->named) return false;
-  if (self.ptr->padding.bytes != other.ptr->padding.bytes) return false;
-  if (self.ptr->size.bytes != other.ptr->size.bytes) return false;
-  if (self.ptr->symbol == ts_builtin_sym_error) return self.ptr->lookahead_char == other.ptr->lookahead_char;
-  if (self.ptr->child_count != other.ptr->child_count) return false;
-  if (self.ptr->child_count > 0) {
-    if (self.ptr->visible_child_count != other.ptr->visible_child_count) return false;
-    if (self.ptr->named_child_count != other.ptr->named_child_count) return false;
-
-    for (uint32_t i = 0; i < self.ptr->child_count; i++) {
-      if (!ts_subtree_eq(ts_subtree_children(self)[i], ts_subtree_children(other)[i])) {
-        return false;
-      }
-    }
-  }
-  return true;
 }
 
 int ts_subtree_compare(Subtree left, Subtree right) {

--- a/lib/src/subtree.h
+++ b/lib/src/subtree.h
@@ -197,7 +197,6 @@ Subtree ts_subtree_new_missing_leaf(SubtreePool *, TSSymbol, Length, const TSLan
 MutableSubtree ts_subtree_make_mut(SubtreePool *, Subtree);
 void ts_subtree_retain(Subtree);
 void ts_subtree_release(SubtreePool *, Subtree);
-bool ts_subtree_eq(Subtree, Subtree);
 int ts_subtree_compare(Subtree, Subtree);
 void ts_subtree_set_symbol(MutableSubtree *, TSSymbol, const TSLanguage *);
 void ts_subtree_summarize(MutableSubtree, const Subtree *, uint32_t, const TSLanguage *);

--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -34,9 +34,11 @@ static inline CursorChildIterator ts_tree_cursor_iterate_children(const TreeCurs
   };
 }
 
-static inline bool ts_tree_cursor_child_iterator_next(CursorChildIterator *self,
-                                                      TreeCursorEntry *result,
-                                                      bool *visible) {
+static inline bool ts_tree_cursor_child_iterator_next(
+  CursorChildIterator *self,
+  TreeCursorEntry *result,
+  bool *visible
+) {
   if (!self->parent.ptr || self->child_index == self->parent.ptr->child_count) return false;
   const Subtree *child = &ts_subtree_children(self->parent)[self->child_index];
   *result = (TreeCursorEntry) {

--- a/test/fixtures/test_grammars/external_tokens/scanner.c
+++ b/test/fixtures/test_grammars/external_tokens/scanner.c
@@ -14,7 +14,7 @@ typedef struct {
 
 void *tree_sitter_external_tokens_external_scanner_create() {
   Scanner *scanner = malloc(sizeof(Scanner));
-  *scanner = (Scanner){
+  *scanner = (Scanner) {
     .open_delimiter = 0,
     .close_delimiter = 0,
     .depth = 0


### PR DESCRIPTION
### Background

Tree-sitter uses context-aware tokenization - in a given parse state, Tree-sitter only recognizes tokens that are syntactically valid in that state. This is what allows Tree-sitter to tokenize languages correctly without requiring the grammar author to think about different lexer modes and states. In general, Tree-sitter tends to be permissive in allowing words that are keywords in some places to be used freely as names in other places.

Sometimes this permissiveness causes unexpected error recoveries. Consider this C syntax error:

```c
float // <-- error
int main() {}
```

Currently, when [tree-sitter-c](https://github.com/tree-sitter/tree-sitter-c) encounters this code, it doesn't detect an error until the word `main`, because it interprets the word `int` as a variable, declared with type `float`. It doesn't see `int` as a keyword, because the keyword `int` wouldn't be allowed in that position.

### Solution

In order improve this error recovery, the grammar author needs a way to explicitly indicate that certain keywords are *not allowed* in certain places. For example in C, primitive types like `int` and control-flow keywords like `while` are not allowed as variable names in declarators.

This PR introduces a new `EXCLUDE` rule to the underlying JSON schema. From JavaScript, you can use it like this:

```js
declarator: choice(
  $.pointer_declarator,
  $.array_declarator,
  $.identifier.exclude('if', 'int', ...etc)
)
```

Conceptually, you're saying "a declarator can match an identifier, but *not* these other tokens".

### Implementation

Internally, all Tree-sitter needs to do is to insert the excluded tokens (`if`, `int`, etc) into the set of valid lookahead symbols that it uses when tokenizing, in the relevant states. Then, when the lexer sees the string "if", it will recognize it as an `if` token, not just an identifier. Then, as always when there's an error, the parser will find that there are no valid parse actions for the token `if`.

### Alternatives

I could have instead introduced a new field on the entire grammar called `keywords`. Then, if we added `if` to the grammar's `keywords`, the word `if` would *always* be treated as its own token, in *every* parse state.

This is less general, and it wouldn't really work AFAICT. Even in C, there are states where the word `int` should *not* be treated as a keyword. For example, inside of a string (`"int"`), as the name of a macro definition `#define int`. And in other languages, there are many *more* cases like this than there are in C. For example in JavaScript, it's fine to have an object property named `if`.

### Relevant Issues

https://github.com/atom/language-c/issues/308