### PR TITLE
Add index.js wrapper for wasm-bindgen compatibility

### DIFF
--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -1145,3 +1145,4 @@ function marshalEdit(edit) {
 }
 
 Parser.Language = Language;
+Parser.Parser = Parser;


### PR DESCRIPTION
This PR adds an `index.js` wrapper module that simply imports and re-exports from the underlying bindings module.

For background, I'm trying to use `web-tree-sitter` with a wasm-bindgen project [`web-tree-sitter-sys`](https://github.com/hvithrafn/web-tree-sitter-sys).

However, when I try to call `Parser::init()` from Rust, based on these wasm-bindgen bindings, I get an error that `init` is undefined:

```rust
#[wasm_bindgen(module = "web-tree-sitter")]
extern {
    #[derive(Clone, Debug)]
    pub type Parser;

    #[wasm_bindgen(static_method_of = Parser)]
    pub fn init() -> Promise;

    // ...
}
```

I found [this issue](https://github.com/rustwasm/wasm-bindgen/issues/1202), which seems to be related.

Based on what was discussed there, I figured that adding an `index.js` module like I've done in this PR might solve the problem, and indeed it does. With this change, I can use the wasm-bindgen bindings without errors.

If adding this wrapper `index.js` module doesn't cause any other problems, could you please merge this and make a new release of `web-tree-sitter`?