### PR TITLE
build: add support for git submodules

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -25,7 +25,15 @@ fn read_git_sha() -> Option<String> {
         }
     }
 
-    let git_head_path = git_path.join("HEAD");
+    let git_dir_path;
+    if git_path.is_dir() {
+        git_dir_path = git_path;
+    } else if let Ok(git_path_content) = fs::read_to_string(&git_path) {
+        git_dir_path = repo_path.join(git_path_content.get("gitdir: ".len()..).unwrap().trim_end());
+    } else {
+        return None;
+    }
+    let git_head_path = git_dir_path.join("HEAD");
     if let Some(path) = git_head_path.to_str() {
         println!("cargo:rerun-if-changed={}", path);
     }
@@ -37,7 +45,7 @@ fn read_git_sha() -> Option<String> {
         // If we're on a branch, read the SHA from the ref file.
         if head_content.starts_with("ref: ") {
             head_content.replace_range(0.."ref: ".len(), "");
-            let ref_filename = git_path.join(&head_content);
+            let ref_filename = git_dir_path.join(&head_content);
             if let Some(path) = ref_filename.to_str() {
                 println!("cargo:rerun-if-changed={}", path);
             }


### PR DESCRIPTION
The `.git` file can contain a reference to the actual git directory as is commonly the case for a submodule[1]. When this is the case, read the `.git` file to discover the actual git directory.

This fixes an issue where tree-sitter would always be rebuilt if it were used as a git submodule in a larger project due to non-existent `.git/*` files in `cargo:rerun-if-changed={}`.

 * `cli/build.rs`: Read the `.git` file to discover the git directory

[1] https://git-scm.com/docs/gitrepository-layout