### PR TITLE
Fix problems found in investigating dropped query matches

### DIFF
--- a/cli/src/generate/build_tables/item.rs
+++ b/cli/src/generate/build_tables/item.rs
@@ -22,18 +22,42 @@ lazy_static! {
     };
 }
 
+/// A ParseItem represents an in-progress match of a single production in a grammar.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct ParseItem<'a> {
+    /// The index of the parent rule within the grammar.
     pub variable_index: u32,
+    /// The number of symbols that have already been matched.
     pub step_index: u32,
+    /// The production being matched.
     pub production: &'a Production,
+    /// A boolean indicating whether any of the already-matched children were
+    /// hidden nodes and had fields. Ordinarily, a parse item's behavior is not
+    /// affected by the symbols of its preceding children; it only needs to
+    /// keep track of their fields and aliases.
+    ///
+    /// Take for example these two items:
+    ///   X -> a b • c
+    ///   X -> a g • c
+    ///
+    /// They can be considered equivalent, for the purposes of parse table
+    /// generation, because they entail the same actions. But if this flag is
+    /// true, then the item's set of inherited fields may depend on the specific
+    /// symbols of its preceding children.
+    pub has_preceding_inherited_fields: bool,
 }
 
+/// A ParseItemSet represents a set of in-progress matches of productions in a
+/// grammar, and for each in-progress match, a set of "lookaheads" - tokens that
+/// are allowed to *follow* the in-progress rule. This object corresponds directly
+/// to a state in the final parse table.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ParseItemSet<'a> {
     pub entries: Vec<(ParseItem<'a>, TokenSet)>,
 }
 
+/// A ParseItemSetCore is like a ParseItemSet, but without the lookahead
+/// information. Parse states with the same core are candidates for merging.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ParseItemSetCore<'a> {
     pub entries: Vec<ParseItem<'a>>,
@@ -64,6 +88,7 @@ impl<'a> ParseItem<'a> {
             variable_index: u32::MAX,
             production: &START_PRODUCTION,
             step_index: 0,
+            has_preceding_inherited_fields: false,
         }
     }
 
@@ -100,12 +125,22 @@ impl<'a> ParseItem<'a> {
         self.variable_index == u32::MAX
     }
 
+    /// Create an item like this one, but advanced by one step.
     pub fn successor(&self) -> ParseItem<'a> {
         ParseItem {
             variable_index: self.variable_index,
             production: self.production,
             step_index: self.step_index + 1,
+            has_preceding_inherited_fields: self.has_preceding_inherited_fields,
         }
+    }
+
+    /// Create an item identical to this one, but with a different production.
+    /// This is used when dynamically "inlining" certain symbols in a production.
+    pub fn substitute_production(&self, production: &'a Production) -> ParseItem<'a> {
+        let mut result = self.clone();
+        result.production = production;
+        result
     }
 }
 
@@ -258,19 +293,18 @@ impl<'a> Hash for ParseItem<'a> {
         self.precedence().hash(hasher);
         self.associativity().hash(hasher);
 
-        // When comparing two parse items, the symbols that were already consumed by
-        // both items don't matter. Take for example these two items:
-        //   X -> a b • c
-        //   X -> a d • c
-        // These two items can be considered equivalent, for the purposes of parse
-        // table generation, because they entail the same actions. However, if the
-        // productions have different aliases or field names, they *cannot* be
-        // treated as equivalent, because those details are ultimately stored as
-        // attributes of the `REDUCE` action that will be performed when the item
-        // is finished.
+        // The already-matched children don't play any role in the parse state for
+        // this item, unless any of the following are true:
+        //   * the children have fields
+        //   * the children have aliases
+        //   * the children are hidden and
+        // See the docs for `has_preceding_inherited_fields`.
         for step in &self.production.steps[0..self.step_index as usize] {
             step.alias.hash(hasher);
             step.field_name.hash(hasher);
+            if self.has_preceding_inherited_fields {
+                step.symbol.hash(hasher);
+            }
         }
         for step in &self.production.steps[self.step_index as usize..] {
             step.hash(hasher);
@@ -286,6 +320,7 @@ impl<'a> PartialEq for ParseItem<'a> {
             || self.production.steps.len() != other.production.steps.len()
             || self.precedence() != other.precedence()
             || self.associativity() != other.associativity()
+            || self.has_preceding_inherited_fields != other.has_preceding_inherited_fields
         {
             return false;
         }
@@ -298,6 +333,11 @@ impl<'a> PartialEq for ParseItem<'a> {
                     return false;
                 }
                 if step.field_name != other.production.steps[i].field_name {
+                    return false;
+                }
+                if self.has_preceding_inherited_fields
+                    && step.symbol != other.production.steps[i].symbol
+                {
                     return false;
                 }
             } else if *step != other.production.steps[i] {

--- a/cli/src/generate/build_tables/item_set_builder.rs
+++ b/cli/src/generate/build_tables/item_set_builder.rs
@@ -204,6 +204,7 @@ impl<'a> ParseItemSetBuilder<'a> {
                         variable_index,
                         production,
                         step_index: 0,
+                        has_preceding_inherited_fields: false,
                     };
 
                     if let Some(inlined_productions) =
@@ -213,11 +214,7 @@ impl<'a> ParseItemSetBuilder<'a> {
                             find_or_push(
                                 additions_for_non_terminal,
                                 TransitiveClosureAddition {
-                                    item: ParseItem {
-                                        variable_index,
-                                        production,
-                                        step_index: item.step_index,
-                                    },
+                                    item: item.substitute_production(production),
                                     info: follow_set_info.clone(),
                                 },
                             );
@@ -248,11 +245,7 @@ impl<'a> ParseItemSetBuilder<'a> {
                 for production in productions {
                     self.add_item(
                         &mut result,
-                        ParseItem {
-                            variable_index: item.variable_index,
-                            production,
-                            step_index: item.step_index,
-                        },
+                        item.substitute_production(production),
                         lookaheads,
                     );
                 }

--- a/cli/src/generate/grammars.rs
+++ b/cli/src/generate/grammars.rs
@@ -238,6 +238,10 @@ impl SyntaxVariable {
     pub fn is_auxiliary(&self) -> bool {
         self.kind == VariableType::Auxiliary
     }
+
+    pub fn is_hidden(&self) -> bool {
+        self.kind == VariableType::Hidden || self.kind == VariableType::Auxiliary
+    }
 }
 
 impl InlinedProductionMap {

--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -1425,6 +1425,7 @@ fn test_query_matches_with_too_many_permutations_to_track() {
             collect_matches(matches, &query, source.as_str())[0],
             (0, vec![("pre", "hello"), ("post", "hello")]),
         );
+        assert_eq!(cursor.did_exceed_match_limit(), true);
     });
 }
 
@@ -1462,6 +1463,7 @@ fn test_query_matches_with_alternatives_and_too_many_permutations_to_track() {
             collect_matches(matches, &query, source.as_str()),
             vec![(1, vec![("method", "b")]); 50],
         );
+        assert_eq!(cursor.did_exceed_match_limit(), true);
     });
 }
 
@@ -3119,6 +3121,7 @@ fn assert_query_matches(
     let mut cursor = QueryCursor::new();
     let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
     assert_eq!(collect_matches(matches, &query, source), expected);
+    assert_eq!(cursor.did_exceed_match_limit(), false);
 }
 
 fn collect_matches<'a>(

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -721,6 +721,16 @@ extern "C" {
     pub fn ts_query_cursor_exec(arg1: *mut TSQueryCursor, arg2: *const TSQuery, arg3: TSNode);
 }
 extern "C" {
+    #[doc = " Check if this cursor has exceeded its maximum number of in-progress"]
+    #[doc = " matches."]
+    #[doc = ""]
+    #[doc = " Currently, query cursors have a fixed capacity for storing lists"]
+    #[doc = " of in-progress captures. If this capacity is exceeded, then the"]
+    #[doc = " earliest-starting match will silently be dropped to make room for"]
+    #[doc = " further matches."]
+    pub fn ts_query_cursor_did_exceed_match_limit(arg1: *const TSQueryCursor) -> bool;
+}
+extern "C" {
     #[doc = " Set the range of bytes or (row, column) positions in which the query"]
     #[doc = " will be executed."]
     pub fn ts_query_cursor_set_byte_range(arg1: *mut TSQueryCursor, arg2: u32, arg3: u32);

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1595,6 +1595,12 @@ impl QueryCursor {
         QueryCursor(unsafe { NonNull::new_unchecked(ffi::ts_query_cursor_new()) })
     }
 
+    /// Check if, on its last execution, this cursor exceeded its maximum number of
+    /// in-progress matches.
+    pub fn did_exceed_match_limit(&self) -> bool {
+        unsafe { ffi::ts_query_cursor_did_exceed_match_limit(self.0.as_ptr()) }
+    }
+
     /// Iterate over all of the matches in the order that they were found.
     ///
     /// Each match contains the index of the pattern that matched, and a list of captures.

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -792,6 +792,17 @@ void ts_query_cursor_delete(TSQueryCursor *);
 void ts_query_cursor_exec(TSQueryCursor *, const TSQuery *, TSNode);
 
 /**
+ * Check if this cursor has exceeded its maximum number of in-progress
+ * matches.
+ *
+ * Currently, query cursors have a fixed capacity for storing lists
+ * of in-progress captures. If this capacity is exceeded, then the
+ * earliest-starting match will silently be dropped to make room for
+ * further matches.
+ */
+bool ts_query_cursor_did_exceed_match_limit(const TSQueryCursor *);
+
+/**
  * Set the range of bytes or (row, column) positions in which the query
  * will be executed.
  */

--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -353,14 +353,12 @@ void ts_tree_cursor_current_status(
       // Determine if the current node can have later siblings with the same field name.
       if (*field_id) {
         for (const TSFieldMapEntry *i = field_map; i < field_map_end; i++) {
-          if (i->field_id == *field_id) {
-            if (
-              i->child_index > entry->structural_child_index ||
-              (i->child_index == entry->structural_child_index && *has_later_named_siblings)
-            ) {
-              *can_have_later_siblings_with_this_field = true;
-              break;
-            }
+          if (
+            i->field_id == *field_id &&
+            i->child_index > entry->structural_child_index
+          ) {
+            *can_have_later_siblings_with_this_field = true;
+            break;
           }
         }
       }


### PR DESCRIPTION
This PR fixes a couple of related bugs (the first of which masked the existence of the second):

1. **Over-eager query state splitting** - For query patterns with fields, we were unnecessarily splitting the query match state in some cases. In the presence of very deeply-nested syntax trees, this could cause query matches to get dropped.
2. **Incorrect field map generation** - The parser generator was failing to account for "inherited" fields when deduping states, which resulted in some generated parsers having missing data in "field maps".

This also adds an API for detecting when a query has dropped matches because of too many simultaneous in-progress matches: `ts_query_cursor_did_exceed_match_limit`. This is currently not exposed in WebAssembly, but is exposed in the Rust API as `QueryCursor::did_exceed_match_limit`.

🍐 'd with @dcreager 