### PR TITLE
Web bindings: fix descendantsOfType memory allocation

### DIFF
--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -362,7 +362,7 @@ class Node {
     }
 
     // Copy the array of symbols to the WASM heap.
-    const symbolsAddress = C._malloc(SIZE_OF_INT * symbols.count);
+    const symbolsAddress = C._malloc(SIZE_OF_INT * symbols.length);
     for (let i = 0, n = symbols.length; i < n; i++) {
       setValue(symbolsAddress + i * SIZE_OF_INT, symbols[i], 'i32');
     }


### PR DESCRIPTION
We started seeing some memory out of bounds errors in version 0.18, and eventually I was able to track it down to this bug. Not sure why it never caused issues before. 