### PR TITLE
Fix the behavior of Lexer.get_column

### DIFF
--- a/cli/src/tests/helpers/fixtures.rs
+++ b/cli/src/tests/helpers/fixtures.rs
@@ -74,3 +74,9 @@ pub fn get_test_language(name: &str, parser_code: &str, path: Option<&Path>) -> 
         .load_language_from_sources(name, &HEADER_DIR, &parser_c_path, &scanner_path)
         .unwrap()
 }
+
+pub fn get_test_grammar(name: &str) -> (String, Option<PathBuf>) {
+    let dir = fixtures_dir().join("test_grammars").join(name);
+    let grammar = fs::read_to_string(&dir.join("grammar.json")).unwrap();
+    (grammar, Some(dir))
+}

--- a/lib/src/lexer.c
+++ b/lib/src/lexer.c
@@ -233,25 +233,8 @@ static void ts_lexer__mark_end(TSLexer *_self) {
 
 static uint32_t ts_lexer__get_column(TSLexer *_self) {
   Lexer *self = (Lexer *)_self;
-  uint32_t goal_byte = self->current_position.bytes;
-
-  ts_lexer_goto(self, (Length) {
-    .bytes = self->current_position.bytes - self->current_position.extent.column,
-    .extent = {
-      .row = self->current_position.extent.row,
-      .column = 0,
-    }
-  });
-  if (!self->chunk_size) ts_lexer__get_chunk(self);
-  if (!self->lookahead_size) ts_lexer__get_lookahead(self);
-
-  uint32_t result = 0;
-  while (self->current_position.bytes < goal_byte) {
-    ts_lexer__advance(&self->data, false);
-    result++;
-  }
-
-  return result;
+  self->did_get_column = true;
+  return self->current_position.extent.column;
 }
 
 // Is the lexer at a boundary between two disjoint included ranges of
@@ -318,6 +301,7 @@ void ts_lexer_start(Lexer *self) {
   self->token_start_position = self->current_position;
   self->token_end_position = LENGTH_UNDEFINED;
   self->data.result_symbol = 0;
+  self->did_get_column = false;
   if (!ts_lexer__eof(&self->data)) {
     if (!self->chunk_size) ts_lexer__get_chunk(self);
     if (!self->lookahead_size) ts_lexer__get_lookahead(self);

--- a/lib/src/lexer.h
+++ b/lib/src/lexer.h
@@ -17,16 +17,17 @@ typedef struct {
   Length token_end_position;
 
   TSRange *included_ranges;
-  size_t included_range_count;
-  size_t current_included_range_index;
-
   const char *chunk;
+  TSInput input;
+  TSLogger logger;
+
+  uint32_t included_range_count;
+  uint32_t current_included_range_index;
   uint32_t chunk_start;
   uint32_t chunk_size;
   uint32_t lookahead_size;
+  bool did_get_column;
 
-  TSInput input;
-  TSLogger logger;
   char debug_buffer[TREE_SITTER_SERIALIZATION_BUFFER_SIZE];
 } Lexer;
 

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -403,6 +403,7 @@ static Subtree ts_parser__lex(
   bool found_external_token = false;
   bool error_mode = parse_state == ERROR_STATE;
   bool skipped_error = false;
+  bool called_get_column = false;
   int32_t first_error_character = 0;
   Length error_start_position = length_zero();
   Length error_end_position = length_zero();
@@ -445,6 +446,7 @@ static Subtree ts_parser__lex(
         (!error_mode && ts_stack_has_advanced_since_error(self->stack, version))
       )) {
         found_external_token = true;
+        called_get_column = self->lexer.did_get_column;
         break;
       }
 
@@ -546,6 +548,7 @@ static Subtree ts_parser__lex(
       lookahead_bytes,
       parse_state,
       found_external_token,
+      called_get_column,
       is_keyword,
       self->language
     );

--- a/lib/src/subtree.h
+++ b/lib/src/subtree.h
@@ -78,6 +78,7 @@ typedef struct {
   bool fragile_right : 1;
   bool has_changes : 1;
   bool has_external_tokens : 1;
+  bool depends_on_column: 1;
   bool is_missing : 1;
   bool is_keyword : 1;
 
@@ -138,7 +139,7 @@ void ts_subtree_pool_delete(SubtreePool *);
 
 Subtree ts_subtree_new_leaf(
   SubtreePool *, TSSymbol, Length, Length, uint32_t,
-  TSStateId, bool, bool, const TSLanguage *
+  TSStateId, bool, bool, bool, const TSLanguage *
 );
 Subtree ts_subtree_new_error(
   SubtreePool *, int32_t, Length, Length, uint32_t, TSStateId, const TSLanguage *
@@ -282,6 +283,10 @@ static inline bool ts_subtree_fragile_right(Subtree self) {
 
 static inline bool ts_subtree_has_external_tokens(Subtree self) {
   return self.data.is_inline ? false : self.ptr->has_external_tokens;
+}
+
+static inline bool ts_subtree_depends_on_column(Subtree self) {
+  return self.data.is_inline ? false : self.ptr->depends_on_column;
 }
 
 static inline bool ts_subtree_is_fragile(Subtree self) {

--- a/test/fixtures/test_grammars/uses_current_column/corpus.txt
+++ b/test/fixtures/test_grammars/uses_current_column/corpus.txt
@@ -1,0 +1,76 @@
+===============
+Simple blocks
+===============
+
+do a
+   e
+f
+
+---
+
+(block
+  (do_expression (block
+    (identifier)
+    (identifier)))
+  (identifier))
+
+=====================
+Nested blocks
+=====================
+
+a = do b
+       c + do e
+              f
+              g
+       h
+i
+
+---
+
+(block
+  (binary_expression
+    (identifier)
+    (do_expression (block
+      (identifier)
+      (binary_expression
+        (identifier)
+        (do_expression (block
+          (identifier)
+          (identifier)
+          (identifier))))
+      (identifier))))
+  (identifier))
+
+===============================
+Blocks with leading newlines
+===============================
+
+do
+
+
+   a = b
+   do
+      c
+      d
+   e
+ f
+
+---
+
+(block
+  (do_expression (block
+    (binary_expression (identifier) (identifier))
+    (do_expression (block
+      (identifier)
+      (identifier)))
+    (identifier)
+    (identifier))))
+
+=====================
+Unterminated blocks
+=====================
+
+do
+---
+
+(ERROR)

--- a/test/fixtures/test_grammars/uses_current_column/grammar.json
+++ b/test/fixtures/test_grammars/uses_current_column/grammar.json
@@ -1,0 +1,69 @@
+{
+  "name": "uses_current_column",
+
+  "externals": [
+    {"type": "SYMBOL", "name": "_indent"},
+    {"type": "SYMBOL", "name": "_dedent"},
+    {"type": "SYMBOL", "name": "_newline"}
+  ],
+
+  "extras": [
+    {"type": "PATTERN", "value": "\\s"}
+  ],
+
+  "rules": {
+    "block": {
+      "type": "REPEAT1",
+      "content": {"type": "SYMBOL", "name": "_statement"}
+    },
+
+    "_statement": {
+      "type": "SEQ",
+      "members": [
+        {"type": "SYMBOL", "name": "_expression"},
+        {"type": "SYMBOL", "name": "_newline"}
+      ]
+    },
+
+    "_expression": {
+      "type": "CHOICE",
+      "members": [
+        {"type": "SYMBOL", "name": "do_expression"},
+        {"type": "SYMBOL", "name": "binary_expression"},
+        {"type": "SYMBOL", "name": "identifier"}
+      ]
+    },
+
+    "do_expression": {
+      "type": "SEQ",
+      "members": [
+        {"type": "STRING", "value": "do"},
+        {"type": "SYMBOL", "name": "_indent"},
+        {"type": "SYMBOL", "name": "block"},
+        {"type": "SYMBOL", "name": "_dedent"}
+      ]
+    },
+
+    "binary_expression": {
+      "type": "PREC_LEFT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {"type": "SYMBOL", "name": "_expression"},
+          {
+            "type": "CHOICE",
+            "members": [
+              {"type": "STRING", "value": "="},
+              {"type": "STRING", "value": "+"},
+              {"type": "STRING", "value": "-"}
+            ]
+          },
+          {"type": "SYMBOL", "name": "_expression"}
+        ]
+      }
+    },
+
+    "identifier": {"type": "PATTERN", "value": "\\w+"}
+  }
+}

--- a/test/fixtures/test_grammars/uses_current_column/scanner.c
+++ b/test/fixtures/test_grammars/uses_current_column/scanner.c
@@ -92,7 +92,7 @@ bool tree_sitter_uses_current_column_external_scanner_scan(
   // If at the end of a statement, then get the current indent
   // level and pop some number of entries off of the indent stack.
   if (valid_symbols[NEWLINE] || valid_symbols[DEDENT]) {
-    while (lexer->lookahead == ' ') {
+    while (iswspace(lexer->lookahead) && lexer->lookahead != '\n') {
       lexer->advance(lexer, false);
     }
 

--- a/test/fixtures/test_grammars/uses_current_column/scanner.c
+++ b/test/fixtures/test_grammars/uses_current_column/scanner.c
@@ -1,0 +1,133 @@
+#include <stdlib.h>
+#include <wctype.h>
+#include <tree_sitter/parser.h>
+
+enum TokenType {
+  INDENT,
+  DEDENT,
+  NEWLINE,
+};
+
+typedef struct {
+  uint8_t queued_dedent_count;
+  uint8_t indent_count;
+  int8_t indents[32];
+} Scanner;
+
+void *tree_sitter_uses_current_column_external_scanner_create() {
+  Scanner *self = malloc(sizeof(Scanner));
+  self->queued_dedent_count = 0;
+  self->indent_count = 1;
+  self->indents[0] = 0;
+  return (void *)self;
+}
+
+void tree_sitter_uses_current_column_external_scanner_destroy(void *payload) {
+  free(payload);
+}
+
+unsigned tree_sitter_uses_current_column_external_scanner_serialize(
+  void *payload,
+  char *buffer
+) {
+  Scanner *self = (Scanner *)payload;
+  buffer[0] = self->queued_dedent_count;
+  for (unsigned i = 0; i < self->indent_count; i++) {
+    buffer[i + 1] = self->indents[i];
+  }
+  return self->indent_count + 1;
+}
+
+void tree_sitter_uses_current_column_external_scanner_deserialize(
+  void *payload,
+  const char *buffer,
+  unsigned length
+) {
+  Scanner *self = (Scanner *)payload;
+  if (length > 0) {
+    self->queued_dedent_count = buffer[0];
+    self->indent_count = length - 1;
+    for (unsigned i = 0; i < self->indent_count; i++) {
+      self->indents[i] = buffer[i + 1];
+    }
+  } else {
+    self->queued_dedent_count = 0;
+    self->indent_count = 1;
+    self->indents[0] = 0;
+  }
+}
+
+bool tree_sitter_uses_current_column_external_scanner_scan(
+  void *payload,
+  TSLexer *lexer,
+  const bool *valid_symbols
+) {
+  Scanner *self = (Scanner *)payload;
+  lexer->mark_end(lexer);
+
+  // If dedents were found in a previous run, and are valid now,
+  // then return a dedent.
+  if (self->queued_dedent_count > 0 && valid_symbols[DEDENT]) {
+    lexer->result_symbol = DEDENT;
+    self->queued_dedent_count--;
+    return true;
+  }
+
+  // If an indent is valid, then add an entry to the indent stack
+  // for the current column, and return an indent.
+  if (valid_symbols[INDENT]) {
+    while (iswspace(lexer->lookahead)) {
+      lexer->advance(lexer, false);
+    }
+    uint32_t column = lexer->get_column(lexer);
+    if (column > self->indents[self->indent_count - 1]) {
+      self->indents[self->indent_count++] = column - 2;
+      lexer->result_symbol = INDENT;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  // If at the end of a statement, then get the current indent
+  // level and pop some number of entries off of the indent stack.
+  if (valid_symbols[NEWLINE] || valid_symbols[DEDENT]) {
+    while (lexer->lookahead == ' ') {
+      lexer->advance(lexer, false);
+    }
+
+    if (lexer->lookahead == '\n') {
+      lexer->advance(lexer, false);
+
+      uint32_t next_column = 0;
+      for (;;) {
+        if (lexer->lookahead == ' ') {
+          next_column++;
+          lexer->advance(lexer, false);
+        } else if (lexer->lookahead == '\n') {
+          next_column = 0;
+          lexer->advance(lexer, false);
+        } else {
+          break;
+        }
+      }
+
+      unsigned dedent_count = 0;
+      while (next_column < self->indents[self->indent_count - 1]) {
+        dedent_count++;
+        self->indent_count--;
+      }
+
+      if (dedent_count > 0 && valid_symbols[DEDENT]) {
+        lexer->result_symbol = DEDENT;
+        return true;
+      } else if (valid_symbols[NEWLINE]) {
+        self->queued_dedent_count += dedent_count;
+        lexer->result_symbol = NEWLINE;
+        return true;
+      }
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
Fixes #516
Fixes #589
Closes #640
Fixes #144

This PR finally makes the `Lexer.get_column` (needed for languages like Haskell, Elm) API work properly.
* Adds unit test coverage for `get_column`, using a test fixture language with Haskell-like layout rules.
* Accounts for tokens' position-dependence when editing a tree, so that incremental parsing is fully correct with respect to these "layout" tokens. This requires tracking which subtrees depend on their start column:
  * any external token where the scanner called `get_column()`
  * recursively, any parent node that has a child node on its *first line* that depends on its own start column
* ⚠️ **Changes the meaning of `get_column` so that it returns a *byte count*, not a character count** ⚠️ 

Regarding this last item - We originally returned a character count from `get_column` because it seemed more technically correct, since GHC counted the unicode characters (as opposed to the bytes) in its implementation of layout. But this adds so much complexity (and perf cost) to our code that I really don't think it's worth it. There could be some slightly incorrect layout-parsing if somebody uses a mixture of different non-ascii whitespace characters for their layout, but this seems like a very uncommon situation.

/cc @Razzeee @tek @bglgwyng @banacorn 