### PR TITLE
Refine web bindings typings

### DIFF
--- a/lib/binding_web/tree-sitter-web.d.ts
+++ b/lib/binding_web/tree-sitter-web.d.ts
@@ -1,8 +1,8 @@
 declare module 'web-tree-sitter' {
   class Parser {
     static init(): Promise<void>;
-    delete(): void;
-    parse(input: string | Parser.Input, previousTree?: Parser.Tree, options?: Parser.Options): Parser.Tree;
+    delete();
+    parse(input: string | Parser.Input, previousTree?: Parser.Tree, options?: Parser.Options): Parser.Tree | null;
     getLanguage(): Parser.Language | null;
     setLanguage(language?: Parser.Language): void;
     getLogger(): Parser.Logger | null;
@@ -61,8 +61,8 @@ declare module 'web-tree-sitter' {
       startIndex: number;
       endIndex: number;
       parent: SyntaxNode | null;
-      children: Array<SyntaxNode>;
-      namedChildren: Array<SyntaxNode>;
+      children: SyntaxNode[];
+      namedChildren: SyntaxNode[];
       childCount: number;
       namedChildCount: number;
       firstChild: SyntaxNode | null;
@@ -85,15 +85,15 @@ declare module 'web-tree-sitter' {
       childForFieldId(fieldId: number): SyntaxNode | null;
       childForFieldName(fieldName: string): SyntaxNode | null;
 
-      descendantForIndex(index: number): SyntaxNode;
-      descendantForIndex(startIndex: number, endIndex: number): SyntaxNode;
-      descendantsOfType(type: string | Array<string>, startPosition?: Point, endPosition?: Point): Array<SyntaxNode>;
-      namedDescendantForIndex(index: number): SyntaxNode;
-      namedDescendantForIndex(startIndex: number, endIndex: number): SyntaxNode;
-      descendantForPosition(position: Point): SyntaxNode;
-      descendantForPosition(startPosition: Point, endPosition: Point): SyntaxNode;
-      namedDescendantForPosition(position: Point): SyntaxNode;
-      namedDescendantForPosition(startPosition: Point, endPosition: Point): SyntaxNode;
+      descendantForIndex(index: number): SyntaxNode | null;
+      descendantForIndex(startIndex: number, endIndex: number): SyntaxNode | null;
+      descendantsOfType(type: string | string[], startPosition?: Point, endPosition?: Point): SyntaxNode[];
+      namedDescendantForIndex(index: number): SyntaxNode | null;
+      namedDescendantForIndex(startIndex: number, endIndex: number): SyntaxNode | null;
+      descendantForPosition(position: Point): SyntaxNode | null;
+      descendantForPosition(startPosition: Point, endPosition: Point): SyntaxNode | null;
+      namedDescendantForPosition(position: Point): SyntaxNode | null;
+      namedDescendantForPosition(startPosition: Point, endPosition: Point): SyntaxNode | null;
 
       walk(): TreeCursor;
     }
@@ -108,11 +108,11 @@ declare module 'web-tree-sitter' {
       startIndex: number;
       endIndex: number;
 
-      reset(node: SyntaxNode): void;
-      delete(): void;
+      reset(node: SyntaxNode);
+      delete();
       currentNode(): SyntaxNode;
-      currentFieldId(): number;
-      currentFieldName(): string;
+      currentFieldId(): number | null;
+      currentFieldName(): string | null;
       gotoParent(): boolean;
       gotoFirstChild(): boolean;
       gotoNextSibling(): boolean;
@@ -122,11 +122,11 @@ declare module 'web-tree-sitter' {
       readonly rootNode: SyntaxNode;
 
       copy(): Tree;
-      delete(): void;
+      delete();
       edit(delta: Edit): Tree;
       walk(): TreeCursor;
       getChangedRanges(other: Tree): Range[];
-      getLanguage(): any;
+      getLanguage(): Language;
     }
 
     class Language {
@@ -158,7 +158,7 @@ declare module 'web-tree-sitter' {
     class Query {
       captureNames: string[];
 
-      delete(): void;
+      delete();
       matches(node: SyntaxNode, startPosition?: Point, endPosition?: Point): QueryMatch[];
       captures(node: SyntaxNode, startPosition?: Point, endPosition?: Point): QueryCapture[];
       predicatesForPattern(patternIndex: number): PredicateResult[];

--- a/lib/binding_web/tree-sitter-web.d.ts
+++ b/lib/binding_web/tree-sitter-web.d.ts
@@ -3,10 +3,13 @@ declare module 'web-tree-sitter' {
     static init(): Promise<void>;
     delete(): void;
     parse(input: string | Parser.Input, previousTree?: Parser.Tree, options?: Parser.Options): Parser.Tree;
-    getLanguage(): any;
-    setLanguage(language: any): void;
-    getLogger(): Parser.Logger;
-    setLogger(logFunc: Parser.Logger): void;
+    getLanguage(): Parser.Language | null;
+    setLanguage(language?: Parser.Language): void;
+    getLogger(): Parser.Logger | null;
+    setLogger(logFunc?: Parser.Logger): void;
+    reset(): void;
+    getTimeoutMicros(): number;
+    setTimeoutMicros(timeout: number);
   }
 
   namespace Parser {
@@ -51,6 +54,7 @@ declare module 'web-tree-sitter' {
       id: number;
       tree: Tree;
       type: string;
+      typeId: number;
       text: string;
       startPosition: Point;
       endPosition: Point;
@@ -97,6 +101,7 @@ declare module 'web-tree-sitter' {
     export interface TreeCursor {
       nodeType: string;
       nodeText: string;
+      nodeIsMissing: boolean;
       nodeIsNamed: boolean;
       startPosition: Point;
       endPosition: Point;

--- a/lib/binding_web/tree-sitter-web.d.ts
+++ b/lib/binding_web/tree-sitter-web.d.ts
@@ -115,7 +115,6 @@ declare module 'web-tree-sitter' {
       currentFieldName(): string;
       gotoParent(): boolean;
       gotoFirstChild(): boolean;
-      gotoFirstChildForIndex(index: number): boolean;
       gotoNextSibling(): boolean;
     }
 
@@ -127,7 +126,6 @@ declare module 'web-tree-sitter' {
       edit(delta: Edit): Tree;
       walk(): TreeCursor;
       getChangedRanges(other: Tree): Range[];
-      getEditedRange(other: Tree): Range;
       getLanguage(): any;
     }
 


### PR DESCRIPTION
This PR refines the `web-tree-sitter` typings a bit.

I noticed in the tests that it's possible to set the language and logger to null, and of course sometimes getting the language and logger will also return null. So it seems a little more accurate to specify this in the typings as well.