### PR TITLE
Fix hiding problems in ./build/Debug/tree_sitter_*_binding.node

### DIFF
--- a/cli/src/generate/templates/index.js
+++ b/cli/src/generate/templates/index.js
@@ -1,10 +1,14 @@
 try {
   module.exports = require("./build/Release/tree_sitter_PARSER_NAME_binding");
 } catch (error) {
-  try {
-    module.exports = require("./build/Debug/tree_sitter_PARSER_NAME_binding");
-  } catch (_) {
+  if (error.code !== 'MODULE_NOT_FOUND')
     throw error
+  else try {
+    module.exports = require("./build/Debug/tree_sitter_PARSER_NAME_binding");
+  } catch (error2) {
+    if (error2.code === 'MODULE_NOT_FOUND')
+      throw error
+    throw error2
   }
 }
 


### PR DESCRIPTION
In debug building modules also may happen errors and a current implementation
completely hides them, so errors like 'undefined symbol' can't be
easily identified due to wrong traceback and error message.