### PR TITLE
size_t variables need %zu, not %lu

### DIFF
--- a/lib/src/alloc.h
+++ b/lib/src/alloc.h
@@ -45,7 +45,7 @@ static inline bool ts_toggle_allocation_recording(bool value) {
 static inline void *ts_malloc(size_t size) {
   void *result = malloc(size);
   if (size > 0 && !result) {
-    fprintf(stderr, "tree-sitter failed to allocate %lu bytes", size);
+    fprintf(stderr, "tree-sitter failed to allocate %zu bytes", size);
     exit(1);
   }
   return result;
@@ -54,7 +54,7 @@ static inline void *ts_malloc(size_t size) {
 static inline void *ts_calloc(size_t count, size_t size) {
   void *result = calloc(count, size);
   if (count > 0 && !result) {
-    fprintf(stderr, "tree-sitter failed to allocate %lu bytes", count * size);
+    fprintf(stderr, "tree-sitter failed to allocate %zu bytes", count * size);
     exit(1);
   }
   return result;
@@ -63,7 +63,7 @@ static inline void *ts_calloc(size_t count, size_t size) {
 static inline void *ts_realloc(void *buffer, size_t size) {
   void *result = realloc(buffer, size);
   if (size > 0 && !result) {
-    fprintf(stderr, "tree-sitter failed to reallocate %lu bytes", size);
+    fprintf(stderr, "tree-sitter failed to reallocate %zu bytes", size);
     exit(1);
   }
   return result;


### PR DESCRIPTION
I got these warnings while compiling a project that uses tree-sitter on windows:
```
c:\projects\radare2\shlr\tree-sitter\lib\src\alloc.h(48): warning C4477: 'fprintf' : format string '%lu' requires an argument of type 'unsigned long', but variadic argument 1 has type 'size_t' [C:\projects\radare2\build\shlr\cafa177@@tree_sitter@sta.vcxproj]
c:\projects\radare2\shlr\tree-sitter\lib\src\alloc.h(57): warning C4477: 'fprintf' : format string '%lu' requires an argument of type 'unsigned long', but variadic argument 1 has type 'size_t' [C:\projects\radare2\build\shlr\cafa177@@tree_sitter@sta.vcxproj]
c:\projects\radare2\shlr\tree-sitter\lib\src\alloc.h(66): warning C4477: 'fprintf' : format string '%lu' requires an argument of type 'unsigned long', but variadic argument 1 has type 'size_t' [C:\projects\radare2\build\shlr\cafa177@@tree_sitter@sta.vcxproj]
```