### PR TITLE
avoid warnings for implicit fallthrough in switch statements

### DIFF
--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -292,6 +292,7 @@ static bool ts_parser__better_version_exists(
         return true;
       case ErrorComparisonPreferRight:
         if (ts_stack_can_merge(self->stack, i, version)) return true;
+        break;
       default:
         break;
     }
@@ -975,6 +976,7 @@ static bool ts_parser__do_all_potential_reductions(
                 .dynamic_precedence = action.params.reduce.dynamic_precedence,
                 .production_id = action.params.reduce.production_id,
               });
+            break;
           default:
             break;
         }


### PR DESCRIPTION
Hello again. Our compiler is configured to warn against implicit fall-through in switches. Added a few extra `break` to silence these warnings.

Note: it is possible to define a macro `FALLTHROUGH;` which expands to whatever magic incantation for each compiler (gcc/clang/etc), for more general cases. For now just adding a few `break;` seems the simplest.