### PR TITLE
Prevent web-tree-sitter from swallowing errors

### DIFF
--- a/cli/src/wasm.rs
+++ b/cli/src/wasm.rs
@@ -73,6 +73,8 @@ pub fn compile_language_to_wasm(language_dir: &Path, force_docker: bool) -> Resu
         "-s",
         "TOTAL_MEMORY=33554432",
         "-s",
+        "NODEJS_CATCH_EXIT=0",
+        "-s",
         &format!("EXPORTED_FUNCTIONS=[\"_tree_sitter_{}\"]", grammar_name),
         "-fno-exceptions",
         "-I",


### PR DESCRIPTION
I was getting an error that I couldn't track down:

```
Error: "abort({}). Build with -s ASSERTIONS=1 for more info."
  at (anonymous) (<my project dir>/node_modules/web-tree-sitter/tree-sitter.js:1:1240)
  at emit (events.js:187:14)
  at process._fatalException (internal/bootstrap/node.js:488:26)
```

It turns out that the error came from something completely unrelated to tree-sitter but just doing `import * as Parser from "web-tree-sitter";` caused errors to be swallowed.

The line in question originates from here:

https://github.com/emscripten-core/emscripten/blob/e9971d17e02d3fc3861f35d629a29baa6931842c/src/shell.js#L158-L165

```js
#if NODEJS_CATCH_EXIT
  process['on']('uncaughtException', function(ex) {
    // suppress ExitStatus exceptions from showing an error
    if (!(ex instanceof ExitStatus)) {
      throw ex;
    }
  });
#endif
```

There are links in the following issue where people ultimately do `NODEJS_CATCH_EXIT=0 emcc ...` to prevent this, and this PR does the same. https://github.com/emscripten-core/emscripten/issues/5957