### PR TITLE
Ignore hidden files in grammar test directories

### DIFF
--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -183,7 +183,14 @@ pub fn parse_tests(path: &Path) -> io::Result<TestEntry> {
         let mut children = Vec::new();
         for entry in fs::read_dir(path)? {
             let entry = entry?;
-            children.push(parse_tests(&entry.path())?);
+            let hidden = entry
+                .file_name()
+                .to_str()
+                .unwrap_or("")
+                .starts_with(".");
+            if !hidden {
+                children.push(parse_tests(&entry.path())?);
+            }
         }
         Ok(TestEntry::Group { name, children })
     } else {


### PR DESCRIPTION
This fixes the "stream did not contain valid UTF-8" error due to `tree-sitter test` attempting to parse Vim's hidden binary swap files.

This change avoids the error by ignoring hidden files in grammar test directories.

A separate problem that this PR does not address is the vagueness of the error message.  It would be helpful if the error message included the problematic file path.

## Example Error

```text
$ tree-sitter test

stream did not contain valid UTF-8
```