### PR TITLE
Avoid introducing certain auxiliary repeat rules in hidden rules

### DIFF
--- a/cli/src/generate/build_tables/build_parse_table.rs
+++ b/cli/src/generate/build_tables/build_parse_table.rs
@@ -331,14 +331,13 @@ impl<'a> ParseTableBuilder<'a> {
             // an `is_repetition` flag.
             let conflicting_variable_index =
                 conflicting_items.iter().next().unwrap().variable_index;
-            if self.syntax_grammar.variables[conflicting_variable_index as usize].is_auxiliary() {
-                if conflicting_items
+            if self.syntax_grammar.variables[conflicting_variable_index as usize].is_auxiliary()
+                && conflicting_items
                     .iter()
                     .all(|item| item.variable_index == conflicting_variable_index)
-                {
-                    *is_repetition = true;
-                    return Ok(());
-                }
+            {
+                *is_repetition = true;
+                return Ok(());
             }
 
             // If the SHIFT action has higher precedence, remove all the REDUCE actions.


### PR DESCRIPTION
This PR avoids introducing an auxiliary repeat rule when `repeat1` is used at the top level of a rule that is already hidden, like [this](https://github.com/tree-sitter/tree-sitter-ruby/blob/ae2db0c8ac1a47b890fc975786ee4815100ac907/grammar.js#L619-L623) rule in the Ruby grammar:

```js
_literal_contents: $ => repeat1(choice(
  $._string_content,
  $.interpolation,
  $.escape_sequence
)),
```