### PR TITLE
Bytes/C Fixes

### DIFF
--- a/cli/src/tests/properties_test.rs
+++ b/cli/src/tests/properties_test.rs
@@ -40,7 +40,7 @@ fn test_walk_with_properties_with_nth_child() {
     parser.set_language(language).unwrap();
     let tree = parser.parse(source_code, None).unwrap();
 
-    let mut cursor = tree.walk_with_properties(&property_sheet, source_code);
+    let mut cursor = tree.walk_with_properties(&property_sheet, source_code.as_bytes());
     assert_eq!(cursor.node().kind(), "program");
     assert!(cursor.goto_first_child());
     assert_eq!(cursor.node().kind(), "expression_statement");
@@ -98,7 +98,7 @@ fn test_walk_with_properties_with_regexes() {
     parser.set_language(language).unwrap();
     let tree = parser.parse(source_code, None).unwrap();
 
-    let mut cursor = tree.walk_with_properties(&property_sheet, source_code);
+    let mut cursor = tree.walk_with_properties(&property_sheet, source_code.as_bytes());
     assert_eq!(cursor.node().kind(), "program");
     assert!(cursor.goto_first_child());
     assert_eq!(cursor.node().kind(), "lexical_declaration");

--- a/lib/binding/lib.rs
+++ b/lib/binding/lib.rs
@@ -123,7 +123,7 @@ pub struct TreePropertyCursor<'a, P> {
     state_stack: Vec<usize>,
     child_index_stack: Vec<usize>,
     property_sheet: &'a PropertySheet<P>,
-    source: &'a str,
+    source: &'a [u8],
 }
 
 impl Language {
@@ -355,7 +355,7 @@ impl Tree {
     pub fn walk_with_properties<'a, P>(
         &'a self,
         property_sheet: &'a PropertySheet<P>,
-        source: &'a str,
+        source: &'a [u8],
     ) -> TreePropertyCursor<'a, P> {
         TreePropertyCursor::new(self, property_sheet, source)
     }
@@ -613,7 +613,7 @@ impl<'a> Drop for TreeCursor<'a> {
 }
 
 impl<'a, P> TreePropertyCursor<'a, P> {
-    fn new(tree: &'a Tree, property_sheet: &'a PropertySheet<P>, source: &'a str) -> Self {
+    fn new(tree: &'a Tree, property_sheet: &'a PropertySheet<P>, source: &'a [u8]) -> Self {
         let mut result = Self {
             cursor: tree.root_node().walk(),
             child_index_stack: vec![0],
@@ -690,7 +690,7 @@ impl<'a, P> TreePropertyCursor<'a, P> {
                 for transition in transitions.iter() {
                     if let Some(text_regex_index) = transition.text_regex_index {
                         let node = self.cursor.node();
-                        let text = &self.source.as_bytes()[node.start_byte()..node.end_byte()];
+                        let text = &self.source[node.start_byte()..node.end_byte()];
                         if let Ok(text) = str::from_utf8(text) {
                             if !self.property_sheet.text_regexes[text_regex_index].is_match(text) {
                                 continue;

--- a/lib/src/get_changed_ranges.c
+++ b/lib/src/get_changed_ranges.c
@@ -376,7 +376,7 @@ unsigned ts_subtree_get_changed_ranges(const Subtree *old_tree, const Subtree *n
           position.bytes, next_position.bytes
         )) {
           next_position = position;
-          // fall through
+          __attribute__ ((fallthrough));
         } else {
           break;
         }

--- a/lib/src/lib.c
+++ b/lib/src/lib.c
@@ -5,6 +5,7 @@
 //   - include
 //   - externals/utf8proc
 
+#define _POSIX_SOURCE
 #include "./get_changed_ranges.c"
 #include "./language.c"
 #include "./lexer.c"


### PR DESCRIPTION
Hi @maxbrunsfeld! You forgot to merge part of my patch in the `rust-tree-sitter` repo: the attributes walker must be fixed to use `&[u8]` too, so we can continue using it from Treelights.

While I was here, I also fixed two C compilation warnings.

Cheers,
vmg