### PR TITLE
[feat] add custom allocation override

### DIFF
--- a/lib/src/alloc.h
+++ b/lib/src/alloc.h
@@ -25,6 +25,7 @@ bool ts_toggle_allocation_recording(bool);
 #else
 
 // Allow clients to override allocation functions
+
 #ifndef ts_malloc
 #define ts_malloc  ts_malloc_default
 #endif

--- a/lib/src/alloc.h
+++ b/lib/src/alloc.h
@@ -9,21 +9,6 @@ extern "C" {
 #include <stdbool.h>
 #include <stdio.h>
 
-// Allow clients to override allocation functions
-
-#ifndef ts_malloc
-#define ts_malloc(size)         ts_malloc_default(size)
-#endif
-#ifndef ts_calloc
-#define ts_calloc(count,size)   ts_calloc_default(count,size)
-#endif
-#ifndef ts_realloc
-#define ts_realloc(buffer,size) ts_realloc_default(buffer,size)
-#endif
-#ifndef ts_free
-#define ts_free(buffer)         ts_free_default(buffer)
-#endif
-
 #if defined(TREE_SITTER_TEST)
 
 void *ts_record_malloc(size_t);
@@ -32,23 +17,26 @@ void *ts_record_realloc(void *, size_t);
 void ts_record_free(void *);
 bool ts_toggle_allocation_recording(bool);
 
-static inline void *ts_malloc_default(size_t size) {
-  return ts_record_malloc(size);
-}
-
-static inline void *ts_calloc_default(size_t count, size_t size) {
-  return ts_record_calloc(count, size);
-}
-
-static inline void *ts_realloc_default(void *buffer, size_t size) {
-  return ts_record_realloc(buffer, size);
-}
-
-static inline void ts_free_default(void *buffer) {
-  ts_record_free(buffer);
-}
+#define ts_malloc  ts_record_malloc
+#define ts_calloc  ts_record_calloc
+#define ts_realloc ts_record_realloc
+#define ts_free    ts_record_free
 
 #else
+
+// Allow clients to override allocation functions
+#ifndef ts_malloc
+#define ts_malloc  ts_malloc_default
+#endif
+#ifndef ts_calloc
+#define ts_calloc  ts_calloc_default
+#endif
+#ifndef ts_realloc
+#define ts_realloc ts_realloc_default
+#endif
+#ifndef ts_free
+#define ts_free    ts_free_default
+#endif
 
 #include <stdlib.h>
 

--- a/lib/src/alloc.h
+++ b/lib/src/alloc.h
@@ -9,6 +9,21 @@ extern "C" {
 #include <stdbool.h>
 #include <stdio.h>
 
+// Allow clients to override allocation functions
+
+#ifndef ts_malloc
+#define ts_malloc(size)         ts_malloc_default(size)
+#endif
+#ifndef ts_calloc
+#define ts_calloc(count,size)   ts_calloc_default(count,size)
+#endif
+#ifndef ts_realloc
+#define ts_realloc(buffer,size) ts_realloc_default(buffer,size)
+#endif
+#ifndef ts_free
+#define ts_free(buffer)         ts_free_default(buffer)
+#endif
+
 #if defined(TREE_SITTER_TEST)
 
 void *ts_record_malloc(size_t);
@@ -17,19 +32,19 @@ void *ts_record_realloc(void *, size_t);
 void ts_record_free(void *);
 bool ts_toggle_allocation_recording(bool);
 
-static inline void *ts_malloc(size_t size) {
+static inline void *ts_malloc_default(size_t size) {
   return ts_record_malloc(size);
 }
 
-static inline void *ts_calloc(size_t count, size_t size) {
+static inline void *ts_calloc_default(size_t count, size_t size) {
   return ts_record_calloc(count, size);
 }
 
-static inline void *ts_realloc(void *buffer, size_t size) {
+static inline void *ts_realloc_default(void *buffer, size_t size) {
   return ts_record_realloc(buffer, size);
 }
 
-static inline void ts_free(void *buffer) {
+static inline void ts_free_default(void *buffer) {
   ts_record_free(buffer);
 }
 
@@ -42,20 +57,8 @@ static inline bool ts_toggle_allocation_recording(bool value) {
   return false;
 }
 
-#ifndef ts_malloc
-#define ts_malloc(_sz)       ts_malloc_dflt(_sz)
-#endif
-#ifndef ts_calloc
-#define ts_calloc(_cnt,_sz)  ts_calloc_dflt(_cnt,_sz)
-#endif
-#ifndef ts_realloc
-#define ts_realloc(_ptr,_sz) ts_realloc_dflt(_ptr,_sz)
-#endif
-#ifndef ts_free
-#define ts_free(_ptr)        ts_free_dflt(_ptr)
-#endif
 
-static inline void *ts_malloc_dflt(size_t size) {
+static inline void *ts_malloc_default(size_t size) {
   void *result = malloc(size);
   if (size > 0 && !result) {
     fprintf(stderr, "tree-sitter failed to allocate %zu bytes", size);
@@ -64,7 +67,7 @@ static inline void *ts_malloc_dflt(size_t size) {
   return result;
 }
 
-static inline void *ts_calloc_dflt(size_t count, size_t size) {
+static inline void *ts_calloc_default(size_t count, size_t size) {
   void *result = calloc(count, size);
   if (count > 0 && !result) {
     fprintf(stderr, "tree-sitter failed to allocate %zu bytes", count * size);
@@ -73,7 +76,7 @@ static inline void *ts_calloc_dflt(size_t count, size_t size) {
   return result;
 }
 
-static inline void *ts_realloc_dflt(void *buffer, size_t size) {
+static inline void *ts_realloc_default(void *buffer, size_t size) {
   void *result = realloc(buffer, size);
   if (size > 0 && !result) {
     fprintf(stderr, "tree-sitter failed to reallocate %zu bytes", size);
@@ -82,7 +85,7 @@ static inline void *ts_realloc_dflt(void *buffer, size_t size) {
   return result;
 }
 
-static inline void ts_free_dflt(void *buffer) {
+static inline void ts_free_default(void *buffer) {
   free(buffer);
 }
 

--- a/lib/src/alloc.h
+++ b/lib/src/alloc.h
@@ -42,7 +42,20 @@ static inline bool ts_toggle_allocation_recording(bool value) {
   return false;
 }
 
-static inline void *ts_malloc(size_t size) {
+#ifndef ts_malloc
+#define ts_malloc(_sz)       ts_malloc_dflt(_sz)
+#endif
+#ifndef ts_calloc
+#define ts_calloc(_cnt,_sz)  ts_calloc_dflt(_cnt,_sz)
+#endif
+#ifndef ts_realloc
+#define ts_realloc(_ptr,_sz) ts_realloc_dflt(_ptr,_sz)
+#endif
+#ifndef ts_free
+#define ts_free(_ptr)        ts_free_dflt(_ptr)
+#endif
+
+static inline void *ts_malloc_dflt(size_t size) {
   void *result = malloc(size);
   if (size > 0 && !result) {
     fprintf(stderr, "tree-sitter failed to allocate %zu bytes", size);
@@ -51,7 +64,7 @@ static inline void *ts_malloc(size_t size) {
   return result;
 }
 
-static inline void *ts_calloc(size_t count, size_t size) {
+static inline void *ts_calloc_dflt(size_t count, size_t size) {
   void *result = calloc(count, size);
   if (count > 0 && !result) {
     fprintf(stderr, "tree-sitter failed to allocate %zu bytes", count * size);
@@ -60,7 +73,7 @@ static inline void *ts_calloc(size_t count, size_t size) {
   return result;
 }
 
-static inline void *ts_realloc(void *buffer, size_t size) {
+static inline void *ts_realloc_dflt(void *buffer, size_t size) {
   void *result = realloc(buffer, size);
   if (size > 0 && !result) {
     fprintf(stderr, "tree-sitter failed to reallocate %zu bytes", size);
@@ -69,7 +82,7 @@ static inline void *ts_realloc(void *buffer, size_t size) {
   return result;
 }
 
-static inline void ts_free(void *buffer) {
+static inline void ts_free_dflt(void *buffer) {
   free(buffer);
 }
 


### PR DESCRIPTION
# Add ability to override allocator

PR meant to be a starting point; happy to implement in a different way

## Problem
Integrating tree-sitter into our main app requires it to use our allocators
Windows does not easily provide a means to override weakly linked symbols (can be done; usually by inserting a trampoline)
We'd like to also leverage all of our existing memory tracking/profiling

## Fix: Macro override
- Simple,  minimal affect on rest of code base. User can define ts_malloc* 
```
#define ts_malloc(_sz)       es2capi_alloc(   OSAlctrHndlUid(), _sz,  0,      __FILE__, __LINE__)
#define ts_calloc(_cnt,_sz)  es2capi_calloc(  OSAlctrHndlUid(), _cnt, _sz, 0, __FILE__, __LINE__)
#define ts_realloc(_ptr,_sz) es2capi_realloc( OSAlctrHndlUid(), _ptr, _sz, 0, __FILE__, __LINE__)
#define ts_free(_ptr)        es2capi_free(    OSAlctrHndlUid(), _ptr, 0,      __FILE__, __LINE__)
```
- Retains default fallback 
- Benefit of macro is allows inserting tracking like __FILE__, __LINE__, etc

## Alternatives
* Add a config struct with callback handlers 
  * - ruffles my perf ocd sensibilities :P Users can decorate their functions with `__pure__ __restrict__` but esoteric knowledge
  * - not easy to handle tracking
* Other variants of the macro override
 
