### PR TITLE
Add fixture tests for different line endings

### DIFF
--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -14,8 +14,8 @@ use std::str;
 use tree_sitter::{Language, LogType, Parser, Query};
 
 lazy_static! {
-    // Since parse_test_content() normalizes the line endings, it's not necessary to account for \r\n in these regexs
-    // If you're using these somewhere else, you may need to adding them back
+    // Since parse_test_content() normalizes the line endings, it's not necessary to account for \r\n in these regexes
+    // If you're using these somewhere else, you may need to add them back
     static ref HEADER_REGEX: ByteRegex = ByteRegexBuilder::new(r"^===+\n([^=]*)\n===+\n")
         .multi_line(true)
         .build()
@@ -366,7 +366,7 @@ pub fn strip_sexp_fields(sexp: String) -> String {
 }
 
 fn parse_test_content(name: String, content: String, file_path: Option<PathBuf>) -> TestEntry {
-    // Normalize line ending. Some languages do not treat \r as a line break so we don't normalize these here
+    // Normalize line ending. Some languages do not treat \r as a line break so we don't normalize those here
     let normalized_content = content.replace("\r\n", "\n");
     std::mem::drop(content);
 

--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -379,10 +379,13 @@ fn flatten_tests(test: TestEntry) -> Vec<(String, Vec<u8>, String, bool)> {
             if ch == '\n' {
                 // 50% probability of a CRLF
                 if rand.unsigned(1) == 1 {
-                    result.push('\r');
+                    result.push_str("\r\n");
+                } else {
+                    result.push('\n');
                 }
+            } else {
+                result.push(ch);
             }
-            result.push(ch);
         }
         result
     }

--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -13,6 +13,7 @@ use tree_sitter::{LogType, Node, Parser, Tree};
 
 const EDIT_COUNT: usize = 3;
 const TRIAL_COUNT: usize = 10;
+const LINE_ENDING_TRIAL_COUNT: usize = 2;
 const LANGUAGES: &'static [&'static str] = &[
     "bash",
     "c",
@@ -410,10 +411,10 @@ fn flatten_tests(test: TestEntry) -> Vec<(String, Vec<u8>, String, bool)> {
                 result.push((name.clone() + " - LF", input.clone(), output.clone(), has_fields));
                 let input_crlf = Vec::from(input_str.replace("\n", "\r\n").as_bytes());
                 result.push((name.clone() + " - CRLF", input_crlf, output.clone(), has_fields));
-                for trial in 1..=TRIAL_COUNT {
+                for trial in 1..=LINE_ENDING_TRIAL_COUNT {
                     let mut rand = Rand::new(*SEED + trial);
                     let input_mix = Vec::from(randomize_line_ending(input_str, &mut rand));
-                    result.push((name.clone() + &format!(" - Mix {}", trial), input_mix, output.clone(), has_fields));
+                    result.push((name.clone() + &format!(" - Random mix {}", trial), input_mix, output.clone(), has_fields));
                 }
             }
             TestEntry::Group { mut name, children, .. } => {

--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -13,7 +13,6 @@ use tree_sitter::{LogType, Node, Parser, Tree};
 
 const EDIT_COUNT: usize = 3;
 const TRIAL_COUNT: usize = 10;
-const LINE_ENDING_TRIAL_COUNT: usize = 2;
 const LANGUAGES: &'static [&'static str] = &[
     "bash",
     "c",
@@ -374,22 +373,6 @@ fn get_parser(session: &mut Option<util::LogSession>, log_filename: &str) -> Par
 }
 
 fn flatten_tests(test: TestEntry) -> Vec<(String, Vec<u8>, String, bool)> {
-    fn randomize_line_ending(str: &str, rand: &mut Rand) -> String {
-        let mut result = String::new();
-        for ch in str.chars() {
-            if ch == '\n' {
-                // 50% probability of a CRLF
-                if rand.unsigned(1) == 1 {
-                    result.push_str("\r\n");
-                } else {
-                    result.push('\n');
-                }
-            } else {
-                result.push(ch);
-            }
-        }
-        result
-    }
     fn helper(test: TestEntry, prefix: &str, result: &mut Vec<(String, Vec<u8>, String, bool)>) {
         match test {
             TestEntry::Example {
@@ -411,11 +394,6 @@ fn flatten_tests(test: TestEntry) -> Vec<(String, Vec<u8>, String, bool)> {
                 result.push((name.clone() + " - LF", input.clone(), output.clone(), has_fields));
                 let input_crlf = Vec::from(input_str.replace("\n", "\r\n").as_bytes());
                 result.push((name.clone() + " - CRLF", input_crlf, output.clone(), has_fields));
-                for trial in 1..=LINE_ENDING_TRIAL_COUNT {
-                    let mut rand = Rand::new(*SEED + trial);
-                    let input_mix = Vec::from(randomize_line_ending(input_str, &mut rand));
-                    result.push((name.clone() + &format!(" - Random mix {}", trial), input_mix, output.clone(), has_fields));
-                }
             }
             TestEntry::Group { mut name, children, .. } => {
                 if !prefix.is_empty() {

--- a/test/fixtures/test_grammars/external_and_internal_tokens/scanner.c
+++ b/test/fixtures/test_grammars/external_and_internal_tokens/scanner.c
@@ -35,7 +35,7 @@ bool tree_sitter_external_and_internal_tokens_external_scanner_scan(
 ) {
   // If a line-break is a valid lookahead token, only skip spaces.
   if (whitelist[LINE_BREAK]) {
-    while (lexer->lookahead == ' ') {
+    while (lexer->lookahead == ' ' || lexer->lookahead == '\r') {
       lexer->advance(lexer, true);
     }
 
@@ -49,7 +49,7 @@ bool tree_sitter_external_and_internal_tokens_external_scanner_scan(
   // If a line-break is not a valid lookahead token, skip line breaks as well
   // as spaces.
   if (whitelist[STRING]) {
-    while (lexer->lookahead == ' ' || lexer->lookahead == '\n') {
+    while (lexer->lookahead == ' ' || lexer->lookahead == '\r' || lexer->lookahead == '\n') {
       lexer->advance(lexer, true);
     }
 


### PR DESCRIPTION
Fix #913. We still need to decide whether to include `\r` as a supported line ending. Also tests will fail, and will take *substantially* longer.