### PR TITLE
Make ts_tree_delete and ts_parser_delete NULL-safe.

### DIFF
--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -1525,6 +1525,8 @@ TSParser *ts_parser_new(void) {
 }
 
 void ts_parser_delete(TSParser *self) {
+  if (!self) return;
+
   ts_stack_delete(self->stack);
   if (self->reduce_actions.contents) {
     array_delete(&self->reduce_actions);

--- a/lib/src/tree.c
+++ b/lib/src/tree.c
@@ -29,6 +29,8 @@ TSTree *ts_tree_copy(const TSTree *self) {
 }
 
 void ts_tree_delete(TSTree *self) {
+  if (!self) return;
+
   SubtreePool pool = ts_subtree_pool_new(0);
   ts_subtree_release(&pool, self->root);
   ts_subtree_pool_delete(&pool);


### PR DESCRIPTION
Historically, `free(3)`-style functions have been NULL-safe, to make
resource handling functions more robust. This doesn't seem to be the
case with tree-sitter's `ts_tree_delete` and `ts_parser_delete` C
functions, which immediately dereference the passed pointer. This
leads to complexity in client libraries that have to ensure that trees
and parsers are cleaned up correctly.

This patch adds NULL checks to `parse_delete` and `tree_delete`. They
should have negligable performance impacts, since null checks are fast.

I didn't change the internal _delete functions, as arguably those
being NULL-unsafe is a feature, not a bug. If there are other places 
where these checks should occur (or if there are some objections to this),
let me know.