### PR TITLE
TypeScript: Correct SyntaxNode isNamed type

### DIFF
--- a/lib/binding_web/tree-sitter-web.d.ts
+++ b/lib/binding_web/tree-sitter-web.d.ts
@@ -50,7 +50,6 @@ declare module 'web-tree-sitter' {
     export interface SyntaxNode {
       tree: Tree;
       type: string;
-      isNamed: boolean;
       text: string;
       startPosition: Point;
       endPosition: Point;
@@ -74,6 +73,7 @@ declare module 'web-tree-sitter' {
       hasError(): boolean;
       equals(other: SyntaxNode): boolean;
       isMissing(): boolean;
+      isNamed(): boolean;
       toString(): string;
       child(index: number): SyntaxNode | null;
       namedChild(index: number): SyntaxNode | null;


### PR DESCRIPTION
`isNamed` is a function not a boolean, see https://github.com/tree-sitter/tree-sitter/blob/40993195b8da0d042161a7b7bb0f6831dcfb4da1/lib/binding_web/binding.js#L237