### PR TITLE
Allow tree queries to match on nodes' supertypes

### DIFF
--- a/cli/src/generate/build_tables/minimize_parse_table.rs
+++ b/cli/src/generate/build_tables/minimize_parse_table.rs
@@ -68,6 +68,7 @@ impl<'a> Minimizer<'a> {
                             ..
                         } => {
                             if !self.simple_aliases.contains_key(&symbol)
+                                && !self.syntax_grammar.supertype_symbols.contains(&symbol)
                                 && !aliased_symbols.contains(&symbol)
                                 && self.syntax_grammar.variables[symbol.index].kind
                                     != VariableType::Named

--- a/cli/src/generate/node_types.rs
+++ b/cli/src/generate/node_types.rs
@@ -325,15 +325,8 @@ pub(crate) fn get_variable_info(
     }
 
     for supertype_symbol in &syntax_grammar.supertype_symbols {
-        let variable = &syntax_grammar.variables[supertype_symbol.index];
-        if variable.kind != VariableType::Hidden {
-            return Err(Error::grammar(&format!(
-                "Supertype symbols must be hidden, but `{}` is not",
-                variable.name
-            )));
-        }
-
         if result[supertype_symbol.index].has_multi_step_production {
+            let variable = &syntax_grammar.variables[supertype_symbol.index];
             return Err(Error::grammar(&format!(
                 "Supertype symbols must always have a single visible child, but `{}` can have multiple",
                 variable.name

--- a/cli/src/generate/prepare_grammar/intern_symbols.rs
+++ b/cli/src/generate/prepare_grammar/intern_symbols.rs
@@ -73,6 +73,12 @@ pub(super) fn intern_symbols(grammar: &InputGrammar) -> Result<InternedGrammar> 
         );
     }
 
+    for (i, variable) in variables.iter_mut().enumerate() {
+        if supertype_symbols.contains(&Symbol::non_terminal(i)) {
+            variable.kind = VariableType::Hidden;
+        }
+    }
+
     Ok(InternedGrammar {
         variables,
         external_tokens,

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -460,6 +460,9 @@ impl Generator {
                     VariableType::Hidden => {
                         add_line!(self, ".visible = false,");
                         add_line!(self, ".named = true,");
+                        if self.syntax_grammar.supertype_symbols.contains(symbol) {
+                            add_line!(self, ".supertype = true,");
+                        }
                     }
                     VariableType::Auxiliary => {
                         add_line!(self, ".visible = false,");

--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -1401,12 +1401,15 @@ fn test_query_matches_with_supertypes() {
         let query = Query::new(
             language,
             r#"
-            ((_simple_statement) @before . (_simple_statement) @after)
+            (argument_list (_expression) @arg)
+
+            (keyword_argument
+                value: (_expression) @kw_arg)
 
             (assignment
-              left: (left_hand_side (identifier) @def))
+              left: (left_hand_side (identifier) @var_def))
 
-            (_primary_expression/identifier) @ref
+            (_primary_expression/identifier) @var_ref
             "#,
         )
         .unwrap();
@@ -1415,19 +1418,19 @@ fn test_query_matches_with_supertypes() {
             language,
             &query,
             "
-                a = b
-                print c
-                if d: print e.f; print g.h.i
+                a = b.c(
+                    [d],
+                    # a comment
+                    e=f
+                )
             ",
             &[
-                (1, vec![("def", "a")]),
-                (2, vec![("ref", "b")]),
-                (0, vec![("before", "a = b"), ("after", "print c")]),
-                (2, vec![("ref", "c")]),
-                (2, vec![("ref", "d")]),
-                (2, vec![("ref", "e")]),
-                (0, vec![("before", "print e.f"), ("after", "print g.h.i")]),
-                (2, vec![("ref", "g")]),
+                (2, vec![("var_def", "a")]),
+                (3, vec![("var_ref", "b")]),
+                (0, vec![("arg", "[d]")]),
+                (3, vec![("var_ref", "d")]),
+                (1, vec![("kw_arg", "f")]),
+                (3, vec![("var_ref", "f")]),
             ],
         );
     });

--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -291,6 +291,24 @@ fn test_query_errors_on_impossible_patterns() {
                 .join("\n")
             ))
         );
+
+        Query::new(
+            js_lang,
+            "(if_statement
+                condition: (parenthesized_expression (_expression) @cond))",
+        )
+        .unwrap();
+        assert_eq!(
+            Query::new(js_lang, "(if_statement condition: (_expression))",),
+            Err(QueryError::Structure(
+                1,
+                [
+                    "(if_statement condition: (_expression))", //
+                    "              ^",
+                ]
+                .join("\n")
+            ))
+        );
     });
 }
 

--- a/lib/include/tree_sitter/parser.h
+++ b/lib/include/tree_sitter/parser.h
@@ -35,6 +35,7 @@ typedef uint16_t TSStateId;
 typedef struct {
   bool visible : 1;
   bool named : 1;
+  bool supertype: 1;
 } TSSymbolMetadata;
 
 typedef struct TSLexer TSLexer;

--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -89,7 +89,7 @@ TSSymbol ts_language_symbol_for_name(
   uint32_t count = ts_language_symbol_count(self);
   for (TSSymbol i = 0; i < count; i++) {
     TSSymbolMetadata metadata = ts_language_symbol_metadata(self, i);
-    if (!metadata.visible || metadata.named != is_named) continue;
+    if ((!metadata.visible && !metadata.supertype) || metadata.named != is_named) continue;
     const char *symbol_name = self->symbol_names[i];
     if (!strncmp(symbol_name, string, length) && !symbol_name[length]) {
       if (self->version >= TREE_SITTER_LANGUAGE_VERSION_WITH_SYMBOL_DEDUPING) {

--- a/lib/src/tree_cursor.h
+++ b/lib/src/tree_cursor.h
@@ -17,5 +17,6 @@ typedef struct {
 
 void ts_tree_cursor_init(TreeCursor *, TSNode);
 TSFieldId ts_tree_cursor_current_status(const TSTreeCursor *, bool *, bool *, bool *);
+bool ts_tree_cursor_has_supertype(const TSTreeCursor *, TSSymbol);
 
 #endif  // TREE_SITTER_TREE_CURSOR_H_

--- a/lib/src/tree_cursor.h
+++ b/lib/src/tree_cursor.h
@@ -16,7 +16,14 @@ typedef struct {
 } TreeCursor;
 
 void ts_tree_cursor_init(TreeCursor *, TSNode);
-TSFieldId ts_tree_cursor_current_status(const TSTreeCursor *, bool *, bool *, bool *);
-bool ts_tree_cursor_has_supertype(const TSTreeCursor *, TSSymbol);
+void ts_tree_cursor_current_status(
+  const TSTreeCursor *,
+  TSFieldId *,
+  bool *,
+  bool *,
+  bool *,
+  TSSymbol *,
+  unsigned *
+);
 
 #endif  // TREE_SITTER_TREE_CURSOR_H_

--- a/test/fixtures/error_corpus/c_errors.txt
+++ b/test/fixtures/error_corpus/c_errors.txt
@@ -158,9 +158,17 @@ int a() {
 (translation_unit
   (function_definition
     (primitive_type)
-    (function_declarator (identifier) (parameter_list))
+    (function_declarator
+      (identifier)
+      (parameter_list))
     (compound_statement
-      (struct_specifier (type_identifier))
-      (ERROR (number_literal))
-      (primitive_type)
-      (ERROR (number_literal)))))
+      (declaration
+        (struct_specifier (type_identifier))
+        (init_declarator
+          (MISSING identifier)
+          (number_literal)))
+      (declaration
+        (primitive_type)
+        (init_declarator
+          (MISSING identifier)
+          (number_literal))))))


### PR DESCRIPTION
In a tree query, you can now match on a node's [*supertypes*](http://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types). For example, in Python, `_expression` is a supertype. You could match any type of `_expression` within an `argument_list` with this pattern:

```clj
(argument_list
  (_expression) @argument)
```

You can also write a pattern that matches on both a node's *visible* type *and* one of its supertypes. For example, this pattern would only match `identifier` nodes that occur as *expressions* (as opposed to other identifier nodes which represent definitions, attributes, or keyword argument names).

```clj
(_primary_expression/identifier) @id
```