### PR TITLE
Fix exporting get/set timeout in web binding

### DIFF
--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -129,8 +129,8 @@ class Parser {
     C._ts_parser_set_timeout_micros(this[0], timeout);
   }
 
-  getTimeoutMicros(timeout) {
-    C._ts_parser_timeout_micros(this[0]);
+  getTimeoutMicros() {
+    return C._ts_parser_timeout_micros(this[0]);
   }
 
   setLogger(callback) {

--- a/lib/binding_web/exports.json
+++ b/lib/binding_web/exports.json
@@ -68,6 +68,8 @@
   "_ts_parser_new_wasm",
   "_ts_parser_parse_wasm",
   "_ts_parser_set_language",
+  "_ts_parser_set_timeout_micros",
+  "_ts_parser_timeout_micros",
   "_ts_query_capture_count",
   "_ts_query_capture_name_for_id",
   "_ts_query_captures_wasm",


### PR DESCRIPTION
Add two symbols "_ts_parser_set_timeout_micros", "_ts_parser_timeout_micros" due to usage in `tree-sitter.js`. Also the `getTimeoutMicros` function was not working, also fixed it.

The fix was trivial enough so I did not add tests.