### PR TITLE
Clean up parse table representation, use 16 bits for production_id

### DIFF
--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -208,8 +208,8 @@ extern "C" {
     #[doc = " following three fields:"]
     #[doc = " 1. `read`: A function to retrieve a chunk of text at a given byte offset"]
     #[doc = "    and (row, column) position. The function should return a pointer to the"]
-    #[doc = "    text and write its length to the the `bytes_read` pointer. The parser"]
-    #[doc = "    does not take ownership of this buffer; it just borrows it until it has"]
+    #[doc = "    text and write its length to the `bytes_read` pointer. The parser does"]
+    #[doc = "    not take ownership of this buffer; it just borrows it until it has"]
     #[doc = "    finished reading it. The function should write a zero value to the"]
     #[doc = "    `bytes_read` pointer to indicate the end of the document."]
     #[doc = " 2. `payload`: An arbitrary pointer that will be passed to each invocation"]
@@ -697,7 +697,7 @@ extern "C" {
     #[doc = " to start running a given query on a given syntax node. Then, there are"]
     #[doc = " two options for consuming the results of the query:"]
     #[doc = " 1. Repeatedly call `ts_query_cursor_next_match` to iterate over all of the"]
-    #[doc = "    the *matches* in the order that they were found. Each match contains the"]
+    #[doc = "    *matches* in the order that they were found. Each match contains the"]
     #[doc = "    index of the pattern that matched, and an array of captures. Because"]
     #[doc = "    multiple patterns can match the same set of nodes, one match may contain"]
     #[doc = "    captures that appear *before* some of the captures from a previous match."]
@@ -804,5 +804,5 @@ extern "C" {
     pub fn ts_language_version(arg1: *const TSLanguage) -> u32;
 }
 
-pub const TREE_SITTER_LANGUAGE_VERSION: usize = 12;
-pub const TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION: usize = 9;
+pub const TREE_SITTER_LANGUAGE_VERSION: usize = 13;
+pub const TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION: usize = 13;

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -21,13 +21,13 @@ extern "C" {
  * The Tree-sitter library is generally backwards-compatible with languages
  * generated using older CLI versions, but is not forwards-compatible.
  */
-#define TREE_SITTER_LANGUAGE_VERSION 12
+#define TREE_SITTER_LANGUAGE_VERSION 13
 
 /**
  * The earliest ABI version that is supported by the current version of the
  * library.
  */
-#define TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION 9
+#define TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION 13
 
 /*******************/
 /* Section - Types */

--- a/lib/include/tree_sitter/parser.h
+++ b/lib/include/tree_sitter/parser.h
@@ -13,6 +13,8 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
+typedef uint16_t TSStateId;
+
 #ifndef TREE_SITTER_API_H_
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
@@ -30,12 +32,10 @@ typedef struct {
   uint16_t length;
 } TSFieldMapSlice;
 
-typedef uint16_t TSStateId;
-
 typedef struct {
-  bool visible : 1;
-  bool named : 1;
-  bool supertype: 1;
+  bool visible;
+  bool named;
+  bool supertype;
 } TSSymbolMetadata;
 
 typedef struct TSLexer TSLexer;
@@ -57,21 +57,21 @@ typedef enum {
   TSParseActionTypeRecover,
 } TSParseActionType;
 
-typedef struct {
-  union {
-    struct {
-      TSStateId state;
-      bool extra : 1;
-      bool repetition : 1;
-    } shift;
-    struct {
-      TSSymbol symbol;
-      int16_t dynamic_precedence;
-      uint8_t child_count;
-      uint8_t production_id;
-    } reduce;
-  } params;
-  TSParseActionType type : 4;
+typedef union {
+  struct {
+    uint8_t type;
+    TSStateId state;
+    bool extra;
+    bool repetition;
+  } shift;
+  struct {
+    uint8_t type;
+    uint8_t child_count;
+    TSSymbol symbol;
+    int16_t dynamic_precedence;
+    uint16_t production_id;
+  } reduce;
+  uint8_t type;
 } TSParseAction;
 
 typedef struct {
@@ -83,7 +83,7 @@ typedef union {
   TSParseAction action;
   struct {
     uint8_t count;
-    bool reusable : 1;
+    bool reusable;
   } entry;
 } TSParseActionEntry;
 
@@ -170,66 +170,50 @@ struct TSLanguage {
 
 #define ACTIONS(id) id
 
-#define SHIFT(state_value)                \
-  {                                       \
-    {                                     \
-      .params = {                         \
-        .shift = {                        \
-          .state = state_value            \
-        }                                 \
-      },                                  \
-      .type = TSParseActionTypeShift      \
-    }                                     \
-  }
+#define SHIFT(state_value)            \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = state_value            \
+    }                                 \
+  }}
 
 #define SHIFT_REPEAT(state_value)     \
-  {                                   \
-    {                                 \
-      .params = {                     \
-        .shift = {                    \
-          .state = state_value,       \
-          .repetition = true          \
-        }                             \
-      },                              \
-      .type = TSParseActionTypeShift  \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = state_value,           \
+      .repetition = true              \
     }                                 \
-  }
-
-#define RECOVER()                        \
-  {                                      \
-    { .type = TSParseActionTypeRecover } \
-  }
+  }}
 
 #define SHIFT_EXTRA()                 \
-  {                                   \
-    {                                 \
-      .params = {                     \
-        .shift = {                    \
-          .extra = true               \
-        }                             \
-      },                              \
-      .type = TSParseActionTypeShift  \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
     }                                 \
-  }
+  }}
 
 #define REDUCE(symbol_val, child_count_val, ...) \
-  {                                              \
-    {                                            \
-      .params = {                                \
-        .reduce = {                              \
-          .symbol = symbol_val,                  \
-          .child_count = child_count_val,        \
-          __VA_ARGS__                            \
-        },                                       \
-      },                                         \
-      .type = TSParseActionTypeReduce            \
-    }                                            \
-  }
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
+  }}
 
-#define ACCEPT_INPUT()                  \
-  {                                     \
-    { .type = TSParseActionTypeAccept } \
-  }
+#define RECOVER()                    \
+  {{                                 \
+    .type = TSParseActionTypeRecover \
+  }}
+
+#define ACCEPT_INPUT()              \
+  {{                                \
+    .type = TSParseActionTypeAccept \
+  }}
 
 #ifdef __cplusplus
 }

--- a/lib/include/tree_sitter/parser.h
+++ b/lib/include/tree_sitter/parser.h
@@ -122,6 +122,7 @@ struct TSLanguage {
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   uint32_t state_count;
+  uint32_t production_id_count;
 };
 
 /*

--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -12,11 +12,7 @@ uint32_t ts_language_version(const TSLanguage *self) {
 }
 
 uint32_t ts_language_field_count(const TSLanguage *self) {
-  if (self->version >= TREE_SITTER_LANGUAGE_VERSION_WITH_FIELDS) {
-    return self->field_count;
-  } else {
-    return 0;
-  }
+  return self->field_count;
 }
 
 void ts_language_table_entry(
@@ -57,11 +53,7 @@ TSSymbol ts_language_public_symbol(
   TSSymbol symbol
 ) {
   if (symbol == ts_builtin_sym_error) return symbol;
-  if (self->version >= TREE_SITTER_LANGUAGE_VERSION_WITH_SYMBOL_DEDUPING) {
-    return self->public_symbol_map[symbol];
-  } else {
-    return symbol;
-  }
+  return self->public_symbol_map[symbol];
 }
 
 const char *ts_language_symbol_name(
@@ -92,11 +84,7 @@ TSSymbol ts_language_symbol_for_name(
     if ((!metadata.visible && !metadata.supertype) || metadata.named != is_named) continue;
     const char *symbol_name = self->symbol_names[i];
     if (!strncmp(symbol_name, string, length) && !symbol_name[length]) {
-      if (self->version >= TREE_SITTER_LANGUAGE_VERSION_WITH_SYMBOL_DEDUPING) {
-        return self->public_symbol_map[i];
-      } else {
-        return i;
-      }
+      return self->public_symbol_map[i];
     }
   }
   return 0;

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -1012,15 +1012,15 @@ static bool ts_parser__do_all_potential_reductions(
         switch (action.type) {
           case TSParseActionTypeShift:
           case TSParseActionTypeRecover:
-            if (!action.params.shift.extra && !action.params.shift.repetition) has_shift_action = true;
+            if (!action.shift.extra && !action.shift.repetition) has_shift_action = true;
             break;
           case TSParseActionTypeReduce:
-            if (action.params.reduce.child_count > 0)
+            if (action.reduce.child_count > 0)
               ts_reduce_action_set_add(&self->reduce_actions, (ReduceAction){
-                .symbol = action.params.reduce.symbol,
-                .count = action.params.reduce.child_count,
-                .dynamic_precedence = action.params.reduce.dynamic_precedence,
-                .production_id = action.params.reduce.production_id,
+                .symbol = action.reduce.symbol,
+                .count = action.reduce.child_count,
+                .dynamic_precedence = action.reduce.dynamic_precedence,
+                .production_id = action.reduce.production_id,
               });
             break;
           default:
@@ -1311,7 +1311,7 @@ static void ts_parser__recover(
   // be counted in error cost calculations.
   unsigned n;
   const TSParseAction *actions = ts_language_actions(self->language, 1, ts_subtree_symbol(lookahead), &n);
-  if (n > 0 && actions[n - 1].type == TSParseActionTypeShift && actions[n - 1].params.shift.extra) {
+  if (n > 0 && actions[n - 1].type == TSParseActionTypeShift && actions[n - 1].shift.extra) {
     MutableSubtree mutable_lookahead = ts_subtree_make_mut(&self->tree_pool, lookahead);
     ts_subtree_set_extra(&mutable_lookahead);
     lookahead = ts_subtree_from_mut(mutable_lookahead);
@@ -1441,17 +1441,13 @@ static bool ts_parser__advance(
 
       switch (action.type) {
         case TSParseActionTypeShift: {
-          if (action.params.shift.repetition) break;
+          if (action.shift.repetition) break;
           TSStateId next_state;
-          if (action.params.shift.extra) {
-
-            // TODO: remove when TREE_SITTER_LANGUAGE_VERSION 9 is out.
-            if (state == ERROR_STATE) continue;
-
+          if (action.shift.extra) {
             next_state = state;
             LOG("shift_extra");
           } else {
-            next_state = action.params.shift.state;
+            next_state = action.shift.state;
             LOG("shift state:%u", next_state);
           }
 
@@ -1460,7 +1456,7 @@ static bool ts_parser__advance(
             next_state = ts_language_next_state(self->language, state, ts_subtree_symbol(lookahead));
           }
 
-          ts_parser__shift(self, version, next_state, lookahead, action.params.shift.extra);
+          ts_parser__shift(self, version, next_state, lookahead, action.shift.extra);
           if (did_reuse) reusable_node_advance(&self->reusable_node);
           return true;
         }
@@ -1468,10 +1464,10 @@ static bool ts_parser__advance(
         case TSParseActionTypeReduce: {
           bool is_fragile = table_entry.action_count > 1;
           bool end_of_non_terminal_extra = lookahead.ptr == NULL;
-          LOG("reduce sym:%s, child_count:%u", SYM_NAME(action.params.reduce.symbol), action.params.reduce.child_count);
+          LOG("reduce sym:%s, child_count:%u", SYM_NAME(action.reduce.symbol), action.reduce.child_count);
           StackVersion reduction_version = ts_parser__reduce(
-            self, version, action.params.reduce.symbol, action.params.reduce.child_count,
-            action.params.reduce.dynamic_precedence, action.params.reduce.production_id,
+            self, version, action.reduce.symbol, action.reduce.child_count,
+            action.reduce.dynamic_precedence, action.reduce.production_id,
             is_fragile, end_of_non_terminal_extra
           );
           if (reduction_version != STACK_VERSION_NONE) {


### PR DESCRIPTION
Fixes #511

### Background

Currently, because of the way that Tree-sitter's parser ABI incrementally evolved, the `production_id` field on parse actions (which is used to identify the sequence of *fields* and *aliases* that applies to a given node's children) is represented as a `uint8_t`. So far, this has not been a problem for any of the grammars that we maintain, but other users have hit the limit, and when it happens, it's very confusing.

### Change

This PR changes `production_id` to a nice `uint16_t`, which should always be more than large enough.

Unfortunately, because of some shortcomings of the old struct layout, this was not feasible to do without making a *breaking change* to the parser ABI. So, for the first time in a long time, I have bumped tree-sitter's `TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION` constant. This means that **new versions of the library will refuse to load parsers that were generated with previous versions of the CLI**. Specifically `ts_parser_set_language` will return `false`. Users will need to regenerate their parsers.

Normally, this is not a problem: I think that for most use cases, users can easily upgrade the library and their parsers together. There are a few exceptions that I know of:
1. Atom - At some point, when Atom adopts this version of Tree-sitter, this change will affect Atom users who have installed packages using third-party Tree-sitter parsers. The packages will needto be updated to use a regenerated version of the parsers. /cc @darangi  - I don't think Atom plans on upgrading Tree-sitter anytime soon, so this is probably not urgent for you I think?

2. Neovim - I think that some end-users of Neovim have installed their own third-party parsers. When Neovim upgrades to the latest version of Tree-sitter, Neovim will refuse to load these older parsers. The end users will need to install new versions of the parsers. /cc @bfredl @vigoux @theHamsta @tjdevries

3. Emacs-Tree-Sitter - /cc @ubolonton I'm not sure if users can install their own parsers. If so, then this is something to be aware of.

### Details

Since an ABI change was already needed, I took this opportunity to fix some dumb aspects of the current ABI. There are no more bitfields (they were used unnecessarily before). Also, I've added one more field to the `TSLanguage` struct - `production_id_count`, which makes it so that all the arrays on `TSLanguage` can have their length known at runtime.