### PR TITLE
Fix some compiler warnings regarding function prototypes

### DIFF
--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -738,7 +738,7 @@ const char *ts_query_string_value_for_id(
  *  You can then start executing another query on another node by calling
  *  `ts_query_cursor_exec` again.
  */
-TSQueryCursor *ts_query_cursor_new();
+TSQueryCursor *ts_query_cursor_new(void);
 
 /**
  * Delete a query cursor, freeing all of the memory that it used.

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -3,6 +3,7 @@
 #include "./array.h"
 #include "./bits.h"
 #include "./point.h"
+#include "./tree_cursor.h"
 #include "utf8proc.h"
 #include <wctype.h>
 


### PR DESCRIPTION
I get these warnings when building latest tree-sitter (as part of neovim build system, which has enabled these warnings):

```
query.c:978:28: warning: implicit declaration of function 'ts_tree_cursor_current_status' is invalid in C99 [-Wimplicit-function-declaration]

api.h:741:35: warning: this function declaration is not a prototype [-Wstrict-prototypes]
TSQueryCursor *ts_query_cursor_new();
```