### PR TITLE
Fix compilation with TinyCC

### DIFF
--- a/lib/src/atomic.h
+++ b/lib/src/atomic.h
@@ -3,7 +3,23 @@
 
 #include <stdint.h>
 
-#ifdef _WIN32
+#ifdef __TINYC__
+
+static inline size_t atomic_load(const volatile size_t *p) {
+  return *p;
+}
+
+static inline uint32_t atomic_inc(volatile uint32_t *p) {
+  *p += 1;
+  return *p;
+}
+
+static inline uint32_t atomic_dec(volatile uint32_t *p) {
+  *p-= 1;
+  return *p;
+}
+
+#elif defined(_WIN32)
 
 #include <windows.h>
 

--- a/lib/src/bits.h
+++ b/lib/src/bits.h
@@ -7,7 +7,20 @@ static inline uint32_t bitmask_for_index(uint16_t id) {
   return (1u << (31 - id));
 }
 
-#if defined _WIN32 && !defined __GNUC__
+#ifdef __TINYC__
+
+// Algorithm taken from the Hacker's Delight book
+// See also https://graphics.stanford.edu/~seander/bithacks.html
+static inline uint32_t count_leading_zeros(uint32_t x) {
+  int count = 0;
+  if (x == 0) return 32;
+  x = x - ((x >> 1) & 0x55555555);
+  x = (x & 0x33333333) + ((x >> 2) & 0x33333333);
+  count = (((x + (x >> 4)) & 0x0f0f0f0f) * 0x01010101) >> 24;
+  return count;
+}
+
+#elif defined _WIN32 && !defined __GNUC__
 
 #include <intrin.h>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/203261/94360702-12072880-00e2-11eb-9340-be75dddb48d6.png)

As part of the [effort to make radare2 buildable with TinyCC](https://github.com/radareorg/radare2/pull/17295), which is the only option on some systems since easier to port rather than GCC or Clang.

Current [TinyCC compiler](https://bellard.org/tcc/) version is at https://repo.or.cz/tinycc.git/ - `mob` branch.