### PR TITLE
Don't attempt to extract keywords that don't entirely match word token

### DIFF
--- a/cli/src/generate/build_tables/mod.rs
+++ b/cli/src/generate/build_tables/mod.rs
@@ -271,6 +271,7 @@ fn identify_keywords(
             cursor.reset(vec![variable.start_state]);
             if all_chars_are_alphabetical(&cursor)
                 && token_conflict_map.does_match_same_string(i, word_token.index)
+                && !token_conflict_map.does_match_different_string(i, word_token.index)
             {
                 info!(
                     "Keywords - add candidate {}",


### PR DESCRIPTION
This fixes a problem I encountered in `tree-sitter-ruby` when attempting to match `true` and `TRUE` as a single token. The token was erroneously extracted as a "keyword", even though the identifier regex does not match `TRUE`.