### PR TITLE
Don't use `clock_gettime` on macOS

### DIFF
--- a/lib/src/clock.h
+++ b/lib/src/clock.h
@@ -48,9 +48,9 @@ static inline bool clock_is_gt(TSClock self, TSClock other) {
   return self > other;
 }
 
-#elif defined(CLOCK_MONOTONIC)
+#elif defined(CLOCK_MONOTONIC) && !defined(__APPLE__)
 
-// POSIX with monotonic clock support (Linux, macOS >= 10.12)
+// POSIX with monotonic clock support (Linux)
 // * Represent a time as a monotonic (seconds, nanoseconds) pair.
 // * Represent a duration as a number of microseconds.
 //
@@ -97,7 +97,7 @@ static inline bool clock_is_gt(TSClock self, TSClock other) {
 
 #else
 
-// POSIX without monotonic clock support
+// macOS or POSIX without monotonic clock support
 // * Represent a time as a process clock value.
 // * Represent a duration as a number of process clock ticks.
 //


### PR DESCRIPTION
This pull request stops using the monotonic clock API on macOS because it is supported only on macOS >= 10.12. Instead, it uses the fallback clock APIs for platforms without monotonic clock support.

The use of `clock_gettime` was causing issues on Atom because, even though we build it on a new macOS version supporting such API, some users may run Atom on older versions of macOS. On those platforms, Atom would crash whenever opening a file parsed with a tree-sitter grammar.