### PR TITLE
Refine "sloppy brackets" handling

### DIFF
--- a/cli/src/generate/prepare_grammar/expand_tokens.rs
+++ b/cli/src/generate/prepare_grammar/expand_tokens.rs
@@ -685,12 +685,15 @@ mod tests {
                     Rule::pattern(r#"\{[ab]{3}\}"#),
                     // Unicode codepoints
                     Rule::pattern(r#"\u{1000A}"#),
+                    // This isn't a repetition
+                    Rule::pattern(r#"{DEADBEEF}"#),
                 ],
                 separators: vec![],
                 examples: vec![
                     ("u{1234} ok", Some((0, "u{1234}"))),
                     ("{aba}}", Some((1, "{aba}"))),
                     ("\u{1000A}", Some((2, "\u{1000A}"))),
+                    ("{DEADBEEF}", Some((3, "{DEADBEEF}"))),
                 ],
             },
         ];


### PR DESCRIPTION
Closes #380.

A better approach would be to write a "sloppy" parser to `regex_syntax::Ast` to use instead of the "strict" one provided, but for now, this adjusts the regex mangling to more precisely target brackets which would be rejected by the strict parser but accepted by the JS regex engine.

I've attempted to make the regex somewhat approachable, but this pushes the edge of regex's usability.