### PR TITLE
fix: don't zeroing provided start position by the end zero position

### DIFF
--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -2294,7 +2294,6 @@ void ts_query_cursor_set_byte_range(
   uint32_t end_byte
 ) {
   if (end_byte == 0) {
-    start_byte = 0;
     end_byte = UINT32_MAX;
   }
   self->start_byte = start_byte;
@@ -2307,7 +2306,6 @@ void ts_query_cursor_set_point_range(
   TSPoint end_point
 ) {
   if (end_point.row == 0 && end_point.column == 0) {
-    start_point = POINT_ZERO;
     end_point = POINT_MAX;
   }
   self->start_point = start_point;


### PR DESCRIPTION
Hello :wave: 
I've stumbled over strange behavior that when I just pass a start position to a query and want that the end position to be at the end of the input then tree-sitter doesn't takes into account passed start position and captures all from the beginning of the input like the starting position also is `{row: 0, column: 0}`.
I suppose that `POINT_ZERO` what means `{row: 0, column: 0}` is a special marker that can be used to mark undefined position and then the end zero position shouldn't affect starting position in any case cause the starting position will be passed in any case because it passed to the `ts_query_cursor_set_byte_range` function by value.