### PR TITLE
highlight: Fix panic when cancelled before parsing a nested document

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,6 +14,7 @@ const BUILD_SHA: Option<&'static str> = option_env!("BUILD_SHA");
 
 fn main() {
     if let Err(e) = run() {
+        println!("");
         eprintln!("{}", e.message());
         exit(1);
     }

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -28,7 +28,7 @@ pub fn parse_file_at_path(
 ) -> Result<bool> {
     let mut _log_session = None;
     let mut parser = Parser::new();
-    parser.set_language(language)?;
+    parser.set_language(language).map_err(|e| e.to_string())?;
     let mut source_code = fs::read(path).map_err(Error::wrap(|| {
         format!("Error reading source file {:?}", path)
     }))?;

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -58,7 +58,7 @@ pub fn run_tests_at_path(
     let test_entry = parse_tests(path)?;
     let mut _log_session = None;
     let mut parser = Parser::new();
-    parser.set_language(language)?;
+    parser.set_language(language).map_err(|e| e.to_string())?;
 
     if debug_graph {
         _log_session = Some(util::log_graphs(&mut parser, "log.html")?);

--- a/highlight/include/tree_sitter/highlight.h
+++ b/highlight/include/tree_sitter/highlight.h
@@ -11,6 +11,7 @@ typedef enum {
   TSHighlightOk,
   TSHighlightUnknownScope,
   TSHighlightTimeout,
+  TSHighlightInvalidLanguage,
 } TSHighlightError;
 
 // The list of scopes which can be styled for syntax highlighting.


### PR DESCRIPTION
This fixes a panic I was seeing when a timeout expired while highlighting a large ERB file.