### PR TITLE
add Rust into languages list for corpus tests

### DIFF
--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -24,6 +24,7 @@ const LANGUAGES: &'static [&'static str] = &[
     "json",
     "php",
     "python",
+    "rust",
 ];
 
 lazy_static! {


### PR DESCRIPTION
For some reason Rust wasn't a part of tested languages.
 
```
$ TREE_SITTER_TEST_LANGUAGE_FILTER=rust cargo test -p tree-sitter-cli --jobs 1 corpus -- --show-output 
```