### PR TITLE
Use CLOCK_MONOTONIC on platforms that support it

### DIFF
--- a/lib/src/clock.h
+++ b/lib/src/clock.h
@@ -3,30 +3,137 @@
 
 #include <stdint.h>
 
+typedef uint64_t TSDuration;
+
 #ifdef _WIN32
 
-#include <windows.h>
+// Windows:
+// * Represent a time as a performance counter value.
+// * Represent a duration as a number of performance counter ticks.
 
-static inline uint64_t get_clock() {
+#include <windows.h>
+typedef uint64_t TSClock;
+
+static inline TSDuration duration_from_micros(uint64_t micros) {
+  LARGE_INTEGER frequency;
+  QueryPerformanceFrequency(&frequency);
+  return micros * (uint64_t)frequency.QuadPart / 1000000;
+}
+
+static inline uint64_t duration_to_micros(TSDuration self) {
+  LARGE_INTEGER frequency;
+  QueryPerformanceFrequency(&frequency);
+  return self * 1000000 / (uint64_t)frequency.QuadPart;
+}
+
+static inline TSClock clock_null() {
+  return 0;
+}
+
+static inline TSClock clock_now() {
   LARGE_INTEGER result;
   QueryPerformanceCounter(&result);
   return (uint64_t)result.QuadPart;
 }
 
-static inline uint64_t get_clocks_per_second() {
-  LARGE_INTEGER result;
-  QueryPerformanceFrequency(&result);
-  return (uint64_t)result.QuadPart;
+static inline TSClock clock_after(TSClock base, TSDuration duration) {
+  return base + duration;
+}
+
+static inline bool clock_is_null(TSClock self) {
+  return !self;
+}
+
+static inline bool clock_is_gt(TSClock self, TSClock other) {
+  return self > other;
+}
+
+#elif defined(CLOCK_MONOTONIC)
+
+// POSIX with monotonic clock support (Linux, macOS >= 10.12)
+// * Represent a time as a monotonic (seconds, nanoseconds) pair.
+// * Represent a duration as a number of microseconds.
+//
+// On these platforms, parse timeouts will correspond accurately to
+// real time, regardless of what other processes are running.
+
+#include <time.h>
+typedef struct timespec TSClock;
+
+static inline TSDuration duration_from_micros(uint64_t micros) {
+  return micros;
+}
+
+static inline uint64_t duration_to_micros(TSDuration self) {
+  return self;
+}
+
+static inline TSClock clock_now() {
+  TSClock result;
+  clock_gettime(CLOCK_MONOTONIC, &result);
+  return result;
+}
+
+static inline TSClock clock_null() {
+  return (TSClock) {0, 0};
+}
+
+static inline TSClock clock_after(TSClock base, TSDuration duration) {
+  TSClock result = base;
+  result.tv_sec += duration / 1000000;
+  result.tv_nsec += (duration % 1000000) * 1000;
+  return result;
+}
+
+static inline bool clock_is_null(TSClock self) {
+  return !self.tv_sec;
+}
+
+static inline bool clock_is_gt(TSClock self, TSClock other) {
+  if (self.tv_sec > other.tv_sec) return true;
+  if (self.tv_sec < other.tv_sec) return false;
+  return self.tv_nsec > other.tv_nsec;
 }
 
 #else
 
-static inline uint64_t get_clock() {
+// POSIX without monotonic clock support
+// * Represent a time as a process clock value.
+// * Represent a duration as a number of process clock ticks.
+//
+// On these platforms, parse timeouts may be affected by other processes,
+// which is not ideal, but is better than using a non-monotonic time API
+// like `gettimeofday`.
+
+#include <time.h>
+typedef uint64_t TSClock;
+
+static inline TSDuration duration_from_micros(uint64_t micros) {
+  return micros * (uint64_t)CLOCKS_PER_SEC / 1000000;
+}
+
+static inline uint64_t duration_to_micros(TSDuration self) {
+  return self * 1000000 / (uint64_t)CLOCKS_PER_SEC;
+}
+
+static inline TSClock clock_null() {
+  return 0;
+}
+
+static inline TSClock clock_now() {
   return (uint64_t)clock();
 }
 
-static inline uint64_t get_clocks_per_second() {
-  return (uint64_t)CLOCKS_PER_SEC;
+static inline TSClock clock_after(TSClock base, TSDuration duration) {
+  return base + duration;
+}
+
+static inline bool clock_is_null(TSClock self) {
+  return !self;
+}
+
+static inline bool clock_is_gt(TSClock self, TSClock other) {
+  return self > other;
 }
 
 #endif


### PR DESCRIPTION
Currently, the timeout API added in #301 uses `clock()` on POSIX systems. But on Linux and macOS 10.12 and above, we have access to a *better* monotonic clock API:
`clock_gettime(CLOCK_MONOTONIC, clock)`.

This clock counts the cycles used system-wide, rather than just the cycles used by the current process. This is good because it means parsing timeouts will apply correctly even if the current process is starved for CPU.

Thanks @vmg for suggesting this!