### PR TITLE
Use Z option for docker-run volume mount

### DIFF
--- a/cli/src/wasm.rs
+++ b/cli/src/wasm.rs
@@ -33,12 +33,12 @@ pub fn compile_language_to_wasm(language_dir: &Path, force_docker: bool) -> Resu
         let mut volume_string;
         if let (Some(parent), Some(filename)) = (language_dir.parent(), language_dir.file_name()) {
             volume_string = OsString::from(parent);
-            volume_string.push(":/src");
+            volume_string.push(":/src:Z");
             command.arg("--workdir");
             command.arg(&Path::new("/src").join(filename));
         } else {
             volume_string = OsString::from(language_dir);
-            volume_string.push(":/src");
+            volume_string.push(":/src:Z");
             command.args(&["--workdir", "/src"]);
         }
 

--- a/script/build-wasm
+++ b/script/build-wasm
@@ -67,7 +67,7 @@ if which emcc > /dev/null && [[ "$force_docker" == "0" ]]; then
 elif which docker > /dev/null; then
   emcc="docker run               \
     --rm                         \
-    -v $(pwd):/src               \
+    -v $(pwd):/src:Z             \
     -u $(id -u)                  \
     -e EMCC_FORCE_STDLIBS=libc++ \
     trzeci/emscripten-slim       \


### PR DESCRIPTION
### Summary

This is necessary on systems with SELinux to prevent file permission/access errors when building WASM output.

I made these changes so that I could locally debug (on Fedora 30) some Travis-CI build failures[1] during `script/test-wasm`, and I am able to locally reproduce them with these changes.

### Detailed changes

 * cli/src/wasm.rs: Use Z volume mount option for docker-run
 * script/build-wasm: Likewise.

[1] https://travis-ci.org/tree-sitter/tree-sitter/jobs/552175504#L1452