### PR TITLE
Add ";" as comment in s-expressions

### DIFF
--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -22,6 +22,7 @@ lazy_static! {
         .multi_line(true)
         .build()
         .unwrap();
+    static ref COMMENT_REGEX: Regex = Regex::new(r";.*").unwrap();
     static ref WHITESPACE_REGEX: Regex = Regex::new(r"\s+").unwrap();
     static ref SEXP_FIELD_REGEX: Regex = Regex::new(r" \w+: \(").unwrap();
 }
@@ -392,8 +393,10 @@ fn parse_test_content(name: String, content: String, file_path: Option<PathBuf>)
                         input.pop();
                     }
 
+                    // Remove all comments
+                    let output = COMMENT_REGEX.replace_all(output, "").to_string();
                     // Normalize the whitespace in the expected output.
-                    let output = WHITESPACE_REGEX.replace_all(output.trim(), " ").to_string();
+                    let output = WHITESPACE_REGEX.replace_all(output.trim(), " ");
                     let output = output.replace(" )", ")");
 
                     // Identify if the expected output has fields indicated. If not, then

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -590,4 +590,54 @@ output 2
             .to_string()
         );
     }
+
+    #[test]
+    fn test_parse_test_content_with_comments_in_sexp() {
+        let entry = parse_test_content(
+            "the-filename".to_string(),
+            r#"
+==================
+Code with comment
+==================
+code
+---
+
+; Line start comment
+(a (b))
+
+=========================
+Code line ending with comment
+=========================
+code
+---
+
+(c (d)) ; Line end comment
+        "#
+            .trim()
+            .to_string(),
+            None,
+        );
+
+        assert_eq!(
+            entry,
+            TestEntry::Group {
+                name: "the-filename".to_string(),
+                children: vec![
+                    TestEntry::Example {
+                        name: "Code with comment".to_string(),
+                        input: "code".as_bytes().to_vec(),
+                        output: "(a (b))".to_string(),
+                        has_fields: false,
+                    },
+                    TestEntry::Example {
+                        name: "Code line ending with comment".to_string(),
+                        input: "code".as_bytes().to_vec(),
+                        output: "(c (d))".to_string(),
+                        has_fields: false,
+                    },
+                ],
+                file_path: None,
+            }
+        );
+    }
 }

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -22,7 +22,7 @@ lazy_static! {
         .multi_line(true)
         .build()
         .unwrap();
-    static ref COMMENT_REGEX: Regex = Regex::new(r";.*").unwrap();
+    static ref COMMENT_REGEX: Regex = Regex::new(r"(?m)^\s*;.*$").unwrap();
     static ref WHITESPACE_REGEX: Regex = Regex::new(r"\s+").unwrap();
     static ref SEXP_FIELD_REGEX: Regex = Regex::new(r" \w+: \(").unwrap();
 }
@@ -597,7 +597,7 @@ output 2
             "the-filename".to_string(),
             r#"
 ==================
-Code with comment
+sexp with comment
 ==================
 code
 ---
@@ -605,13 +605,26 @@ code
 ; Line start comment
 (a (b))
 
+==================
+sexp with comment between
+==================
+code
+---
+
+; Line start comment
+(a 
+; ignore this
+    (b)
+    ; also ignore this
+)
+
 =========================
-Code line ending with comment
+sexp with ';'
 =========================
 code
 ---
 
-(c (d)) ; Line end comment
+(MISSING ";")
         "#
             .trim()
             .to_string(),
@@ -624,17 +637,23 @@ code
                 name: "the-filename".to_string(),
                 children: vec![
                     TestEntry::Example {
-                        name: "Code with comment".to_string(),
+                        name: "sexp with comment".to_string(),
                         input: "code".as_bytes().to_vec(),
                         output: "(a (b))".to_string(),
                         has_fields: false,
                     },
                     TestEntry::Example {
-                        name: "Code line ending with comment".to_string(),
+                        name: "sexp with comment between".to_string(),
                         input: "code".as_bytes().to_vec(),
-                        output: "(c (d))".to_string(),
+                        output: "(a (b))".to_string(),
                         has_fields: false,
                     },
+                    TestEntry::Example {
+                        name: "sexp with ';'".to_string(),
+                        input: "code".as_bytes().to_vec(),
+                        output: "(MISSING \";\")".to_string(),
+                        has_fields: false,
+                    }
                 ],
                 file_path: None,
             }


### PR DESCRIPTION
Remove everything after a ";" 

So
```
; Comment
(a 
  ; Comment
  (b)
)
```

Becomes
```
(a (b))
```

Related issue: https://github.com/tree-sitter/tree-sitter/issues/752