### PR TITLE
Fix a few cases of Clang 10 with UBSAN detecting undefined behavior

### DIFF
--- a/lib/src/lexer.c
+++ b/lib/src/lexer.c
@@ -73,7 +73,6 @@ static void ts_lexer__get_chunk(Lexer *self) {
 // code that spans the current position.
 static void ts_lexer__get_lookahead(Lexer *self) {
   uint32_t position_in_chunk = self->current_position.bytes - self->chunk_start;
-  const uint8_t *chunk = (const uint8_t *)self->chunk + position_in_chunk;
   uint32_t size = self->chunk_size - position_in_chunk;
 
   if (size == 0) {
@@ -82,6 +81,7 @@ static void ts_lexer__get_lookahead(Lexer *self) {
     return;
   }
 
+  const uint8_t *chunk = (const uint8_t *)self->chunk + position_in_chunk;
   UnicodeDecodeFunction decode = self->input.encoding == TSInputEncodingUTF8
     ? ts_decode_utf8
     : ts_decode_utf16;

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -1252,6 +1252,9 @@ const TSQueryPredicateStep *ts_query_predicates_for_pattern(
 ) {
   Slice slice = self->predicates_by_pattern.contents[pattern_index];
   *step_count = slice.length;
+  if (self->predicate_steps.contents == NULL) {
+    return NULL;
+  }
   return &self->predicate_steps.contents[slice.offset];
 }
 


### PR DESCRIPTION
Clang 10 considers adding any offset, including 0, to the null pointer to be undefined behavior. `((void *)NULL) + 0 = kaboom`.

Noticed this when trying to compile neovim+tree-sitter after upgrading to clang 10.0.0. There might be more cases, but these are the cases detected by our test suite.