### PR TITLE
Properly handle productions that contain named aliases

### DIFF
--- a/cli/src/generate/node_types.rs
+++ b/cli/src/generate/node_types.rs
@@ -1210,7 +1210,10 @@ mod tests {
                 Variable {
                     name: "b".to_string(),
                     kind: VariableType::Named,
-                    rule: Rule::choice(vec![Rule::seq(vec![Rule::string("B")]), Rule::named("c")]),
+                    rule: Rule::choice(vec![
+                        Rule::field("f".to_string(), Rule::string("B")),
+                        Rule::named("c"),
+                    ]),
                 },
                 Variable {
                     name: "c".to_string(),
@@ -1263,7 +1266,21 @@ mod tests {
                         },
                     ]
                 }),
-                fields: Some(BTreeMap::new()),
+                fields: Some(
+                    vec![(
+                        "f".to_string(),
+                        FieldInfoJSON {
+                            required: false,
+                            multiple: false,
+                            types: vec![NodeTypeJSON {
+                                named: false,
+                                kind: "B".to_string(),
+                            }]
+                        }
+                    )]
+                    .into_iter()
+                    .collect()
+                ),
             }
         );
     }

--- a/cli/src/generate/node_types.rs
+++ b/cli/src/generate/node_types.rs
@@ -1170,6 +1170,95 @@ mod tests {
     }
 
     #[test]
+    fn test_node_types_with_named_aliases() {
+        let node_types = get_node_types(InputGrammar {
+            name: String::new(),
+            extra_symbols: Vec::new(),
+            external_tokens: Vec::new(),
+            expected_conflicts: Vec::new(),
+            variables_to_inline: Vec::new(),
+            word_token: None,
+            supertype_symbols: vec![],
+            variables: vec![
+                Variable {
+                    name: "expression".to_string(),
+                    kind: VariableType::Named,
+                    rule: Rule::choice(vec![Rule::named("yield"), Rule::named("argument_list")]),
+                },
+                Variable {
+                    name: "yield".to_string(),
+                    kind: VariableType::Named,
+                    rule: Rule::Seq(vec![Rule::string("YIELD")]),
+                },
+                Variable {
+                    name: "argument_list".to_string(),
+                    kind: VariableType::Named,
+                    rule: Rule::choice(vec![
+                        Rule::named("x"),
+                        Rule::alias(Rule::named("b"), "expression".to_string(), true),
+                    ]),
+                },
+                Variable {
+                    name: "b".to_string(),
+                    kind: VariableType::Named,
+                    rule: Rule::choice(vec![Rule::seq(vec![Rule::string("B")]), Rule::named("c")]),
+                },
+                Variable {
+                    name: "c".to_string(),
+                    kind: VariableType::Named,
+                    rule: Rule::seq(vec![Rule::string("C")]),
+                },
+                Variable {
+                    name: "x".to_string(),
+                    kind: VariableType::Named,
+                    rule: Rule::seq(vec![Rule::string("X")]),
+                },
+            ],
+        });
+
+        assert_eq!(
+            node_types.iter().map(|n| &n.kind).collect::<Vec<_>>(),
+            &[
+                "argument_list",
+                "c",
+                "expression",
+                "x",
+                "yield",
+                "B",
+                "C",
+                "X",
+                "YIELD"
+            ]
+        );
+        assert_eq!(
+            node_types[2],
+            NodeInfoJSON {
+                kind: "expression".to_string(),
+                named: true,
+                subtypes: None,
+                children: Some(FieldInfoJSON {
+                    multiple: false,
+                    required: true,
+                    types: vec![
+                        NodeTypeJSON {
+                            kind: "argument_list".to_string(),
+                            named: true,
+                        },
+                        NodeTypeJSON {
+                            kind: "c".to_string(),
+                            named: true,
+                        },
+                        NodeTypeJSON {
+                            kind: "yield".to_string(),
+                            named: true,
+                        },
+                    ]
+                }),
+                fields: Some(BTreeMap::new()),
+            }
+        );
+    }
+    #[test]
     fn test_node_types_with_tokens_aliased_to_match_rules() {
         let node_types = get_node_types(InputGrammar {
             name: String::new(),

--- a/cli/src/generate/node_types.rs
+++ b/cli/src/generate/node_types.rs
@@ -615,12 +615,20 @@ pub(crate) fn generate_node_types_json(
                     .iter()
                     .map(child_type_to_node_type)
                     .collect::<Vec<_>>();
+                let mut multiple = info.children_without_fields.quantity.multiple;
+                let mut required = info.children_without_fields.quantity.required;
+                if let Some(children) = &mut node_type_json.children {
+                    println!("children: {:?}", children);
+                    children_types.append(&mut children.types);
+                    multiple |= children.multiple;
+                    required |= children.required;
+                }
                 if children_types.len() > 0 {
                     children_types.sort_unstable();
                     children_types.dedup();
                     node_type_json.children = Some(FieldInfoJSON {
-                        multiple: info.children_without_fields.quantity.multiple,
-                        required: info.children_without_fields.quantity.required,
+                        multiple: multiple,
+                        required: required,
                         types: children_types,
                     });
                 }

--- a/cli/src/generate/node_types.rs
+++ b/cli/src/generate/node_types.rs
@@ -618,7 +618,6 @@ pub(crate) fn generate_node_types_json(
                 let mut multiple = info.children_without_fields.quantity.multiple;
                 let mut required = info.children_without_fields.quantity.required;
                 if let Some(children) = &mut node_type_json.children {
-                    println!("children: {:?}", children);
                     children_types.append(&mut children.types);
                     multiple |= children.multiple;
                     required |= children.required;


### PR DESCRIPTION
This fixes the last failing test over on https://github.com/tree-sitter/haskell-tree-sitter/pull/241 which had to do with a python example like this (call expression with parenthesized list splat as an argument):

```python
i((*a))
```

which has this tree:

```
(module [0, 0] - [1, 0]
  (expression_statement [0, 0] - [0, 7]
    (call [0, 0] - [0, 7]
      function: (identifier [0, 0] - [0, 1])
      arguments: (argument_list [0, 1] - [0, 7]
        (parenthesized_expression [0, 2] - [0, 6]
          (list_splat [0, 3] - [0, 5]
            (identifier [0, 4] - [0, 5])))))))
```

The trouble comes from node-types.json which doesn't get properly generated for [an alias](https://github.com/tree-sitter/tree-sitter-python/blob/225e757b4580ecc2b3da36d13679188b7c8abe4e/grammar.js#L421) within the `argument_list` production:
```
alias($.parenthesized_list_splat, $.parenthesized_expression)
```

[`parenthesized_expression` only has `_expression` and `yield`](https://github.com/tree-sitter/tree-sitter-python/blob/225e757b4580ecc2b3da36d13679188b7c8abe4e/src/node-types.json#L1753-L1770), but should also include all the children of `parenthesized_list_splat`.

``` json
{
    "type": "parenthesized_expression",
    "named": true,
    "fields": {},
    "children": {
      "multiple": false,
      "required": true,
      "types": [
        {
          "type": "_expression",
          "named": true
        },
        {
          "type": "yield",
          "named": true
        }
      ]
    }
  }
```

I wrote a test that demonstrates the problem (could probably be a bit more concise, but it was tricky to figure out what exactly was going wrong) and then did some debugging to figure out where this information was getting lost.

cc @maxbrunsfeld 