### PR TITLE
parser.c - added LOG_LOOKAHEAD macro to escape \n in logging

### DIFF
--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -25,33 +25,34 @@
     ts_parser__log(self);                                                                   \
   }
 
-#define LOG_LOOKAHEAD(symbol_name, size)                     \
-  if (self->lexer.logger.log || self->dot_graph_file) {      \
-    char *buf = self->lexer.debug_buffer;                    \
-    const char *symbol = symbol_name;                        \
-    int off = sprintf(buf, "lexed_lookahead sym:");          \
-    for (                                                    \
-      int i = 0;                                             \
-      symbol[i] != '\0'                                      \
-      && off < TREE_SITTER_SERIALIZATION_BUFFER_SIZE;        \
-      i++                                                    \
-    ) {                                                      \
-      switch (symbol[i]) {                                   \
-      case '\t': buf[off++] = '\\'; buf[off++] = 't'; break; \
-      case '\n': buf[off++] = '\\'; buf[off++] = 'n'; break; \
-      case '\v': buf[off++] = '\\'; buf[off++] = 'v'; break; \
-      case '\f': buf[off++] = '\\'; buf[off++] = 'f'; break; \
-      case '\r': buf[off++] = '\\'; buf[off++] = 'r'; break; \
-      default:   buf[off++] = symbol[i]; break;              \
-      }                                                      \
-    }                                                        \
-    snprintf(                                                \
-      buf + off,                                             \
-      TREE_SITTER_SERIALIZATION_BUFFER_SIZE - off,           \
-      ", size:%u",                                           \
-      size                                                   \
-    );                                                       \
-    ts_parser__log(self);                                    \
+#define LOG_LOOKAHEAD(symbol_name, size)                      \
+  if (self->lexer.logger.log || self->dot_graph_file) {       \
+    char *buf = self->lexer.debug_buffer;                     \
+    const char *symbol = symbol_name;                         \
+    int off = sprintf(buf, "lexed_lookahead sym:");           \
+    for (                                                     \
+      int i = 0;                                              \
+      symbol[i] != '\0'                                       \
+      && off < TREE_SITTER_SERIALIZATION_BUFFER_SIZE;         \
+      i++                                                     \
+    ) {                                                       \
+      switch (symbol[i]) {                                    \
+      case '\t': buf[off++] = '\\'; buf[off++] = 't'; break;  \
+      case '\n': buf[off++] = '\\'; buf[off++] = 'n'; break;  \
+      case '\v': buf[off++] = '\\'; buf[off++] = 'v'; break;  \
+      case '\f': buf[off++] = '\\'; buf[off++] = 'f'; break;  \
+      case '\r': buf[off++] = '\\'; buf[off++] = 'r'; break;  \
+      case '\\': buf[off++] = '\\'; buf[off++] = '\\'; break; \
+      default:   buf[off++] = symbol[i]; break;               \
+      }                                                       \
+    }                                                         \
+    snprintf(                                                 \
+      buf + off,                                              \
+      TREE_SITTER_SERIALIZATION_BUFFER_SIZE - off,            \
+      ", size:%u",                                            \
+      size                                                    \
+    );                                                        \
+    ts_parser__log(self);                                     \
   }
 
 #define LOG_STACK()                                                              \

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -25,7 +25,7 @@
     ts_parser__log(self);                                                                   \
   }
 
-#define LOG_LOOKAHEAD(symbol_name, size, ...)                \
+#define LOG_LOOKAHEAD(symbol_name, size)                     \
   if (self->lexer.logger.log || self->dot_graph_file) {      \
     char *buf = self->lexer.debug_buffer;                    \
     const char *symbol = symbol_name;                        \
@@ -45,17 +45,11 @@
       default:   buf[off++] = symbol[i]; break;              \
       }                                                      \
     }                                                        \
-    off += snprintf(                                         \
+    snprintf(                                                \
       buf + off,                                             \
       TREE_SITTER_SERIALIZATION_BUFFER_SIZE - off,           \
       ", size:%u",                                           \
       size                                                   \
-    );                                                       \
-    if (sizeof( (char[]){#__VA_ARGS__} ) == 1)               \
-    snprintf(                                                \
-      buf + off,                                             \
-      TREE_SITTER_SERIALIZATION_BUFFER_SIZE - off,           \
-      ", " __VA_ARGS__                                       \
     );                                                       \
     ts_parser__log(self);                                    \
   }
@@ -514,9 +508,7 @@ static Subtree ts_parser__lex(
 
     LOG_LOOKAHEAD(
       SYM_NAME(ts_subtree_symbol(result)),
-      ts_subtree_total_size(result).bytes,
-      "character:'%c'",
-      first_error_character
+      ts_subtree_total_size(result).bytes
     );
   } else {
     if (self->lexer.token_end_position.bytes < self->lexer.token_start_position.bytes) {

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -25,6 +25,41 @@
     ts_parser__log(self);                                                                   \
   }
 
+#define LOG_LOOKAHEAD(symbol_name, size, ...)                \
+  if (self->lexer.logger.log || self->dot_graph_file) {      \
+    char *buf = self->lexer.debug_buffer;                    \
+    const char *symbol = symbol_name;                        \
+    int off = sprintf(buf, "lexed_lookahead sym:");          \
+    for (                                                    \
+      int i = 0;                                             \
+      symbol[i] != '\0'                                      \
+      && off < TREE_SITTER_SERIALIZATION_BUFFER_SIZE;        \
+      i++                                                    \
+    ) {                                                      \
+      switch (symbol[i]) {                                   \
+      case '\t': buf[off++] = '\\'; buf[off++] = 't'; break; \
+      case '\n': buf[off++] = '\\'; buf[off++] = 'n'; break; \
+      case '\v': buf[off++] = '\\'; buf[off++] = 'v'; break; \
+      case '\f': buf[off++] = '\\'; buf[off++] = 'f'; break; \
+      case '\r': buf[off++] = '\\'; buf[off++] = 'r'; break; \
+      default:   buf[off++] = symbol[i]; break;              \
+      }                                                      \
+    }                                                        \
+    off += snprintf(                                         \
+      buf + off,                                             \
+      TREE_SITTER_SERIALIZATION_BUFFER_SIZE - off,           \
+      ", size:%u",                                           \
+      size                                                   \
+    );                                                       \
+    if (sizeof( (char[]){#__VA_ARGS__} ) == 1)               \
+    snprintf(                                                \
+      buf + off,                                             \
+      TREE_SITTER_SERIALIZATION_BUFFER_SIZE - off,           \
+      ", " __VA_ARGS__                                       \
+    );                                                       \
+    ts_parser__log(self);                                    \
+  }
+
 #define LOG_STACK()                                                              \
   if (self->dot_graph_file) {                                                    \
     ts_stack_print_dot_graph(self->stack, self->language, self->dot_graph_file); \
@@ -477,10 +512,10 @@ static Subtree ts_parser__lex(
       self->language
     );
 
-    LOG(
-      "lexed_lookahead sym:%s, size:%u, character:'%c'",
+    LOG_LOOKAHEAD(
       SYM_NAME(ts_subtree_symbol(result)),
       ts_subtree_total_size(result).bytes,
+      "character:'%c'",
       first_error_character
     );
   } else {
@@ -534,8 +569,7 @@ static Subtree ts_parser__lex(
       );
     }
 
-    LOG(
-      "lexed_lookahead sym:%s, size:%u",
+    LOG_LOOKAHEAD(
       SYM_NAME(ts_subtree_symbol(result)),
       ts_subtree_total_size(result).bytes
     );


### PR DESCRIPTION
Current debug log output hard to understand due to broken lines for the parser part logging when it prints unnamed symbols where new line symbols may happen. The lexer solves this problem by printing just a symbol code instead of a symbol itself and this works for lexer because every time it prints just one symbol. On the other hand the parser prints one or several symbols at once and approach with symbol codes wouldn't be easy understandable. This patch introduces a new preprocessor macro that escapes \s symbols < 127 in the range of codes 9 - 13 except the code 32 - space symbol  itself.