### PR TITLE
Add '.' as a valid start of a query predicate, in addition to '#'

### DIFF
--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -2087,6 +2087,35 @@ fn test_query_disable_pattern() {
     });
 }
 
+#[test]
+fn test_query_alternative_predicate_prefix() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(language, r#"
+            ((call_expression
+              function: (identifier) @keyword
+              arguments: (argument_list
+                          (string_literal) @function))
+             (.eq? @keyword "DEFUN"))
+        "#).unwrap();
+        let source = r#"
+            DEFUN ("identity", Fidentity, Sidentity, 1, 1, 0,
+                   doc: /* Return the argument unchanged.  */
+                   attributes: const)
+              (Lisp_Object arg)
+            {
+              return arg;
+            }
+        "#;
+        assert_query_matches(
+            language,
+            &query,
+            source,
+            &[(0, vec![("keyword", "DEFUN"), ("function", "\"identity\"")])],
+        );
+    });
+}
+
 fn assert_query_matches(
     language: Language,
     query: &Query,

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -805,8 +805,8 @@ static TSQueryError ts_query__parse_pattern(
       }
     }
 
-    // A pound character indicates the start of a predicate.
-    else if (stream->next == '#') {
+    // A dot/pound character indicates the start of a predicate.
+    else if (stream->next == '.' || stream->next == '#') {
       stream_advance(stream);
       return ts_query__parse_predicate(self, stream);
     }


### PR DESCRIPTION
From the discussion at https://github.com/ubolonton/emacs-tree-sitter/issues/38#issuecomment-638964308.

This will make it more convenient to embed queries in Lisp dialects, for things like ad-hoc custom highlighting:

```emacs-lisp
;; Before:
(tree-sitter-hl-add-patterns 'python
  "((string) @constant
    (#match? @constant \"^'\"))")

;; After:
(tree-sitter-hl-add-patterns 'python
  ((string) @constant
   (.match? @constant "^'")))
```