### PR TITLE
Add --stats flag for reporting parse information.

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -64,6 +64,7 @@ fn run() -> error::Result<()> {
                 .arg(Arg::with_name("debug").long("debug").short("d"))
                 .arg(Arg::with_name("debug-graph").long("debug-graph").short("D"))
                 .arg(Arg::with_name("quiet").long("quiet").short("q"))
+                .arg(Arg::with_name("stat").long("stat").short("s"))
                 .arg(Arg::with_name("time").long("time").short("t"))
                 .arg(Arg::with_name("allow-cancellation").long("cancel"))
                 .arg(Arg::with_name("timeout").long("timeout").takes_value(true))
@@ -234,6 +235,9 @@ fn run() -> error::Result<()> {
         let max_path_length = paths.iter().map(|p| p.chars().count()).max().unwrap();
         let mut has_error = false;
         loader.find_all_languages(&config.parser_directories)?;
+
+        let mut stats : parse::Stats = Default::default();
+
         for path in paths {
             let path = Path::new(&path);
             let language =
@@ -249,8 +253,14 @@ fn run() -> error::Result<()> {
                 debug,
                 debug_graph,
                 allow_cancellation,
+                &mut stats,
             )?;
         }
+
+        if matches.is_present("stat") {
+            println!("{}", stats)
+        }
+
         if has_error {
             return Error::err(String::new());
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -237,7 +237,7 @@ fn run() -> error::Result<()> {
         loader.find_all_languages(&config.parser_directories)?;
 
         let should_track_stats = matches.is_present("stat");
-        let mut stats : parse::Stats = Default::default();
+        let mut stats = parse::Stats::default();
 
         for path in paths {
             let path = Path::new(&path);

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -16,8 +16,8 @@ pub struct Edit {
 
 #[derive(Debug, Default)]
 pub struct Stats {
-    successful_parses : usize,
-    total_parses : usize,
+    pub successful_parses : usize,
+    pub total_parses : usize,
 }
 
 impl fmt::Display for Stats {
@@ -41,7 +41,6 @@ pub fn parse_file_at_path(
     debug: bool,
     debug_graph: bool,
     allow_cancellation: bool,
-    stats: &mut Stats,
 ) -> Result<bool> {
     let mut _log_session = None;
     let mut parser = Parser::new();
@@ -176,11 +175,6 @@ pub fn parse_file_at_path(
             } else if !cursor.goto_next_sibling() {
                 break;
             }
-        }
-
-        stats.total_parses += 1;
-        if first_error.is_none() {
-            stats.successful_parses += 1;
         }
 
         if first_error.is_some() || print_time {

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -16,8 +16,8 @@ pub struct Edit {
 
 #[derive(Debug, Default)]
 pub struct Stats {
-    pub successful_parses : usize,
-    pub total_parses : usize,
+    pub successful_parses: usize,
+    pub total_parses: usize,
 }
 
 impl fmt::Display for Stats {

--- a/docs/section-3-creating-parsers.md
+++ b/docs/section-3-creating-parsers.md
@@ -184,10 +184,10 @@ You can run your parser on an arbitrary file using `tree-sitter parse`. This wil
           (int_literal [1, 9] - [1, 10]))))))
 ```
 
-You can pass any number of file paths and glob patterns to `tree-sitter parse`, and it will parse all of the given files. The command will exit with a non-zero status code if any parse errors occurred. You can also prevent the syntax trees from being printed using the `--quiet` flag. This makes `tree-sitter parse` usable as a secondary testing strategy: you can check that a large number of files parse without error:
+You can pass any number of file paths and glob patterns to `tree-sitter parse`, and it will parse all of the given files. The command will exit with a non-zero status code if any parse errors occurred. You can also prevent the syntax trees from being printed using the `--quiet` flag. Additionally, the `--stat` flag prints out aggregated parse success/failure information for all processed files. This makes `tree-sitter parse` usable as a secondary testing strategy: you can check that a large number of files parse without error:
 
 ```sh
-tree-sitter parse 'examples/**/*.go' --quiet
+tree-sitter parse 'examples/**/*.go' --quiet --stat
 ```
 
 ### Command: `highlight`


### PR DESCRIPTION
You can now invoke `tree-sitter parse --stat` to see an informative block, printed at the end of the `parse` invocation, outlining the degree to which parsing of the specified files succeeded. Here's example output from parsing C# (here, the Roslyn repo):

```
Total parses: 9849; successful parses: 9617; failed parses: 232; success percentage: 97.64%
```

Fixes #741.