### PR TITLE
web binding: fix equals()

### DIFF
--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -258,11 +258,7 @@ class Node {
   }
 
   equals(other) {
-    if (this === other) return true;
-    for (let i = 0; i < 5; i++) {
-      if (this[i] !== other[i]) return false;
-    }
-    return true;
+    return this.id === other.id;
   }
 
   child(index) {

--- a/lib/binding_web/test/node-test.js
+++ b/lib/binding_web/test/node-test.js
@@ -388,4 +388,24 @@ describe("Node", () => {
       assert.throws(() => number.closest({a: 1}), /Argument must be a string or array of strings/)
     });
   });
+
+  describe('.equals(other)', () => {
+    it('returns true if the nodes are the same', () => {
+      tree = parser.parse('1 + 2');
+
+      const sumNode = tree.rootNode.firstChild.firstChild;
+      const node1 = sumNode.firstChild;
+      const node2 = sumNode.firstChild;
+      assert(node1.equals(node2));
+    });
+
+    it('returns false if the nodes are not the same', () => {
+      tree = parser.parse('1 + 2');
+
+      const sumNode = tree.rootNode.firstChild.firstChild;
+      const node1 = sumNode.firstChild;
+      const node2 = node1.nextSibling;
+      assert(!node1.equals(node2));
+    });
+  });
 });


### PR DESCRIPTION
Node.equals() used to always return true. Now it works.
Also added unit tests for it.