### PR TITLE
Provide error messages for missing wasm files during `cargo build`.

### DIFF
--- a/cli/src/web_ui.rs
+++ b/cli/src/web_ui.rs
@@ -14,6 +14,10 @@ macro_rules! resource {
             if let Some(tree_sitter_dir) = tree_sitter_dir {
                 fs::read(tree_sitter_dir.join($path)).unwrap()
             } else {
+                let target = concat!("../../", $path);
+                if !Path::new(target).exists() {
+                    std::compile_error!("Couldn't find required resource files; have you run `script/build-wasm`?")
+                }
                 include_bytes!(concat!("../../", $path)).to_vec()
             }
         }
@@ -27,6 +31,10 @@ macro_rules! posix_resource {
             if let Some(tree_sitter_dir) = tree_sitter_dir {
                 fs::read(tree_sitter_dir.join($path)).unwrap()
             } else {
+                let target = concat!("../../", $path);
+                if !Path::new(target).exists() {
+                    std::compile_error!("Couldn't find required resource files; have you run `script/build-wasm`?")
+                }
                 include_bytes!(concat!("../../", $path)).to_vec()
             }
         }

--- a/cli/src/web_ui.rs
+++ b/cli/src/web_ui.rs
@@ -14,11 +14,7 @@ macro_rules! resource {
             if let Some(tree_sitter_dir) = tree_sitter_dir {
                 fs::read(tree_sitter_dir.join($path)).unwrap()
             } else {
-                let target = concat!("../../", $path);
-                if !Path::new(target).exists() {
-                    std::compile_error!("Couldn't find required resource files; have you run `script/build-wasm`?")
-                }
-                include_bytes!(concat!("../../", $path)).to_vec()
+                /* Compile errors here? Please ensure you've run `script/build-wasm first! */ include_bytes!(concat!("../../", $path)).to_vec()
             }
         }
     };
@@ -31,11 +27,7 @@ macro_rules! posix_resource {
             if let Some(tree_sitter_dir) = tree_sitter_dir {
                 fs::read(tree_sitter_dir.join($path)).unwrap()
             } else {
-                let target = concat!("../../", $path);
-                if !Path::new(target).exists() {
-                    std::compile_error!("Couldn't find required resource files; have you run `script/build-wasm`?")
-                }
-                include_bytes!(concat!("../../", $path)).to_vec()
+                /* Compile errors here? Please ensure you've run `script/build-wasm first! */ include_bytes!(concat!("../../", $path)).to_vec()
             }
         }
 


### PR DESCRIPTION
~I can confirm this works in the negative case (because Docker is throwing a no-space-on-device error, lol) and CI seems to indicate that this works in the positive case.~

It turns out that `include_bytes!` is a magical compiler builtin that does the required munging of paths to correctly locate paths relative to the build directory, so a corresponding `File::new(path).exists()` call can’t do a correct check. I resorted to putting a comment here, which at least gives some indication as to the problem. Perhaps @maxbrunsfeld can come up with a better solution.

This closes #718 and #353.