### PR TITLE
Tweak the query API for specifying *combined injections* for syntax highlighting

### DIFF
--- a/cli/benches/benchmark.rs
+++ b/cli/benches/benchmark.rs
@@ -17,7 +17,6 @@ lazy_static! {
     static ref REPETITION_COUNT: usize = env::var("TREE_SITTER_BENCHMARK_REPETITION_COUNT")
         .map(|s| usize::from_str_radix(&s, 10).unwrap())
         .unwrap_or(5);
-
     static ref TEST_LOADER: Loader = Loader::new(SCRATCH_DIR.clone());
     static ref EXAMPLE_PATHS_BY_LANGUAGE_DIR: BTreeMap<PathBuf, Vec<PathBuf>> = {
         fn process_dir(result: &mut BTreeMap<PathBuf, Vec<PathBuf>>, dir: &Path) {
@@ -137,7 +136,7 @@ fn main() {
     eprintln!("");
 }
 
-fn aggregate(speeds: &Vec<(usize)>) -> Option<(usize, usize)> {
+fn aggregate(speeds: &Vec<usize>) -> Option<(usize, usize)> {
     if speeds.is_empty() {
         return None;
     }

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -51,13 +51,25 @@ pub fn query_files_at_paths(
             for m in query_cursor.matches(&query, tree.root_node(), text_callback) {
                 writeln!(&mut stdout, "  pattern: {}", m.pattern_index)?;
                 for capture in m.captures {
-                    writeln!(
-                        &mut stdout,
-                        "    capture: {}, row: {}, text: {:?}",
-                        &query.capture_names()[capture.index as usize],
-                        capture.node.start_position().row,
-                        capture.node.utf8_text(&source_code).unwrap_or("")
-                    )?;
+                    let start = capture.node.start_position();
+                    let end = capture.node.end_position();
+                    if end.row == start.row {
+                        writeln!(
+                            &mut stdout,
+                            "    capture: {}, start: {}, text: {:?}",
+                            &query.capture_names()[capture.index as usize],
+                            start,
+                            capture.node.utf8_text(&source_code).unwrap_or("")
+                        )?;
+                    } else {
+                        writeln!(
+                            &mut stdout,
+                            "    capture: {}, start: {}, end: {}",
+                            &query.capture_names()[capture.index as usize],
+                            start,
+                            end,
+                        )?;
+                    }
                 }
             }
         }

--- a/cli/src/tests/highlight_test.rs
+++ b/cli/src/tests/highlight_test.rs
@@ -317,8 +317,8 @@ fn test_highlighting_empty_lines() {
 }
 
 #[test]
-fn test_highlighting_ejs() {
-    let source = vec!["<div><% foo() %></div>"].join("\n");
+fn test_highlighting_ejs_with_html_and_javascript() {
+    let source = vec!["<div><% foo() %></div><script> bar() </script>"].join("\n");
 
     assert_eq!(
         &to_token_vector(&source, &EJS_HIGHLIGHT).unwrap(),
@@ -335,7 +335,18 @@ fn test_highlighting_ejs() {
             ("%>", vec!["keyword"]),
             ("</", vec!["punctuation.bracket"]),
             ("div", vec!["tag"]),
-            (">", vec!["punctuation.bracket"])
+            (">", vec!["punctuation.bracket"]),
+            ("<", vec!["punctuation.bracket"]),
+            ("script", vec!["tag"]),
+            (">", vec!["punctuation.bracket"]),
+            (" ", vec![]),
+            ("bar", vec!["function"]),
+            ("(", vec!["punctuation.bracket"]),
+            (")", vec!["punctuation.bracket"]),
+            (" ", vec![]),
+            ("</", vec!["punctuation.bracket"]),
+            ("script", vec!["tag"]),
+            (">", vec!["punctuation.bracket"]),
         ]],
     );
 }

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -669,6 +669,12 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Disable a certain pattern within a query. This prevents the pattern"]
+    #[doc = " from matching and removes most of the overhead associated with the"]
+    #[doc = " pattern."]
+    pub fn ts_query_disable_pattern(arg1: *mut TSQuery, arg2: u32);
+}
+extern "C" {
     #[doc = " Create a new cursor for executing a given query."]
     #[doc = ""]
     #[doc = " The cursor stores the state that is needed to iteratively search"]

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1322,6 +1322,14 @@ impl Query {
         }
     }
 
+    /// Disable a certain pattern within a query.
+    ///
+    /// This prevents the pattern from matching, and also avoids any resource usage
+    /// associated with the pattern.
+    pub fn disable_pattern(&mut self, index: usize) {
+        unsafe { ffi::ts_query_disable_pattern(self.ptr.as_ptr(), index as u32) }
+    }
+
     fn parse_property(
         function_name: &str,
         capture_names: &[String],

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -732,11 +732,21 @@ const char *ts_query_string_value_for_id(
 );
 
 /**
- * Disable a certain capture within a query. This prevents the capture
- * from being returned in matches, and also avoids any resource usage
- * associated with recording the capture.
+ * Disable a certain capture within a query.
+ *
+ * This prevents the capture from being returned in matches, and also avoids
+ * any resource usage associated with recording the capture. Currently, there
+ * is no way to undo this.
  */
 void ts_query_disable_capture(TSQuery *, const char *, uint32_t);
+
+/**
+ * Disable a certain pattern within a query.
+ *
+ * This prevents the pattern from matching and removes most of the overhead
+ * associated with the pattern. Currently, there is no way to undo this.
+ */
+void ts_query_disable_pattern(TSQuery *, uint32_t);
 
 /**
  * Create a new cursor for executing a given query.

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -893,6 +893,8 @@ void ts_query_disable_capture(
   const char *name,
   uint32_t length
 ) {
+  // Remove capture information for any pattern step that previously
+  // captured with the given name.
   int id = symbol_table_id_for_name(&self->captures, name, length);
   if (id != -1) {
     for (unsigned i = 0; i < self->steps.size; i++) {
@@ -901,8 +903,23 @@ void ts_query_disable_capture(
         step->capture_id = NONE;
       }
     }
+    ts_query__finalize_steps(self);
   }
-  ts_query__finalize_steps(self);
+}
+
+void ts_query_disable_pattern(
+  TSQuery *self,
+  uint32_t pattern_index
+) {
+  // Remove the given pattern from the pattern map. Its steps will still
+  // be in the `steps` array, but they will never be read.
+  for (unsigned i = 0; i < self->pattern_map.size; i++) {
+    PatternEntry *pattern = &self->pattern_map.contents[i];
+    if (pattern->pattern_index == pattern_index) {
+      array_erase(&self->pattern_map, i);
+      i--;
+    }
+  }
 }
 
 /***************

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -62,10 +62,12 @@ typedef struct {
 } SymbolTable;
 
 /*
- * PatternEntry - The set of steps needed to match a particular pattern,
- * represented as a slice of a shared array. These entries are stored in a
- * 'pattern map' - a sorted array that makes it possible to efficiently lookup
- * patterns based on the symbol for their first step.
+ * PatternEntry - Information about the starting point for matching a
+ * particular pattern, consisting of the index of the pattern within the query,
+ * and the index of the patter's first step in the shared `steps` array. These
+ * entries are stored in a 'pattern map' - a sorted array that makes it
+ * possible to efficiently lookup patterns based on the symbol for their first
+ * step.
  */
 typedef struct {
   uint16_t step_index;
@@ -333,7 +335,7 @@ static uint16_t symbol_table_insert_name(
 // to quickly find the starting steps of all of the patterns whose root matches
 // that node. Each entry has two fields: a `pattern_index`, which identifies one
 // of the patterns in the query, and a `step_index`, which indicates the start
-// offset of that pattern's steps pattern within the `steps` array.
+// offset of that pattern's steps within the `steps` array.
 //
 // The entries are sorted by the patterns' root symbols, and lookups use a
 // binary search. This ensures that the cost of this initial lookup step
@@ -1010,7 +1012,7 @@ static bool ts_query_cursor__first_in_progress_capture(
 
 static bool ts_query__cursor_add_state(
   TSQueryCursor *self,
-  const PatternEntry *slice
+  const PatternEntry *pattern
 ) {
   uint32_t list_id = capture_list_pool_acquire(&self->capture_list_pool);
 
@@ -1037,11 +1039,11 @@ static bool ts_query__cursor_add_state(
     }
   }
 
-  LOG("  start state. pattern:%u\n", slice->pattern_index);
+  LOG("  start state. pattern:%u\n", pattern->pattern_index);
   array_push(&self->states, ((QueryState) {
     .capture_list_id = list_id,
-    .step_index = slice->step_index,
-    .pattern_index = slice->pattern_index,
+    .step_index = pattern->step_index,
+    .pattern_index = pattern->pattern_index,
     .start_depth = self->depth,
     .capture_count = 0,
     .consumed_capture_count = 0,
@@ -1157,31 +1159,31 @@ static inline bool ts_query_cursor__advance(TSQueryCursor *self) {
 
       // Add new states for any patterns whose root node is a wildcard.
       for (unsigned i = 0; i < self->query->wildcard_root_pattern_count; i++) {
-        PatternEntry *slice = &self->query->pattern_map.contents[i];
-        QueryStep *step = &self->query->steps.contents[slice->step_index];
+        PatternEntry *pattern = &self->query->pattern_map.contents[i];
+        QueryStep *step = &self->query->steps.contents[pattern->step_index];
 
         // If this node matches the first step of the pattern, then add a new
         // state at the start of this pattern.
         if (step->field && field_id != step->field) continue;
-        if (!ts_query__cursor_add_state(self, slice)) break;
+        if (!ts_query__cursor_add_state(self, pattern)) break;
       }
 
       // Add new states for any patterns whose root node matches this node.
       unsigned i;
       if (ts_query__pattern_map_search(self->query, symbol, &i)) {
-        PatternEntry *slice = &self->query->pattern_map.contents[i];
-        QueryStep *step = &self->query->steps.contents[slice->step_index];
+        PatternEntry *pattern = &self->query->pattern_map.contents[i];
+        QueryStep *step = &self->query->steps.contents[pattern->step_index];
         do {
           // If this node matches the first step of the pattern, then add a new
           // state at the start of this pattern.
           if (step->field && field_id != step->field) continue;
-          if (!ts_query__cursor_add_state(self, slice)) break;
+          if (!ts_query__cursor_add_state(self, pattern)) break;
 
           // Advance to the next pattern whose root node matches this node.
           i++;
           if (i == self->query->pattern_map.size) break;
-          slice = &self->query->pattern_map.contents[i];
-          step = &self->query->steps.contents[slice->step_index];
+          pattern = &self->query->pattern_map.contents[i];
+          step = &self->query->steps.contents[pattern->step_index];
         } while (step->symbol == symbol);
       }
 

--- a/script/fetch-fixtures
+++ b/script/fetch-fixtures
@@ -24,9 +24,9 @@ fetch_grammar() {
 fetch_grammar bash              master
 fetch_grammar c                 master
 fetch_grammar cpp               master
-fetch_grammar embedded-template master
+fetch_grammar embedded-template new-highlight-injection-api
 fetch_grammar go                master
-fetch_grammar html              master
+fetch_grammar html              new-highlight-injection-api
 fetch_grammar javascript        master
 fetch_grammar json              master
 fetch_grammar python            master

--- a/script/fetch-fixtures.cmd
+++ b/script/fetch-fixtures.cmd
@@ -3,9 +3,9 @@
 call:fetch_grammar bash              master
 call:fetch_grammar c                 master
 call:fetch_grammar cpp               master
-call:fetch_grammar embedded-template master
+call:fetch_grammar embedded-template new-highlight-injection-api
 call:fetch_grammar go                master
-call:fetch_grammar html              master
+call:fetch_grammar html              new-highlight-injection-api
 call:fetch_grammar javascript        master
 call:fetch_grammar json              master
 call:fetch_grammar python            master


### PR DESCRIPTION
🚧 In Progress 🚧 

### Background

In the Tree-sitter syntax highlighting system, 'combined injections' are language injections where we take the text from *multiple* disjoint syntax nodes, and parse that text in another language. Currently, the only places that I've used this are in templating languages like ERB and EJS. For example, in an ERB document like this:

```erb
<span>
  <%= people.each do |person| %>
    <li><%= person.name %>
  <%= end %>
</ul>
```

... we take all of the `code` nodes from the ERB syntax tree, and parse their text together as *one* ruby document.

### Current API

Currently, the way this injection is specified (as designed in #448) is with [this pattern](https://github.com/tree-sitter/tree-sitter-embedded-template/blob/5fb8d9392593c388a3f92e413d4ca9efd520a85d/queries/injections-erb.scm#L5-L7):

```clj
((template
  (* (code) @injection.content)) @injection.site
 (set! injection.language "ruby"))
```

Every `code` node is captured as `injection.content`, and for every match, the ERB template's root node is captured as `injection.site`. The highlighting system then *uses* the fact that all of the matches have the same `injection.site` as the indication that all of the matches should be parsed *together*, as one ruby syntax tree.

### The Problem

Now, I'm working on highlighting PHP. The goal is to highlight the *text* content of the PHP file as HTML. In the PHP parser (as of https://github.com/tree-sitter/tree-sitter-php/pull/41), there can be `text` nodes *anywhere* in the tree. This is different from the ERB case, where all of the `code` nodes have a fixed relationship with the root node (1 level of nesting).

So with PHP trees, since the `text` nodes can be arbitrarily nested, there's no way for me to use [the query API](https://github.com/tree-sitter/tree-sitter/pull/444) to capture all of the `text` nodes, and with each match, *also* capture some common ancestor node (e.g. the root node) that will be the same for all the matches.

### The API Change

The current API is unnecessarily general; as far as I know of, *combined injections* can just always be combined across the *entire* document. In other words, we don't need to be able to specify arbitrary `injection.site` nodes, *within* which the matches will be combined. It can just always be the root.

So I'm going to remove the `injection.site` concept, and instead have a simple boolean flag associated with injection patterns called `injection.combined`. The ERB rule will now be written like this:

```clj
((code) @injection.content)
 (set! injection.language "ruby")
 (set! injection.combined true))
```

And the PHP -> HTML injection will be written like this:

```clj
((text) @injection.content
 (set! injection.language "html")
 (set! injection.combined true))
```

When the highlighting engine sees an injection pattern with `injection.combined` set to true, it will know that it should take the text of all *all* of the captured nodes, and parse them all together as one syntax tree in the specified language, as opposed to parsing each one as its own small tree.

### Steps

* [x] Update the `highlight` crate to look for this new `injection.combined` property and handle it, removing the handling of `injection.site`.
* [ ] Update all of the language repos to remove `injection.site`, and in `tree-sitter-embedded-template`, add `injection.combined`.