### PR TITLE
Create ts_tree_cursor_copy function

### DIFF
--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -593,6 +593,8 @@ bool ts_tree_cursor_goto_first_child(TSTreeCursor *);
  * if no such child was found.
  */
 int64_t ts_tree_cursor_goto_first_child_for_byte(TSTreeCursor *, uint32_t);
+    
+TSTreeCursor ts_tree_cursor_copy(const TSTreeCursor *);
 
 /**********************/
 /* Section - Language */

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -86,6 +86,16 @@ typedef struct {
   const void *id;
   uint32_t context[2];
 } TSTreeCursor;
+    
+typedef struct {
+    void *parent;
+    void *parent_alias_sequence;
+    void *subtree;
+    uint32_t byte_offset;
+    uint32_t child_index;
+    uint32_t structural_child_index;
+} TSZipper;
+
 
 /********************/
 /* Section - Parser */
@@ -646,6 +656,22 @@ TSSymbolType ts_language_symbol_type(const TSLanguage *, TSSymbol);
  * See also `ts_parser_set_language`.
  */
 uint32_t ts_language_version(const TSLanguage *);
+    
+
+
+    
+void ts_zipper_new(TSTree *tree, TSZipper *result);
+
+bool ts_zipper_right(const TSZipper *zip, TSZipper *result);
+
+bool ts_zipper_down(const TSZipper *zip, TSZipper *result, TSLanguage *lang);
+    
+TSZipper *ts_zipper_up(const TSZipper *zip);
+
+TSSymbol ts_zipper_node_type(const TSZipper *zip);
+uint32_t ts_zipper_start_byte(const TSZipper *zip);
+uint32_t ts_zipper_end_byte(const TSZipper *zip);
+
 
 #ifdef __cplusplus
 }

--- a/lib/src/lib.c
+++ b/lib/src/lib.c
@@ -18,3 +18,4 @@
 #include "./tree.c"
 #include "./utf16.c"
 #include "utf8proc.c"
+#include "zipper.c"

--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -291,3 +291,12 @@ const char *ts_tree_cursor_current_field_name(const TSTreeCursor *_self) {
     return NULL;
   }
 }
+
+TSTreeCursor ts_tree_cursor_copy(const TSTreeCursor *_cursor) {
+    const TreeCursor *cursor = (const TreeCursor *)_cursor;
+    TSTreeCursor res = {NULL, NULL, {0, 0}};
+    TreeCursor *copy = (TreeCursor *)&res;
+    copy->tree = cursor->tree;
+    array_push_all(&copy->stack, &cursor->stack);
+    return res;
+}

--- a/lib/src/zipper.c
+++ b/lib/src/zipper.c
@@ -1,0 +1,146 @@
+//
+//  zipper.c
+//  jsitter
+//
+//  Created by Andrey Zaytsev on 12.06.19.
+//
+
+#include "tree_sitter/api.h"
+#include "./alloc.h"
+#include "./language.h"
+#include "./tree.h"
+
+typedef struct _TSZipper {
+    const struct _TSZipper *parent;
+    const TSSymbol *parent_alias_sequence;
+    Subtree subtree;
+    uint32_t byte_offset;
+    uint32_t child_index;
+    uint32_t structural_child_index;
+} _TSZipper;
+
+bool __is_visible(_TSZipper *zip) {
+    if (ts_subtree_visible(zip->subtree)) {
+        return true;
+    } else {
+        bool extra = ts_subtree_extra(zip->subtree);
+        if (!extra && zip->parent_alias_sequence) {
+            return zip->parent_alias_sequence[zip->structural_child_index];
+        } else {
+            return false;
+        }
+    }
+}
+
+bool __ts_zipper_right(const _TSZipper *zip, _TSZipper *result) {
+    if (!zip->parent) {
+        return false;
+    }
+    Subtree parent_subtree = zip->parent->subtree;
+    if (zip->child_index == parent_subtree.ptr->child_count - 1) {
+        return false;
+    }
+    const Subtree sibling = parent_subtree.ptr->children[zip->child_index + 1];
+    
+    bool extra = ts_subtree_extra(zip->subtree);
+    uint32_t structural_child_index;
+    if (!extra && zip->parent_alias_sequence) {
+        structural_child_index = zip->structural_child_index + 1;
+    } else {
+        structural_child_index = zip->structural_child_index;
+    }
+    
+    *result = (_TSZipper) {
+        .parent = zip->parent,
+        .parent_alias_sequence = zip->parent_alias_sequence,
+        .subtree = sibling,
+        .byte_offset = ts_subtree_size(zip->subtree).bytes + ts_subtree_padding(sibling).bytes,
+        .child_index = zip->child_index + 1,
+        .structural_child_index = structural_child_index
+    };
+    return true;
+}
+
+bool _ts_zipper_right(const _TSZipper *zip, _TSZipper *result) {
+    while (__ts_zipper_right(zip, result)) {
+        if (__is_visible(result)) {
+            return true;
+        }
+        zip = result;
+    }
+    return false;
+}
+
+bool _ts_zipper_down(const _TSZipper *zip, _TSZipper *result, TSLanguage *lang) {
+    if (ts_subtree_child_count(zip->subtree) == 0) {
+        return false;
+    } else {
+        Subtree child = zip->subtree.ptr->children[0];
+        const TSSymbol *alias_sequence = ts_language_alias_sequence(lang, zip->subtree.ptr->production_id);
+        *result = (_TSZipper) {
+            .parent = zip,
+            .parent_alias_sequence = alias_sequence,
+            .subtree = child,
+            .byte_offset = zip->byte_offset,
+            .child_index = 0,
+            .structural_child_index = 0
+        };
+        if (__is_visible(result)) {
+            return true;
+        } else {
+            uint32_t visible_child_count = ts_subtree_visible_child_count(child);
+            if (visible_child_count > 0) {
+                _TSZipper *z = (_TSZipper *)malloc(sizeof(_TSZipper));
+                *z = *result;
+                return _ts_zipper_down(z, result, lang);
+            } else {
+                return _ts_zipper_right(result, result);
+            }
+        }
+    }
+}
+
+void _ts_zipper_new(TSTree *tree, _TSZipper *result) {
+    *result = (_TSZipper) {
+        .parent = NULL,
+        .parent_alias_sequence = NULL,
+        .subtree = tree->root,
+        .byte_offset = 0,
+        .child_index = 0,
+        .structural_child_index = 0
+    };
+}
+
+void ts_zipper_new(TSTree *tree, TSZipper *result) {
+    return _ts_zipper_new(tree, (_TSZipper *)result);
+}
+
+bool ts_zipper_right(const TSZipper *zip, TSZipper *result) {
+    return _ts_zipper_right((_TSZipper *)zip, (_TSZipper *)result);
+}
+
+bool ts_zipper_down(const TSZipper *zip, TSZipper *result, TSLanguage *lang) {
+    return _ts_zipper_down((_TSZipper *)zip, (_TSZipper *)result, lang);
+}
+
+
+
+TSSymbol ts_zipper_node_type(const TSZipper *zip) {
+    _TSZipper *z = (_TSZipper *)zip;
+    return ts_subtree_symbol(z->subtree);
+}
+
+uint32_t ts_zipper_start_byte(const TSZipper *zip) {
+    return zip->byte_offset;
+}
+
+uint32_t ts_zipper_end_byte(const TSZipper *zip) {
+    _TSZipper *z = (_TSZipper *) zip;
+    return z->byte_offset + ts_subtree_size(z->subtree).bytes;
+}
+
+TSZipper *ts_zipper_up(const TSZipper *zip) {
+    return (TSZipper *)(((_TSZipper *)zip)->parent);
+}
+
+

--- a/lib/src/zipper.c
+++ b/lib/src/zipper.c
@@ -100,11 +100,11 @@ bool _ts_zipper_down(const _TSZipper *zip, _TSZipper *result, TSLanguage *lang) 
     }
 }
 
-void _ts_zipper_new(TSTree *tree, _TSZipper *result) {
+void _ts_zipper_new(Subtree tree, _TSZipper *result) {
     *result = (_TSZipper) {
         .parent = NULL,
         .parent_alias_sequence = NULL,
-        .subtree = tree->root,
+        .subtree = tree,
         .byte_offset = 0,
         .child_index = 0,
         .structural_child_index = 0
@@ -112,7 +112,7 @@ void _ts_zipper_new(TSTree *tree, _TSZipper *result) {
 }
 
 void ts_zipper_new(TSTree *tree, TSZipper *result) {
-    return _ts_zipper_new(tree, (_TSZipper *)result);
+    return _ts_zipper_new(tree->root, (_TSZipper *)result);
 }
 
 bool ts_zipper_right(const TSZipper *zip, TSZipper *result) {


### PR DESCRIPTION
It is impossible to implement this function in user-space using existing functions without breaking encapsulation of TSTreeCursor. 
Sometimes it is useful to save current position in tree and `ts_tree_cursor_new` will not do the trick because cursor created for some node will not be able to ascend to it's parent with `ts_tree_cursor_goto_parent`