### PR TITLE
Make Tree::changed_ranges return an Iterator instead of a Vec

### DIFF
--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -337,7 +337,7 @@ fn check_consistent_sizes(tree: &Tree, input: &Vec<u8>) {
 }
 
 fn check_changed_ranges(old_tree: &Tree, new_tree: &Tree, input: &Vec<u8>) -> Result<(), String> {
-    let changed_ranges = old_tree.changed_ranges(new_tree);
+    let changed_ranges = old_tree.changed_ranges(new_tree).collect();
     let old_scope_sequence = ScopeSequence::new(old_tree);
     let new_scope_sequence = ScopeSequence::new(new_tree);
     old_scope_sequence.check_changes(&new_scope_sequence, &input, &changed_ranges)

--- a/cli/src/tests/parser_test.rs
+++ b/cli/src/tests/parser_test.rs
@@ -767,7 +767,7 @@ fn test_parsing_with_a_newly_excluded_range() {
     );
 
     assert_eq!(
-        tree.changed_ranges(&first_tree),
+        tree.changed_ranges(&first_tree).collect::<Vec<_>>(),
         vec![
             // The first range that has changed syntax is the range of the newly-inserted text.
             Range {
@@ -837,7 +837,7 @@ fn test_parsing_with_a_newly_included_range() {
     );
 
     assert_eq!(
-        tree.changed_ranges(&first_tree),
+        tree.changed_ranges(&first_tree).collect::<Vec<_>>(),
         vec![Range {
             start_byte: first_code_end_index + 1,
             end_byte: second_code_end_index + 1,

--- a/cli/src/tests/tree_test.rs
+++ b/cli/src/tests/tree_test.rs
@@ -370,7 +370,7 @@ fn get_changed_ranges(
 ) -> Vec<Range> {
     perform_edit(tree, source_code, &edit);
     let new_tree = parser.parse(&source_code, Some(tree)).unwrap();
-    let result = tree.changed_ranges(&new_tree);
+    let result = tree.changed_ranges(&new_tree).collect();
     *tree = new_tree;
     result
 }

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1,4 +1,5 @@
 mod ffi;
+mod util;
 
 #[macro_use]
 extern crate serde_derive;
@@ -16,7 +17,7 @@ use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::os::raw::{c_char, c_void};
 use std::sync::atomic::AtomicUsize;
-use std::{fmt, ptr, slice, str, u16};
+use std::{fmt, ptr, str, u16};
 
 pub const LANGUAGE_VERSION: usize = ffi::TREE_SITTER_LANGUAGE_VERSION;
 pub const PARSER_HEADER: &'static str = include_str!("../include/tree_sitter/parser.h");
@@ -447,15 +448,11 @@ impl Tree {
         TreePropertyCursor::new(self, property_sheet, source)
     }
 
-    pub fn changed_ranges(&self, other: &Tree) -> Vec<Range> {
+    pub fn changed_ranges(&self, other: &Tree) -> impl Iterator<Item = Range> {
+        let mut count = 0;
         unsafe {
-            let mut count = 0;
-            let ptr =
-                ffi::ts_tree_get_changed_ranges(self.0, other.0, &mut count as *mut _ as *mut u32);
-            let ranges = slice::from_raw_parts(ptr, count);
-            let result = ranges.into_iter().map(|r| r.clone().into()).collect();
-            free_ptr(ptr as *mut c_void);
-            result
+            let ptr = ffi::ts_tree_get_changed_ranges(self.0, other.0, &mut count as *mut _ as *mut u32);
+            util::CBufferIter::new(ptr, count, free_ptr).map(|r| r.into())
         }
     }
 }

--- a/lib/binding_rust/util.rs
+++ b/lib/binding_rust/util.rs
@@ -1,0 +1,37 @@
+use std::os::raw::c_void;
+
+type Free = unsafe extern "C" fn(ptr: *mut c_void);
+
+pub struct CBufferIter<T> {
+    ptr: *mut T,
+    count: usize,
+    free: Free,
+    i: usize,
+}
+
+impl<T> CBufferIter<T> {
+    pub unsafe fn new(ptr: *mut T, count: usize, free: Free) -> Self {
+        Self { ptr, count, free, i: 0 }
+    }
+}
+
+impl<T: Copy> Iterator for CBufferIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let i = self.i;
+        self.i += 1;
+        if i >= self.count {
+            None
+        } else {
+            Some(unsafe { *self.ptr.offset(i as isize) })
+        }
+    }
+}
+
+impl<T> Drop for CBufferIter<T> {
+    fn drop(&mut self) {
+        let free = self.free;
+        unsafe { free(self.ptr as *mut c_void); }
+    }
+}


### PR DESCRIPTION
This allows user code to create a `Vec` only if/when needed.

One example is in the Emacs binding, where the final result is a Lisp vector, and the immediate `Vec` would be thrown away.