### PR TITLE
Simplify lifetimes in Node::children

### DIFF
--- a/lib/binding/lib.rs
+++ b/lib/binding/lib.rs
@@ -469,10 +469,11 @@ impl<'tree> Node<'tree> {
         unsafe { ffi::ts_node_child_count(self.0) as usize }
     }
 
-    pub fn children<'a>(&'a self) -> impl Iterator<Item = Node<'tree>> + 'a {
+    pub fn children(&self) -> impl Iterator<Item = Node<'tree>> {
+        let me = self.clone();
         (0..self.child_count())
             .into_iter()
-            .map(move |i| self.child(i).unwrap())
+            .map(move |i| me.child(i).unwrap())
     }
 
     pub fn named_child<'a>(&'a self, i: usize) -> Option<Self> {


### PR DESCRIPTION
Previously, the lifetimes made it impossible to write a function that recursed over `.children()` and returned one of the subnodes. Specifically, the problem arose because in the previous scheme, rust thought the returned children depended on the lifetime of the parent node. AFAICT, they technically wouldn't need to - but this was the only way I could convince the borrow checker of that.

In true rust style, I kept mucking with the lifetimes until it worked. ;)

In this case, it _looks_ like it's pretty cheap to clone self, and to my wishy-washy understanding, this ought to be a backwards-compatible change (these lifetimes should be strictly more flexible).

Motivating example usage: https://github.com/joshuawarner32/hornbeam/blob/42aee6398f047282c00194f24370abdb51b7bee6/src/bin/hornbeam.rs#L97

(note, in that example I'm technically using a small convenience wrapper around the tree-sitter's `Node`, but it inherits exactly the same lifetime issues)