### PR TITLE
fix invalid docs for ts_tree_get_changed_ranges

### DIFF
--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -355,14 +355,14 @@ const TSLanguage *ts_tree_language(const TSTree *);
 void ts_tree_edit(TSTree *self, const TSInputEdit *edit);
 
 /**
- * Compare a new syntax tree to a previous syntax tree representing the same
+ * Compare an old edited syntax tree to a new syntax tree representing the same
  * document, returning an array of ranges whose syntactic structure has changed.
  *
  * For this to work correctly, the old syntax tree must have been edited such
  * that its ranges match up to the new tree. Generally, you'll want to call
- * this function right after calling one of the `ts_parser_parse` functions,
- * passing in the new tree that was returned from `ts_parser_parse` and the old
- * tree that was passed as a parameter.
+ * this function right after calling one of the `ts_parser_parse` functions.
+ * You need to pass the old tree that was passed to parse, as well as the new
+ * tree that was returned from that function.
  *
  * The returned array is allocated using `malloc` and the caller is responsible
  * for freeing it using `free`. The length of the array will be written to the
@@ -370,7 +370,7 @@ void ts_tree_edit(TSTree *self, const TSInputEdit *edit);
  */
 TSRange *ts_tree_get_changed_ranges(
   const TSTree *old_tree,
-  const TSTree *self,
+  const TSTree *new_tree,
   uint32_t *length
 );
 

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -369,8 +369,8 @@ void ts_tree_edit(TSTree *self, const TSInputEdit *edit);
  * given `length` pointer.
  */
 TSRange *ts_tree_get_changed_ranges(
-  const TSTree *self,
   const TSTree *old_tree,
+  const TSTree *self,
   uint32_t *length
 );
 

--- a/lib/src/tree.c
+++ b/lib/src/tree.c
@@ -89,7 +89,7 @@ TSRange *ts_tree_get_changed_ranges(const TSTree *self, const TSTree *other, uin
   TreeCursor cursor2 = {NULL, array_new()};
   TSNode root = ts_tree_root_node(self);
   ts_tree_cursor_init(&cursor1, root);
-  ts_tree_cursor_init(&cursor2, root);
+  ts_tree_cursor_init(&cursor2, root); // really other's root, but reinitialized later
 
   TSRangeArray included_range_differences = array_new();
   ts_range_array_get_changed_ranges(

--- a/lib/src/tree.c
+++ b/lib/src/tree.c
@@ -84,12 +84,10 @@ void ts_tree_edit(TSTree *self, const TSInputEdit *edit) {
 }
 
 TSRange *ts_tree_get_changed_ranges(const TSTree *self, const TSTree *other, uint32_t *count) {
-  TSRange *result;
   TreeCursor cursor1 = {NULL, array_new()};
   TreeCursor cursor2 = {NULL, array_new()};
-  TSNode root = ts_tree_root_node(self);
-  ts_tree_cursor_init(&cursor1, root);
-  ts_tree_cursor_init(&cursor2, root); // really other's root, but reinitialized later
+  ts_tree_cursor_init(&cursor1, ts_tree_root_node(self));
+  ts_tree_cursor_init(&cursor2, ts_tree_root_node(other));
 
   TSRangeArray included_range_differences = array_new();
   ts_range_array_get_changed_ranges(
@@ -98,6 +96,7 @@ TSRange *ts_tree_get_changed_ranges(const TSTree *self, const TSTree *other, uin
     &included_range_differences
   );
 
+  TSRange *result;
   *count = ts_subtree_get_changed_ranges(
     &self->root, &other->root, &cursor1, &cursor2,
     self->language, &included_range_differences, &result


### PR DESCRIPTION
`ts_tree_get_changed_ranges` works very well but only if `old_tree` is passed as first parameter.

Also added a comment for a confusing initialization I stumbled upon while debugging this : cursor2 is used with "other" tree but is initialized with "self" tree, though this works as it is reinitialized later.