### PR TITLE
Ensure TypeScript bindings are published to npm

### DIFF
--- a/lib/binding_web/.npmignore
+++ b/lib/binding_web/.npmignore
@@ -2,3 +2,4 @@
 !README.md
 !tree-sitter.js
 !tree-sitter.wasm
+!tree-sitter-web.d.ts


### PR DESCRIPTION
As mentioned in https://github.com/tree-sitter/tree-sitter/issues/344#issuecomment-497809222, TypeScript definitions were added in #342 but aren't being published to npm.

See https://unpkg.com/web-tree-sitter@0.15.4/tree-sitter-web.d.ts

I confirmed this worked locally via `npm pack`