### PR TITLE
Add --xml option to save the parsed code into XML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "html-escape"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d348900ce941b7474395ba922ed3735a517df4546a2939ddb416ce85eeaa988e"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +850,7 @@ dependencies = [
  "difference",
  "dirs",
  "glob",
+ "html-escape",
  "lazy_static",
  "libloading",
  "log",
@@ -939,6 +949,12 @@ name = "utf8-ranges"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9071ac216321a4470a69fb2b28cfc68dcd1a39acd877c8be8e014df6772d8efa"
 
 [[package]]
 name = "vec_map"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,6 +36,7 @@ serde_derive = "1.0"
 smallbitvec = "2.3.0"
 tiny_http = "0.6"
 webbrowser = "0.5.1"
+html-escape = "0.2.6"
 
 [dependencies.tree-sitter]
 version = ">= 0.17.0"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -63,6 +63,7 @@ fn run() -> error::Result<()> {
                 .arg(Arg::with_name("scope").long("scope").takes_value(true))
                 .arg(Arg::with_name("debug").long("debug").short("d"))
                 .arg(Arg::with_name("debug-graph").long("debug-graph").short("D"))
+                .arg(Arg::with_name("debug-xml").long("xml").short("x"))
                 .arg(Arg::with_name("quiet").long("quiet").short("q"))
                 .arg(Arg::with_name("stat").long("stat").short("s"))
                 .arg(Arg::with_name("time").long("time").short("t"))
@@ -222,6 +223,7 @@ fn run() -> error::Result<()> {
     } else if let Some(matches) = matches.subcommand_matches("parse") {
         let debug = matches.is_present("debug");
         let debug_graph = matches.is_present("debug-graph");
+        let debug_xml = matches.is_present("debug-xml");
         let quiet = matches.is_present("quiet");
         let time = matches.is_present("time");
         let edits = matches
@@ -257,6 +259,7 @@ fn run() -> error::Result<()> {
                 timeout,
                 debug,
                 debug_graph,
+                debug_xml,
                 Some(&cancellation_flag),
             )?;
 


### PR DESCRIPTION
I work on Huawei's Trusted Programming Language project, which was recently asked to analyse the source code files of multiple programming languages.  We believe `tree-sitter` is a suitable tool for this purpose. However, `tree-sitter` saves the parsed code into a format that is not interoperable with other tools we use yet. Hence, I've completed a working prototype for saving parsed source code into XML, and add `--xml` or `-x` option to the CLI: 
```bash
tree-sitter parse -q -x <path_to_code>
```
Here the `<path_to_code>` is the path to a source code file.  As a result, the output code will be printed to the standard output in XML format. The XML elements are generated from the `node.kind()`, and the textual value of these elements are extracted from the `source_code` string in-between the `start` and the `end` positions.  If these text strings contain special characters, they will be escaped into XML-compatible entities using the `html-escape` crate, hence the extra dependency. 

If someone with more experience developing in `tree-sitter` can give this an early look and send feedback, that would be really helpful. Apologies in advance for the current lack of tests and limited documentation. I'll be working on this full time for a while, so it will improve rapidly.

Thanks!