### PR TITLE
add missing unicode include to query.c

### DIFF
--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -4,6 +4,7 @@
 #include "./bits.h"
 #include "./point.h"
 #include "./tree_cursor.h"
+#include "./unicode.h"
 #include <wctype.h>
 
 /*


### PR DESCRIPTION
it causes problems with building tree-sitter with cgo