### PR TITLE
Add a system for testing syntax highlighting queries

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,3 +1,4 @@
+use super::test_highlight;
 use std::fmt::Write;
 use std::io;
 use tree_sitter::QueryError;
@@ -95,6 +96,12 @@ impl From<io::Error> for Error {
 impl From<regex_syntax::ast::Error> for Error {
     fn from(error: regex_syntax::ast::Error) -> Self {
         Error::new(error.to_string())
+    }
+}
+
+impl From<test_highlight::Failure> for Error {
+    fn from(error: test_highlight::Failure) -> Self {
+        Error::new(error.message())
     }
 }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -7,6 +7,7 @@ pub mod logger;
 pub mod parse;
 pub mod query;
 pub mod test;
+pub mod test_highlight;
 pub mod util;
 pub mod wasm;
 pub mod web_ui;

--- a/cli/src/test_highlight.rs
+++ b/cli/src/test_highlight.rs
@@ -1,0 +1,256 @@
+use super::error::Result;
+use crate::loader::Loader;
+use lazy_static::lazy_static;
+use regex::Regex;
+use tree_sitter::{Language, Parser, Point};
+use tree_sitter_highlight::{Highlight, HighlightConfiguration, HighlightEvent, Highlighter};
+
+lazy_static! {
+    static ref HIGHLIGHT_NAME_REGEX: Regex = Regex::new("[\\w_\\-.]+").unwrap();
+}
+
+pub struct Failure {
+    row: usize,
+    column: usize,
+    expected_highlight: String,
+    actual_highlights: Vec<String>,
+}
+
+impl Failure {
+    pub fn message(&self) -> String {
+        let mut result = format!(
+            "Failed assertion at row: {}, column: {}.\nExpected highlight: '{}'.\nActual highlights: ",
+            self.row, self.column, self.expected_highlight
+        );
+        if self.actual_highlights.is_empty() {
+            result += "none.";
+        } else {
+            for (i, actual_highlight) in self.actual_highlights.iter().enumerate() {
+                if i > 0 {
+                    result += ", ";
+                }
+                result += "'";
+                result += actual_highlight;
+                result += "'";
+            }
+        }
+        result
+    }
+}
+
+pub fn test_highlight(
+    loader: &Loader,
+    highlighter: &mut Highlighter,
+    highlight_config: &HighlightConfiguration,
+    source: &[u8],
+) -> Result<()> {
+    // Highlight the file, and parse out all of the highlighting assertions.
+    let highlight_names = loader.highlight_names();
+    let highlights = get_highlight_positions(loader, highlighter, highlight_config, source)?;
+    let assertions = parse_highlight_test(highlighter.parser(), highlight_config.language, source)?;
+
+    // Iterate through all of the highlighting assertions, checking each one against the
+    // actual highlights.
+    let mut i = 0;
+    let mut actual_highlights = Vec::<&String>::new();
+    for (position, expected_highlight) in assertions {
+        let mut passed = false;
+        actual_highlights.clear();
+
+        'highlight_loop: loop {
+            // The assertions are ordered by position, so skip past all of the highlights that
+            // end at or before this assertion's position.
+            if let Some(highlight) = highlights.get(i) {
+                if highlight.1 <= position {
+                    i += 1;
+                    continue;
+                }
+
+                // Iterate through all of the highlights that start at or before this assertion's,
+                // position, looking for one that matches the assertion.
+                let mut j = i;
+                while let (false, Some(highlight)) = (passed, highlights.get(j)) {
+                    if highlight.0 > position {
+                        break 'highlight_loop;
+                    }
+
+                    // If the highlight matches the assertion, this test passes. Otherwise,
+                    // add this highlight to the list of actual highlights that span the
+                    // assertion's position, in order to generate an error message in the event
+                    // of a failure.
+                    let highlight_name = &highlight_names[(highlight.2).0];
+                    if *highlight_name == expected_highlight {
+                        passed = true;
+                        break 'highlight_loop;
+                    } else {
+                        actual_highlights.push(highlight_name);
+                    }
+
+                    j += 1;
+                }
+            } else {
+                break;
+            }
+        }
+
+        if !passed {
+            return Err(Failure {
+                row: position.row,
+                column: position.column,
+                expected_highlight: expected_highlight.clone(),
+                actual_highlights: actual_highlights.into_iter().cloned().collect(),
+            }
+            .into());
+        }
+    }
+
+    Ok(())
+}
+
+/// Parse the given source code, finding all of the comments that contain
+/// highlighting assertions. Return a vector of (position, expected highlight name)
+/// pairs.
+pub fn parse_highlight_test(
+    parser: &mut Parser,
+    language: Language,
+    source: &[u8],
+) -> Result<Vec<(Point, String)>> {
+    let mut result = Vec::new();
+    let mut assertion_ranges = Vec::new();
+
+    // Parse the code.
+    parser.set_language(language).unwrap();
+    let tree = parser.parse(source, None).unwrap();
+
+    // Walk the tree, finding comment nodes that contain assertions.
+    let mut ascending = false;
+    let mut cursor = tree.root_node().walk();
+    loop {
+        if ascending {
+            let node = cursor.node();
+
+            // Find every comment node.
+            if node.kind().contains("comment") {
+                if let Ok(text) = node.utf8_text(source) {
+                    let mut position = node.start_position();
+                    if position.row == 0 {
+                        continue;
+                    }
+
+                    // Find the arrow character ("^" or '<-") in the comment. A left arrow
+                    // refers to the column where the comment node starts. An up arrow refers
+                    // to its own column.
+                    let mut has_left_caret = false;
+                    let mut has_arrow = false;
+                    let mut arrow_end = 0;
+                    for (i, c) in text.char_indices() {
+                        arrow_end = i + 1;
+                        if c == '-' && has_left_caret {
+                            has_arrow = true;
+                            break;
+                        }
+                        if c == '^' {
+                            has_arrow = true;
+                            position.column += i;
+                            break;
+                        }
+                        has_left_caret = c == '<';
+                    }
+
+                    // If the comment node contains an arrow and a highlight name, record the
+                    // highlight name and the position.
+                    if let (true, Some(mat)) =
+                        (has_arrow, HIGHLIGHT_NAME_REGEX.find(&text[arrow_end..]))
+                    {
+                        assertion_ranges.push((node.start_position(), node.end_position()));
+                        result.push((position, mat.as_str().to_string()));
+                    }
+                }
+            }
+
+            // Continue walking the tree.
+            if cursor.goto_next_sibling() {
+                ascending = false;
+            } else if !cursor.goto_parent() {
+                break;
+            }
+        } else if !cursor.goto_first_child() {
+            ascending = true;
+        }
+    }
+
+    // Adjust the row number in each assertion's position to refer to the line of
+    // code *above* the assertion. There can be multiple lines of assertion comments,
+    // so the positions may have to be decremented by more than one row.
+    let mut i = 0;
+    for (position, _) in result.iter_mut() {
+        loop {
+            let on_assertion_line = assertion_ranges[i..]
+                .iter()
+                .any(|(start, _)| start.row == position.row);
+            if on_assertion_line {
+                position.row -= 1;
+            } else {
+                while i < assertion_ranges.len() && assertion_ranges[i].0.row < position.row {
+                    i += 1;
+                }
+                break;
+            }
+        }
+    }
+
+    // The assertions can end up out of order due to the line adjustments.
+    result.sort_unstable_by_key(|a| a.0);
+
+    Ok(result)
+}
+
+pub fn get_highlight_positions(
+    loader: &Loader,
+    highlighter: &mut Highlighter,
+    highlight_config: &HighlightConfiguration,
+    source: &[u8],
+) -> Result<Vec<(Point, Point, Highlight)>> {
+    let mut row = 0;
+    let mut column = 0;
+    let mut byte_offset = 0;
+    let mut was_newline = false;
+    let mut result = Vec::new();
+    let mut highlight_stack = Vec::new();
+    let source = String::from_utf8_lossy(source);
+    let mut char_indices = source.char_indices();
+    for event in highlighter.highlight(highlight_config, source.as_bytes(), None, |string| {
+        loader.highlight_config_for_injection_string(string)
+    })? {
+        match event? {
+            HighlightEvent::HighlightStart(h) => highlight_stack.push(h),
+            HighlightEvent::HighlightEnd => {
+                highlight_stack.pop();
+            }
+            HighlightEvent::Source { start, end } => {
+                let mut start_position = Point::new(row, column);
+                while byte_offset < end {
+                    if byte_offset <= start {
+                        start_position = Point::new(row, column);
+                    }
+                    if let Some((i, c)) = char_indices.next() {
+                        if was_newline {
+                            row += 1;
+                            column = 0;
+                        } else {
+                            column += i - byte_offset;
+                        }
+                        was_newline = c == '\n';
+                        byte_offset = i;
+                    } else {
+                        break;
+                    }
+                }
+                if let Some(highlight) = highlight_stack.last() {
+                    result.push((start_position, Point::new(row, column), *highlight))
+                }
+            }
+        }
+    }
+    Ok(result)
+}

--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -58,7 +58,11 @@ fn test_real_language_corpus_files() {
         }
 
         let language = get_language(language_name);
-        let corpus_dir = grammars_dir.join(language_name).join("corpus");
+        let mut corpus_dir = grammars_dir.join(language_name).join("corpus");
+        if !corpus_dir.is_dir() {
+            corpus_dir = grammars_dir.join(language_name).join("test").join("corpus");
+        }
+
         let error_corpus_file = error_corpus_dir.join(&format!("{}_errors.txt", language_name));
         let main_tests = parse_tests(&corpus_dir).unwrap();
         let error_tests = parse_tests(&error_corpus_file).unwrap_or(TestEntry::default());

--- a/cli/src/tests/helpers/mod.rs
+++ b/cli/src/tests/helpers/mod.rs
@@ -1,5 +1,5 @@
 pub(super) mod allocations;
+pub(super) mod edits;
 pub(super) mod fixtures;
 pub(super) mod random;
 pub(super) mod scope_sequence;
-pub(super) mod edits;

--- a/cli/src/tests/mod.rs
+++ b/cli/src/tests/mod.rs
@@ -4,4 +4,5 @@ mod highlight_test;
 mod node_test;
 mod parser_test;
 mod query_test;
+mod test_highlight_test;
 mod tree_test;

--- a/cli/src/tests/test_highlight_test.rs
+++ b/cli/src/tests/test_highlight_test.rs
@@ -1,0 +1,53 @@
+use super::helpers::fixtures::{get_highlight_config, get_language, test_loader};
+use crate::test_highlight::{get_highlight_positions, parse_highlight_test};
+use tree_sitter::{Parser, Point};
+use tree_sitter_highlight::{Highlight, Highlighter};
+
+#[test]
+fn test_highlight_test_with_basic_test() {
+    let language = get_language("javascript");
+    let config = get_highlight_config(
+        "javascript",
+        "injections.scm",
+        &[
+            "function.definition".to_string(),
+            "variable.parameter".to_string(),
+            "keyword".to_string(),
+        ],
+    );
+    let source = [
+        "var abc = function(d) {",
+        "  // ^ function.definition",
+        "  //       ^ keyword",
+        "  return d + e;",
+        "  //     ^ variable.parameter",
+        "};",
+    ]
+    .join("\n");
+
+    let assertions = parse_highlight_test(&mut Parser::new(), language, source.as_bytes()).unwrap();
+    assert_eq!(
+        assertions,
+        &[
+            (Point::new(0, 5), "function.definition".to_string()),
+            (Point::new(0, 11), "keyword".to_string()),
+            (Point::new(3, 9), "variable.parameter".to_string()),
+        ]
+    );
+
+    let mut highlighter = Highlighter::new();
+    let highlight_positions =
+        get_highlight_positions(test_loader(), &mut highlighter, &config, source.as_bytes())
+            .unwrap();
+    assert_eq!(
+        highlight_positions,
+        &[
+            (Point::new(0, 0), Point::new(0, 3), Highlight(2)), // "var"
+            (Point::new(0, 4), Point::new(0, 7), Highlight(0)), // "abc"
+            (Point::new(0, 10), Point::new(0, 18), Highlight(2)), // "function"
+            (Point::new(0, 19), Point::new(0, 20), Highlight(1)), // "d"
+            (Point::new(3, 2), Point::new(3, 8), Highlight(2)), // "return"
+            (Point::new(3, 9), Point::new(3, 10), Highlight(1)), // "d"
+        ]
+    );
+}

--- a/highlight/README.md
+++ b/highlight/README.md
@@ -14,66 +14,64 @@ extern "C" tree_sitter_html();
 extern "C" tree_sitter_javascript();
 ```
 
-Create a highlighter. You only need one of these:
+Define the list of highlight names that you will recognize:
+
+```rust
+let highlight_names = [
+    "attribute",
+    "constant",
+    "function.builtin",
+    "function",
+    "keyword",
+    "operator",
+    "property",
+    "punctuation",
+    "punctuation.bracket",
+    "punctuation.delimiter",
+    "string",
+    "string.special",
+    "tag",
+    "type",
+    "type.builtin",
+    "variable",
+    "variable.builtin",
+    "variable.parameter",
+]
+.iter()
+.cloned()
+.map(String::from)
+.collect();
+```
+
+Create a highlighter. You need one of these for each thread that you're using for syntax highlighting:
 
 ```rust
 use tree_sitter_highlight::Highlighter;
 
-let highlighter = Highlighter::new(
-    [
-        "attribute",
-        "constant",
-        "function.builtin",
-        "function",
-        "keyword",
-        "operator",
-        "property",
-        "punctuation",
-        "punctuation.bracket",
-        "punctuation.delimiter",
-        "string",
-        "string.special",
-        "tag",
-        "type",
-        "type.builtin",
-        "variable",
-        "variable.builtin",
-        "variable.parameter",
-    ]
-    .iter()
-    .cloned()
-    .map(String::from)
-    .collect()
-);
-```
-
-Create a highlight context. You need one of these for each thread that you're using for syntax highlighting:
-
-```rust
-use tree_sitter_highlight::HighlightContext;
-
-let context = HighlightContext::new();
+let highlighter = Highlighter::new();
 ```
 
 Load some highlighting queries from the `queries` directory of some language repositories:
 
 ```rust
+use tree_sitter_highlight::HighlightConfiguration;
+
 let html_language = unsafe { tree_sitter_html() };
 let javascript_language = unsafe { tree_sitter_javascript() };
 
-let html_config = highlighter.load_configuration(
+let html_config = HighlightConfiguration::new(
     html_language,
     &fs::read_to_string("./tree-sitter-html/queries/highlights.scm").unwrap(),
     &fs::read_to_string("./tree-sitter-html/queries/injections.scm").unwrap(),
     "",
-);
+).unwrap();
 
-let javascript_config = highlighter.load_configuration(
+let javascript_config = HighlightConfiguration::new(
     javascript_language,
     &fs::read_to_string("./tree-sitter-javascript/queries/highlights.scm").unwrap(),
     &fs::read_to_string("./tree-sitter-javascript/queries/injections.scm").unwrap(),
     &fs::read_to_string("./tree-sitter-javascript/queries/locals.scm").unwrap(),
-);
+).unwrap();
 ```
 
 Highlight some code:
@@ -82,7 +80,6 @@ Highlight some code:
 use tree_sitter_highlight::HighlightEvent;
 
 let highlights = highlighter.highlight(
-    &mut context,
     javascript_config,
     b"const x = new Y();",
     None,


### PR DESCRIPTION
This PR adds new functionality to the `tree-sitter test` command, which allows you run automated tests for syntax highlighting queries (see #444, #448).

#### Directory Structure

The new test files are expected to live in the `test/highlight` folder. In addition, since there's now multiple forms of tests, **you can now put the `corpus` folder nested inside of the `test` folder**. This way, all of the tests can be grouped together.

Example:

```
.
├── grammar.json
├── package.json
├── queries
│   ├── highlights.scm
│   ├── injections.scm
│   └── locals.scm
├── src
│   ├── binding.cc
│   ├── grammar.json
│   ├── node-types.json
│   ├── parser.c
│   ├── scanner.c
│   └── tree_sitter
│       └── parser.h
|
|  # 👇 NEW 👇 
|
└── test
    ├── corpus
    │   ├── destructuring.txt
    │   ├── expressions.txt
    │   ├── literals.txt
    │   ├── semicolon_insertion.txt
    │   └── statements.txt
    └── highlight
        ├── functions.js
        ├── keywords.js
        └── variables.js
```

#### Test Syntax

The testing syntax is based on [Sublime Text's system](https://www.sublimetext.com/docs/3/syntax.html#testing), in which you use a normal source file with specially-formatted comments that assert about the highlights at specific positions.

For example, in [tree-sitter-javascript](https://github.com/tree-sitter/tree-sitter-javascript), you could add this file at the path `test/highlight/test.js`:

```js
var abc = function(d) {
  // <- keyword
  //          ^ keyword
  //               ^ variable.parameter
  // ^ function

  if (a) {
  // <- keyword
  // ^ punctuation.bracket

    foo(`foo ${bar}`);
    // <- function
    //    ^ string
    //          ^ variable
  }
};
```

From the Sublime text docs:

> The two types of tests are:
>
> **Caret**: ^ this will test the following selector against the scope on the most recent non-test line. It will test it at the same column the ^ is in. Consecutive ^s will test each column against the selector.
>
> **Arrow**: <- this will test the following selector against the scope on the most recent non-test line. It will test it at the same column as the comment character is in.


