### PR TITLE
Return TSTreeCursor by reference

### DIFF
--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -134,7 +134,7 @@ TSNode ts_node_descendant_for_point_range(TSNode, TSPoint, TSPoint);
 TSNode ts_node_named_descendant_for_point_range(TSNode, TSPoint, TSPoint);
 void ts_node_edit(TSNode *, const TSInputEdit *);
 
-TSTreeCursor ts_tree_cursor_new(TSNode);
+TSTreeCursor *ts_tree_cursor_new(TSNode);
 void ts_tree_cursor_delete(TSTreeCursor *);
 void ts_tree_cursor_reset(TSTreeCursor *, TSNode);
 TSNode ts_tree_cursor_current_node(const TSTreeCursor *);

--- a/src/runtime/tree_cursor.c
+++ b/src/runtime/tree_cursor.c
@@ -65,10 +65,12 @@ static inline bool ts_tree_cursor_child_iterator_next(CursorChildIterator *self,
 
 // TSTreeCursor - lifecycle
 
-TSTreeCursor ts_tree_cursor_new(TSNode node) {
+TSTreeCursor *ts_tree_cursor_new(TSNode node) {
   TSTreeCursor self = {NULL, NULL, {0, 0}};
+  size_t sz = sizeof(TSTreeCursor);
+  void *mem = calloc(1, sz);
   ts_tree_cursor_init((TreeCursor *)&self, node);
-  return self;
+  return mem ? memcpy(mem, &self, sz) : NULL;
 }
 
 void ts_tree_cursor_reset(TSTreeCursor *_self, TSNode node) {
@@ -92,6 +94,7 @@ void ts_tree_cursor_init(TreeCursor *self, TSNode node) {
 void ts_tree_cursor_delete(TSTreeCursor *_self) {
   TreeCursor *self = (TreeCursor *)_self;
   array_delete(&self->stack);
+  free(_self);
 }
 
 // TSTreeCursor - walking the tree

--- a/test/runtime/node_test.cc
+++ b/test/runtime/node_test.cc
@@ -610,19 +610,19 @@ describe("Node", [&]() {
     auto get_all_nodes = [&]() {
       vector<TSNode> result;
       bool visited_children = false;
-      TSTreeCursor cursor = ts_tree_cursor_new(ts_tree_root_node(tree));
+      TSTreeCursor* cursor = ts_tree_cursor_new(ts_tree_root_node(tree));
       while (true) {
-        result.push_back(ts_tree_cursor_current_node(&cursor));
-        if (!visited_children && ts_tree_cursor_goto_first_child(&cursor)) continue;
-        if (ts_tree_cursor_goto_next_sibling(&cursor)) {
+        result.push_back(ts_tree_cursor_current_node(cursor));
+        if (!visited_children && ts_tree_cursor_goto_first_child(cursor)) continue;
+        if (ts_tree_cursor_goto_next_sibling(cursor)) {
           visited_children = false;
-        } else if (ts_tree_cursor_goto_parent(&cursor)) {
+        } else if (ts_tree_cursor_goto_parent(cursor)) {
           visited_children = true;
         } else {
           break;
         }
       }
-      ts_tree_cursor_delete(&cursor);
+      ts_tree_cursor_delete(cursor);
       return result;
     };
 
@@ -680,7 +680,7 @@ describe("Node", [&]() {
 describe("TreeCursor", [&]() {
   TSParser *parser;
   TSTree *tree;
-  TSTreeCursor cursor;
+  TSTreeCursor *cursor;
 
   before_each([&]() {
     record_alloc::start();
@@ -693,7 +693,7 @@ describe("TreeCursor", [&]() {
 
   after_each([&]() {
     ts_tree_delete(tree);
-    ts_tree_cursor_delete(&cursor);
+    ts_tree_cursor_delete(cursor);
     ts_parser_delete(parser);
 
     record_alloc::stop();
@@ -701,154 +701,154 @@ describe("TreeCursor", [&]() {
   });
 
   it("can walk the tree", [&]() {
-    TSNode node = ts_tree_cursor_current_node(&cursor);
+    TSNode node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("value"));
     AssertThat(ts_node_start_byte(node), Equals(array_index));
 
-    AssertThat(ts_tree_cursor_goto_first_child(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_first_child(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("array"));
     AssertThat(ts_node_start_byte(node), Equals(array_index));
 
-    AssertThat(ts_tree_cursor_goto_first_child(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_first_child(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("["));
     AssertThat(ts_node_start_byte(node), Equals(array_index));
 
     // Cannot descend into a node with no children
-    AssertThat(ts_tree_cursor_goto_first_child(&cursor), IsFalse());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_first_child(cursor), IsFalse());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("["));
     AssertThat(ts_node_start_byte(node), Equals(array_index));
 
-    AssertThat(ts_tree_cursor_goto_next_sibling(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_next_sibling(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("number"));
     AssertThat(ts_node_start_byte(node), Equals(number_index));
 
-    AssertThat(ts_tree_cursor_goto_next_sibling(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_next_sibling(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals(","));
     AssertThat(ts_node_start_byte(node), Equals(number_end_index));
 
-    AssertThat(ts_tree_cursor_goto_next_sibling(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_next_sibling(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("false"));
     AssertThat(ts_node_start_byte(node), Equals(false_index));
 
-    AssertThat(ts_tree_cursor_goto_next_sibling(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_next_sibling(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals(","));
     AssertThat(ts_node_start_byte(node), Equals(false_end_index));
 
-    AssertThat(ts_tree_cursor_goto_next_sibling(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_next_sibling(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("object"));
     AssertThat(ts_node_start_byte(node), Equals(object_index));
 
-    AssertThat(ts_tree_cursor_goto_first_child(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_first_child(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("{"));
     AssertThat(ts_node_start_byte(node), Equals(object_index));
 
-    AssertThat(ts_tree_cursor_goto_next_sibling(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_next_sibling(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("pair"));
     AssertThat(ts_node_start_byte(node), Equals(string_index));
 
-    AssertThat(ts_tree_cursor_goto_first_child(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_first_child(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("string"));
     AssertThat(ts_node_start_byte(node), Equals(string_index));
 
-    AssertThat(ts_tree_cursor_goto_next_sibling(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_next_sibling(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals(":"));
     AssertThat(ts_node_start_byte(node), Equals(string_end_index));
 
-    AssertThat(ts_tree_cursor_goto_next_sibling(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_next_sibling(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("null"));
     AssertThat(ts_node_start_byte(node), Equals(null_index));
 
     // Cannot move beyond a node with no next sibling
-    AssertThat(ts_tree_cursor_goto_next_sibling(&cursor), IsFalse());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_next_sibling(cursor), IsFalse());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("null"));
     AssertThat(ts_node_start_byte(node), Equals(null_index));
 
-    AssertThat(ts_tree_cursor_goto_parent(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_parent(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("pair"));
     AssertThat(ts_node_start_byte(node), Equals(string_index));
 
-    AssertThat(ts_tree_cursor_goto_parent(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_parent(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("object"));
     AssertThat(ts_node_start_byte(node), Equals(object_index));
 
-    AssertThat(ts_tree_cursor_goto_parent(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_parent(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("array"));
     AssertThat(ts_node_start_byte(node), Equals(array_index));
 
-    AssertThat(ts_tree_cursor_goto_parent(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_parent(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("value"));
     AssertThat(ts_node_start_byte(node), Equals(array_index));
 
     // The root node doesn't have a parent.
-    AssertThat(ts_tree_cursor_goto_parent(&cursor), IsFalse());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_parent(cursor), IsFalse());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("value"));
     AssertThat(ts_node_start_byte(node), Equals(array_index));
   });
 
   it("can find the first child of a given node which spans the given byte offset", [&]() {
-    int64_t child_index = ts_tree_cursor_goto_first_child_for_byte(&cursor, 1);
-    TSNode node = ts_tree_cursor_current_node(&cursor);
+    int64_t child_index = ts_tree_cursor_goto_first_child_for_byte(cursor, 1);
+    TSNode node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("array"));
     AssertThat(ts_node_start_byte(node), Equals(array_index));
     AssertThat(child_index, Equals(0));
 
-    child_index = ts_tree_cursor_goto_first_child_for_byte(&cursor, array_index);
-    node = ts_tree_cursor_current_node(&cursor);
+    child_index = ts_tree_cursor_goto_first_child_for_byte(cursor, array_index);
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("["));
     AssertThat(ts_node_start_byte(node), Equals(array_index));
     AssertThat(child_index, Equals(0));
 
-    ts_tree_cursor_goto_parent(&cursor);
-    child_index = ts_tree_cursor_goto_first_child_for_byte(&cursor, array_index + 1);
-    node = ts_tree_cursor_current_node(&cursor);
+    ts_tree_cursor_goto_parent(cursor);
+    child_index = ts_tree_cursor_goto_first_child_for_byte(cursor, array_index + 1);
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("number"));
     AssertThat(ts_node_start_byte(node), Equals(number_index));
     AssertThat(child_index, Equals(1));
 
-    ts_tree_cursor_goto_parent(&cursor);
-    child_index = ts_tree_cursor_goto_first_child_for_byte(&cursor, number_index + 1);
-    node = ts_tree_cursor_current_node(&cursor);
+    ts_tree_cursor_goto_parent(cursor);
+    child_index = ts_tree_cursor_goto_first_child_for_byte(cursor, number_index + 1);
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("number"));
     AssertThat(ts_node_start_byte(node), Equals(number_index));
     AssertThat(child_index, Equals(1));
 
-    ts_tree_cursor_goto_parent(&cursor);
-    child_index = ts_tree_cursor_goto_first_child_for_byte(&cursor, false_index - 1);
-    node = ts_tree_cursor_current_node(&cursor);
+    ts_tree_cursor_goto_parent(cursor);
+    child_index = ts_tree_cursor_goto_first_child_for_byte(cursor, false_index - 1);
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("false"));
     AssertThat(ts_node_start_byte(node), Equals(false_index));
     AssertThat(child_index, Equals(3));
 
-    ts_tree_cursor_goto_parent(&cursor);
-    child_index = ts_tree_cursor_goto_first_child_for_byte(&cursor, object_end_index - 1);
-    node = ts_tree_cursor_current_node(&cursor);
+    ts_tree_cursor_goto_parent(cursor);
+    child_index = ts_tree_cursor_goto_first_child_for_byte(cursor, object_end_index - 1);
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("object"));
     AssertThat(ts_node_start_byte(node), Equals(object_index));
     AssertThat(child_index, Equals(5));
 
     // There is no child past the end of the array
-    ts_tree_cursor_goto_parent(&cursor);
-    child_index = ts_tree_cursor_goto_first_child_for_byte(&cursor, array_end_index);
-    node = ts_tree_cursor_current_node(&cursor);
+    ts_tree_cursor_goto_parent(cursor);
+    child_index = ts_tree_cursor_goto_first_child_for_byte(cursor, array_end_index);
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("array"));
     AssertThat(ts_node_start_byte(node), Equals(array_index));
     AssertThat(child_index, Equals(-1));
@@ -856,105 +856,105 @@ describe("TreeCursor", [&]() {
 
   it("walks the tree correctly when the node contains aliased children and extras", [&]() {
     ts_parser_set_language(parser, language_with_aliases_and_extras);
-    ts_tree_cursor_delete(&cursor);
+    ts_tree_cursor_delete(cursor);
     ts_tree_delete(tree);
 
     tree = ts_parser_parse_string(parser, nullptr, "b ... b ... c", 13);
     cursor = ts_tree_cursor_new(ts_tree_root_node(tree));
 
-    TSNode node = ts_tree_cursor_current_node(&cursor);
+    TSNode node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("a"));
 
-    AssertThat(ts_tree_cursor_goto_first_child(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_first_child(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("b"));
 
-    AssertThat(ts_tree_cursor_goto_next_sibling(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_next_sibling(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("comment"));
 
-    AssertThat(ts_tree_cursor_goto_next_sibling(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_next_sibling(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("B"));
 
-    AssertThat(ts_tree_cursor_goto_next_sibling(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_next_sibling(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("comment"));
 
-    AssertThat(ts_tree_cursor_goto_next_sibling(&cursor), IsTrue());
-    node = ts_tree_cursor_current_node(&cursor);
+    AssertThat(ts_tree_cursor_goto_next_sibling(cursor), IsTrue());
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("C"));
 
-    AssertThat(ts_tree_cursor_goto_next_sibling(&cursor), IsFalse());
-    AssertThat(ts_tree_cursor_goto_parent(&cursor), IsTrue());
-    AssertThat(ts_tree_cursor_goto_first_child_for_byte(&cursor, 0), Equals(0));
+    AssertThat(ts_tree_cursor_goto_next_sibling(cursor), IsFalse());
+    AssertThat(ts_tree_cursor_goto_parent(cursor), IsTrue());
+    AssertThat(ts_tree_cursor_goto_first_child_for_byte(cursor, 0), Equals(0));
   });
 
   it("walks the tree correctly when there are hidden leaf nodes", [&]() {
     ts_parser_set_language(parser, load_real_language("javascript"));
-    ts_tree_cursor_delete(&cursor);
+    ts_tree_cursor_delete(cursor);
     ts_tree_delete(tree);
 
     tree = ts_parser_parse_string(parser, nullptr, "`abc${1}def${2}ghi`", 19);
     cursor = ts_tree_cursor_new(ts_tree_root_node(tree));
-    TSNode node = ts_tree_cursor_current_node(&cursor);
+    TSNode node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("program"));
 
-    ts_tree_cursor_goto_first_child(&cursor);
-    node = ts_tree_cursor_current_node(&cursor);
+    ts_tree_cursor_goto_first_child(cursor);
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("expression_statement"));
 
-    ts_tree_cursor_goto_first_child(&cursor);
-    node = ts_tree_cursor_current_node(&cursor);
+    ts_tree_cursor_goto_first_child(cursor);
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("template_string"));
 
-    int index = ts_tree_cursor_goto_first_child_for_byte(&cursor, 9);
+    int index = ts_tree_cursor_goto_first_child_for_byte(cursor, 9);
     AssertThat(index, Equals(2));
-    node = ts_tree_cursor_current_node(&cursor);
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("template_substitution"));
     AssertThat(ts_node_start_byte(node), Equals(11u));
     AssertThat(ts_node_end_byte(node), Equals(15u));
 
-    index = ts_tree_cursor_goto_first_child_for_byte(&cursor, 20);
+    index = ts_tree_cursor_goto_first_child_for_byte(cursor, 20);
     AssertThat(index, Equals(-1));
-    node = ts_tree_cursor_current_node(&cursor);
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("template_substitution"));
 
-    ts_tree_cursor_goto_first_child(&cursor);
-    node = ts_tree_cursor_current_node(&cursor);
+    ts_tree_cursor_goto_first_child(cursor);
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("${"));
 
-    index = ts_tree_cursor_goto_first_child_for_byte(&cursor, 20);
+    index = ts_tree_cursor_goto_first_child_for_byte(cursor, 20);
     AssertThat(index, Equals(-1));
-    node = ts_tree_cursor_current_node(&cursor);
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("${"));
   });
 
   it("handles parent nodes that are aliased", [&]() {
     ts_parser_set_language(parser, load_real_language("html"));
-    ts_tree_cursor_delete(&cursor);
+    ts_tree_cursor_delete(cursor);
     ts_tree_delete(tree);
 
     tree = ts_parser_parse_string(parser, nullptr, "<script></script>", 18);
 
     cursor = ts_tree_cursor_new(ts_tree_root_node(tree));
-    TSNode node = ts_tree_cursor_current_node(&cursor);
+    TSNode node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("fragment"));
 
-    ts_tree_cursor_goto_first_child(&cursor);
-    node = ts_tree_cursor_current_node(&cursor);
+    ts_tree_cursor_goto_first_child(cursor);
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("raw_element"));
 
-    ts_tree_cursor_goto_first_child(&cursor);
-    node = ts_tree_cursor_current_node(&cursor);
+    ts_tree_cursor_goto_first_child(cursor);
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("start_tag"));
 
-    ts_tree_cursor_goto_first_child(&cursor);
-    node = ts_tree_cursor_current_node(&cursor);
+    ts_tree_cursor_goto_first_child(cursor);
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("<"));
 
-    ts_tree_cursor_goto_parent(&cursor);
-    node = ts_tree_cursor_current_node(&cursor);
+    ts_tree_cursor_goto_parent(cursor);
+    node = ts_tree_cursor_current_node(cursor);
     AssertThat(ts_node_type(node), Equals("start_tag"));
   });
 });


### PR DESCRIPTION
To create vala binding to tree-sitter API there're a series of conventions:

https://wiki.gnome.org/Projects/Vala/LegacyBindings

We can deal with most of them (like passing `TSNode` by value) except one: Return `TSTreeCursor` by value in `ts_tree_cursor_new`

This patch is a convenience modification to allocate `TSTreeCursor` struct and free it, allowing vala to use it.

https://gitlab.gnome.org/albfan/vala-tree-sitter/blob/master/.gitmodules#L3-4

I'm not a API expert, but taking with people who is, they suggest to contribute upstream to iron this little quirks. If you are open to API refinement just let us (GNOME) know.

I'm gonna directly use this binding into https://gitlab.gnome.org/albfan/gtk-code-folding-vala/issues/4 but I'm sure there're a bunch of IDEs (GNOME Builder, code from elementary) looking for AST using tree-sitter. As much standard the API is, the better and easier it will be to integrate. 

Don't get me wrong, I know tree-sitter is totally usable right now.   