### PR TITLE
query.c - allow "\"" in s-expressions

### DIFF
--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -1348,6 +1348,9 @@ static TSQueryError ts_query__parse_string_literal(
     if (is_escaped) {
       is_escaped = false;
       switch (stream->next) {
+        case '"':
+          array_push(&self->string_buffer, '"');
+          break;
         case 'n':
           array_push(&self->string_buffer, '\n');
           break;


### PR DESCRIPTION
If there are literal tokens in the grammar defined like `'"'` there is no possibility to match them literally in queries' s-expressions due to  missing support of escaping for double quotes inside of double quoted literals. This PR fixes this seems omitted case.