### PR TITLE
tags: fix compilation on aarch64

### DIFF
--- a/tags/src/c_lib.rs
+++ b/tags/src/c_lib.rs
@@ -1,6 +1,7 @@
 use super::{Error, TagsConfiguration, TagsContext};
 use std::collections::HashMap;
 use std::ffi::CStr;
+use std::os::raw::c_char;
 use std::process::abort;
 use std::sync::atomic::AtomicUsize;
 use std::{fmt, slice, str};
@@ -73,7 +74,7 @@ pub extern "C" fn ts_tagger_delete(this: *mut TSTagger) {
 #[no_mangle]
 pub extern "C" fn ts_tagger_add_language(
     this: *mut TSTagger,
-    scope_name: *const i8,
+    scope_name: *const c_char,
     language: Language,
     tags_query: *const u8,
     locals_query: *const u8,
@@ -109,7 +110,7 @@ pub extern "C" fn ts_tagger_add_language(
 #[no_mangle]
 pub extern "C" fn ts_tagger_tag(
     this: *mut TSTagger,
-    scope_name: *const i8,
+    scope_name: *const c_char,
     source_code: *const u8,
     source_code_len: u32,
     output: *mut TSTagsBuffer,
@@ -234,7 +235,7 @@ pub extern "C" fn ts_tags_buffer_found_parse_error(this: *const TSTagsBuffer) ->
 #[no_mangle]
 pub extern "C" fn ts_tagger_syntax_kinds_for_scope_name(
     this: *mut TSTagger,
-    scope_name: *const i8,
+    scope_name: *const c_char,
     len: *mut u32,
 ) -> *const *const i8 {
     let tagger = unwrap_mut_ptr(this);

--- a/tags/src/lib.rs
+++ b/tags/src/lib.rs
@@ -5,6 +5,7 @@ use regex::Regex;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::ops::Range;
+use std::os::raw::c_char;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{char, fmt, mem, str};
 use tree_sitter::{
@@ -230,8 +231,9 @@ impl TagsConfiguration {
 
     pub fn syntax_type_name(&self, id: u32) -> &str {
         unsafe {
-            let cstr = CStr::from_ptr(self.syntax_type_names[id as usize].as_ptr() as *const i8)
-                .to_bytes();
+            let cstr =
+                CStr::from_ptr(self.syntax_type_names[id as usize].as_ptr() as *const c_char)
+                    .to_bytes();
             str::from_utf8(cstr).expect("syntax type name was not valid utf-8")
         }
     }


### PR DESCRIPTION
`CStr::from_ptr` type is not always `i8`. On `aarch64` architecture it is `u8`.
Using `std::os::raw::c_char` fixes the issue.

Fixes #798