### PR TITLE
removed duplicate key in grammar-schema.json

### DIFF
--- a/cli/src/generate/grammar-schema.json
+++ b/cli/src/generate/grammar-schema.json
@@ -102,7 +102,6 @@
     },
 
     "symbol-rule": {
-      "required": ["name"],
       "type": "object",
       "properties": {
         "type": {


### PR DESCRIPTION
The key "required" was duplicated on "symbol-rule". I removed the more permissive copy.