### PR TITLE
Modify Language.load to accept bytes directly

### DIFF
--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -856,26 +856,31 @@ class Language {
     );
   }
 
-  static load(url) {
+  static load(input) {
     let bytes;
-    if (
-      typeof process !== 'undefined' &&
-      process.versions &&
-      process.versions.node
-    ) {
-      const fs = require('fs');
-      bytes = Promise.resolve(fs.readFileSync(url));
+    if (input instanceof Uint8Array) {
+      bytes = Promise.resolve(input);
     } else {
-      bytes = fetch(url)
-        .then(response => response.arrayBuffer()
-          .then(buffer => {
-            if (response.ok) {
-              return new Uint8Array(buffer);
-            } else {
-              const body = new TextDecoder('utf-8').decode(buffer);
-              throw new Error(`Language.load failed with status ${response.status}.\n\n${body}`)
-            }
-          }));
+      const url = input;
+      if (
+        typeof process !== 'undefined' &&
+        process.versions &&
+        process.versions.node
+      ) {
+        const fs = require('fs');
+        bytes = Promise.resolve(fs.readFileSync(url));
+      } else {
+        bytes = fetch(url)
+          .then(response => response.arrayBuffer()
+            .then(buffer => {
+              if (response.ok) {
+                return new Uint8Array(buffer);
+              } else {
+                const body = new TextDecoder('utf-8').decode(buffer);
+                throw new Error(`Language.load failed with status ${response.status}.\n\n${body}`)
+              }
+            }));
+      }
     }
 
     // emscripten-core/emscripten#12969

--- a/lib/binding_web/tree-sitter-web.d.ts
+++ b/lib/binding_web/tree-sitter-web.d.ts
@@ -127,7 +127,7 @@ declare module 'web-tree-sitter' {
     }
 
     class Language {
-      static load(path: string): Promise<Language>;
+      static load(input: string | Uint8Array): Promise<Language>;
 
       readonly version: number;
       readonly fieldCount: number;


### PR DESCRIPTION
This PR modifies `Language.load` to also accept a `Uint8Array` so that the language grammar wasm bytes can be passed in directly rather than loaded from a URL.

This pattern seems to be more suitable for using `web-tree-sitter` with my wasm-bindgen bindings. It's easier to just include the grammar bytes with `include_bytes!` since cargo doesn't make it easy to control how external assets are installed and later referenced.