### PR TITLE
Clarify where to put `cc` dependency for build script.

### DIFF
--- a/lib/binding_rust/README.md
+++ b/lib/binding_rust/README.md
@@ -36,6 +36,12 @@ fn main() {
 }
 ```
 
+Add the `cc` crate to your `Cargo.toml` under `[build-dependencies]`:
+```toml
+[build-dependencies]
+cc="*"
+```
+
 To then use languages from rust, you must declare them as `extern "C"` functions and invoke them with `unsafe`. Then you can assign them to the parser. 
 
 ```rust


### PR DESCRIPTION
This is obvious in retrospect but costed me some time when I had it under `[dependencies]` instead.

I thought it was some problem with the `cc` crate because this is a POWER9 machine, not x86 or ARM, and that happens some times, for instance when running `npm install` inside `tree-sitter-rust`:
```
> tree-sitter-cli@0.16.5 install /[...]/tree-sitter-rust/node_modules/tree-sitter-cli
> node install.js

/[...]/tree-sitter-rust/node_modules/tree-sitter-cli/install.js:24
  throw new Error(`Cannot install tree-sitter-cli for architecture ${process.arch}`);
  ^

Error: Cannot install tree-sitter-cli for architecture ppc64
```

I’ve been doing experiments with the Javascript binding so far, but needed it in Rust.
Now it finally works, and I’m very happy with the result.