### PR TITLE
Use regex Hir instead of regex Ast

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -74,6 +74,12 @@ impl From<regex_syntax::ast::Error> for Error {
     }
 }
 
+impl From<regex_syntax::Error> for Error {
+    fn from(error: regex_syntax::Error) -> Self {
+        Error::new(error.to_string())
+    }
+}
+
 impl From<String> for Error {
     fn from(error: String) -> Self {
         Error::new(error)

--- a/cli/src/generate/nfa.rs
+++ b/cli/src/generate/nfa.rs
@@ -7,6 +7,7 @@ use std::mem::swap;
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum CharacterSet {
     Include(Vec<char>),
+    #[allow(dead_code)]
     Exclude(Vec<char>),
 }
 
@@ -55,6 +56,7 @@ impl CharacterSet {
         CharacterSet::Include(Vec::new())
     }
 
+    #[allow(dead_code)]
     pub fn negate(self) -> CharacterSet {
         match self {
             CharacterSet::Include(chars) => CharacterSet::Exclude(chars),
@@ -77,7 +79,9 @@ impl CharacterSet {
         if let CharacterSet::Include(mut chars) = self {
             let mut c = start as u32;
             while c <= end as u32 {
-                chars.push(char::from_u32(c).unwrap());
+                if let Some(c) = char::from_u32(c) {
+                    chars.push(c);
+                }
                 c += 1;
             }
             chars.sort_unstable();

--- a/cli/src/generate/prepare_grammar/expand_tokens.rs
+++ b/cli/src/generate/prepare_grammar/expand_tokens.rs
@@ -685,12 +685,15 @@ mod tests {
                     Rule::pattern(r#"\{[ab]{3}\}"#),
                     // Unicode codepoints
                     Rule::pattern(r#"\u{1000A}"#),
+                    // This isn't a repetition
+                    Rule::pattern(r#"{DEADBEEF}"#),
                 ],
                 separators: vec![],
                 examples: vec![
                     ("u{1234} ok", Some((0, "u{1234}"))),
                     ("{aba}}", Some((1, "{aba}"))),
                     ("\u{1000A}", Some((2, "\u{1000A}"))),
+                    ("{DEADBEEF}", Some((3, "{DEADBEEF}"))),
                 ],
             },
         ];


### PR DESCRIPTION
This is mainly a proof-of-concept to move to using `regex_syntax::Ast` instead of `regex_syntax::Hir`. This enables all of the "fancy" regex features provided by the regex crate "for free", as they get translated into the simpler Hir language.

This includes #381 because it's most useful with it.

A lot of regexes will suddenly accept a _lot_ more things because of unicode-aware translation, so I suspect this will very unacceptably regress performance until `CharacterSet` uses a strategy similar to [`ClassUnicode`](https://docs.rs/regex-syntax/0.6.8/regex_syntax/hir/struct.ClassUnicode.html) wherein ranges are stored rather than every single character. Especially since, uh, this translates negated sets into positive ones.