### PR TITLE
Use regex Hir instead of regex Ast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,6 +727,7 @@ dependencies = [
  "tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tree-sitter 0.3.10",
  "tree-sitter-highlight 0.1.6",
+ "unic-char-range 0.9.0 (git+https://github.com/open-i18n/rust-unic/?branch=CAD97-patch-1)",
  "webbrowser 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -745,6 +746,11 @@ dependencies = [
 name = "ucd-util"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unic-char-range"
+version = "0.9.0"
+source = "git+https://github.com/open-i18n/rust-unic/?branch=CAD97-patch-1#639815504c0ee5a68d19b4b225fdb85ff3a5a8ee"
 
 [[package]]
 name = "unicode-bidi"
@@ -931,6 +937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1661fa0a44c95d01604bd05c66732a446c657efb62b5164a7a083a3b552b4951"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
+"checksum unic-char-range 0.9.0 (git+https://github.com/open-i18n/rust-unic/?branch=CAD97-patch-1)" = "<none>"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ members = [
     "cli",
     "lib",
 ]
+
+[patch.'crates-io']
+unic-char-range = { git = "https://github.com/open-i18n/rust-unic/", branch = "CAD97-patch-1" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -35,6 +35,7 @@ regex = "1"
 rsass = "^0.9.8"
 tiny_http = "0.6"
 webbrowser = "0.5.1"
+unic-char-range = "0.9.0"
 
 [dependencies.tree-sitter]
 version = ">= 0.3.7"

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -74,6 +74,12 @@ impl From<regex_syntax::ast::Error> for Error {
     }
 }
 
+impl From<regex_syntax::Error> for Error {
+    fn from(error: regex_syntax::Error) -> Self {
+        Error::new(error.to_string())
+    }
+}
+
 impl From<String> for Error {
     fn from(error: String) -> Self {
         Error::new(error)

--- a/cli/src/generate/build_tables/mod.rs
+++ b/cli/src/generate/build_tables/mod.rs
@@ -14,7 +14,7 @@ use self::minimize_parse_table::minimize_parse_table;
 use self::token_conflicts::TokenConflictMap;
 use crate::error::Result;
 use crate::generate::grammars::{InlinedProductionMap, LexicalGrammar, SyntaxGrammar};
-use crate::generate::nfa::{CharacterSet, NfaCursor};
+use crate::generate::nfa::NfaCursor;
 use crate::generate::node_types::VariableInfo;
 use crate::generate::rules::{AliasMap, Symbol, SymbolType};
 use crate::generate::tables::{LexTable, ParseAction, ParseTable, ParseTableEntry};
@@ -348,10 +348,8 @@ fn all_chars_are_alphabetical(cursor: &NfaCursor) -> bool {
     cursor.transition_chars().all(|(chars, is_sep)| {
         if is_sep {
             true
-        } else if let CharacterSet::Include(chars) = chars {
-            chars.iter().all(|c| c.is_alphabetic() || *c == '_')
         } else {
-            false
+            chars.iter().all(|c| c.is_alphabetic() || c == '_')
         }
     })
 }

--- a/cli/src/generate/nfa.rs
+++ b/cli/src/generate/nfa.rs
@@ -7,6 +7,7 @@ use std::mem::swap;
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum CharacterSet {
     Include(Vec<char>),
+    #[allow(dead_code)]
     Exclude(Vec<char>),
 }
 
@@ -55,6 +56,7 @@ impl CharacterSet {
         CharacterSet::Include(Vec::new())
     }
 
+    #[allow(dead_code)]
     pub fn negate(self) -> CharacterSet {
         match self {
             CharacterSet::Include(chars) => CharacterSet::Exclude(chars),
@@ -77,7 +79,9 @@ impl CharacterSet {
         if let CharacterSet::Include(mut chars) = self {
             let mut c = start as u32;
             while c <= end as u32 {
-                chars.push(char::from_u32(c).unwrap());
+                if let Some(c) = char::from_u32(c) {
+                    chars.push(c);
+                }
                 c += 1;
             }
             chars.sort_unstable();

--- a/cli/src/generate/prepare_grammar/expand_tokens.rs
+++ b/cli/src/generate/prepare_grammar/expand_tokens.rs
@@ -685,12 +685,15 @@ mod tests {
                     Rule::pattern(r#"\{[ab]{3}\}"#),
                     // Unicode codepoints
                     Rule::pattern(r#"\u{1000A}"#),
+                    // This isn't a repetition
+                    Rule::pattern(r#"{DEADBEEF}"#),
                 ],
                 separators: vec![],
                 examples: vec![
                     ("u{1234} ok", Some((0, "u{1234}"))),
                     ("{aba}}", Some((1, "{aba}"))),
                     ("\u{1000A}", Some((2, "\u{1000A}"))),
+                    ("{DEADBEEF}", Some((3, "{DEADBEEF}"))),
                 ],
             },
         ];

--- a/cli/src/generate/prepare_grammar/expand_tokens.rs
+++ b/cli/src/generate/prepare_grammar/expand_tokens.rs
@@ -234,14 +234,14 @@ impl NfaBuilder {
                     Literal::Unicode(c) => *c,
                     Literal::Byte(_) => unreachable!("all regex are utf8-correct"),
                 };
-                self.push_advance(CharacterSet::Include(vec![c]), next_state_id);
+                self.push_advance(CharacterSet::singleton(c), next_state_id);
                 Ok(true)
             }
             HirKind::Class(class) => {
                 let chars = self.expand_character_class(class)?;
                 self.push_advance(chars, next_state_id);
                 Ok(true)
-            },
+            }
             HirKind::Anchor(_) => Err(Error::regex("Anchors are not supported")),
             HirKind::WordBoundary(_) => Err(Error::regex("Word boundaries are not supported")),
             HirKind::Repetition(repetition) => {
@@ -267,7 +267,8 @@ impl NfaBuilder {
                             }
                         }
                         HirRepetitionKind::Range(HirRepetitionRange::Bounded(min, max)) => {
-                            let mut result = self.expand_count(&repetition.hir, min, next_state_id)?;
+                            let mut result =
+                                self.expand_count(&repetition.hir, min, next_state_id)?;
                             for _ in min..max {
                                 if result {
                                     next_state_id = self.nfa.last_state_id();


### PR DESCRIPTION
This is mainly a proof-of-concept to move to using regex_syntax::Ast instead of regex_syntax::Hir. This enables all of the "fancy" regex features provided by the regex crate "for free", as they get translated into the simpler Hir language.

This includes #381 because it's most useful with it.

A lot of regexes will suddenly accept a lot more things because of unicode-aware translation, so I suspect this will very unacceptably regress performance until CharacterSet uses a strategy similar to ClassUnicode wherein ranges are stored rather than every single character. Especially since, uh, this translates negated sets into positive ones.