### PR TITLE
Increase memory limit for language wasm files (continued)

### DIFF
--- a/script/build-wasm
+++ b/script/build-wasm
@@ -18,6 +18,7 @@ docker run                          \
                                     \
   emcc                              \
   -s WASM=1                         \
+  -s TOTAL_MEMORY=33554432          \
   -s ALLOW_MEMORY_GROWTH            \
   -s MAIN_MODULE=1                  \
   -s EXPORT_ALL=1                   \


### PR DESCRIPTION
The `TOTAL_MEMORY` for language wasm files was bumped in https://github.com/tree-sitter/tree-sitter/commit/8315a6277b9e8d8a0b38ec090e42a9a5e1101a3a, which started causing [CI problems](https://travis-ci.org/tree-sitter/tree-sitter/jobs/525478081):

>      LinkError: WebAssembly Instantiation: memory import 5 is smaller than initial 512, got 256

This sets `TOTAL_MEMORY` on the main wasm to the same as the side modules (33554432).