### PR TITLE
Fix behavior of the last child operator in tree queries

### DIFF
--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -667,6 +667,41 @@ fn test_query_matches_with_immediate_siblings() {
                 (2, vec![("first-element", "1")]),
             ],
         );
+
+        let query = Query::new(
+            language,
+            "
+            (block . (_) @first-stmt)
+            (block (_) @stmt)
+            (block (_) @last-stmt .)
+            ",
+        )
+        .unwrap();
+
+        assert_query_matches(
+            language,
+            &query,
+            "
+            if a:
+                b()
+                c()
+                if d(): e(); f()
+                g()
+            ",
+            &[
+                (0, vec![("first-stmt", "b()")]),
+                (1, vec![("stmt", "b()")]),
+                (1, vec![("stmt", "c()")]),
+                (1, vec![("stmt", "if d(): e(); f()")]),
+                (0, vec![("first-stmt", "e()")]),
+                (1, vec![("stmt", "e()")]),
+                (1, vec![("stmt", "f()")]),
+                (2, vec![("last-stmt", "f()")]),
+                (1, vec![("stmt", "g()")]),
+                (2, vec![("last-stmt", "g()")]),
+            ],
+        );
+
     });
 }
 

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -2549,11 +2549,13 @@ static inline bool ts_query_cursor__advance(
       if (symbol != ts_builtin_sym_error && self->query->symbol_map) {
         symbol = self->query->symbol_map[symbol];
       }
-      bool can_have_later_siblings;
+      bool has_later_siblings;
+      bool has_later_named_siblings;
       bool can_have_later_siblings_with_this_field;
       TSFieldId field_id = ts_tree_cursor_current_status(
         &self->cursor,
-        &can_have_later_siblings,
+        &has_later_siblings,
+        &has_later_named_siblings,
         &can_have_later_siblings_with_this_field
       );
       LOG(
@@ -2613,11 +2615,11 @@ static inline bool ts_query_cursor__advance(
           step->symbol == symbol ||
           step->symbol == WILDCARD_SYMBOL ||
           (step->symbol == NAMED_WILDCARD_SYMBOL && is_named);
-        bool later_sibling_can_match = can_have_later_siblings;
+        bool later_sibling_can_match = has_later_siblings;
         if ((step->is_immediate && is_named) || state->seeking_immediate_match) {
           later_sibling_can_match = false;
         }
-        if (step->is_last_child && can_have_later_siblings) {
+        if (step->is_last_child && has_later_named_siblings) {
           node_does_match = false;
         }
         if (step->field) {

--- a/lib/src/tree_cursor.h
+++ b/lib/src/tree_cursor.h
@@ -16,6 +16,6 @@ typedef struct {
 } TreeCursor;
 
 void ts_tree_cursor_init(TreeCursor *, TSNode);
-TSFieldId ts_tree_cursor_current_status(const TSTreeCursor *, bool *, bool *);
+TSFieldId ts_tree_cursor_current_status(const TSTreeCursor *, bool *, bool *, bool *);
 
 #endif  // TREE_SITTER_TREE_CURSOR_H_


### PR DESCRIPTION
In https://github.com/tree-sitter/tree-sitter/pull/549, I added a `.` operator in tree queries, which allowed "anchoring" child patterns to each other, or the beginning or end of a parent node. One of the behaviors of `.`, declaring that a pattern matched the *last named child* of its parent, didn't really work.

Now it works.

/cc @BekaValentine 
