### PR TITLE
Fix compilation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: rust
 rust:
   - stable
 
+env:
+  CFLAGS="-Wall -Wextra -Werror -Wstrict-prototypes"
+
 matrix:
   include:
     - os: osx

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 OBJ := $(SRC:.c=.o)
 
 # define default flags, and override to append mandatory flags
-CFLAGS ?= -O3
+CFLAGS ?= -O3 -Wall -Wextra -Werror
 override CFLAGS += -std=gnu99 -fPIC -Ilib/src -Ilib/include
 
 # ABI versioning

--- a/lib/src/alloc.h
+++ b/lib/src/alloc.h
@@ -38,6 +38,7 @@ static inline void ts_free(void *buffer) {
 #include <stdlib.h>
 
 static inline bool ts_toggle_allocation_recording(bool value) {
+  (void)value;
   return false;
 }
 

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -101,9 +101,10 @@ typedef struct {
 static const char *ts_string_input_read(
   void *_self,
   uint32_t byte,
-  TSPoint _,
+  TSPoint pt,
   uint32_t *length
 ) {
+  (void)pt;
   TSStringInput *self = (TSStringInput *)_self;
   if (byte >= self->length) {
     *length = 0;
@@ -210,6 +211,7 @@ static ErrorComparison ts_parser__compare_versions(
   ErrorStatus a,
   ErrorStatus b
 ) {
+  (void)self;
   if (!a.is_in_error && b.is_in_error) {
     if (a.cost < b.cost) {
       return ErrorComparisonTakeLeft;

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -259,7 +259,7 @@ static void stream_scan_identifier(Stream *stream) {
  * CaptureListPool
  ******************/
 
-static CaptureListPool capture_list_pool_new() {
+static CaptureListPool capture_list_pool_new(void) {
   return (CaptureListPool) {
     .empty_list = array_new(),
     .usage_map = UINT32_MAX,
@@ -315,7 +315,7 @@ static void capture_list_pool_release(CaptureListPool *self, uint16_t id) {
  * SymbolTable
  **************/
 
-static SymbolTable symbol_table_new() {
+static SymbolTable symbol_table_new(void) {
   return (SymbolTable) {
     .characters = array_new(),
     .slices = array_new(),
@@ -752,7 +752,7 @@ static TSQueryError ts_query__parse_pattern(
       array_push(&branch_step_indices, start_index);
       array_push(&self->steps, query_step__new(0, depth, false));
     }
-    array_pop(&self->steps);
+    (void)array_pop(&self->steps);
 
     // For all of the branches except for the last one, add the subsequent branch as an
     // alternative, and link the end of the branch to the current end of the steps.
@@ -1267,7 +1267,7 @@ void ts_query_disable_pattern(
  * QueryCursor
  ***************/
 
-TSQueryCursor *ts_query_cursor_new() {
+TSQueryCursor *ts_query_cursor_new(void) {
   TSQueryCursor *self = ts_malloc(sizeof(TSQueryCursor));
   *self = (TSQueryCursor) {
     .ascending = false,

--- a/lib/src/stack.c
+++ b/lib/src/stack.c
@@ -480,6 +480,7 @@ StackSliceArray ts_stack_pop_count(Stack *self, StackVersion version, uint32_t c
 }
 
 inline StackAction pop_pending_callback(void *payload, const StackIterator *iterator) {
+  (void)payload;
   if (iterator->subtree_count >= 1) {
     if (iterator->is_pending) {
       return StackActionPop | StackActionStop;
@@ -532,6 +533,7 @@ SubtreeArray ts_stack_pop_error(Stack *self, StackVersion version) {
 }
 
 inline StackAction pop_all_callback(void *payload, const StackIterator *iterator) {
+  (void)payload;
   return iterator->node->link_count == 0 ? StackActionPop : StackActionNone;
 }
 


### PR DESCRIPTION
This PR fixes some compilation warnings triggered while compiling the C library.

Some of them are triggered when building within neovim (see https://github.com/neovim/neovim/pull/12321 for more informations).

cc @tjdevries