### PR TITLE
Do not use unnamed structs/union to make it compatible with GCC 4

### DIFF
--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -1022,7 +1022,7 @@ impl Generator {
         for (i, entry) in parse_table_entries {
             add!(
                 self,
-                "  [{}] = {{.count = {}, .reusable = {}}},",
+                "  [{}] = {{.d.count = {}, .d.reusable = {}}},",
                 i,
                 entry.actions.len(),
                 entry.reusable
@@ -1052,10 +1052,10 @@ impl Generator {
                     } => {
                         add!(self, "REDUCE({}, {}", self.symbol_ids[&symbol], child_count);
                         if dynamic_precedence != 0 {
-                            add!(self, ", .dynamic_precedence = {}", dynamic_precedence);
+                            add!(self, ", .p.dynamic_precedence = {}", dynamic_precedence);
                         }
                         if production_id != 0 {
-                            add!(self, ", .production_id = {}", production_id);
+                            add!(self, ", .p.production_id = {}", production_id);
                         }
                         add!(self, ")");
                     }

--- a/lib/include/tree_sitter/parser.h
+++ b/lib/include/tree_sitter/parser.h
@@ -62,13 +62,13 @@ typedef struct {
       TSStateId state;
       bool extra : 1;
       bool repetition : 1;
-    };
+    } s;
     struct {
       TSSymbol symbol;
       int16_t dynamic_precedence;
       uint8_t child_count;
       uint8_t production_id;
-    };
+    } p;
   } params;
   TSParseActionType type : 4;
 } TSParseAction;
@@ -83,7 +83,7 @@ typedef union {
   struct {
     uint8_t count;
     bool reusable : 1;
-  };
+  } d;
 } TSParseActionEntry;
 
 struct TSLanguage {
@@ -167,12 +167,12 @@ struct TSLanguage {
 
 #define ACTIONS(id) id
 
-#define SHIFT(state_value)              \
-  {                                     \
-    {                                   \
-      .type = TSParseActionTypeShift,   \
-      .params = {.state = state_value}, \
-    }                                   \
+#define SHIFT(state_value)                \
+  {                                       \
+    {                                     \
+      .type = TSParseActionTypeShift,     \
+      .params = {.s.state = state_value}, \
+    }                                     \
   }
 
 #define SHIFT_REPEAT(state_value)     \
@@ -180,8 +180,8 @@ struct TSLanguage {
     {                                 \
       .type = TSParseActionTypeShift, \
       .params = {                     \
-        .state = state_value,         \
-        .repetition = true            \
+        .s.state = state_value,       \
+        .s.repetition = true          \
       },                              \
     }                                 \
   }
@@ -195,7 +195,7 @@ struct TSLanguage {
   {                                   \
     {                                 \
       .type = TSParseActionTypeShift, \
-      .params = {.extra = true}       \
+      .params = {.s.extra = true}     \
     }                                 \
   }
 
@@ -204,8 +204,8 @@ struct TSLanguage {
     {                                            \
       .type = TSParseActionTypeReduce,           \
       .params = {                                \
-        .symbol = symbol_val,                    \
-        .child_count = child_count_val,          \
+        .p.symbol = symbol_val,                  \
+        .p.child_count = child_count_val,        \
         __VA_ARGS__                              \
       }                                          \
     }                                            \

--- a/lib/src/get_changed_ranges.c
+++ b/lib/src/get_changed_ranges.c
@@ -148,7 +148,7 @@ static bool iterator_tree_is_visible(const Iterator *self) {
     Subtree parent = *self->cursor.stack.contents[self->cursor.stack.size - 2].subtree;
     const TSSymbol *alias_sequence = ts_language_alias_sequence(
       self->language,
-      parent.ptr->production_id
+      parent.ptr->d.non_terminal.production_id
     );
     return alias_sequence && alias_sequence[entry.structural_child_index] != 0;
   }
@@ -171,7 +171,7 @@ static void iterator_get_visible_state(const Iterator *self, Subtree *tree,
       const Subtree *parent = self->cursor.stack.contents[i - 1].subtree;
       const TSSymbol *alias_sequence = ts_language_alias_sequence(
         self->language,
-        parent->ptr->production_id
+        parent->ptr->d.non_terminal.production_id
       );
       if (alias_sequence) {
         *alias_symbol = alias_sequence[entry.structural_child_index];
@@ -203,7 +203,7 @@ static bool iterator_descend(Iterator *self, uint32_t goal_position) {
     Length position = entry.position;
     uint32_t structural_child_index = 0;
     for (uint32_t i = 0, n = ts_subtree_child_count(*entry.subtree); i < n; i++) {
-      const Subtree *child = &entry.subtree->ptr->children[i];
+      const Subtree *child = &entry.subtree->ptr->d.non_terminal.children[i];
       Length child_left = length_add(position, ts_subtree_padding(*child));
       Length child_right = length_add(child_left, ts_subtree_size(*child));
 
@@ -258,7 +258,7 @@ static void iterator_advance(Iterator *self) {
       Length position = length_add(entry.position, ts_subtree_total_size(*entry.subtree));
       uint32_t structural_child_index = entry.structural_child_index;
       if (!ts_subtree_extra(*entry.subtree)) structural_child_index++;
-      const Subtree *next_child = &parent->ptr->children[child_index];
+      const Subtree *next_child = &parent->ptr->d.non_terminal.children[child_index];
 
       array_push(&self->cursor.stack, ((TreeCursorEntry){
         .subtree = next_child,

--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -33,8 +33,8 @@ void ts_language_table_entry(
     assert(symbol < self->token_count);
     uint32_t action_index = ts_language_lookup(self, state, symbol);
     const TSParseActionEntry *entry = &self->parse_actions[action_index];
-    result->action_count = entry->count;
-    result->is_reusable = entry->reusable;
+    result->action_count = entry->d.count;
+    result->is_reusable = entry->d.reusable;
     result->actions = (const TSParseAction *)(entry + 1);
   }
 }

--- a/lib/src/language.h
+++ b/lib/src/language.h
@@ -93,7 +93,7 @@ static inline TSStateId ts_language_next_state(const TSLanguage *self,
     if (count > 0) {
       TSParseAction action = actions[count - 1];
       if (action.type == TSParseActionTypeShift) {
-        return action.params.extra ? state : action.params.state;
+        return action.params.s.extra ? state : action.params.s.state;
       }
     }
     return 0;

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -58,7 +58,7 @@ static inline NodeChildIterator ts_node_iterate_children(const TSNode *node) {
   }
   const TSSymbol *alias_sequence = ts_language_alias_sequence(
     node->tree->language,
-    subtree.ptr->production_id
+    subtree.ptr->d.non_terminal.production_id
   );
   return (NodeChildIterator) {
     .tree = node->tree,
@@ -79,7 +79,7 @@ static inline bool ts_node_child_iterator_next(
   TSNode *result
 ) {
   if (!self->parent.ptr || ts_node_child_iterator_done(self)) return false;
-  const Subtree *child = &self->parent.ptr->children[self->child_index];
+  const Subtree *child = &self->parent.ptr->d.non_terminal.children[self->child_index];
   TSSymbol alias_symbol = 0;
   if (!ts_subtree_extra(*child)) {
     if (self->alias_sequence) {
@@ -124,9 +124,9 @@ static inline uint32_t ts_node__relevant_child_count(
   Subtree tree = ts_node__subtree(self);
   if (ts_subtree_child_count(tree) > 0) {
     if (include_anonymous) {
-      return tree.ptr->visible_child_count;
+      return tree.ptr->d.non_terminal.visible_child_count;
     } else {
-      return tree.ptr->named_child_count;
+      return tree.ptr->d.non_terminal.named_child_count;
     }
   } else {
     return 0;
@@ -178,7 +178,7 @@ static bool ts_subtree_has_trailing_empty_descendant(
   Subtree other
 ) {
   for (unsigned i = ts_subtree_child_count(self) - 1; i + 1 > 0; i--) {
-    Subtree child = self.ptr->children[i];
+    Subtree child = self.ptr->d.non_terminal.children[i];
     if (ts_subtree_total_bytes(child) > 0) break;
     if (child.ptr == other.ptr || ts_subtree_has_trailing_empty_descendant(child, other)) {
       return true;
@@ -513,7 +513,7 @@ recur:
   const TSFieldMapEntry *field_map, *field_map_end;
   ts_language_field_map(
     self.tree->language,
-    ts_node__subtree(self).ptr->production_id,
+    ts_node__subtree(self).ptr->d.non_terminal.production_id,
     &field_map,
     &field_map_end
   );
@@ -588,7 +588,7 @@ TSNode ts_node_child_by_field_name(
 uint32_t ts_node_child_count(TSNode self) {
   Subtree tree = ts_node__subtree(self);
   if (ts_subtree_child_count(tree) > 0) {
-    return tree.ptr->visible_child_count;
+    return tree.ptr->d.non_terminal.visible_child_count;
   } else {
     return 0;
   }
@@ -597,7 +597,7 @@ uint32_t ts_node_child_count(TSNode self) {
 uint32_t ts_node_named_child_count(TSNode self) {
   Subtree tree = ts_node__subtree(self);
   if (ts_subtree_child_count(tree) > 0) {
-    return tree.ptr->named_child_count;
+    return tree.ptr->d.non_terminal.named_child_count;
   } else {
     return 0;
   }

--- a/lib/src/reusable_node.h
+++ b/lib/src/reusable_node.h
@@ -62,7 +62,7 @@ static inline void reusable_node_advance(ReusableNode *self) {
   } while (ts_subtree_child_count(tree) <= next_index);
 
   array_push(&self->stack, ((StackEntry) {
-    .tree = tree.ptr->children[next_index],
+    .tree = tree.ptr->d.non_terminal.children[next_index],
     .child_index = next_index,
     .byte_offset = byte_offset,
   }));
@@ -72,7 +72,7 @@ static inline bool reusable_node_descend(ReusableNode *self) {
   StackEntry last_entry = *array_back(&self->stack);
   if (ts_subtree_child_count(last_entry.tree) > 0) {
     array_push(&self->stack, ((StackEntry) {
-      .tree = last_entry.tree.ptr->children[0],
+      .tree = last_entry.tree.ptr->d.non_terminal.children[0],
       .child_index = 0,
       .byte_offset = last_entry.byte_offset,
     }));

--- a/lib/src/stack.c
+++ b/lib/src/stack.c
@@ -742,7 +742,7 @@ bool ts_stack_print_dot_graph(Stack *self, const TSLanguage *language, FILE *f) 
     );
 
     if (head->last_external_token.ptr) {
-      const ExternalScannerState *state = &head->last_external_token.ptr->external_scanner_state;
+      const ExternalScannerState *state = &head->last_external_token.ptr->d.external_scanner_state;
       const char *data = ts_external_scanner_state_data(state);
       fprintf(f, "\nexternal_scanner_state:");
       for (uint32_t j = 0; j < state->length; j++) fprintf(f, " %2X", data[j]);

--- a/lib/src/subtree.h
+++ b/lib/src/subtree.h
@@ -24,7 +24,7 @@ typedef struct {
   union {
     char *long_data;
     char short_data[24];
-  };
+  } data;
   uint32_t length;
 } ExternalScannerState;
 
@@ -79,14 +79,14 @@ typedef struct {
         TSSymbol symbol;
         TSStateId parse_state;
       } first_leaf;
-    };
+    } non_terminal;
 
     // External terminal subtrees (`child_count == 0 && has_external_tokens`)
     ExternalScannerState external_scanner_state;
 
     // Error terminal subtrees (`child_count == 0 && symbol == ts_builtin_sym_error`)
     int32_t lookahead_char;
-  };
+  } d;
 } SubtreeHeapData;
 
 union Subtree {
@@ -167,13 +167,13 @@ static inline void ts_subtree_set_extra(MutableSubtree *self) {
 static inline TSSymbol ts_subtree_leaf_symbol(Subtree self) {
   if (self.data.is_inline) return self.data.symbol;
   if (self.ptr->child_count == 0) return self.ptr->symbol;
-  return self.ptr->first_leaf.symbol;
+  return self.ptr->d.non_terminal.first_leaf.symbol;
 }
 
 static inline TSStateId ts_subtree_leaf_parse_state(Subtree self) {
   if (self.data.is_inline) return self.data.parse_state;
   if (self.ptr->child_count == 0) return self.ptr->parse_state;
-  return self.ptr->first_leaf.parse_state;
+  return self.ptr->d.non_terminal.first_leaf.parse_state;
 }
 
 static inline Length ts_subtree_padding(Subtree self) {
@@ -207,16 +207,16 @@ static inline uint32_t ts_subtree_child_count(Subtree self) {
 }
 
 static inline uint32_t ts_subtree_repeat_depth(Subtree self) {
-  return self.data.is_inline ? 0 : self.ptr->repeat_depth;
+  return self.data.is_inline ? 0 : self.ptr->d.non_terminal.repeat_depth;
 }
 
 static inline uint32_t ts_subtree_node_count(Subtree self) {
-  return (self.data.is_inline || self.ptr->child_count == 0) ? 1 : self.ptr->node_count;
+  return (self.data.is_inline || self.ptr->child_count == 0) ? 1 : self.ptr->d.non_terminal.node_count;
 }
 
 static inline uint32_t ts_subtree_visible_child_count(Subtree self) {
   if (ts_subtree_child_count(self) > 0) {
-    return self.ptr->visible_child_count;
+    return self.ptr->d.non_terminal.visible_child_count;
   } else {
     return 0;
   }
@@ -231,12 +231,12 @@ static inline uint32_t ts_subtree_error_cost(Subtree self) {
 }
 
 static inline int32_t ts_subtree_dynamic_precedence(Subtree self) {
-  return (self.data.is_inline || self.ptr->child_count == 0) ? 0 : self.ptr->dynamic_precedence;
+  return (self.data.is_inline || self.ptr->child_count == 0) ? 0 : self.ptr->d.non_terminal.dynamic_precedence;
 }
 
 static inline uint16_t ts_subtree_production_id(Subtree self) {
   if (ts_subtree_child_count(self) > 0) {
-    return self.ptr->production_id;
+    return self.ptr->d.non_terminal.production_id;
   } else {
     return 0;
   }

--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -22,7 +22,7 @@ static inline CursorChildIterator ts_tree_cursor_iterate_children(const TreeCurs
   }
   const TSSymbol *alias_sequence = ts_language_alias_sequence(
     self->tree->language,
-    last_entry->subtree->ptr->production_id
+    last_entry->subtree->ptr->d.non_terminal.production_id
   );
   return (CursorChildIterator) {
     .tree = self->tree,
@@ -38,7 +38,7 @@ static inline bool ts_tree_cursor_child_iterator_next(CursorChildIterator *self,
                                                       TreeCursorEntry *result,
                                                       bool *visible) {
   if (!self->parent.ptr || self->child_index == self->parent.ptr->child_count) return false;
-  const Subtree *child = &self->parent.ptr->children[self->child_index];
+  const Subtree *child = &self->parent.ptr->d.non_terminal.children[self->child_index];
   *result = (TreeCursorEntry) {
     .subtree = child,
     .position = self->position,
@@ -56,7 +56,7 @@ static inline bool ts_tree_cursor_child_iterator_next(CursorChildIterator *self,
   self->child_index++;
 
   if (self->child_index < self->parent.ptr->child_count) {
-    Subtree next_child = self->parent.ptr->children[self->child_index];
+    Subtree next_child = self->parent.ptr->d.non_terminal.children[self->child_index];
     self->position = length_add(self->position, ts_subtree_padding(next_child));
   }
 
@@ -210,7 +210,7 @@ bool ts_tree_cursor_goto_parent(TSTreeCursor *_self) {
       TreeCursorEntry *parent_entry = &self->stack.contents[i - 1];
       const TSSymbol *alias_sequence = ts_language_alias_sequence(
         self->tree->language,
-        parent_entry->subtree->ptr->production_id
+        parent_entry->subtree->ptr->d.non_terminal.production_id
       );
       is_aliased = alias_sequence && alias_sequence[entry->structural_child_index];
     }
@@ -230,7 +230,7 @@ TSNode ts_tree_cursor_current_node(const TSTreeCursor *_self) {
     TreeCursorEntry *parent_entry = &self->stack.contents[self->stack.size - 2];
     const TSSymbol *alias_sequence = ts_language_alias_sequence(
       self->tree->language,
-      parent_entry->subtree->ptr->production_id
+      parent_entry->subtree->ptr->d.non_terminal.production_id
     );
     if (alias_sequence && !ts_subtree_extra(*last_entry->subtree)) {
       alias_symbol = alias_sequence[last_entry->structural_child_index];
@@ -265,7 +265,7 @@ TSFieldId ts_tree_cursor_current_status(
       if (ts_subtree_visible(*entry->subtree)) break;
       const TSSymbol *alias_sequence = ts_language_alias_sequence(
         self->tree->language,
-        parent_entry->subtree->ptr->production_id
+        parent_entry->subtree->ptr->d.non_terminal.production_id
       );
       if (alias_sequence && alias_sequence[entry->structural_child_index]) {
         break;
@@ -281,7 +281,7 @@ TSFieldId ts_tree_cursor_current_status(
     const TSFieldMapEntry *field_map, *field_map_end;
     ts_language_field_map(
       self->tree->language,
-      parent_entry->subtree->ptr->production_id,
+      parent_entry->subtree->ptr->d.non_terminal.production_id,
       &field_map, &field_map_end
     );
 
@@ -323,7 +323,7 @@ TSFieldId ts_tree_cursor_current_field_id(const TSTreeCursor *_self) {
       if (ts_subtree_visible(*entry->subtree)) break;
       const TSSymbol *alias_sequence = ts_language_alias_sequence(
         self->tree->language,
-        parent_entry->subtree->ptr->production_id
+        parent_entry->subtree->ptr->d.non_terminal.production_id
       );
       if (alias_sequence && alias_sequence[entry->structural_child_index]) {
         break;
@@ -335,7 +335,7 @@ TSFieldId ts_tree_cursor_current_field_id(const TSTreeCursor *_self) {
     const TSFieldMapEntry *field_map, *field_map_end;
     ts_language_field_map(
       self->tree->language,
-      parent_entry->subtree->ptr->production_id,
+      parent_entry->subtree->ptr->d.non_terminal.production_id,
       &field_map, &field_map_end
     );
     for (const TSFieldMapEntry *i = field_map; i < field_map_end; i++) {


### PR DESCRIPTION
I know GCC 4 is a very old version, but it would be great for a project I work on to be able to build there as well. We recently included tree-sitter compiled by default and I noticed there are some constructs that do not work well with such a old gcc (used for example in RHEL6/Centos 6).

I understand those unnamed structs/union are probably handy as they avoid too long names, but I think it would be great to make tree-sitter compile on a wider range of systems.

I hope you can consider such inclusion. For the names of those unnamed unions/structs I am very open to suggestion :) Thanks!