### PR TITLE
Represent CharacterSet internally as a vector of ranges

### DIFF
--- a/cli/src/generate/build_tables/mod.rs
+++ b/cli/src/generate/build_tables/mod.rs
@@ -13,7 +13,7 @@ use self::minimize_parse_table::minimize_parse_table;
 use self::token_conflicts::TokenConflictMap;
 use crate::error::Result;
 use crate::generate::grammars::{InlinedProductionMap, LexicalGrammar, SyntaxGrammar};
-use crate::generate::nfa::{CharacterSet, NfaCursor};
+use crate::generate::nfa::NfaCursor;
 use crate::generate::node_types::VariableInfo;
 use crate::generate::rules::{AliasMap, Symbol, SymbolType, TokenSet};
 use crate::generate::tables::{LexTable, ParseAction, ParseTable, ParseTableEntry};
@@ -472,10 +472,8 @@ fn all_chars_are_alphabetical(cursor: &NfaCursor) -> bool {
     cursor.transition_chars().all(|(chars, is_sep)| {
         if is_sep {
             true
-        } else if let CharacterSet::Include(chars) = chars {
-            chars.iter().all(|c| c.is_alphabetic() || *c == '_')
         } else {
-            false
+            chars.chars().all(|c| c.is_alphabetic() || c == '_')
         }
     })
 }

--- a/cli/src/generate/prepare_grammar/expand_tokens.rs
+++ b/cli/src/generate/prepare_grammar/expand_tokens.rs
@@ -198,11 +198,11 @@ impl NfaBuilder {
             Ast::Empty(_) => Ok(false),
             Ast::Flags(_) => Err(Error::regex("Flags are not supported")),
             Ast::Literal(literal) => {
-                self.push_advance(CharacterSet::Include(vec![literal.c]), next_state_id);
+                self.push_advance(CharacterSet::from_char(literal.c), next_state_id);
                 Ok(true)
             }
             Ast::Dot(_) => {
-                self.push_advance(CharacterSet::Exclude(vec!['\n']), next_state_id);
+                self.push_advance(CharacterSet::from_char('\n').negate(), next_state_id);
                 Ok(true)
             }
             Ast::Assertion(_) => Err(Error::regex("Assertions are not supported")),
@@ -344,11 +344,9 @@ impl NfaBuilder {
 
     fn expand_character_class(&self, item: &ClassSetItem) -> Result<CharacterSet> {
         match item {
-            ClassSetItem::Empty(_) => Ok(CharacterSet::Include(Vec::new())),
-            ClassSetItem::Literal(literal) => Ok(CharacterSet::Include(vec![literal.c])),
-            ClassSetItem::Range(range) => {
-                Ok(CharacterSet::empty().add_range(range.start.c, range.end.c))
-            }
+            ClassSetItem::Empty(_) => Ok(CharacterSet::empty()),
+            ClassSetItem::Literal(literal) => Ok(CharacterSet::from_char(literal.c)),
+            ClassSetItem::Range(range) => Ok(CharacterSet::from_range(range.start.c, range.end.c)),
             ClassSetItem::Union(union) => {
                 let mut result = CharacterSet::empty();
                 for item in &union.items {
@@ -366,7 +364,7 @@ impl NfaBuilder {
 
     fn expand_perl_character_class(&self, item: &ClassPerlKind) -> CharacterSet {
         match item {
-            ClassPerlKind::Digit => CharacterSet::empty().add_range('0', '9'),
+            ClassPerlKind::Digit => CharacterSet::from_range('0', '9'),
             ClassPerlKind::Space => CharacterSet::empty()
                 .add_char(' ')
                 .add_char('\t')


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter/issues/778

### Background

The Tree-sitter generator internally uses a type called `CharacterSet` to represent character sets associated with lexical state transitions. Currently, a `CharacterSet` is represented as a simple sorted vector of characters. In order to deal with negated character classes like `[^"]`, it is an `enum` with two variants: `Include` and `Exclude`.

During parser generation, we do a lot of `CharacterSet` copies and set-intersection operations. If grammars use regexes with very large character classes, these operations (on very large vectors) can become pretty slow.

### Change

This PR changes the internal representation of `CharacterSet` so that it uses *ranges* of characters. Because most large character classes contain relatively few disjoint *ranges* of characters, they can be represented much more compactly with this scheme.

The new representation also simplifies the code in some ways, because we don't need a special `Exclude` variant. The character set `[^"]` can be represented with just two ranges: `0..'"'` and `('"' + 1)..char::MAX` (in other words, the range of all characters *less than* `"`, and the range of all characters *greater than* `"`.

This is one of the last steps toward being able to efficiently support *unicode property escapes* in regexes.