### PR TITLE
Requery the parse table when breaking down the parse stack on invalid lookahead

### DIFF
--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -70,10 +70,18 @@ pub fn parse_file_at_path(
     let mut stdout = stdout.lock();
 
     if let Some(mut tree) = tree {
-        for edit in edits {
+        if debug_graph && !edits.is_empty() {
+            println!("BEFORE:\n{}", String::from_utf8_lossy(&source_code));
+        }
+
+        for (i, edit) in edits.iter().enumerate() {
             let edit = parse_edit_flag(&source_code, edit)?;
             perform_edit(&mut tree, &mut source_code, &edit);
             tree = parser.parse(&source_code, Some(&tree)).unwrap();
+
+            if debug_graph {
+                println!("AFTER {}:\n{}", i, String::from_utf8_lossy(&source_code));
+            }
         }
 
         let duration = time.elapsed();

--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -24,6 +24,7 @@ const LANGUAGES: &'static [&'static str] = &[
     "json",
     "php",
     "python",
+    "ruby",
     "rust",
 ];
 

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -1339,6 +1339,7 @@ static bool ts_parser__advance(
     );
   }
 
+lex:
   // Otherwise, re-run the lexer.
   if (!lookahead.ptr) {
     lookahead = ts_parser__lex(self, version, state);
@@ -1501,12 +1502,9 @@ static bool ts_parser__advance(
     // lookahead.
     if (ts_parser__breakdown_top_of_stack(self, version)) {
       state = ts_stack_state(self->stack, version);
-      ts_language_table_entry(
-        self->language,
-        state,
-        ts_subtree_leaf_symbol(lookahead),
-        &table_entry
-      );
+      ts_subtree_release(&self->tree_pool, lookahead);
+      lookahead = NULL_SUBTREE;
+      goto lex;
       continue;
     }
 

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -1500,6 +1500,13 @@ static bool ts_parser__advance(
     // push each of its children. Then try again to process the current
     // lookahead.
     if (ts_parser__breakdown_top_of_stack(self, version)) {
+      state = ts_stack_state(self->stack, version);
+      ts_language_table_entry(
+        self->language,
+        state,
+        ts_subtree_leaf_symbol(lookahead),
+        &table_entry
+      );
       continue;
     }
 

--- a/lib/src/stack.c
+++ b/lib/src/stack.c
@@ -571,7 +571,12 @@ void ts_stack_record_summary(Stack *self, StackVersion version, unsigned max_dep
   };
   array_init(session.summary);
   stack__iter(self, version, summarize_stack_callback, &session, -1);
-  self->heads.contents[version].summary = session.summary;
+  StackHead *head = &self->heads.contents[version];
+  if (head->summary) {
+    array_delete(head->summary);
+    ts_free(head->summary);
+  }
+  head->summary = session.summary;
 }
 
 StackSummary *ts_stack_get_summary(Stack *self, StackVersion version) {
@@ -742,6 +747,10 @@ bool ts_stack_print_dot_graph(Stack *self, const TSLanguage *language, FILE *f) 
       ts_stack_node_count_since_error(self, i),
       ts_stack_error_cost(self, i)
     );
+
+    if (head->summary) {
+      fprintf(f, "\nsummary_size: %u", head->summary->size);
+    }
 
     if (head->last_external_token.ptr) {
       const ExternalScannerState *state = &head->last_external_token.ptr->external_scanner_state;


### PR DESCRIPTION
Fixes #633

This piece of incremental parsing has clearly been broken for some time. It must have been broken by some big refactor quite a while ago. I'm amazed that it hasn't caused more noticeable problems in our more commonly-used languages.

* [x] Fix incomplete incremental logic
* [x] Understand why existing tests haven't caught this, find simplest possible test case

Update - the problem had to do with [non-terminal extra nodes](https://github.com/tree-sitter/tree-sitter/pull/469). This feature is only used by two of the languages that we maintain: Ruby and PHP. Previously, Ruby [was not included](https://github.com/tree-sitter/tree-sitter/blob/81d533d2d1b580fdb507accabc91ceddffb5b6f0/cli/src/tests/corpus_test.rs#L16-L28) in the randomized test suite. The main bug reported in #633 was exposed by adding it.

There is actually still another bug [mentioned in that issue](https://github.com/tree-sitter/tree-sitter/issues/633#issuecomment-638466743) related to incremental parsing and non-terminal extras, but it doesn't appear to show up in any of the languages that we maintain, and the issue author is no longer experiencing it, so I consider it slightly lower priority and am opening a separate issue for it.