### PR TITLE
[cli]: add an option to no open browser in web-ui command

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -149,7 +149,8 @@ fn run() -> error::Result<()> {
                 .arg(Arg::with_name("path").index(1).multiple(true)),
         )
         .subcommand(
-            SubCommand::with_name("web-ui").about("Test a parser interactively in the browser"),
+            SubCommand::with_name("web-ui").about("Test a parser interactively in the browser")
+                .arg(Arg::with_name("quiet").long("quiet").short("q").help("open in default browser")),
         )
         .subcommand(
             SubCommand::with_name("dump-languages")
@@ -318,8 +319,9 @@ fn run() -> error::Result<()> {
     } else if let Some(matches) = matches.subcommand_matches("build-wasm") {
         let grammar_path = current_dir.join(matches.value_of("path").unwrap_or(""));
         wasm::compile_language_to_wasm(&grammar_path, matches.is_present("docker"))?;
-    } else if matches.subcommand_matches("web-ui").is_some() {
-        web_ui::serve(&current_dir);
+    } else if let Some(matches) = matches.subcommand_matches("web-ui") {
+        let open_in_browser = !matches.is_present("quiet");
+        web_ui::serve(&current_dir, open_in_browser);
     } else if matches.subcommand_matches("dump-languages").is_some() {
         loader.find_all_languages(&config.parser_directories)?;
         for (configuration, language_path) in loader.get_all_language_configurations() {

--- a/cli/src/web_ui.rs
+++ b/cli/src/web_ui.rs
@@ -43,7 +43,7 @@ resource!(get_playground_js, "docs/assets/js/playground.js");
 posix_resource!(get_lib_js, "lib/binding_web/tree-sitter.js");
 posix_resource!(get_lib_wasm, "lib/binding_web/tree-sitter.wasm");
 
-pub fn serve(grammar_path: &Path) {
+pub fn serve(grammar_path: &Path, open_in_browser: bool) {
     let port = get_available_port().expect("Couldn't find an available port");
     let url = format!("127.0.0.1:{}", port);
     let server = Server::http(&url).expect("Failed to start web server");
@@ -59,12 +59,11 @@ pub fn serve(grammar_path: &Path) {
             )
         }))
         .unwrap();
-
-    webbrowser::open(&format!("http://127.0.0.1:{}", port))
-        .map_err(Error::wrap(|| {
-            format!("Failed to open '{}' in a web browser", url)
-        }))
-        .unwrap();
+    if open_in_browser {
+        if let Err(_) = webbrowser::open(&format!("http://127.0.0.1:{}", port)) {
+            eprintln!("Failed to open '{}' in a web browser", url);
+        }
+    }
 
     let tree_sitter_dir = env::var("TREE_SITTER_BASE_DIR").map(PathBuf::from).ok();
     let main_html = String::from_utf8(get_main_html(&tree_sitter_dir))


### PR DESCRIPTION
I need to test my grammar in browser frequently.
`tree-sitter web-ui` will open a new browser each time, which may be unnecessary.
This option disable it.
I think this can also close #506 .