### PR TITLE
Fix warning about undefined snprintf

### DIFF
--- a/lib/src/lib.c
+++ b/lib/src/lib.c
@@ -4,7 +4,7 @@
 //   - include
 //   - utf8proc
 
-#define _POSIX_SOURCE
+#define _POSIX_C_SOURCE 200112L
 #define UTF8PROC_STATIC
 
 #include "./get_changed_ranges.c"


### PR DESCRIPTION
(on macOS 10.14, with "Apple LLVM version 10.0.0")

This is a follow-on to 9a951c859d0c9928591a6e3d8027333583bf1a7b. That commit introduced _POSIX_SOURCE,
and it turns out that doing so causes `snprintf` to not be defined on my machine.

Cross platform C is hard. Sigh.

My understanding here is that _POSIX_C_SOURCE is a more modern version of _POSIX_SOURCE.

The manpage of snprintf tells me:

```
snprintf(), vsnprintf():
    _BSD_SOURCE || _XOPEN_SOURCE >= 500 || _ISOC99_SOURCE || _POSIX_C_SOURCE >= 200112L;
    or cc -std=c99
```

And, for `fdopen`:
```
fdopen(): _POSIX_C_SOURCE >= 1 || _XOPEN_SOURCE || _POSIX_SOURCE
```

... which seems reasonable. I think at least that means this shouldn't regress this for fdopen.

For posterity, here's the warning I was seeing:
```
warning: In file included from src/lib.c:12:
warning: src/./lexer.c:102:5: warning: implicitly declaring library function 'snprintf' with type 'int (char *, unsigned long, const char *, ...)' [-Wimplicit-function-declaration]
warning:     LOG_CHARACTER("skip", self->data.lookahead);
warning:     ^
warning: src/./lexer.c:15:3: note: expanded from macro 'LOG_CHARACTER'
warning:   LOG(                                    \
warning:   ^
warning: src/./lexer.c:10:5: note: expanded from macro 'LOG'
warning:     snprintf(self->debug_buffer, TREE_SITTER_SERIALIZATION_BUFFER_SIZE, __VA_ARGS__); \
warning:     ^
warning: src/./lexer.c:102:5: note: include the header <stdio.h> or explicitly provide a declaration for 'snprintf'
warning: src/./lexer.c:15:3: note: expanded from macro 'LOG_CHARACTER'
warning:   LOG(                                    \
warning:   ^
warning: src/./lexer.c:10:5: note: expanded from macro 'LOG'
warning:     snprintf(self->debug_buffer, TREE_SITTER_SERIALIZATION_BUFFER_SIZE, __VA_ARGS__); \
warning:     ^
warning: 1 warning generated.
```