### PR TITLE
Fix crash when nonexistent files were passed to `parse`.

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -426,6 +426,10 @@ fn collect_paths<'a>(
             }
         }
 
+        if result.is_empty() {
+            Error::err("No files were found at or matched by the provided pathname/glob".to_string())?;
+        }
+
         return Ok(result);
     }
 


### PR DESCRIPTION
We were unwrapping the result of counting the characters in the vector
returned by collect_files(), which, if that vector is empty, returns
None. The most correct behavior is to halt if a nonexistent filename
was provided or a glob failed.


----

#