### PR TITLE
[WIP] Highlight Improvements

### DIFF
--- a/cli/src/generate/prepare_grammar/expand_tokens.rs
+++ b/cli/src/generate/prepare_grammar/expand_tokens.rs
@@ -12,7 +12,7 @@ use std::i32;
 
 lazy_static! {
     static ref CURLY_BRACE_REGEX: Regex =
-        Regex::new(r#"(^|[^\\])\{([^}]*[^0-9A-F,}][^}]*)\}"#).unwrap();
+        Regex::new(r#"(^|[^\\])\{([^}]*[^0-9A-Fa-f,}][^}]*)\}"#).unwrap();
 }
 
 const ALLOWED_REDUNDANT_ESCAPED_CHARS: [char; 4] = ['!', '\'', '"', '/'];
@@ -653,12 +653,15 @@ mod tests {
                     Rule::pattern(r#"\{[ab]{3}\}"#),
                     // Unicode codepoints
                     Rule::pattern(r#"\u{1000A}"#),
+                    // Unicode codepoints (lowercase)
+                    Rule::pattern(r#"\u{1000b}"#),
                 ],
                 separators: vec![],
                 examples: vec![
                     ("u{1234} ok", Some((0, "u{1234}"))),
                     ("{aba}}", Some((1, "{aba}"))),
                     ("\u{1000A}", Some((2, "\u{1000A}"))),
+                    ("\u{1000b}", Some((3, "\u{1000b}"))),
                 ],
             },
         ];

--- a/cli/src/highlight.rs
+++ b/cli/src/highlight.rs
@@ -293,7 +293,7 @@ pub fn ansi(
     {
         let event = event.map_err(|e| e.to_string())?;
         match event {
-            HighlightEvent::Source(s) => {
+            HighlightEvent::Source(s, _) => {
                 if let Some(style) = highlight_stack.last().and_then(|s| theme.ansi_style(*s)) {
                     write!(&mut stdout, "{}", style.paint(s))?;
                 } else {

--- a/cli/src/tests/highlight_test.rs
+++ b/cli/src/tests/highlight_test.rs
@@ -481,7 +481,7 @@ fn to_token_vector<'a>(
             HighlightEvent::HighlightEnd => {
                 highlights.pop();
             }
-            HighlightEvent::Source(s) => {
+            HighlightEvent::Source(s, _) => {
                 // Safety: This is safe because we know the original source is kept around
                 // immutably for the duration of the test.
                 let s: &'a str = unsafe { mem::transmute(s.as_ref()) };

--- a/cli/src/tests/highlight_test.rs
+++ b/cli/src/tests/highlight_test.rs
@@ -3,7 +3,7 @@ use lazy_static::lazy_static;
 use std::ffi::CString;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::{ptr, slice, str};
+use std::{ptr, slice, str, mem};
 use tree_sitter::{Language, PropertySheet};
 use tree_sitter_highlight::{
     c, highlight, highlight_html, Error, Highlight, HighlightEvent, Properties,
@@ -482,6 +482,9 @@ fn to_token_vector<'a>(
                 highlights.pop();
             }
             HighlightEvent::Source(s) => {
+                // Safety: This is safe because we know the original source is kept around
+                // immutably for the duration of the test.
+                let s: &'a str = unsafe { mem::transmute(s.as_ref()) };
                 for (i, l) in s.split("\n").enumerate() {
                     let l = l.trim_end_matches('\r');
                     if i > 0 {

--- a/highlight/src/c_lib.rs
+++ b/highlight/src/c_lib.rs
@@ -197,7 +197,7 @@ impl TSHighlighter {
                         highlights.pop();
                         output.end_highlight();
                     }
-                    Ok(HighlightEvent::Source(src)) => {
+                    Ok(HighlightEvent::Source(src, _)) => {
                         output.add_text(src.as_ref(), &highlights, &self.attribute_strings);
                     },
                     Err(Error::Cancelled) => {

--- a/highlight/src/c_lib.rs
+++ b/highlight/src/c_lib.rs
@@ -198,7 +198,7 @@ impl TSHighlighter {
                         output.end_highlight();
                     }
                     Ok(HighlightEvent::Source(src)) => {
-                        output.add_text(src, &highlights, &self.attribute_strings);
+                        output.add_text(src.as_ref(), &highlights, &self.attribute_strings);
                     },
                     Err(Error::Cancelled) => {
                         return ErrorCode::Timeout;

--- a/highlight/src/cow.rs
+++ b/highlight/src/cow.rs
@@ -1,0 +1,28 @@
+use std::{borrow::Cow, str};
+
+pub fn decode_utf8(input: Cow<[u8]>) -> Result<Cow<str>, (str::Utf8Error, Cow<[u8]>)> {
+    match input {
+        Cow::Borrowed(bytes) => {
+            match str::from_utf8(bytes) {
+                Ok(s) => Ok(s.into()),
+                Err(e) => Err((e, Cow::Borrowed(bytes))),
+            }
+        }
+        Cow::Owned(bytes) => {
+            match String::from_utf8(bytes) {
+                Ok(s) => Ok(s.into()),
+                Err(e) => Err((e.utf8_error(), Cow::Owned(e.into_bytes()))),
+            }
+        }
+    }
+}
+
+pub unsafe fn decode_utf8_unchecked(input: Cow<[u8]>, len: usize) -> Cow<str> {
+    match input {
+        Cow::Borrowed(bytes) => Cow::Borrowed(str::from_utf8_unchecked(&bytes[0..len])),
+        Cow::Owned(mut bytes) => {
+            bytes.truncate(len);
+            Cow::Owned(String::from_utf8_unchecked(bytes))
+        }
+    }
+}

--- a/highlight/src/lib.rs
+++ b/highlight/src/lib.rs
@@ -97,7 +97,7 @@ struct Scope<'a> {
 
 struct Layer<'a> {
     _tree: Tree,
-    cursor: TreePropertyCursor<'a, Properties>,
+    cursor: TreePropertyCursor<'a, Properties, &'a [u8]>,
     ranges: Vec<Range>,
     at_node_end: bool,
     depth: usize,
@@ -944,10 +944,9 @@ impl<'a> Layer<'a> {
     }
 
     fn enter_node(&mut self) {
-        let node = self.cursor.node();
         let props = self.cursor.node_properties();
         let node_text = if props.local_definition || props.local_reference {
-            node.utf8_text(self.cursor.source()).ok()
+            self.cursor.current_source().ok()
         } else {
             None
         };


### PR DESCRIPTION
I'm working on tree-sitter-based syntax highlighting for Emacs.

I added a trait that would enable callback-based [sources](https://github.com/ubolonton/emacs-tree-sitter/blob/3e1b1feb180d82604c6c1a56b9e2428dc60da047/src/highlight.rs#L22) for `Highlighter`, and was able to make it work with Emacs (up to the part where highlight events are generated, the rest would be Emacs-specific details).

It seems to be a bit slow, due to the overhead of a large number of callbacks. On a 23K JavaScript file:
- Non-incremental parsing takes a couple of ms.
- Looping through all the highlight events (using the already parsed tree) takes around 60-70ms.

As far as I understand, the highlighter uses `source` for several things:
1. Supporting regex selectors in CSS mappings.
2. Emitting highlight events with source fragments.
3. Tracking names of local references and definitions.
4. Something to do with embedded language, in `injection_language_string`?

In my quick tests, most of the source accesses come from 1. and 2.

I have some questions:
- Can 1. be refactored to access the parse tree instead of the source?
- Should 2. be moved to specific rendererers, leaving `HighlightEvent` to contain only the byte-offset range? A text editor renderer would apply these to its internal datastructures, while renderers that want to output texts (HTML/terminal) would hold the original source themselves.
- Can `Highlight` be modified to support custom classes (e.g. `Custom(&'static str)`)? That would give editors some freedom to define their own mappings.
- Should I continue with this refactoring, or should it be a different highlight implementation?
