### PR TITLE
Allow an arbitrary curly-brace-delimited block after each query pattern

### DIFF
--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -630,6 +630,14 @@ extern "C" {
     pub fn ts_query_start_byte_for_pattern(arg1: *const TSQuery, arg2: u32) -> u32;
 }
 extern "C" {
+    pub fn ts_query_metadata_range_for_pattern(
+        arg1: *const TSQuery,
+        arg2: u32,
+        arg3: *mut u32,
+        arg4: *mut u32,
+    ) -> bool;
+}
+extern "C" {
     #[doc = " Get all of the predicates for the given pattern in the query."]
     #[doc = ""]
     #[doc = " The predicates are represented as a single array of steps. There are three"]

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -697,6 +697,8 @@ uint32_t ts_query_string_count(const TSQuery *);
  */
 uint32_t ts_query_start_byte_for_pattern(const TSQuery *, uint32_t);
 
+bool ts_query_metadata_range_for_pattern(const TSQuery *, uint32_t, uint32_t *, uint32_t *);
+
 /**
  * Get all of the predicates for the given pattern in the query.
  *


### PR DESCRIPTION
This expands the query syntax to allow an arbitrary curly brace-delimited "metadata block" after each pattern in a query. For example:

```clj
(identifier)
{
  MY CUSTOM DATA HERE
}

(string_literal)
{
  {nested} (braces) [are] {{allowed}}
}
```

These blocks don't **do** anything. They just let you put your own data into the query which can be retrieved later. I don't know if this is generally useful, but it is helpful for an internal GitHub initiative, and it may be useful more generally, so I thought it would make sense to include in the core library.

### API

This adds a new C API for accessing the byte range associated with each pattern's "metadata block":

```c
bool ts_query_metadata_range_for_pattern(
  const TSQuery *self,
  uint32_t pattern_index,
  uint32_t *start,
  uint32_t *end
);
```

And a Rust binding for it, `Query::metadata_range_for_pattern()`.