### PR TITLE
Reduce parsers' static memory footprint by storing "small" parse states more compactly

### DIFF
--- a/cli/src/generate/build_tables/build_parse_table.rs
+++ b/cli/src/generate/build_tables/build_parse_table.rs
@@ -108,6 +108,7 @@ impl<'a> ParseTableBuilder<'a> {
                 self.parse_table.states.push(ParseState {
                     id: state_id,
                     lex_state_id: 0,
+                    external_lex_state_id: 0,
                     terminal_entries: HashMap::new(),
                     nonterminal_entries: HashMap::new(),
                     core_id,
@@ -777,6 +778,7 @@ pub(crate) fn build_parse_table(
         parse_table: ParseTable {
             states: Vec::new(),
             symbols: Vec::new(),
+            external_lex_states: Vec::new(),
             production_infos: Vec::new(),
             max_aliased_production_length: 1,
         },

--- a/cli/src/generate/build_tables/item.rs
+++ b/cli/src/generate/build_tables/item.rs
@@ -1,5 +1,8 @@
-use crate::generate::grammars::{LexicalGrammar, Production, ProductionStep, SyntaxGrammar};
-use crate::generate::rules::{Associativity, Symbol, SymbolType, TokenSet};
+use crate::generate::grammars::{
+    LexicalGrammar, Production, ProductionStep, SyntaxGrammar,
+};
+use crate::generate::rules::Associativity;
+use crate::generate::rules::{Symbol, SymbolType, TokenSet};
 use lazy_static::lazy_static;
 use std::cmp::Ordering;
 use std::fmt;
@@ -161,12 +164,14 @@ impl<'a> fmt::Display for ParseItemDisplay<'a> {
         for (i, step) in self.0.production.steps.iter().enumerate() {
             if i == self.0.step_index as usize {
                 write!(f, " •")?;
-                if step.precedence != 0 || step.associativity.is_some() {
-                    write!(
-                        f,
-                        " (prec {:?} assoc {:?})",
-                        step.precedence, step.associativity
-                    )?;
+                if let Some(associativity) = step.associativity {
+                    if step.precedence != 0 {
+                        write!(f, " ({} {:?})", step.precedence, associativity)?;
+                    } else {
+                        write!(f, " ({:?})", associativity)?;
+                    }
+                } else if step.precedence != 0 {
+                    write!(f, " ({})", step.precedence)?;
                 }
             }
 
@@ -184,19 +189,21 @@ impl<'a> fmt::Display for ParseItemDisplay<'a> {
             }
 
             if let Some(alias) = &step.alias {
-                write!(f, " (alias {})", alias.value)?;
+                write!(f, "@{}", alias.value)?;
             }
         }
 
         if self.0.is_done() {
             write!(f, " •")?;
             if let Some(step) = self.0.production.steps.last() {
-                if step.precedence != 0 || step.associativity.is_some() {
-                    write!(
-                        f,
-                        " (prec {:?} assoc {:?})",
-                        step.precedence, step.associativity
-                    )?;
+                if let Some(associativity) = step.associativity {
+                    if step.precedence != 0 {
+                        write!(f, " ({} {:?})", step.precedence, associativity)?;
+                    } else {
+                        write!(f, " ({:?})", associativity)?;
+                    }
+                } else if step.precedence != 0 {
+                    write!(f, " ({})", step.precedence)?;
                 }
             }
         }

--- a/cli/src/generate/build_tables/minimize_parse_table.rs
+++ b/cli/src/generate/build_tables/minimize_parse_table.rs
@@ -26,6 +26,7 @@ pub(crate) fn minimize_parse_table(
     minimizer.merge_compatible_states();
     minimizer.remove_unit_reductions();
     minimizer.remove_unused_states();
+    minimizer.reorder_states_by_descending_size();
 }
 
 struct Minimizer<'a> {
@@ -453,5 +454,38 @@ impl<'a> Minimizer<'a> {
             }
             original_state_id += 1;
         }
+    }
+
+    fn reorder_states_by_descending_size(&mut self) {
+        // Get a mapping of old state index -> new_state_index
+        let mut old_ids_by_new_id = (0..self.parse_table.states.len()).collect::<Vec<_>>();
+        &old_ids_by_new_id.sort_unstable_by_key(|i| {
+            // Don't changes states 0 (the error state) or 1 (the start state).
+            if *i <= 1 {
+                return *i as i64 - 1_000_000;
+            }
+
+            // Reorder all the other states by descending symbol count.
+            let state = &self.parse_table.states[*i];
+            -((state.terminal_entries.len() + state.nonterminal_entries.len()) as i64)
+        });
+
+        // Get the inverse mapping
+        let mut new_ids_by_old_id = vec![0; old_ids_by_new_id.len()];
+        for (id, old_id) in old_ids_by_new_id.iter().enumerate() {
+            new_ids_by_old_id[*old_id] = id;
+        }
+
+        // Reorder the parse states and update their references to reflect
+        // the new ordering.
+        self.parse_table.states = old_ids_by_new_id
+            .iter()
+            .map(|old_id| {
+                let mut state = ParseState::default();
+                mem::swap(&mut state, &mut self.parse_table.states[*old_id]);
+                state.update_referenced_states(|id, _| new_ids_by_old_id[id]);
+                state
+            })
+            .collect();
     }
 }

--- a/cli/src/generate/mod.rs
+++ b/cli/src/generate/mod.rs
@@ -42,6 +42,7 @@ pub fn generate_parser_in_directory(
     repo_path: &PathBuf,
     grammar_path: Option<&str>,
     properties_only: bool,
+    report_symbol_name: Option<&str>,
 ) -> Result<()> {
     let src_path = repo_path.join("src");
     let header_path = src_path.join("tree_sitter");
@@ -102,6 +103,7 @@ pub fn generate_parser_in_directory(
             lexical_grammar,
             inlines,
             simple_aliases,
+            report_symbol_name,
         )?;
 
         write_file(&src_path.join("parser.c"), c_code)?;
@@ -132,6 +134,7 @@ pub fn generate_parser_for_grammar(grammar_json: &str) -> Result<(String, String
         lexical_grammar,
         inlines,
         simple_aliases,
+        None,
     )?;
     Ok((input_grammar.name, parser.c_code))
 }
@@ -142,6 +145,7 @@ fn generate_parser_for_grammar_with_opts(
     lexical_grammar: LexicalGrammar,
     inlines: InlinedProductionMap,
     simple_aliases: AliasMap,
+    report_symbol_name: Option<&str>,
 ) -> Result<GeneratedParser> {
     let variable_info = node_types::get_variable_info(&syntax_grammar, &lexical_grammar, &inlines)?;
     let node_types_json = node_types::generate_node_types_json(
@@ -156,6 +160,7 @@ fn generate_parser_for_grammar_with_opts(
         &simple_aliases,
         &variable_info,
         &inlines,
+        report_symbol_name,
     )?;
     let c_code = render_c_code(
         name,

--- a/cli/src/generate/tables.rs
+++ b/cli/src/generate/tables.rs
@@ -1,7 +1,6 @@
 use super::nfa::CharacterSet;
-use super::rules::{Alias, Associativity, Symbol};
+use super::rules::{Alias, Associativity, Symbol, TokenSet};
 use std::collections::{BTreeMap, HashMap};
-
 pub(crate) type ProductionInfoId = usize;
 pub(crate) type ParseStateId = usize;
 pub(crate) type LexStateId = usize;
@@ -37,6 +36,7 @@ pub(crate) struct ParseState {
     pub terminal_entries: HashMap<Symbol, ParseTableEntry>,
     pub nonterminal_entries: HashMap<Symbol, ParseStateId>,
     pub lex_state_id: usize,
+    pub external_lex_state_id: usize,
     pub core_id: usize,
 }
 
@@ -58,6 +58,7 @@ pub(crate) struct ParseTable {
     pub symbols: Vec<Symbol>,
     pub production_infos: Vec<ProductionInfo>,
     pub max_aliased_production_length: usize,
+    pub external_lex_states: Vec<TokenSet>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/cli/src/generate/tables.rs
+++ b/cli/src/generate/tables.rs
@@ -94,6 +94,10 @@ impl Default for LexTable {
 }
 
 impl ParseState {
+    pub fn symbol_count(&self) -> usize {
+        self.terminal_entries.len() + self.nonterminal_entries.len()
+    }
+
     pub fn referenced_states<'a>(&'a self) -> impl Iterator<Item = ParseStateId> + 'a {
         self.terminal_entries
             .iter()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -39,6 +39,12 @@ fn run() -> error::Result<()> {
                 .arg(Arg::with_name("grammar-path").index(1))
                 .arg(Arg::with_name("log").long("log"))
                 .arg(Arg::with_name("properties-only").long("properties"))
+                .arg(
+                    Arg::with_name("report-states-for-rule")
+                        .long("report-states-for-rule")
+                        .value_name("rule-name")
+                        .takes_value(true),
+                )
                 .arg(Arg::with_name("no-minimize").long("no-minimize")),
         )
         .subcommand(
@@ -121,10 +127,22 @@ fn run() -> error::Result<()> {
     } else if let Some(matches) = matches.subcommand_matches("generate") {
         let grammar_path = matches.value_of("grammar-path");
         let properties_only = matches.is_present("properties-only");
+        let report_symbol_name = matches.value_of("report-states-for-rule").or_else(|| {
+            if matches.is_present("report-states") {
+                Some("")
+            } else {
+                None
+            }
+        });
         if matches.is_present("log") {
             logger::init();
         }
-        generate::generate_parser_in_directory(&current_dir, grammar_path, properties_only)?;
+        generate::generate_parser_in_directory(
+            &current_dir,
+            grammar_path,
+            properties_only,
+            report_symbol_name,
+        )?;
     } else if let Some(matches) = matches.subcommand_matches("test") {
         let debug = matches.is_present("debug");
         let debug_graph = matches.is_present("debug-graph");

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -38,6 +38,7 @@ fn run() -> error::Result<()> {
                 .about("Generate a parser")
                 .arg(Arg::with_name("grammar-path").index(1))
                 .arg(Arg::with_name("log").long("log"))
+                .arg(Arg::with_name("next-abi").long("next-abi"))
                 .arg(Arg::with_name("properties-only").long("properties"))
                 .arg(
                     Arg::with_name("report-states-for-rule")
@@ -137,10 +138,12 @@ fn run() -> error::Result<()> {
         if matches.is_present("log") {
             logger::init();
         }
+        let next_abi = matches.is_present("next-abi");
         generate::generate_parser_in_directory(
             &current_dir,
             grammar_path,
             properties_only,
+            next_abi,
             report_symbol_name,
         )?;
     } else if let Some(matches) = matches.subcommand_matches("test") {

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -591,5 +591,5 @@ extern "C" {
     pub fn ts_language_version(arg1: *const TSLanguage) -> u32;
 }
 
-pub const TREE_SITTER_LANGUAGE_VERSION: usize = 10;
+pub const TREE_SITTER_LANGUAGE_VERSION: usize = 11;
 pub const TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION: usize = 9;

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -14,7 +14,7 @@ extern "C" {
 /* Section - ABI Versioning */
 /****************************/
 
-#define TREE_SITTER_LANGUAGE_VERSION 10
+#define TREE_SITTER_LANGUAGE_VERSION 11
 #define TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION 9
 
 /*******************/

--- a/lib/include/tree_sitter/parser.h
+++ b/lib/include/tree_sitter/parser.h
@@ -114,6 +114,9 @@ struct TSLanguage {
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const char **field_names;
+  uint32_t large_state_count;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
 };
 
 /*
@@ -154,6 +157,8 @@ struct TSLanguage {
 /*
  *  Parse Table Macros
  */
+
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
 
 #define STATE(id) id
 

--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -11,7 +11,7 @@ void ts_language_table_entry(const TSLanguage *self, TSStateId state,
     result->actions = NULL;
   } else {
     assert(symbol < self->token_count);
-    uint32_t action_index = self->parse_table[state * self->symbol_count + symbol];
+    uint32_t action_index = ts_language_lookup(self, state, symbol);
     const TSParseActionEntry *entry = &self->parse_actions[action_index];
     result->action_count = entry->count;
     result->is_reusable = entry->reusable;


### PR DESCRIPTION
### Background

Currently, Tree-sitter's parse table is represented as a two-dimensional array of `uint16_t` values (which represent either action ids or successor state ids), indexed by parse state and by lookahead symbol.

```c
static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
  [0] = {
    sym_identifier = ACTIONS(250),
    anon_sym_LBRACE = ACTIONS(251),
    sym_expression = STATE(102),

    // ...
  },

  // ...
};
```

### Problem

With many parsers having around 2000 states and 200 symbols, this array occupies a significant amount of statically-allocated memory. I wrote a script to display the sizes of each symbol in a Tree-sitter parser binary:

```sh
$ ./script/show-symbol-sizes ~/.tree-sitter/bin/javascript.so

total                                                            	 1034.8 kb
_ts_parse_table                                                  	 931.6 kb
_ts_parse_actions                                                	 40.1 kb
_ts_lex                                                          	 34.6 kb
_ts_lex_modes                                                    	 8.4 kb
_ts_lex_keywords                                                 	 7.4 kb
_ts_alias_sequences                                              	 4.7 kb

# ...
```

### Solution

A lot of states in this table are *sparse* - they have very few valid lookahead symbols. This means that we can save space by representing them in a different way.

In this PR, I've introduced the notion of *small parse states*. These states are represented as arrays of (`lookahead`, `value`) pairs instead of as arrays of size `SYMBOL_COUNT`, indexed by lookahead. 

```c
static uint16_t ts_small_parse_table[] = {
  [0] = 3,
    sym_identifier, ACTIONS(1306),
    anon_sym_extern, ACTIONS(27),
    anon_sym_static, ACTIONS(27),
  [7] = 2,
    sym_comment, ACTIONS(3),
    sym_parenthesized_expression, STATE(102),

  // ...
};
```

The small parse states are all stored in a single 1-D array. The *starting index* of each small state is stored in a separate array:

```c
static uint32_t ts_small_parse_table_map[] = {
  [SMALL_STATE(385)] = 0,
  [SMALL_STATE(386)] = 97,
  [SMALL_STATE(387)] = 194,

  // ...
};
```

So the procedure for *looking* up a value in the parse table [now](https://github.com/tree-sitter/tree-sitter/blob/8af0afac2eb2cf644e5d7a029647e55c3c48e4a4/lib/src/language.h#L55-L77) has a little bit of conditional logic.

### Results

This reduces the size of language binaries (and their static memory footprint) by 50% to 75%:

```sh
 $ ./script/show-symbol-sizes ~/.tree-sitter/bin/javascript.so
total                                                            	 570.9 kb
_ts_parse_table                                                  	 362.4 kb
_ts_small_parse_table                                            	 99.7 kb
_ts_parse_actions                                                	 40.1 kb
# ...
```

In Python, the *majority* of parse states are actually *small*, so there's more than a 50% savings:

```sh
$ ./script/show-symbol-sizes ~/.tree-sitter/bin/python.so
total                                                            	 339.5 kb
_ts_small_parse_table                                            	 217.3 kb
_ts_parse_actions                                                	 39.3 kb
_ts_parse_table                                                  	 24.9 kb
```

### Notes

* **ABI versioning** - This PR entails another backward-compatible ABI change, so I've bumped `TREE_SITTER_LANGUAGE_VERSION` up to 11. But the library will still be able to *load* parsers that were compiled with ABI version 9 and up, so the transition will be easy to manage.

* **Runtime cost** - This change doesn't make a measurable difference in parsing speed. The symbols within a small parse state are ordered, so we *could* search them using a binary search, but for small arrays, I'm not sure it's worth it. Currently I just use a linear search with an early `break` based on the ordering.

* **WASM** - Unfortunately, the *gzipped* size of the binaries is not really affected by this change. Some binaries gzip *slightly* smaller, and some have actually gotten slightly larger. On average, they remain around 70k gzipped. Still, I think the memory savings are worthwhile in their own right.

🎩 to @marijnh for pointing out how much room for optimization exists due to sparse parse states.