### PR TITLE
Web bindings: Auto-generate Node subclasses with getters for node fields

### DIFF
--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -65,6 +65,9 @@ class Parser {
     } else {
       throw new Error('Argument must be a Language');
     }
+    if (language && !language.nodeSubclasses) {
+      initializeLanguageNodeClasses(language)
+    }
     this.language = language;
     C._ts_parser_set_language(this[0], address);
     return this;
@@ -174,8 +177,7 @@ class Tree {
   }
 
   get rootNode() {
-    C._ts_tree_root_node_wasm(this[0]);
-    return unmarshalNode(this);
+    return unmarshalNode(C._ts_tree_root_node_wasm(this[0]), this, TRANSFER_BUFFER, true);
   }
 
   getLanguage() {
@@ -207,7 +209,7 @@ class Tree {
   }
 }
 
-class Node {
+class SyntaxNode {
   constructor(internal, tree) {
     assertInternal(internal);
     this.tree = tree;
@@ -267,25 +269,32 @@ class Node {
 
   child(index) {
     marshalNode(this);
-    C._ts_node_child_wasm(this.tree[0], index);
-    return unmarshalNode(this.tree);
+    return unmarshalNode(C._ts_node_child_wasm(this.tree[0], index), this.tree);
   }
 
   namedChild(index) {
     marshalNode(this);
-    C._ts_node_named_child_wasm(this.tree[0], index);
-    return unmarshalNode(this.tree);
+    return unmarshalNode(C._ts_node_named_child_wasm(this.tree[0], index), this.tree);
   }
 
   childForFieldId(fieldId) {
     marshalNode(this);
-    C._ts_node_child_by_field_id_wasm(this.tree[0], fieldId);
-    return unmarshalNode(this.tree);
+    return unmarshalNode(C._ts_node_child_by_field_id_wasm(this.tree[0], fieldId), this.tree);
   }
 
   childForFieldName(fieldName) {
     const fieldId = this.tree.language.fields.indexOf(fieldName);
     if (fieldId !== -1) return this.childForFieldId(fieldId);
+  }
+
+  childrenForFieldId(fieldId) {
+    marshalNode(this);
+    return unmarshalNodes(C._ts_node_children_by_field_id_wasm(this.tree[0], fieldId), this.tree);
+  }
+
+  childrenForFieldName(fieldName) {
+    const fieldId = this.tree.language.fields.indexOf(fieldName);
+    if (fieldId !== -1) return this.childrenForFieldId(fieldId);
   }
 
   get childCount() {
@@ -317,18 +326,7 @@ class Node {
   get children() {
     if (!this._children) {
       marshalNode(this);
-      C._ts_node_children_wasm(this.tree[0]);
-      const count = getValue(TRANSFER_BUFFER, 'i32');
-      const buffer = getValue(TRANSFER_BUFFER + SIZE_OF_INT, 'i32');
-      this._children = new Array(count);
-      if (count > 0) {
-        let address = buffer;
-        for (let i = 0; i < count; i++) {
-          this._children[i] = unmarshalNode(this.tree, address);
-          address += SIZE_OF_NODE;
-        }
-        C._free(buffer);
-      }
+      this._children = unmarshalNodes(C._ts_node_children_wasm(this.tree[0]), this.tree);
     }
     return this._children;
   }
@@ -336,18 +334,7 @@ class Node {
   get namedChildren() {
     if (!this._namedChildren) {
       marshalNode(this);
-      C._ts_node_named_children_wasm(this.tree[0]);
-      const count = getValue(TRANSFER_BUFFER, 'i32');
-      const buffer = getValue(TRANSFER_BUFFER + SIZE_OF_INT, 'i32');
-      this._namedChildren = new Array(count);
-      if (count > 0) {
-        let address = buffer;
-        for (let i = 0; i < count; i++) {
-          this._namedChildren[i] = unmarshalNode(this.tree, address);
-          address += SIZE_OF_NODE;
-        }
-        C._free(buffer);
-      }
+      this._namedChildren = unmarshalNodes(C._ts_node_named_children_wasm(this.tree[0]), this.tree);
     }
     return this._namedChildren;
   }
@@ -374,7 +361,7 @@ class Node {
 
     // Call the C API to compute the descendants.
     marshalNode(this);
-    C._ts_node_descendants_of_type_wasm(
+    const symbolsBuffer = C._ts_node_descendants_of_type_wasm(
       this.tree[0],
       symbolsAddress,
       symbols.length,
@@ -384,52 +371,36 @@ class Node {
       endPosition.column
     );
 
-    // Instantiate the nodes based on the data returned.
-    const descendantCount = getValue(TRANSFER_BUFFER, 'i32');
-    const descendantAddress = getValue(TRANSFER_BUFFER + SIZE_OF_INT, 'i32');
-    const result = new Array(descendantCount);
-    if (descendantCount > 0) {
-      let address = descendantAddress;
-      for (let i = 0; i < descendantCount; i++) {
-        result[i] = unmarshalNode(this.tree, address);
-        address += SIZE_OF_NODE;
-      }
-    }
-
     // Free the intermediate buffers
-    C._free(descendantAddress);
     C._free(symbolsAddress);
-    return result;
+
+    // Instantiate the nodes based on the data returned.
+    return unmarshalNodes(symbolsBuffer, this.tree)
   }
 
   get nextSibling() {
     marshalNode(this);
-    C._ts_node_next_sibling_wasm(this.tree[0]);
-    return unmarshalNode(this.tree);
+    return unmarshalNode(C._ts_node_next_sibling_wasm(this.tree[0]), this.tree);
   }
 
   get previousSibling() {
     marshalNode(this);
-    C._ts_node_prev_sibling_wasm(this.tree[0]);
-    return unmarshalNode(this.tree);
+    return unmarshalNode(C._ts_node_prev_sibling_wasm(this.tree[0]), this.tree);
   }
 
   get nextNamedSibling() {
     marshalNode(this);
-    C._ts_node_next_named_sibling_wasm(this.tree[0]);
-    return unmarshalNode(this.tree);
+    return unmarshalNode(C._ts_node_next_named_sibling_wasm(this.tree[0]), this.tree);
   }
 
   get previousNamedSibling() {
     marshalNode(this);
-    C._ts_node_prev_named_sibling_wasm(this.tree[0]);
-    return unmarshalNode(this.tree);
+    return unmarshalNode(C._ts_node_prev_named_sibling_wasm(this.tree[0]), this.tree);
   }
 
   get parent() {
     marshalNode(this);
-    C._ts_node_parent_wasm(this.tree[0]);
-    return unmarshalNode(this.tree);
+    return unmarshalNode(C._ts_node_parent_wasm(this.tree[0]), this.tree);
   }
 
   descendantForIndex(start, end = start) {
@@ -441,8 +412,7 @@ class Node {
     let address = TRANSFER_BUFFER + SIZE_OF_NODE;
     setValue(address, start, 'i32');
     setValue(address + SIZE_OF_INT, end, 'i32');
-    C._ts_node_descendant_for_index_wasm(this.tree[0]);
-    return unmarshalNode(this.tree);
+    return unmarshalNode(C._ts_node_descendant_for_index_wasm(this.tree[0]), this.tree);
   }
 
   namedDescendantForIndex(start, end = start) {
@@ -454,8 +424,7 @@ class Node {
     let address = TRANSFER_BUFFER + SIZE_OF_NODE;
     setValue(address, start, 'i32');
     setValue(address + SIZE_OF_INT, end, 'i32');
-    C._ts_node_named_descendant_for_index_wasm(this.tree[0]);
-    return unmarshalNode(this.tree);
+    return unmarshalNode(C._ts_node_named_descendant_for_index_wasm(this.tree[0]), this.tree);
   }
 
   descendantForPosition(start, end = start) {
@@ -467,8 +436,7 @@ class Node {
     let address = TRANSFER_BUFFER + SIZE_OF_NODE;
     marshalPoint(address, start);
     marshalPoint(address + SIZE_OF_POINT, end);
-    C._ts_node_descendant_for_position_wasm(this.tree[0]);
-    return unmarshalNode(this.tree);
+    return unmarshalNode(C._ts_node_descendant_for_position_wasm(this.tree[0]), this.tree);
   }
 
   namedDescendantForPosition(start, end = start) {
@@ -480,8 +448,7 @@ class Node {
     let address = TRANSFER_BUFFER + SIZE_OF_NODE;
     marshalPoint(address, start);
     marshalPoint(address + SIZE_OF_POINT, end);
-    C._ts_node_named_descendant_for_position_wasm(this.tree[0]);
-    return unmarshalNode(this.tree);
+    return unmarshalNode(C._ts_node_named_descendant_for_position_wasm(this.tree[0]), this.tree);
   }
 
   walk() {
@@ -574,8 +541,7 @@ class TreeCursor {
 
   currentNode() {
     marshalTreeCursor(this);
-    C._ts_tree_cursor_current_node_wasm(this.tree[0]);
-    return unmarshalNode(this.tree);
+    return unmarshalNode(C._ts_tree_cursor_current_node_wasm(this.tree[0]), this.tree);
   }
 
   currentFieldId() {
@@ -861,7 +827,7 @@ class Language {
     );
   }
 
-  static load(url) {
+  static load(url, nodeTypes) {
     let bytes;
     if (
       typeof process !== 'undefined' &&
@@ -895,7 +861,9 @@ class Language {
           console.log(`Couldn't find language function in WASM file. Symbols:\n${JSON.stringify(symbolNames, null, 2)}`)
         }
         const languageAddress = mod[functionName]();
-        return new Language(INTERNAL, languageAddress);
+        const language = new Language(INTERNAL, languageAddress);
+        language.nodeTypeInfo = nodeTypes;
+        return language;
       });
   }
 }
@@ -926,7 +894,7 @@ class Query {
 
     marshalNode(node);
 
-    C._ts_query_matches_wasm(
+    const symbolsBuffer = C._ts_query_matches_wasm(
       this[0],
       node.tree[0],
       startPosition.row,
@@ -947,7 +915,7 @@ class Query {
       address += SIZE_OF_INT;
 
       const captures = new Array(captureCount);
-      address = unmarshalCaptures(this, node.tree, address, captures);
+      address = unmarshalCaptures(this, node.tree, address, captures, symbolsBuffer);
       if (this.textPredicates[pattern].every(p => p(captures))) {
         result[i] = {pattern, captures};
         const setProperties = this.setProperties[pattern];
@@ -969,7 +937,7 @@ class Query {
 
     marshalNode(node);
 
-    C._ts_query_captures_wasm(
+    const symbolsBuffer = C._ts_query_captures_wasm(
       this[0],
       node.tree[0],
       startPosition.row,
@@ -993,7 +961,7 @@ class Query {
       address += SIZE_OF_INT;
 
       captures.length = captureCount
-      address = unmarshalCaptures(this, node.tree, address, captures);
+      address = unmarshalCaptures(this, node.tree, address, captures, symbolsBuffer);
 
       if (this.textPredicates[pattern].every(p => p(captures))) {
         const capture = captures[captureIndex];
@@ -1035,11 +1003,11 @@ function getText(tree, startIndex, endIndex) {
   return result;
 }
 
-function unmarshalCaptures(query, tree, address, result) {
+function unmarshalCaptures(query, tree, address, result, symbolsBuffer) {
   for (let i = 0, n = result.length; i < n; i++) {
     const captureIndex = getValue(address, 'i32');
     address += SIZE_OF_INT;
-    const node = unmarshalNode(tree, address);
+    const node = unmarshalNode(getValue(symbolsBuffer + i * SIZE_OF_INT, 'i32'), tree, address);
     address += SIZE_OF_NODE;
     result[i] = {name: query.captureNames[captureIndex], node};
   }
@@ -1071,7 +1039,7 @@ function marshalNode(node) {
   setValue(address, node[0], 'i32');
 }
 
-function unmarshalNode(tree, address = TRANSFER_BUFFER) {
+function unmarshalNode(typeId, tree, address = TRANSFER_BUFFER) {
   const id = getValue(address, 'i32');
   address += SIZE_OF_INT;
   if (id === 0) return null;
@@ -1084,13 +1052,33 @@ function unmarshalNode(tree, address = TRANSFER_BUFFER) {
   address += SIZE_OF_INT;
   const other = getValue(address, 'i32');
 
-  const result = new Node(INTERNAL, tree);
+  const nodeSubclass = tree.language.nodeSubclasses[typeId];
+  const NodeClass = nodeSubclass ? nodeSubclass : SyntaxNode;
+
+  const result = new NodeClass(INTERNAL, tree);
   result.id = id;
   result.startIndex = index;
   result.startPosition = {row, column};
   result[0] = other;
 
   return result;
+}
+
+function unmarshalNodes(symbolsBuffer, tree) {
+  const count = getValue(TRANSFER_BUFFER, 'i32');
+  const buffer = getValue(TRANSFER_BUFFER + SIZE_OF_INT, 'i32');
+  const nodes = new Array(count);
+
+  if (count > 0) {
+    let address = buffer;
+    for (let i = 0; i < count; i++) {
+      nodes[i] = unmarshalNode(getValue(symbolsBuffer + i * SIZE_OF_INT, 'i32'), tree, address);
+      address += SIZE_OF_NODE;
+    }
+  }
+
+  C._free(buffer);
+  return nodes;
 }
 
 function marshalTreeCursor(cursor, address = TRANSFER_BUFFER) {
@@ -1141,6 +1129,63 @@ function marshalEdit(edit) {
   setValue(address, edit.startIndex, 'i32'); address += SIZE_OF_INT;
   setValue(address, edit.oldEndIndex, 'i32'); address += SIZE_OF_INT;
   setValue(address, edit.newEndIndex, 'i32'); address += SIZE_OF_INT;
+}
+
+function initializeLanguageNodeClasses(language) {
+  const nodeTypeInfo = language.nodeTypeInfo || [];
+
+  const nodeSubclasses = [];
+  for (let id = 0, n = language.types.length; id < n; id++) {
+    nodeSubclasses[id] = SyntaxNode;
+
+    const typeName = language.types[id];
+    if (!typeName) continue;
+
+    const typeInfo = nodeTypeInfo.find(info => info.named && info.type === typeName);
+    if (!typeInfo) continue;
+
+    const fieldNames = [];
+    let classBody = '\n';
+    if (typeInfo.fields) {
+      for (const fieldName in typeInfo.fields) {
+        const fieldId = language.fields.indexOf(fieldName);
+        if (fieldId === -1) continue;
+        if (typeInfo.fields[fieldName].multiple) {
+          const getterName = camelCase(fieldName) + 'Nodes';
+          fieldNames.push(getterName);
+          classBody += `
+            get ${getterName}() {
+              marshalNode(this);
+              return unmarshalNodes(C._ts_node_children_by_field_id_wasm(this.tree[0], ${fieldId}), this.tree);
+            }
+          `.replace(/\s+/g, ' ') + '\n';
+        } else {
+          const getterName = camelCase(fieldName, false) + 'Node';
+          fieldNames.push(getterName);
+          classBody += `
+            get ${getterName}() {
+              marshalNode(this);
+              return unmarshalNode(C._ts_node_child_by_field_id_wasm(this.tree[0], ${fieldId}), this.tree);
+            }
+          `.replace(/\s+/g, ' ') + '\n';
+        }
+      }
+    }
+
+    const className = camelCase(typeName, true) + 'Node';
+    const nodeSubclass = eval(`class ${className} extends SyntaxNode {${classBody}}; ${className}`);
+    nodeSubclass.prototype.type = typeName;
+    nodeSubclass.prototype.fields = Object.freeze(fieldNames.sort())
+    nodeSubclasses[id] = nodeSubclass;
+  }
+
+  language.nodeSubclasses = nodeSubclasses;
+}
+
+function camelCase(name, upperCase) {
+  name = name.replace(/_(\w)/g, (match, letter) => letter.toUpperCase());
+  if (upperCase) name = name[0].toUpperCase() + name.slice(1);
+  return name;
 }
 
 Parser.Language = Language;

--- a/lib/binding_web/exports.json
+++ b/lib/binding_web/exports.json
@@ -36,6 +36,7 @@
   "_ts_language_symbol_type",
   "_ts_language_version",
   "_ts_node_child_by_field_id_wasm",
+  "_ts_node_children_by_field_id_wasm",
   "_ts_node_child_count_wasm",
   "_ts_node_child_wasm",
   "_ts_node_children_wasm",

--- a/lib/binding_web/test/helper.js
+++ b/lib/binding_web/test/helper.js
@@ -4,8 +4,12 @@ function languageURL(name) {
   return require.resolve(`../../../target/release/tree-sitter-${name}.wasm`);
 }
 
+function nodeTypes(name) {
+  return require(`../../../test/fixtures/grammars/${name}/src/node-types.json`);
+}
+
 module.exports = Parser.init().then(async () => ({
   Parser,
   languageURL,
-  JavaScript: await Parser.Language.load(languageURL('javascript')),
+  JavaScript: await Parser.Language.load(languageURL('javascript'), nodeTypes('javascript')),
 }));

--- a/lib/binding_web/test/node-test.js
+++ b/lib/binding_web/test/node-test.js
@@ -364,6 +364,48 @@ describe("Node", () => {
     })
   });
 
+  describe("generated field getters", () => {
+    it("returns the field nodes with generated getters", () => {
+      tree = parser.parse(`
+        class A {
+          @autobind
+          @something
+          b(c, d) {
+            return c + d;
+          }
+        }
+      `);
+
+      const classNode = tree.rootNode.firstChild;
+      assert.deepEqual(classNode.fields, ['bodyNode', 'decoratorNodes', 'nameNode'])
+
+      const methodNode = classNode.bodyNode.firstNamedChild;
+      assert.equal(methodNode.constructor.name, 'MethodDefinitionNode');
+      assert.equal(methodNode.nameNode.text, 'b');
+      assert.deepEqual(methodNode.fields, ['bodyNode', 'decoratorNodes', 'nameNode', 'parametersNode'])
+
+      const decoratorNodes = methodNode.decoratorNodes;
+      assert.deepEqual(decoratorNodes.map(_ => _.text), ['@autobind', '@something'])
+
+      const paramsNode = methodNode.parametersNode;
+      assert.equal(paramsNode.constructor.name, 'FormalParametersNode');
+      assert.equal(paramsNode.namedChildren.length, 2);
+
+      const bodyNode = methodNode.bodyNode;
+      assert.equal(bodyNode.constructor.name, 'StatementBlockNode');
+
+      const returnNode = bodyNode.namedChildren[0];
+      assert.equal(returnNode.constructor.name, 'ReturnStatementNode');
+
+      const binaryNode = returnNode.firstNamedChild;
+      assert.equal(binaryNode.constructor.name, 'BinaryExpressionNode');
+
+      assert.equal(binaryNode.leftNode.text, 'c');
+      assert.equal(binaryNode.rightNode.text, 'd');
+      assert.equal(binaryNode.operatorNode.type, '+');
+    });
+  });
+
   describe.skip('.closest(type)', () => {
     it('returns the closest ancestor of the given type', () => {
       tree = parser.parse("a(b + -d.e)");

--- a/lib/binding_web/tree-sitter-web.d.ts
+++ b/lib/binding_web/tree-sitter-web.d.ts
@@ -48,6 +48,7 @@ declare module 'web-tree-sitter' {
     ) => string | null;
 
     export interface SyntaxNode {
+      id: number;
       tree: Tree;
       type: string;
       isNamed: boolean;
@@ -79,6 +80,8 @@ declare module 'web-tree-sitter' {
       namedChild(index: number): SyntaxNode | null;
       childForFieldId(fieldId: number): SyntaxNode | null;
       childForFieldName(fieldName: string): SyntaxNode | null;
+      childrenForFieldId(fieldId: number): Array<SyntaxNode>;
+      childrenForFieldName(fieldName: string): Array<SyntaxNode>;
 
       descendantForIndex(index: number): SyntaxNode;
       descendantForIndex(startIndex: number, endIndex: number): SyntaxNode;
@@ -126,7 +129,7 @@ declare module 'web-tree-sitter' {
     }
 
     class Language {
-      static load(path: string): Promise<Language>;
+      static load(path: string, nodeTypes?: object): Promise<Language>;
 
       readonly version: number;
       readonly fieldCount: number;


### PR DESCRIPTION
Subclasses will only generate if the node-types object is passed as the second arg to `Parser.Language.Load`. This makes the web bindings more like the node bindings and was modeled after [this commit](https://github.com/tree-sitter/node-tree-sitter/commit/c69d03a9f5d5da44ef70fecd95a0fb10bf7bd6b9#diff-168726dbe96b3ce427e7fedce31bb0bc).

This makes tree-sitter for  very powerful using TypeScript when combined with a tool like described here: https://github.com/tree-sitter/tree-sitter/issues/707. As many users are using the web bindings in a node environment for cross-platform compatibility (like a LSP), I think it is beneficial to allow optional `node-types` to passed when loading the language so they can benefit from subclasses and extra type information.

The motivation for this is I'm implementing type inference for the Elm Language Server, and this will make things much cleaner. 
/cc @Razzeee 