### PR TITLE
dsl.js - Reuse sym() in RuleBuilder

### DIFF
--- a/cli/src/generate/dsl.js
+++ b/cli/src/generate/dsl.js
@@ -199,10 +199,7 @@ function normalize(value) {
 function RuleBuilder(ruleMap) {
   return new Proxy({}, {
     get(target, propertyName) {
-      const symbol = {
-        type: 'SYMBOL',
-        name: propertyName
-      };
+      const symbol = sym(propertyName);
 
       if (!ruleMap || ruleMap.hasOwnProperty(propertyName)) {
         return symbol;


### PR DESCRIPTION
This PR replaces duplicated piece of code in `dsl.js` with a `sym()` function call that does the same.