### PR TITLE
Fix typo in document

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1478,7 +1478,7 @@ impl Query {
     ///
     /// This includes predicate with operators other than:
     /// * `match?`
-    /// * `eq?` and `not-eq?
+    /// * `eq?` and `not-eq?`
     /// * `is?` and `is-not?`
     /// * `set!`
     pub fn general_predicates(&self, index: usize) -> &[QueryPredicate] {


### PR DESCRIPTION
I found missing backtick in document. This PR fixes it.

https://docs.rs/tree-sitter/0.17.1/tree_sitter/struct.Query.html#method.general_predicates