### PR TITLE
Multiple typo fixes

### DIFF
--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -220,8 +220,8 @@ const TSRange *ts_parser_included_ranges(
  * following three fields:
  * 1. `read`: A function to retrieve a chunk of text at a given byte offset
  *    and (row, column) position. The function should return a pointer to the
- *    text and write its length to the the `bytes_read` pointer. The parser
- *    does not take ownership of this buffer; it just borrows it until it has
+ *    text and write its length to the `bytes_read` pointer. The parser does
+ *    not take ownership of this buffer; it just borrows it until it has
  *    finished reading it. The function should write a zero value to the
  *    `bytes_read` pointer to indicate the end of the document.
  * 2. `payload`: An arbitrary pointer that will be passed to each invocation
@@ -765,7 +765,7 @@ void ts_query_disable_pattern(TSQuery *, uint32_t);
  * to start running a given query on a given syntax node. Then, there are
  * two options for consuming the results of the query:
  * 1. Repeatedly call `ts_query_cursor_next_match` to iterate over all of the
- *    the *matches* in the order that they were found. Each match contains the
+ *    *matches* in the order that they were found. Each match contains the
  *    index of the pattern that matched, and an array of captures. Because
  *    multiple patterns can match the same set of nodes, one match may contain
  *    captures that appear *before* some of the captures from a previous match.

--- a/lib/src/lexer.c
+++ b/lib/src/lexer.c
@@ -203,7 +203,7 @@ static uint32_t ts_lexer__get_column(TSLexer *_self) {
 
 // Is the lexer at a boundary between two disjoint included ranges of
 // source code? This is exposed as an API because some languages' external
-// scanners need to perform custom actions at these bounaries.
+// scanners need to perform custom actions at these boundaries.
 static bool ts_lexer__is_at_included_range_start(const TSLexer *_self) {
   const Lexer *self = (const Lexer *)_self;
   if (self->current_included_range_index < self->included_range_count) {

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -1221,7 +1221,7 @@ static void ts_parser__recover(
     }
   }
 
-  // In the process of attemping to recover, some stack versions may have been created
+  // In the process of attempting to recover, some stack versions may have been created
   // and subsequently halted. Remove those versions.
   for (unsigned i = previous_version_count; i < ts_stack_version_count(self->stack); i++) {
     if (!ts_stack_is_active(self->stack, i)) {


### PR DESCRIPTION
* This is a patch from neovim PR: https://github.com/neovim/neovim/pull/13063

CC: @vigoux 