### PR TITLE
Expect text_callback to return a byte iterator rather than a byte slice

### DIFF
--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -34,7 +34,7 @@ pub fn query_files_at_paths(
         let source_code = fs::read(&path).map_err(Error::wrap(|| {
             format!("Error reading source file {:?}", path)
         }))?;
-        let text_callback = |n: Node| &source_code[n.byte_range()];
+        let text_callback = |n: Node| source_code[n.byte_range()].iter().cloned();
         let tree = parser.parse(&source_code, None).unwrap();
 
         if ordered_captures {

--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -3,6 +3,8 @@ use super::helpers::fixtures::get_language;
 use lazy_static::lazy_static;
 use std::env;
 use std::fmt::Write;
+use std::iter;
+use std::slice;
 use tree_sitter::{
     Language, Node, Parser, Query, QueryCapture, QueryCursor, QueryError, QueryErrorKind,
     QueryMatch, QueryPredicate, QueryPredicateArg, QueryProperty,
@@ -2968,6 +2970,6 @@ fn format_captures<'a>(
         .collect()
 }
 
-fn to_callback<'a>(source: &'a str) -> impl Fn(Node) -> &'a [u8] {
-    move |n| &source.as_bytes()[n.byte_range()]
+fn to_callback<'a>(source: &'a str) -> impl Fn(Node) -> iter::Cloned<slice::Iter<'a, u8>> {
+    move |n| source.as_bytes()[n.byte_range()].iter().cloned()
 }

--- a/highlight/src/lib.rs
+++ b/highlight/src/lib.rs
@@ -101,7 +101,7 @@ where
 struct HighlightIterLayer<'a> {
     _tree: Tree,
     cursor: QueryCursor,
-    captures: iter::Peekable<QueryCaptures<'a, &'a [u8]>>,
+    captures: iter::Peekable<QueryCaptures<'a, std::iter::Cloned<std::slice::Iter<'a, u8>>>>,
     config: &'a HighlightConfiguration,
     highlight_end_stack: Vec<usize>,
     scope_stack: Vec<LocalScope<'a>>,
@@ -357,7 +357,7 @@ impl<'a> HighlightIterLayer<'a> {
                         vec![(None, Vec::new(), false); combined_injections_query.pattern_count()];
                     let matches =
                         cursor.matches(combined_injections_query, tree.root_node(), |n: Node| {
-                            &source[n.byte_range()]
+                            source[n.byte_range()].iter().cloned()
                         });
                     for mat in matches {
                         let entry = &mut injections_by_pattern_index[mat.pattern_index];
@@ -396,7 +396,7 @@ impl<'a> HighlightIterLayer<'a> {
                     unsafe { mem::transmute::<_, &'static mut QueryCursor>(&mut cursor) };
                 let captures = cursor_ref
                     .captures(&config.query, tree_ref.root_node(), move |n: Node| {
-                        &source[n.byte_range()]
+                        source[n.byte_range()].iter().cloned()
                     })
                     .peekable();
 

--- a/tags/src/lib.rs
+++ b/tags/src/lib.rs
@@ -264,7 +264,7 @@ impl TagsContext {
         let matches = self
             .cursor
             .matches(&config.query, tree_ref.root_node(), move |node| {
-                &source[node.byte_range()]
+                source[node.byte_range()].iter().cloned()
             });
         Ok((
             TagsIter {


### PR DESCRIPTION
I'm using Tree-sitter in a situation where I can't return byte slices from the `text_callback` passed to `QueryCursor::matches` and `QueryCursor::captures`, because my document is composed of many fragments in a rope-style data structure. To support this use case, this PR changes the expected return value of that callback to be an exact-sized byte *iterator* rather than a byte slice.

The big downside is that I have to copy the bytes into a scratch buffer in order to match regular expressions. However, the scratch buffer is allocated only once when the iterator is created. Other comparisons are performed with `Iterator::eq`, which I assume has performance similar to comparing byte slices, though I could be wrong about that.

One other idea I explored was to take a `TextProvider` object that can return references to itself and buffers internally. The problem with that approach was when I needed to compare the text of two different nodes. The internal buffer of the `TextProvider` can't be used for two different values at the same time.

Happy to explore other approaches with different trade-offs if you have any ideas. Also, no offense taken if you simply don't want to take on complexity to serve this use case. I can maintain this in a fork if necessary.

You know I have always thought this project is a masterpiece, and it keeps getting better.