### PR TITLE
Fix the getting started example in docs

### DIFF
--- a/docs/section-2-using-parsers.md
+++ b/docs/section-2-using-parsers.md
@@ -78,7 +78,7 @@ int main() {
   TSNode number_node = ts_node_named_child(array_node, 0);
 
   // Check that the nodes have the expected types.
-  assert(strcmp(ts_node_type(root_node), "value") == 0);
+  assert(strcmp(ts_node_type(root_node), "document") == 0);
   assert(strcmp(ts_node_type(array_node), "array") == 0);
   assert(strcmp(ts_node_type(number_node), "number") == 0);
 


### PR DESCRIPTION
Running the first example of the Getting Started failed with:

```
  main: Assertion `strcmp(ts_node_type(root_node), "value") == 0' failed.
```

The cause is the json parser that renamed the entry rule from `value` to
`document` in commit tree-sitter/tree-sitter-json@1e4abcc. This commit
fixes the example in docs to make the assert passes.