### PR TITLE
Fix wasm tests on CI

### DIFF
--- a/cli/src/wasm.rs
+++ b/cli/src/wasm.rs
@@ -89,11 +89,11 @@ pub fn compile_language_to_wasm(language_dir: &Path, force_docker: bool) -> Resu
     let scanner_cc_path = src.join("scanner.cc");
     let scanner_cpp_path = src.join("scanner.cpp");
 
-    if scanner_cc_path.exists() {
+    if language_dir.join(&scanner_cc_path).exists() {
         command.arg("-xc++").arg(&scanner_cc_path);
-    } else if scanner_cpp_path.exists() {
+    } else if language_dir.join(&scanner_cpp_path).exists() {
         command.arg("-xc++").arg(&scanner_cpp_path);
-    } else if scanner_c_path.exists() {
+    } else if language_dir.join(&scanner_c_path).exists() {
         command.arg(&scanner_c_path);
     }
 

--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -872,10 +872,14 @@ class Language {
     return bytes
       .then(bytes => loadWebAssemblyModule(bytes, {loadAsync: true}))
       .then(mod => {
-        const functionName = Object.keys(mod).find(key =>
+        const symbolNames = Object.keys(mod)
+        const functionName = symbolNames.find(key =>
           LANGUAGE_FUNCTION_REGEX.test(key) &&
           !key.includes("external_scanner_")
         );
+        if (!functionName) {
+          console.log(`Couldn't find language function in WASM file. Symbols:\n${JSON.stringify(symbolNames, null, 2)}`)
+        }
         const languageAddress = mod[functionName]();
         return new Language(INTERNAL, languageAddress);
       });


### PR DESCRIPTION
I've had to make a series of tweaks to the way the library and parsers are compiled to Wasm due to a change to emscripten. I'm seeing different results on CI than I do locally, so I'm opening this PR to push a series of changes to try and fix the issue.