### PR TITLE
Update CC for additional target support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.25"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,7 +20,7 @@ harness = false
 
 [dependencies]
 ansi_term = "0.11"
-cc = "1.0"
+cc = "^1.0.58"
 atty = "0.2"
 clap = "2.32"
 difference = "2.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -24,7 +24,7 @@ include = [
 regex = "1"
 
 [build-dependencies]
-cc = "1.0"
+cc = "^1.0.58"
 
 [lib]
 path = "binding_rust/lib.rs"


### PR DESCRIPTION
This just explicitly sets a new minimum for `cc`, and allows tree-sitter to build on additional platforms, namely Apple M1