### PR TITLE
Small improvements to test & update-corpus cycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
+
+[[package]]
 name = "arrayref"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +837,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18dcb776d3affaba6db04d11d645946d34a69b3172e588af96ce9fecd20faac"
+dependencies = [
+ "cc",
+ "regex",
+]
+
+[[package]]
 name = "tree-sitter-cli"
 version = "0.17.3"
 dependencies = [
@@ -855,8 +871,9 @@ dependencies = [
  "spin",
  "tempfile",
  "tiny_http",
- "tree-sitter",
+ "tree-sitter 0.17.1",
  "tree-sitter-highlight",
+ "tree-sitter-sexp",
  "tree-sitter-tags",
  "webbrowser",
 ]
@@ -866,7 +883,17 @@ name = "tree-sitter-highlight"
 version = "0.3.0"
 dependencies = [
  "regex",
- "tree-sitter",
+ "tree-sitter 0.17.1",
+]
+
+[[package]]
+name = "tree-sitter-sexp"
+version = "0.1.0"
+source = "git+https://github.com/AbstractMachinesLab/tree-sitter-sexp.git?branch=main#8761ec3844bae68dfdec1067052d824c09f2809a"
+dependencies = [
+ "anyhow",
+ "cc",
+ "tree-sitter 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -875,7 +902,7 @@ version = "0.3.0"
 dependencies = [
  "memchr",
  "regex",
- "tree-sitter",
+ "tree-sitter 0.17.1",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,6 +36,7 @@ serde_derive = "1.0"
 smallbitvec = "2.3.0"
 tiny_http = "0.6"
 webbrowser = "0.5.1"
+tree-sitter-sexp = { git = "https://github.com/AbstractMachinesLab/tree-sitter-sexp", branch = "main" }
 
 [dependencies.tree-sitter]
 version = ">= 0.17.0"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -7,6 +7,7 @@ pub mod logger;
 pub mod parse;
 pub mod query;
 pub mod query_testing;
+pub mod sexp;
 pub mod tags;
 pub mod test;
 pub mod test_highlight;


### PR DESCRIPTION
Following #442 and #828, here's a few small changes that make the flow a little smoother, and one rather larger one that gives us S-expressions that are easier on the eyes, and should make for easier to read diffs with #827 as well.

#### Changes:

* Do not reprint the list of changed tests, just the number of them

* Use new character for updated tests (arrow pointing up)

* Depend on the `tree-sitter-sexpr` crate that implements a thin
  idiomatic Rust layer to parse and pretty print S-expressions on top of
  a tree-sitter generated parser fo them.

---

cc/ @maxbrunsfeld @ikatyang  