### PR TITLE
Tree-queries - add optional node syntax, improve handling of repeated nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ docs/assets/js/tree-sitter.js
 /target
 *.rs.bk
 *.a
+*.dylib
 *.o
 *.obj
 *.exp

--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -596,6 +596,33 @@ fn test_query_matches_with_top_level_repetitions() {
 }
 
 #[test]
+fn test_query_matches_with_non_terminal_repetitions_within_root() {
+    allocations::record(|| {
+        let language = get_language("javascript");
+        let query = Query::new(
+            language,
+            r#"
+            (*
+                (expression_statement
+                  (identifier) @id)+)
+            "#,
+        )
+        .unwrap();
+
+        assert_query_matches(
+            language,
+            &query,
+            r#"
+            a;
+            b;
+            c;
+            "#,
+            &[(0, vec![("id", "a"), ("id", "b"), ("id", "c")])],
+        );
+    });
+}
+
+#[test]
 fn test_query_matches_with_nested_repetitions() {
     allocations::record(|| {
         let language = get_language("javascript");

--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -2,8 +2,8 @@ use super::helpers::allocations;
 use super::helpers::fixtures::get_language;
 use std::fmt::Write;
 use tree_sitter::{
-    Node, Parser, Query, QueryCapture, QueryCursor, QueryError, QueryMatch, QueryPredicate,
-    QueryPredicateArg, QueryProperty,
+    Language, Node, Parser, Query, QueryCapture, QueryCursor, QueryError, QueryMatch,
+    QueryPredicate, QueryPredicateArg, QueryProperty,
 };
 
 #[test]
@@ -163,19 +163,13 @@ fn test_query_matches_with_simple_pattern() {
         )
         .unwrap();
 
-        let source = "function one() { two(); function three() {} }";
-        let mut parser = Parser::new();
-        parser.set_language(language).unwrap();
-        let tree = parser.parse(source, None).unwrap();
-
-        let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
-
-        assert_eq!(
-            collect_matches(matches, &query, source),
+        assert_query_matches(
+            language,
+            &query,
+            "function one() { two(); function three() {} }",
             &[
                 (0, vec![("fn-name", "one")]),
-                (0, vec![("fn-name", "three")])
+                (0, vec![("fn-name", "three")]),
             ],
         );
     });
@@ -195,7 +189,10 @@ fn test_query_matches_with_multiple_on_same_root() {
         )
         .unwrap();
 
-        let source = "
+        assert_query_matches(
+            language,
+            &query,
+            "
             class Person {
                 // the constructor
                 constructor(name) { this.name = name; }
@@ -203,30 +200,21 @@ fn test_query_matches_with_multiple_on_same_root() {
                 // the getter
                 getFullName() { return this.name; }
             }
-        ";
-
-        let mut parser = Parser::new();
-        parser.set_language(language).unwrap();
-        let tree = parser.parse(source, None).unwrap();
-        let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
-
-        assert_eq!(
-            collect_matches(matches, &query, source),
+            ",
             &[
                 (
                     0,
                     vec![
                         ("the-class-name", "Person"),
-                        ("the-method-name", "constructor")
-                    ]
+                        ("the-method-name", "constructor"),
+                    ],
                 ),
                 (
                     0,
                     vec![
                         ("the-class-name", "Person"),
-                        ("the-method-name", "getFullName")
-                    ]
+                        ("the-method-name", "getFullName"),
+                    ],
                 ),
             ],
         );
@@ -246,20 +234,14 @@ fn test_query_matches_with_multiple_patterns_different_roots() {
         )
         .unwrap();
 
-        let source = "
+        assert_query_matches(
+            language,
+            &query,
+            "
             function f1() {
                 f2(f3());
             }
-        ";
-
-        let mut parser = Parser::new();
-        parser.set_language(language).unwrap();
-        let tree = parser.parse(source, None).unwrap();
-        let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
-
-        assert_eq!(
-            collect_matches(matches, &query, source),
+            ",
             &[
                 (0, vec![("fn-def", "f1")]),
                 (1, vec![("fn-ref", "f2")]),
@@ -287,21 +269,15 @@ fn test_query_matches_with_multiple_patterns_same_root() {
         )
         .unwrap();
 
-        let source = "
+        assert_query_matches(
+            language,
+            &query,
+            "
             a = {
                 b: () => { return c; },
                 d: function() { return d; }
             };
-        ";
-
-        let mut parser = Parser::new();
-        parser.set_language(language).unwrap();
-        let tree = parser.parse(source, None).unwrap();
-        let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
-
-        assert_eq!(
-            collect_matches(matches, &query, source),
+            ",
             &[
                 (1, vec![("method-def", "b")]),
                 (0, vec![("method-def", "d")]),
@@ -325,20 +301,14 @@ fn test_query_matches_with_nesting_and_no_fields() {
         )
         .unwrap();
 
-        let source = "
+        assert_query_matches(
+            language,
+            &query,
+            "
             [[a]];
             [[c, d], [e, f, g, h]];
             [[h], [i]];
-        ";
-
-        let mut parser = Parser::new();
-        parser.set_language(language).unwrap();
-        let tree = parser.parse(source, None).unwrap();
-        let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
-
-        assert_eq!(
-            collect_matches(matches, &query, source),
+            ",
             &[
                 (0, vec![("x1", "c"), ("x2", "d")]),
                 (0, vec![("x1", "e"), ("x2", "f")]),
@@ -358,17 +328,11 @@ fn test_query_matches_with_many() {
         let language = get_language("javascript");
         let query = Query::new(language, "(array (identifier) @element)").unwrap();
 
-        let source = "[hello];\n".repeat(50);
-
-        let mut parser = Parser::new();
-        parser.set_language(language).unwrap();
-        let tree = parser.parse(&source, None).unwrap();
-        let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(&source));
-
-        assert_eq!(
-            collect_matches(matches, &query, source.as_str()),
-            vec![(0, vec![("element", "hello")]); 50],
+        assert_query_matches(
+            language,
+            &query,
+            &"[hello];\n".repeat(50),
+            &vec![(0, vec![("element", "hello")]); 50],
         );
     });
 }
@@ -385,20 +349,11 @@ fn test_query_matches_capturing_error_nodes() {
         )
         .unwrap();
 
-        let source = "function a(b,, c, d :e:) {}";
-
-        let mut parser = Parser::new();
-        parser.set_language(language).unwrap();
-        let tree = parser.parse(source, None).unwrap();
-        let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
-
-        assert_eq!(
-            collect_matches(matches, &query, source),
-            &[(
-                0,
-                vec![("the-error", ":e:"), ("the-error-identifier", "e"),]
-            ),]
+        assert_query_matches(
+            language,
+            &query,
+            "function a(b,, c, d :e:) {}",
+            &[(0, vec![("the-error", ":e:"), ("the-error-identifier", "e")])],
         );
     });
 }
@@ -439,10 +394,6 @@ fn test_query_matches_with_named_wildcard() {
 fn test_query_matches_with_wildcard_at_the_root() {
     allocations::record(|| {
         let language = get_language("javascript");
-        let mut cursor = QueryCursor::new();
-        let mut parser = Parser::new();
-        parser.set_language(language).unwrap();
-
         let query = Query::new(
             language,
             "
@@ -455,13 +406,11 @@ fn test_query_matches_with_wildcard_at_the_root() {
         )
         .unwrap();
 
-        let source = "/* one */ var x; /* two */ function y() {} /* three */ class Z {}";
-
-        let tree = parser.parse(source, None).unwrap();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
-        assert_eq!(
-            collect_matches(matches, &query, source),
-            &[(0, vec![("doc", "/* two */"), ("name", "y")]),]
+        assert_query_matches(
+            language,
+            &query,
+            "/* one */ var x; /* two */ function y() {} /* three */ class Z {}",
+            &[(0, vec![("doc", "/* two */"), ("name", "y")])],
         );
 
         let query = Query::new(
@@ -475,17 +424,15 @@ fn test_query_matches_with_wildcard_at_the_root() {
         )
         .unwrap();
 
-        let source = "['hi', x(true), {y: false}]";
-
-        let tree = parser.parse(source, None).unwrap();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
-        assert_eq!(
-            collect_matches(matches, &query, source),
+        assert_query_matches(
+            language,
+            &query,
+            "['hi', x(true), {y: false}]",
             &[
                 (0, vec![("a", "'hi'")]),
                 (2, vec![("c", "true")]),
                 (3, vec![("d", "false")]),
-            ]
+            ],
         );
     });
 }
@@ -519,16 +466,10 @@ fn test_query_matches_with_immediate_siblings() {
         )
         .unwrap();
 
-        let source = "import a.b.c.d; return [w, [1, y], z]";
-
-        let mut parser = Parser::new();
-        parser.set_language(language).unwrap();
-        let tree = parser.parse(source, None).unwrap();
-        let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
-
-        assert_eq!(
-            collect_matches(matches, &query, source),
+        assert_query_matches(
+            language,
+            &query,
+            "import a.b.c.d; return [w, [1, y], z]",
             &[
                 (0, vec![("parent", "a"), ("child", "b")]),
                 (0, vec![("parent", "b"), ("child", "c")]),
@@ -536,7 +477,7 @@ fn test_query_matches_with_immediate_siblings() {
                 (0, vec![("parent", "c"), ("child", "d")]),
                 (2, vec![("first-element", "w")]),
                 (2, vec![("first-element", "1")]),
-            ]
+            ],
         );
     });
 }
@@ -564,7 +505,10 @@ fn test_query_matches_with_repeated_leaf_nodes() {
         )
         .unwrap();
 
-        let source = "
+        assert_query_matches(
+            language,
+            &query,
+            "
             // one
             // two
             a();
@@ -582,16 +526,7 @@ fn test_query_matches_with_repeated_leaf_nodes() {
                 // eight
                 function d() {}
             }
-        ";
-
-        let mut parser = Parser::new();
-        parser.set_language(language).unwrap();
-        let tree = parser.parse(source, None).unwrap();
-        let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
-
-        assert_eq!(
-            collect_matches(matches, &query, source),
+            ",
             &[
                 (
                     0,
@@ -599,11 +534,31 @@ fn test_query_matches_with_repeated_leaf_nodes() {
                         ("doc", "// four"),
                         ("doc", "// five"),
                         ("doc", "// six"),
-                        ("name", "B")
-                    ]
+                        ("name", "B"),
+                    ],
                 ),
                 (1, vec![("doc", "// eight"), ("name", "d")]),
-            ]
+            ],
+        );
+    });
+}
+
+#[test]
+fn test_query_matches_with_optional_nodes_inside_of_repetitions() {
+    allocations::record(|| {
+        let language = get_language("javascript");
+        let query = Query::new(language, r#"(array (","? (number) @num)+)"#).unwrap();
+
+        assert_query_matches(
+            language,
+            &query,
+            r#"
+            var a = [1, 2, 3, 4]
+            "#,
+            &[(
+                0,
+                vec![("num", "1"), ("num", "2"), ("num", "3"), ("num", "4")],
+            )],
         );
     });
 }
@@ -625,43 +580,37 @@ fn test_query_matches_with_leading_optional_repeated_leaf_nodes() {
         )
         .unwrap();
 
-        let source = "
-        function a() {
-            // one
-            var b;
+        assert_query_matches(
+            language,
+            &query,
+            "
+            function a() {
+                // one
+                var b;
 
-            function c() {}
+                function c() {}
 
-            // two
-            // three
-            var d;
+                // two
+                // three
+                var d;
 
-            // four
-            // five
-            function e() {
+                // four
+                // five
+                function e() {
 
+                }
             }
-        }
 
-        // six
-        ";
-
-        let mut parser = Parser::new();
-        parser.set_language(language).unwrap();
-        let tree = parser.parse(source, None).unwrap();
-        let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
-
-        assert_eq!(
-            collect_matches(matches, &query, source),
+            // six
+            ",
             &[
                 (0, vec![("name", "a")]),
                 (0, vec![("name", "c")]),
                 (
                     0,
-                    vec![("doc", "// four"), ("doc", "// five"), ("name", "e")]
+                    vec![("doc", "// four"), ("doc", "// five"), ("name", "e")],
                 ),
-            ]
+            ],
         );
     });
 }
@@ -682,37 +631,21 @@ fn test_query_matches_with_optional_nodes() {
         )
         .unwrap();
 
-        let mut parser = Parser::new();
-        parser.set_language(language).unwrap();
+        assert_query_matches(language, &query, "class A {}", &[(0, vec![("class", "A")])]);
 
-        let source = "
-            class A {}
-        ";
-        let tree = parser.parse(source, None).unwrap();
-        let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
-
-        assert_eq!(
-            collect_matches(matches, &query, source),
-            &[(0, vec![("class", "A")]),]
-        );
-
-        let source = "
+        assert_query_matches(
+            language,
+            &query,
+            "
             class A {}
             class B extends C {}
             class D extends (E.F) {}
-        ";
-        let tree = parser.parse(source, None).unwrap();
-        let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
-
-        assert_eq!(
-            collect_matches(matches, &query, source),
+            ",
             &[
                 (0, vec![("class", "A")]),
                 (0, vec![("class", "B"), ("superclass", "C")]),
                 (0, vec![("class", "D")]),
-            ]
+            ],
         );
     });
 }
@@ -721,10 +654,6 @@ fn test_query_matches_with_optional_nodes() {
 fn test_query_matches_with_repeated_internal_nodes() {
     allocations::record(|| {
         let language = get_language("javascript");
-        let mut parser = Parser::new();
-        parser.set_language(language).unwrap();
-        let mut cursor = QueryCursor::new();
-
         let query = Query::new(
             language,
             "
@@ -735,18 +664,18 @@ fn test_query_matches_with_repeated_internal_nodes() {
             ",
         )
         .unwrap();
-        let source = "
+
+        assert_query_matches(
+            language,
+            &query,
+            "
             class A {
                 @c
                 @d
                 e() {}
             }
-        ";
-        let tree = parser.parse(source, None).unwrap();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
-        assert_eq!(
-            collect_matches(matches, &query, source),
-            &[(0, vec![("deco", "c"), ("deco", "d"), ("name", "e")]),]
+            ",
+            &[(0, vec![("deco", "c"), ("deco", "d"), ("name", "e")])],
         );
     })
 }
@@ -760,20 +689,16 @@ fn test_query_matches_in_language_with_simple_aliases() {
         // tag names, script tag names, and style tag names. All of
         // these tokens are aliased to `tag_name`.
         let query = Query::new(language, "(tag_name) @tag").unwrap();
-        let source = "
+
+        assert_query_matches(
+            language,
+            &query,
+            "
             <div>
                 <script>hi</script>
                 <style>hi</style>
-            </div>";
-
-        let mut parser = Parser::new();
-        parser.set_language(language).unwrap();
-        let tree = parser.parse(&source, None).unwrap();
-        let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(&source));
-
-        assert_eq!(
-            collect_matches(matches, &query, source),
+            </div>
+            ",
             &[
                 (0, vec![("tag", "div")]),
                 (0, vec![("tag", "script")]),
@@ -789,6 +714,8 @@ fn test_query_matches_in_language_with_simple_aliases() {
 #[test]
 fn test_query_matches_with_different_tokens_with_the_same_string_value() {
     allocations::record(|| {
+        // In Rust, there are two '<' tokens: one for the binary operator,
+        // and one with higher precedence for generics.
         let language = get_language("rust");
         let query = Query::new(
             language,
@@ -799,24 +726,16 @@ fn test_query_matches_with_different_tokens_with_the_same_string_value() {
         )
         .unwrap();
 
-        // In Rust, there are two '<' tokens: one for the binary operator,
-        // and one with higher precedence for generics.
-        let source = "const A: B<C> = d < e || f > g;";
-
-        let mut parser = Parser::new();
-        parser.set_language(language).unwrap();
-        let tree = parser.parse(&source, None).unwrap();
-        let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
-
-        assert_eq!(
-            collect_matches(matches, &query, source),
+        assert_query_matches(
+            language,
+            &query,
+            "const A: B<C> = d < e || f > g;",
             &[
                 (0, vec![("less", "<")]),
                 (1, vec![("greater", ">")]),
                 (0, vec![("less", "<")]),
                 (1, vec![("greater", ">")]),
-            ]
+            ],
         );
     });
 }
@@ -866,20 +785,14 @@ fn test_query_matches_with_anonymous_tokens() {
         )
         .unwrap();
 
-        let source = "foo(a && b);";
-
-        let mut parser = Parser::new();
-        parser.set_language(language).unwrap();
-        let tree = parser.parse(&source, None).unwrap();
-        let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
-
-        assert_eq!(
-            collect_matches(matches, &query, source),
+        assert_query_matches(
+            language,
+            &query,
+            "foo(a && b);",
             &[
                 (1, vec![("operator", "&&")]),
                 (0, vec![("punctuation", ";")]),
-            ]
+            ],
         );
     });
 }
@@ -1770,6 +1683,20 @@ fn test_query_disable_pattern() {
             ],
         );
     });
+}
+
+fn assert_query_matches(
+    language: Language,
+    query: &Query,
+    source: &str,
+    expected: &[(usize, Vec<(&str, &str)>)],
+) {
+    let mut parser = Parser::new();
+    parser.set_language(language).unwrap();
+    let tree = parser.parse(source, None).unwrap();
+    let mut cursor = QueryCursor::new();
+    let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
+    assert_eq!(collect_matches(matches, &query, source), expected);
 }
 
 fn collect_matches<'a>(

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -1456,21 +1456,8 @@ static inline bool ts_query_cursor__advance(TSQueryCursor *self) {
         return self->finished_states.size > 0;
       }
     } else {
-      bool can_have_later_siblings;
-      bool can_have_later_siblings_with_this_field;
-      TSFieldId field_id = ts_tree_cursor_current_status(
-        &self->cursor,
-        &can_have_later_siblings,
-        &can_have_later_siblings_with_this_field
-      );
-      TSNode node = ts_tree_cursor_current_node(&self->cursor);
-      TSSymbol symbol = ts_node_symbol(node);
-      bool is_named = ts_node_is_named(node);
-      if (symbol != ts_builtin_sym_error && self->query->symbol_map) {
-        symbol = self->query->symbol_map[symbol];
-      }
-
       // If this node is before the selected range, then avoid descending into it.
+      TSNode node = ts_tree_cursor_current_node(&self->cursor);
       if (
         ts_node_end_byte(node) <= self->start_byte ||
         point_lte(ts_node_end_point(node), self->start_point)
@@ -1487,6 +1474,19 @@ static inline bool ts_query_cursor__advance(TSQueryCursor *self) {
         point_lte(self->end_point, ts_node_start_point(node))
       ) return false;
 
+      // Get the properties of the current node.
+      TSSymbol symbol = ts_node_symbol(node);
+      bool is_named = ts_node_is_named(node);
+      if (symbol != ts_builtin_sym_error && self->query->symbol_map) {
+        symbol = self->query->symbol_map[symbol];
+      }
+      bool can_have_later_siblings;
+      bool can_have_later_siblings_with_this_field;
+      TSFieldId field_id = ts_tree_cursor_current_status(
+        &self->cursor,
+        &can_have_later_siblings,
+        &can_have_later_siblings_with_this_field
+      );
       LOG(
         "enter node. type:%s, field:%s, row:%u state_count:%u, finished_state_count:%u\n",
         ts_node_type(node),


### PR DESCRIPTION
### Summary

This PR adds a new postfix `?` operator to the tree-query syntax, which indicates that a node in a pattern is *optional*. It also fixes bugs in the handling of the postfix `+` operator in tree queries.

### Motivation

In #583, we introduced a system for computing `ctags`-style tags, using Tree-queries to specify how they should work for each language. As part of that effort, we realized that in order to capture documentation comments, we would need a *repetition* operator in tree queries. It is also very convenient to have an *optional* operator, so that we don't have to specify each pattern twice: once with doc comments and once without.

### Implementation Notes

The compiled `TSQuery` objects now have a structure that's a bit more general, and a bit more like a classic NFA. Branching in the state graph is expressed by the "query step" structs having an optional `alternative_index`, which stores the index of another query step. This more general structure allows for things like nested repetitions/optionals to be handled correctly.

### Next Steps

With these structural improvements in place, it will be easy to make the query syntax more powerful and convenient.

#### Changing the meaning of `*`

Currently, the `+` operator means *one-or-more*, and the `?` means *optional*. So in order to get a *zero-or-more* repetition, you need to write `+?`. This is dumb. But unfortunately, the `*` operator is already used as a 'wildcard' matcher (match any node type).

We should change the wildcard syntax to use a different character, probably `_`, a la Rust's pattern syntax. Then we could change `*` to mean *zero-or-more*. That would match regex syntax, which is familiar to many people.

Fortunately, the `*` operator is not yet documented, so it's unlikely people outside of GitHub are using it.

#### Parenthesized sequences

Currently, you can't write a pattern that matches multiple sibling nodes without also including a *parent* node that wraps them all. In the future, I'd like you to be able to write siblings as a simple parenthesized list, like this:

```
(
  (comment)* @doc
  (function_declaration
    name: (identifier) @name) @function
)
```

Note that there is no *parent* node written that contains both the `comment` and the `function_declaration`. Today, we work around this missing feature by using a wildcard (`*`) for the parent node.

This could also be useful if you wanted to apply *repetition* to a sibling sequence. For example, you could capture an arbitrary number of strings in an array like this:

```
(array
  (string) @element
  ("," (string) @element)*)
```

I plan to do these things ☝️ in follow-up PRs, so that this PR will be non-breaking.