### PR TITLE
Walk query files recursively in `tree-sitter test`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +878,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-highlight",
  "tree-sitter-tags",
+ "walkdir",
  "webbrowser",
 ]
 
@@ -970,6 +980,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "webbrowser"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1021,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,12 +20,13 @@ harness = false
 
 [dependencies]
 ansi_term = "0.11"
-cc = "^1.0.58"
 atty = "0.2"
+cc = "^1.0.58"
 clap = "2.32"
 difference = "2.0"
 dirs = "2.0.2"
 glob = "0.3.0"
+html-escape = "0.2.6"
 lazy_static = "1.2.0"
 libloading = "0.5"
 once_cell = "0.1.8"
@@ -35,8 +36,8 @@ serde = "1.0"
 serde_derive = "1.0"
 smallbitvec = "2.3.0"
 tiny_http = "0.6"
+walkdir = "2.3"
 webbrowser = "0.5.1"
-html-escape = "0.2.6"
 
 [dependencies.tree-sitter]
 version = ">= 0.17.0"

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -2,6 +2,7 @@ use super::test_highlight;
 use std::fmt::Write;
 use std::io;
 use tree_sitter::{QueryError, QueryErrorKind};
+use walkdir;
 
 #[derive(Debug)]
 pub struct Error(pub Vec<String>);
@@ -119,5 +120,11 @@ impl From<test_highlight::Failure> for Error {
 impl From<String> for Error {
     fn from(error: String) -> Self {
         Error::new(error)
+    }
+}
+
+impl From<walkdir::Error> for Error {
+    fn from(error: walkdir::Error) -> Self {
+        Error::new(error.to_string())
     }
 }


### PR DESCRIPTION
We were only walking one level of depth into the `queries/` folder
during invocations of `test`, which made us attempt to open folders
rather than recurse into them.

We have to pull in the `walkdir` crate, which is required for
cross-platform walking of directories.

Fixes #938.