### PR TITLE
Include info about children w/o fields in node-types.json

### DIFF
--- a/cli/src/generate/build_tables/item.rs
+++ b/cli/src/generate/build_tables/item.rs
@@ -272,7 +272,9 @@ impl<'a> ParseItemSet<'a> {
     }
 
     pub fn core(&self) -> ParseItemSetCore<'a> {
-        ParseItemSetCore { entries: self.entries.iter().map(|e| e.0).collect() }
+        ParseItemSetCore {
+            entries: self.entries.iter().map(|e| e.0).collect(),
+        }
     }
 }
 

--- a/cli/src/generate/grammars.rs
+++ b/cli/src/generate/grammars.rs
@@ -2,7 +2,7 @@ use super::nfa::Nfa;
 use super::rules::{Alias, Associativity, Rule, Symbol};
 use hashbrown::HashMap;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum VariableType {
     Hidden,
     Auxiliary,

--- a/cli/src/generate/grammars.rs
+++ b/cli/src/generate/grammars.rs
@@ -64,6 +64,7 @@ pub(crate) struct Production {
     pub dynamic_precedence: i32,
 }
 
+#[derive(Default)]
 pub(crate) struct InlinedProductionMap {
     pub productions: Vec<Production>,
     pub production_map: HashMap<(*const Production, u32), Vec<usize>>,

--- a/cli/src/generate/mod.rs
+++ b/cli/src/generate/mod.rs
@@ -97,7 +97,7 @@ fn generate_parser_for_grammar_with_opts(
     let input_grammar = parse_grammar(grammar_json)?;
     let (syntax_grammar, lexical_grammar, inlines, simple_aliases) =
         prepare_grammar(&input_grammar)?;
-    let variable_info = node_types::get_variable_info(&syntax_grammar, &lexical_grammar)?;
+    let variable_info = node_types::get_variable_info(&syntax_grammar, &lexical_grammar, &inlines)?;
     let node_types_json = node_types::generate_node_types_json(
         &syntax_grammar,
         &lexical_grammar,

--- a/cli/src/generate/node_types.rs
+++ b/cli/src/generate/node_types.rs
@@ -668,6 +668,85 @@ mod tests {
     }
 
     #[test]
+    fn test_node_types_for_children_without_fields() {
+        let node_types = get_node_types(InputGrammar {
+            name: String::new(),
+            extra_tokens: Vec::new(),
+            external_tokens: Vec::new(),
+            expected_conflicts: Vec::new(),
+            variables_to_inline: Vec::new(),
+            word_token: None,
+            supertype_symbols: vec![],
+            variables: vec![
+                Variable {
+                    name: "v1".to_string(),
+                    kind: VariableType::Named,
+                    rule: Rule::seq(vec![
+                        Rule::named("v2"),
+                        Rule::field("f1".to_string(), Rule::named("v3")),
+                        Rule::named("v4")
+                    ]),
+                },
+                Variable {
+                    name: "v2".to_string(),
+                    kind: VariableType::Named,
+                    rule: Rule::string("x"),
+                },
+                Variable {
+                    name: "v3".to_string(),
+                    kind: VariableType::Named,
+                    rule: Rule::string("x"),
+                },
+                Variable {
+                    name: "v4".to_string(),
+                    kind: VariableType::Named,
+                    rule: Rule::string("x"),
+                },
+            ],
+        });
+
+        assert_eq!(
+            node_types[0],
+            NodeInfoJSON {
+                kind: "v1".to_string(),
+                named: true,
+                subtypes: None,
+                children: Some(FieldInfoJSON {
+                    multiple: true,
+                    required: false,
+                    types: vec![
+                        NodeTypeJSON {
+                            kind: "v2".to_string(),
+                            named: true,
+                        },
+                        NodeTypeJSON {
+                            kind: "v4".to_string(),
+                            named: true,
+                        },
+                    ]
+                }),
+                fields: Some(
+                    vec![
+                        (
+                            "f1".to_string(),
+                            FieldInfoJSON {
+                                multiple: false,
+                                required: true,
+                                types: vec![NodeTypeJSON {
+                                    kind: "v3".to_string(),
+                                    named: true,
+                                }]
+                            }
+                        ),
+                    ]
+                    .into_iter()
+                    .collect()
+                )
+            }
+        );
+    }
+
+    #[test]
     fn test_get_variable_info() {
         let variable_info = get_variable_info(
             &build_syntax_grammar(

--- a/cli/src/generate/node_types.rs
+++ b/cli/src/generate/node_types.rs
@@ -523,14 +523,17 @@ pub(crate) fn generate_node_types_json(
             }
             node_type_json.fields = Some(fields_json);
             if info.child_types_without_fields.len() > 0 {
+                let mut children_types = info
+                    .child_types_without_fields
+                    .iter()
+                    .map(child_type_to_node_type)
+                    .collect::<Vec<_>>();
+                children_types.sort_unstable();
+                children_types.dedup();
                 node_type_json.children = Some(FieldInfoJSON {
                     multiple: true,
                     required: false,
-                    types: info
-                        .child_types_without_fields
-                        .iter()
-                        .map(child_type_to_node_type)
-                        .collect(),
+                    types: children_types,
                 });
             }
         }


### PR DESCRIPTION
This PR adds a new property called `children` to the node type descriptions in the generated `node-types.json` file. For a given type of syntax node, the `children` property describes the set of named children that do *not* have fields.

/cc @robrix 