### PR TITLE
Fix getting node by field name or ID.

### DIFF
--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -564,7 +564,10 @@ recur:
       // If the field refers to a hidden node, return its first visible
       // child.
       else {
-        return ts_node_child(child, 0);
+        TSNode result = ts_node_child(child, 0);
+        if (result.id) return result;
+        field_map++;
+        if (field_map == field_map_end) return ts_node__null();
       }
     }
   }


### PR DESCRIPTION
Getting node child by field name or ID sometimes does not work.

It is visible when parsing following Python code:

```Python
while b:
    pass
```

The code is parsed into: `(while_statement condition: (identifier) body: (block (pass_statement)))`.
However getting child from field named `"body"` results in null node (`ts_node__null()`).

Further investigation gave following conclusions:
1. `while_statement` has 5 children: `("while")`, `("expression")("primary_expression")(identifier)`, `(":")`, `(_indent)`, `(block (pass_statement))`
2. There are two field map entries associated with `body` field. First one with `child_index = 3` and one with `child_index = 4`.
3. `ts_node_child_by_field_id` processes the first field map entry (`child_index = 3`). The child is `(_indent)`. As the field is not inherited from any grandchild and `(_indent)` is not visible, the first visible descendant is taken, but there is no such one. Thus `ts_node__null()` is returned.
4. The right behavior would be to check the second field map entry (`child_index = 4`), which is `(block (pass_statement))`. It is visible, and thus, should be returned.

This PR introduces such behavior.