### PR TITLE
Fix build with GCC 11

### DIFF
--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -448,6 +448,7 @@ TSTreeCursor ts_tree_cursor_copy(const TSTreeCursor *_cursor) {
   TSTreeCursor res = {NULL, NULL, {0, 0}};
   TreeCursor *copy = (TreeCursor *)&res;
   copy->tree = cursor->tree;
+  array_init(&copy->stack);
   array_push_all(&copy->stack, &cursor->stack);
   return res;
 }


### PR DESCRIPTION
It seems redundant to array_init() when the structure is zeroed already
in the static assignment. But probably the fact that this code juggles
between TSTreeCursor and TreeCursor, without using a union, leaves the
compiler unable to tell that it's been initialized.

Fixes https://github.com/tree-sitter/tree-sitter/issues/853