### PR TITLE
Instruct parcel to skip analysis of fs calls

### DIFF
--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/tree-sitter/tree-sitter/issues"
   },
   "homepage": "https://github.com/tree-sitter/tree-sitter/tree/master/lib/binding_web",
+  "browser": {
+    "fs": false
+  },
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^6.1.4",


### PR DESCRIPTION
Prior to this change, https://github.com/parcel-bundler/parcel would throw errors saying it can't statically analyze some calls to `fs.readFileSync`.

I noticed all of the calls are guarded by environment checks so that the calls are not made in the browser environment. Parcel has a feature to skip analysis by module, but the original `package.json` needs to be modified. Found at https://github.com/parcel-bundler/parcel/issues/496#issuecomment-366993459

After this change, those `fs` calls are ignored by Parcel, which enables bundling to complete successfully.