### PR TITLE
fix example snippet in creating parsers docs

### DIFF
--- a/docs/section-3-creating-parsers.md
+++ b/docs/section-3-creating-parsers.md
@@ -77,7 +77,7 @@ Then run the the following command:
 tree-sitter generate
 ```
 
-This will generate the C code required to parse this trivial language, as well as all of the files needed to compile and load this native parser as a Node.js module. You can test this parser by creating a source file with the contents `hello;` and parsing it:
+This will generate the C code required to parse this trivial language, as well as all of the files needed to compile and load this native parser as a Node.js module. You can test this parser by creating a source file with the contents `hello` and parsing it:
 
 ```sh
 tree-sitter parse ./the-file


### PR DESCRIPTION
Maybe I don't quite understand, but afaict the input `hello;` for a
grammar expecting `hello` yields now the result:

```
(source_file [0, 0] - [1, 0]
  (ERROR [0, 5] - [0, 6]
      (ERROR [0, 5] - [0, 6])))
```

Since there is an error from the unexpected semicolon?