### PR TITLE
Ts tree cursor copy

### DIFF
--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -593,6 +593,8 @@ bool ts_tree_cursor_goto_first_child(TSTreeCursor *);
  * if no such child was found.
  */
 int64_t ts_tree_cursor_goto_first_child_for_byte(TSTreeCursor *, uint32_t);
+    
+TSTreeCursor ts_tree_cursor_copy(const TSTreeCursor *);
 
 /**********************/
 /* Section - Language */

--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -293,10 +293,10 @@ const char *ts_tree_cursor_current_field_name(const TSTreeCursor *_self) {
 }
 
 TSTreeCursor ts_tree_cursor_copy(const TSTreeCursor *_cursor) {
-    const TreeCursor *cursor = (const TreeCursor *)_cursor;
-    TSTreeCursor res = {NULL, NULL, {0, 0}};
-    TreeCursor *copy = (TreeCursor *)&res;
-    copy->tree = cursor->tree;
-    array_push_all(&copy->stack, &cursor->stack);
-    return res;
+  const TreeCursor *cursor = (const TreeCursor *)_cursor;
+  TSTreeCursor res = {NULL, NULL, {0, 0}};
+  TreeCursor *copy = (TreeCursor *)&res;
+  copy->tree = cursor->tree;
+  array_push_all(&copy->stack, &cursor->stack);
+  return res;
 }

--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -291,3 +291,12 @@ const char *ts_tree_cursor_current_field_name(const TSTreeCursor *_self) {
     return NULL;
   }
 }
+
+TSTreeCursor ts_tree_cursor_copy(const TSTreeCursor *_cursor) {
+    const TreeCursor *cursor = (const TreeCursor *)_cursor;
+    TSTreeCursor res = {NULL, NULL, {0, 0}};
+    TreeCursor *copy = (TreeCursor *)&res;
+    copy->tree = cursor->tree;
+    array_push_all(&copy->stack, &cursor->stack);
+    return res;
+}


### PR DESCRIPTION
It is impossible to implement this function in user-space using existing functions without breaking encapsulation of TSTreeCursor.
Sometimes it is useful to save current position in tree and ts_tree_cursor_new will not do the trick because cursor created for some node will not be able to ascend to it's parent with ts_tree_cursor_goto_parent