### PR TITLE
Fix out-of-bounds array access in `Language` APIs

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -212,10 +212,13 @@ impl Language {
     }
 
     /// Get the field names for the given numerical id.
-    pub fn field_name_for_id(&self, field_id: u16) -> &'static str {
-        unsafe { CStr::from_ptr(ffi::ts_language_field_name_for_id(self.0, field_id)) }
-            .to_str()
-            .unwrap()
+    pub fn field_name_for_id(&self, field_id: u16) -> Option<&'static str> {
+        let ptr = unsafe { ffi::ts_language_field_name_for_id(self.0, field_id) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(unsafe { CStr::from_ptr(ptr) }.to_str().unwrap())
+        }
     }
 
     /// Get the numerical id for the given field name.

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -176,10 +176,13 @@ impl Language {
     }
 
     /// Get the name of the node kind for the given numerical id.
-    pub fn node_kind_for_id(&self, id: u16) -> &'static str {
-        unsafe { CStr::from_ptr(ffi::ts_language_symbol_name(self.0, id)) }
-            .to_str()
-            .unwrap()
+    pub fn node_kind_for_id(&self, id: u16) -> Option<&'static str> {
+        let ptr = unsafe { ffi::ts_language_symbol_name(self.0, id) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(unsafe { CStr::from_ptr(ptr) }.to_str().unwrap())
+        }
     }
 
     /// Get the numeric id for the given node kind.

--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -72,8 +72,10 @@ const char *ts_language_symbol_name(
     return "ERROR";
   } else if (symbol == ts_builtin_sym_error_repeat) {
     return "_ERROR";
-  } else {
+  } else if (symbol < ts_language_symbol_count(self)) {
     return self->symbol_names[symbol];
+  } else {
+    return NULL;
   }
 }
 

--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -119,7 +119,7 @@ const char *ts_language_field_name_for_id(
   TSFieldId id
 ) {
   uint32_t count = ts_language_field_count(self);
-  if (count) {
+  if (count && id <= count) {
     return self->field_names[id];
   } else {
     return NULL;


### PR DESCRIPTION
I found these while working on the Emacs Lisp's binding.