### PR TITLE
Fix "Comparison between x of type TSSymbol and y of wider type unsigned int"

### DIFF
--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -87,7 +87,7 @@ TSSymbol ts_language_symbol_for_name(
 ) {
   if (!strncmp(string, "ERROR", length)) return ts_builtin_sym_error;
   uint32_t count = ts_language_symbol_count(self);
-  for (TSSymbol i = 0; i < count; i++) {
+  for (TSSymbol i = 0; i < count && i < UINT16_MAX; i++) {
     TSSymbolMetadata metadata = ts_language_symbol_metadata(self, i);
     if (!metadata.visible || metadata.named != is_named) continue;
     const char *symbol_name = self->symbol_names[i];
@@ -134,7 +134,7 @@ TSFieldId ts_language_field_id_for_name(
   uint32_t name_length
 ) {
   uint32_t count = ts_language_field_count(self);
-  for (TSSymbol i = 1; i < count + 1; i++) {
+  for (TSSymbol i = 1; i < count + 1 && i < UINT16_MAX; i++) {
     switch (strncmp(name, self->field_names[i], name_length)) {
       case 0:
         if (self->field_names[i][name_length] == 0) return i;

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -1034,7 +1034,7 @@ static void ts_parser__handle_error(
     if (!did_insert_missing_token) {
       TSStateId state = ts_stack_state(self->stack, v);
       for (TSSymbol missing_symbol = 1;
-           missing_symbol < self->language->token_count;
+           missing_symbol < self->language->token_count && missing_symbol < UINT16_MAX;
            missing_symbol++) {
         TSStateId state_after_missing_symbol = ts_language_next_state(
           self->language, state, missing_symbol


### PR DESCRIPTION
Detected in:
https://github.com/radareorg/radare2/security/code-scanning/27?query=ref%3Arefs%2Fheads%2Fmaster
https://github.com/radareorg/radare2/security/code-scanning/26?query=ref%3Arefs%2Fheads%2Fmaster
https://github.com/radareorg/radare2/security/code-scanning/25?query=ref%3Arefs%2Fheads%2Fmaster

Probably the best thing would be to make TSSymbol uint32_t, but I'm not sure you want to do that. Maybe it breaks compatibility and such? Advices are welcome!