### PR TITLE
feat(cli): documented optional supertypes string[] in grammar schema

### DIFF
--- a/cli/src/generate/grammar-schema.json
+++ b/cli/src/generate/grammar-schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "tree-sitter grammar specification",
   "type": "object",
 
   "required": ["name", "rules"],
@@ -7,6 +9,7 @@
 
   "properties": {
     "name": {
+      "description": "the name of the grammar",
       "type": "string",
       "pattern": "^[a-zA-Z_]\\w*"
     },
@@ -57,6 +60,15 @@
     "word": {
       "type": "string",
       "pattern": "^[a-zA-Z_]\\w*"
+    },
+
+    "supertypes": {
+      "description": "each supertype instructs the parser to replace a set of subtypes in the `types` list with a single supertype.",
+      "type": "array",
+      "items": {
+        "description": "the name of a rule in `rules` or `extras`",
+        "type": "string"
+      }
     }
   },
 

--- a/cli/src/generate/grammar-schema.json
+++ b/cli/src/generate/grammar-schema.json
@@ -63,7 +63,7 @@
     },
 
     "supertypes": {
-      "description": "each supertype instructs the parser to replace a set of subtypes in the `types` list with a single supertype.",
+      "description": "A list of hidden rule names that should be considered supertypes in the generated node types file. See http://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types.",
       "type": "array",
       "items": {
         "description": "the name of a rule in `rules` or `extras`",


### PR DESCRIPTION
Addressed #524 .

drive-by fixes: I also added a `title` key and a `$schema` key to pin the JSON schema version.

Before merge, reviews should ascertain
- I've entered the correct type definition for `supertypes` and 
-  the `description` of `supertypes` correctly describes what `supertypes` does.