### PR TITLE
Fix ALLOW_MEMORY_GROWTH setting

### DIFF
--- a/script/build-wasm
+++ b/script/build-wasm
@@ -84,7 +84,7 @@ mkdir -p target/scratch
 $emcc                                \
   -s WASM=1                          \
   -s TOTAL_MEMORY=33554432           \
-  -s ALLOW_MEMORY_GROWTH             \
+  -s ALLOW_MEMORY_GROWTH=1           \
   -s MAIN_MODULE=2                   \
   -s NO_FILESYSTEM=1                 \
   -s "EXPORTED_FUNCTIONS=${exports}" \


### PR DESCRIPTION
Fixes `ERROR:root:ALLOW_MEMORY_GROWTH: No such file or directory ("ALLOW_MEMORY_GROWTH" was expected to be an input file, based on the commandline arguments provided)` according to https://emscripten.org/docs/optimizing/Optimizing-Code.html#memory-growth

I'm on macOS so that could be why I experienced this and CI didn't.