### PR TITLE
Fix build with MinGW tooling.

### DIFF
--- a/lib/src/atomic.h
+++ b/lib/src/atomic.h
@@ -12,11 +12,11 @@ static inline size_t atomic_load(const volatile size_t *p) {
 }
 
 static inline uint32_t atomic_inc(volatile uint32_t *p) {
-  return InterlockedIncrement(p);
+  return InterlockedIncrement((long volatile *)p);
 }
 
 static inline uint32_t atomic_dec(volatile uint32_t *p) {
-  return InterlockedDecrement(p);
+  return InterlockedDecrement((long volatile *)p);
 }
 
 #else

--- a/lib/src/bits.h
+++ b/lib/src/bits.h
@@ -7,7 +7,7 @@ static inline uint32_t bitmask_for_index(uint16_t id) {
   return (1u << (31 - id));
 }
 
-#ifdef _WIN32
+#if defined _WIN32 && !defined __GNUC__
 
 #include <intrin.h>
 

--- a/lib/src/stack.c
+++ b/lib/src/stack.c
@@ -11,7 +11,7 @@
 #define MAX_NODE_POOL_SIZE 50
 #define MAX_ITERATOR_COUNT 64
 
-#ifdef _WIN32
+#if defined _WIN32 && !defined __GNUC__
 #define inline __forceinline
 #else
 #define inline static inline __attribute__((always_inline))

--- a/script/build-lib
+++ b/script/build-lib
@@ -10,7 +10,7 @@ fi
 ${CC}                   \
   -c                    \
   -O3                   \
-  -std=c99              \
+  -std=gnu99            \
   $CFLAGS               \
   -I lib/src            \
   -I lib/include        \


### PR DESCRIPTION
Courtesy of @Eli-Zaretskii, these fixes should unblock people from
building tree-sitter with MinGW. I’m not sure how we’re going to test
this—can Appveyor set up a MinGW environment?

I don't think this is an unreasonable maintenance burden, especially
given the Emacs project's interest in using tree-sitter, but
@maxbrunsfeld gets the final call.

Fixes #513.