### PR TITLE
Use 1-indexed rows in CLI and log output (resolves #287)

### DIFF
--- a/cli/src/tests/parser_test.rs
+++ b/cli/src/tests/parser_test.rs
@@ -56,6 +56,10 @@ fn test_parsing_with_logging() {
         "reduce sym:struct_item, child_count:3".to_string()
     )));
     assert!(messages.contains(&(LogType::Lex, "skip character:' '".to_string())));
+
+    for (_, m) in &messages {
+        assert!(!m.contains("row:0"));
+    }
 }
 
 #[test]

--- a/cli/src/util.rs
+++ b/cli/src/util.rs
@@ -55,9 +55,6 @@ impl Drop for LogSession {
             {
                 Command::new("open").arg(&self.0).output().unwrap();
             }
-
-            #[cfg(any(debug_assertions, test))]
-            validate_graph_log(&self);
         } else {
             eprintln!(
                 "Dot failed: {} {}",
@@ -65,21 +62,5 @@ impl Drop for LogSession {
                 String::from_utf8_lossy(&output.stderr)
             );
         }
-    }
-}
-
-#[cfg(all(unix, any(debug_assertions, test)))]
-fn validate_graph_log(session: &LogSession) {
-    use std::io::{BufRead, BufReader};
-
-    let has_zero_indexed_row = |s: &str| s.contains("position: 0,");
-
-    let graph_log = std::fs::File::open(&session.0)
-        .expect("Failed to open graph log");
-    let log_reader = BufReader::new(graph_log)
-        .lines()
-        .map(|l| l.expect("Failed to read line from graph log"));
-    for line in log_reader {
-        assert!(!has_zero_indexed_row(&line), "Graph log output includes zero-indexed row: {}", line);
     }
 }

--- a/cli/src/util.rs
+++ b/cli/src/util.rs
@@ -55,6 +55,9 @@ impl Drop for LogSession {
             {
                 Command::new("open").arg(&self.0).output().unwrap();
             }
+
+            #[cfg(any(debug_assertions, test))]
+            validate_graph_log(&self);
         } else {
             eprintln!(
                 "Dot failed: {} {}",
@@ -62,5 +65,21 @@ impl Drop for LogSession {
                 String::from_utf8_lossy(&output.stderr)
             );
         }
+    }
+}
+
+#[cfg(all(unix, any(debug_assertions, test)))]
+fn validate_graph_log(session: &LogSession) {
+    use std::io::{BufRead, BufReader};
+
+    let has_zero_indexed_row = |s: &str| s.contains("position: 0,");
+
+    let graph_log = std::fs::File::open(&session.0)
+        .expect("Failed to open graph log");
+    let log_reader = BufReader::new(graph_log)
+        .lines()
+        .map(|l| l.expect("Failed to read line from graph log"));
+    for line in log_reader {
+        assert!(!has_zero_indexed_row(&line), "Graph log output includes zero-indexed row: {}", line);
     }
 }

--- a/docs/section-3-creating-parsers.md
+++ b/docs/section-3-creating-parsers.md
@@ -86,7 +86,7 @@ tree-sitter parse ./the-file
 This should print the following:
 
 ```
-(source_file [0, 0] - [0, 5])
+(source_file [1, 0] - [1, 5])
 ```
 
 You might notice that the first time you run `tree-sitter parse`, it takes a few seconds. This is because Tree-sitter automatically compiles your C code into a dynamically-loadable library. Whenever you make changes to your grammar, you can update the parser simply by re-running `tree-sitter generate`. When the parser changes, Tree-sitter will recompile it as needed.

--- a/lib/src/get_changed_ranges.c
+++ b/lib/src/get_changed_ranges.c
@@ -331,8 +331,8 @@ static inline void iterator_print_state(Iterator *self) {
     "(%-25s %s\t depth:%u [%u, %u] - [%u, %u])",
     name, self->in_padding ? "(p)" : "   ",
     self->visible_depth,
-    start.row, start.column,
-    end.row, end.column
+    start.row + 1, start.column,
+    end.row + 1, end.column
   );
 }
 #endif
@@ -361,7 +361,7 @@ unsigned ts_subtree_get_changed_ranges(const Subtree *old_tree, const Subtree *n
 
   do {
     #ifdef DEBUG_GET_CHANGED_RANGES
-    printf("At [%-2u, %-2u] Compare ", position.extent.row, position.extent.column);
+    printf("At [%-2u, %-2u] Compare ", position.extent.row + 1, position.extent.column);
     iterator_print_state(&old_iter);
     printf("\tvs\t");
     iterator_print_state(&new_iter);
@@ -443,8 +443,8 @@ unsigned ts_subtree_get_changed_ranges(const Subtree *old_tree, const Subtree *n
       #ifdef DEBUG_GET_CHANGED_RANGES
       printf(
         "  change: [[%u, %u] - [%u, %u]]\n",
-        position.extent.row, position.extent.column,
-        next_position.extent.row, next_position.extent.column
+        position.extent.row + 1, position.extent.column,
+        next_position.extent.row + 1, next_position.extent.column
       );
       #endif
 

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -332,7 +332,7 @@ static Subtree ts_parser__lex(TSParser *self, StackVersion version, TSStateId pa
       LOG(
         "lex_external state:%d, row:%u, column:%u",
         lex_mode.external_lex_state,
-        current_position.extent.row,
+        current_position.extent.row + 1,
         current_position.extent.column
       );
       ts_lexer_start(&self->lexer);
@@ -370,7 +370,7 @@ static Subtree ts_parser__lex(TSParser *self, StackVersion version, TSStateId pa
     LOG(
       "lex_internal state:%d, row:%u, column:%u",
       lex_mode.lex_state,
-      current_position.extent.row,
+      current_position.extent.row + 1,
       current_position.extent.column
     );
     ts_lexer_start(&self->lexer);
@@ -1674,7 +1674,7 @@ TSTree *ts_parser_parse(TSParser *self, const TSTree *old_tree, TSInput input) {
         LOG("process version:%d, version_count:%u, state:%d, row:%u, col:%u",
             version, ts_stack_version_count(self->stack),
             ts_stack_state(self->stack, version),
-            ts_stack_position(self->stack, version).extent.row,
+            ts_stack_position(self->stack, version).extent.row + 1,
             ts_stack_position(self->stack, version).extent.column);
 
         if (!ts_parser__advance(self, version, allow_node_reuse)) return NULL;

--- a/lib/src/stack.c
+++ b/lib/src/stack.c
@@ -785,7 +785,7 @@ bool ts_stack_print_dot_graph(Stack *self, const TSLanguage *language, FILE *f) 
       fprintf(
         f,
         " tooltip=\"position: %u,%u\nnode_count:%u\nerror_cost: %u\ndynamic_precedence: %d\"];\n",
-        node->position.extent.row,
+        node->position.extent.row + 1,
         node->position.extent.column,
         node->node_count,
         node->error_cost,


### PR DESCRIPTION
Switches the CLI/logging output from 0-indexed rows to 1-indexed.

I _think_ I caught all the relevant cases where rows are emitted, although it's possible some are missing.

## Automated test coverage

- [x] Verify `row:0` doesn't appear in debug logs
- [x] Verify `position: 0,` doesn't appear in graph logs when the `TREE_SITTER_TEST_ENABLE_LOG_GRAPHS` environment variable is manually set
- [ ] Verify `[0,` doesn't appear in `tree-sitter parse` standard output
  - checked manually
- [ ] Verify fixes in `get_changed_ranges.c`
  - not attempted, in part because of #303