### PR TITLE
More TypeScript fixes

### DIFF
--- a/lib/binding_web/tree-sitter-web.d.ts
+++ b/lib/binding_web/tree-sitter-web.d.ts
@@ -92,9 +92,9 @@ declare module 'web-tree-sitter' {
       endPosition: Point;
       startIndex: number;
       endIndex: number;
-      readonly currentNode: SyntaxNode
 
       reset(node: SyntaxNode): void
+      currentNode(): SyntaxNode;
       gotoParent(): boolean;
       gotoFirstChild(): boolean;
       gotoFirstChildForIndex(index: number): boolean;

--- a/lib/binding_web/tree-sitter-web.d.ts
+++ b/lib/binding_web/tree-sitter-web.d.ts
@@ -96,6 +96,7 @@ declare module 'web-tree-sitter' {
       reset(node: SyntaxNode): void;
       delete(): void;
       currentNode(): SyntaxNode;
+      currentFieldName(): string;
       gotoParent(): boolean;
       gotoFirstChild(): boolean;
       gotoFirstChildForIndex(index: number): boolean;

--- a/lib/binding_web/tree-sitter-web.d.ts
+++ b/lib/binding_web/tree-sitter-web.d.ts
@@ -93,7 +93,8 @@ declare module 'web-tree-sitter' {
       startIndex: number;
       endIndex: number;
 
-      reset(node: SyntaxNode): void
+      reset(node: SyntaxNode): void;
+      delete(): void;
       currentNode(): SyntaxNode;
       gotoParent(): boolean;
       gotoFirstChild(): boolean;


### PR DESCRIPTION
Sorry, missed these last night:

* Add `delete()` to `TreeCursor`
* Correct `currentNode()` to be a method instead of a property on `TreeCursor`
* Add missing `currentFieldName()` to `TreeCursor`