### PR TITLE
include language.h in query.c

### DIFF
--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -2,6 +2,7 @@
 #include "./alloc.h"
 #include "./array.h"
 #include "./bits.h"
+#include "./language.h"
 #include "./point.h"
 #include "./tree_cursor.h"
 #include "./unicode.h"


### PR DESCRIPTION
Building `query.c` requires `TREE_SITTER_LANGUAGE_VERSION_WITH_SYMBOL_DEDUPING` which is defined in `language.h`.

It produces an error:
```
query.c:744:40: error: use of undeclared identifier 'TREE_SITTER_LANGUAGE_VERSION_WITH_SYMBOL_DEDUPING'
```

when building with cgo.