### PR TITLE
FIxing the README in highlight

### DIFF
--- a/highlight/README.md
+++ b/highlight/README.md
@@ -83,19 +83,19 @@ let highlights = highlighter.highlight(
     javascript_config,
     b"const x = new Y();",
     None,
-    &|_| None
+    |_| None
 ).unwrap();
 
 for event in highlights {
     match event? {
-        HighlightEvent::Source(s) {
-            eprintln!("source: {:?}", s);
+        HighlightEvent::Source{start, end} => {
+            eprintln!("source: {}-{}", start, end);
         },
         HighlightEvent::HighlightStart(s) {
             eprintln!("highlight style started: {:?}", s);
         },
-        HighlightEvent::HighlightEnd(s) {
-            eprintln!("highlight style ended: {:?}", s);
+        HighlightEvent::HighlightEnd {
+            eprintln!("highlight style ended");
         },
     }
 }

--- a/highlight/README.md
+++ b/highlight/README.md
@@ -88,7 +88,7 @@ let highlights = highlighter.highlight(
 
 for event in highlights {
     match event? {
-        HighlightEvent::Source{start, end} => {
+        HighlightEvent::Source {start, end} => {
             eprintln!("source: {}-{}", start, end);
         },
         HighlightEvent::HighlightStart(s) {

--- a/highlight/README.md
+++ b/highlight/README.md
@@ -80,7 +80,7 @@ Highlight some code:
 use tree_sitter_highlight::HighlightEvent;
 
 let highlights = highlighter.highlight(
-    javascript_config,
+    &javascript_config,
     b"const x = new Y();",
     None,
     |_| None


### PR DESCRIPTION
The README in highlight seems to be too rough and cannot work.

Small fix on the lifetime and match cases