### PR TITLE
Fix declarations of functions without arguments

### DIFF
--- a/include/tree_sitter/parser.h
+++ b/include/tree_sitter/parser.h
@@ -92,7 +92,7 @@ struct TSLanguage {
   struct {
     const bool *states;
     const TSSymbol *symbol_map;
-    void *(*create)();
+    void *(*create)(void);
     void (*destroy)(void *);
     bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
     unsigned (*serialize)(void *, char *);

--- a/include/tree_sitter/runtime.h
+++ b/include/tree_sitter/runtime.h
@@ -77,7 +77,7 @@ typedef struct {
   uint32_t context[2];
 } TSTreeCursor;
 
-TSParser *ts_parser_new();
+TSParser *ts_parser_new(void);
 void ts_parser_delete(TSParser *);
 const TSLanguage *ts_parser_language(const TSParser *);
 bool ts_parser_set_language(TSParser *, const TSLanguage *);

--- a/src/compiler/generate_code/c_code.cc
+++ b/src/compiler/generate_code/c_code.cc
@@ -499,7 +499,7 @@ class CCodeGenerator {
     string external_scanner_name = language_function_name + "_external_scanner";
 
     if (!syntax_grammar.external_tokens.empty()) {
-      line("void *" + external_scanner_name + "_create();");
+      line("void *" + external_scanner_name + "_create(void);");
       line("void " + external_scanner_name + "_destroy(void *);");
       line("bool " + external_scanner_name + "_scan(void *, TSLexer *, const bool *);");
       line("unsigned " + external_scanner_name + "_serialize(void *, char *);");
@@ -512,7 +512,7 @@ class CCodeGenerator {
     line("#endif");
     line();
 
-    line("extern const TSLanguage *" + language_function_name + "() {");
+    line("extern const TSLanguage *" + language_function_name + "(void) {");
     indent([&]() {
       line("static TSLanguage language = {");
       indent([&]() {

--- a/src/runtime/length.h
+++ b/src/runtime/length.h
@@ -36,7 +36,7 @@ static inline Length length_sub(Length len1, Length len2) {
   return result;
 }
 
-static inline Length length_zero() {
+static inline Length length_zero(void) {
   Length result = {0, {0, 0}};
   return result;
 }

--- a/src/runtime/node.c
+++ b/src/runtime/node.c
@@ -22,7 +22,7 @@ TSNode ts_node_new(const TSTree *tree, const Subtree *subtree, Length position, 
   };
 }
 
-static inline TSNode ts_node__null() {
+static inline TSNode ts_node__null(void) {
   return ts_node_new(NULL, NULL, length_zero(), 0);
 }
 

--- a/src/runtime/parser.c
+++ b/src/runtime/parser.c
@@ -1472,7 +1472,7 @@ static bool ts_parser_has_outstanding_parse(TSParser *self) {
 
 // Parser - Public
 
-TSParser *ts_parser_new() {
+TSParser *ts_parser_new(void) {
   TSParser *self = ts_calloc(1, sizeof(TSParser));
   ts_lexer_init(&self->lexer);
   array_init(&self->reduce_actions);

--- a/src/runtime/reusable_node.h
+++ b/src/runtime/reusable_node.h
@@ -11,7 +11,7 @@ typedef struct {
   Subtree last_external_token;
 } ReusableNode;
 
-static inline ReusableNode reusable_node_new() {
+static inline ReusableNode reusable_node_new(void) {
   return (ReusableNode) {array_new(), NULL_SUBTREE};
 }
 


### PR DESCRIPTION
When compiled with `-Wstrict-prototypes` warnings are emitted for functions which don't take declare the type of their arguments. By setting the argument list to `void`, we can explicitely specify that the functions take no arguments. The patch only affects C code and is backwards-compatible.