### PR TITLE
Added libtree-sitter.so* files into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ docs/assets/js/tree-sitter.js
 *.rs.bk
 *.a
 *.dylib
+*.so
+*.so.[0-9]*
 *.o
 *.obj
 *.exp


### PR DESCRIPTION
This PR adds `*.so*` files to `.gitignore` to make git repo not marked with `-dirty` suffix when used as submodule some where else.
Macos `*.dylib` files are already in `.gitignore`, so this PR makes the same but for Linux environment.