### PR TITLE
feat: Show leaf nodes text in comments

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -76,7 +76,12 @@ fn run() -> error::Result<()> {
                         .takes_value(true)
                         .multiple(true)
                         .number_of_values(1),
-                ),
+                )
+                .arg(
+                    Arg::with_name("nodes-text")
+                        .help("Show leaf nodes text as comments")
+                        .long("nodes-text").short("n"),
+                )
         )
         .subcommand(
             SubCommand::with_name("query")
@@ -255,6 +260,8 @@ fn run() -> error::Result<()> {
         let should_track_stats = matches.is_present("stat");
         let mut stats = parse::Stats::default();
 
+        let nodes_text_comment = matches.is_present("nodes-text");
+
         for path in paths {
             let path = Path::new(&path);
             let language =
@@ -271,6 +278,7 @@ fn run() -> error::Result<()> {
                 debug,
                 debug_graph,
                 debug_xml,
+                nodes_text_comment,
                 Some(&cancellation_flag),
             )?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -78,9 +78,9 @@ fn run() -> error::Result<()> {
                         .number_of_values(1),
                 )
                 .arg(
-                    Arg::with_name("nodes-text")
+                    Arg::with_name("node-text-comments")
                         .help("Show leaf nodes text as comments")
-                        .long("nodes-text").short("n"),
+                        .long("node-text-comments").short("c"),
                 )
         )
         .subcommand(
@@ -260,7 +260,7 @@ fn run() -> error::Result<()> {
         let should_track_stats = matches.is_present("stat");
         let mut stats = parse::Stats::default();
 
-        let nodes_text_comment = matches.is_present("nodes-text");
+        let nodes_text_comments = matches.is_present("node-text-comments");
 
         for path in paths {
             let path = Path::new(&path);
@@ -278,7 +278,7 @@ fn run() -> error::Result<()> {
                 debug,
                 debug_graph,
                 debug_xml,
-                nodes_text_comment,
+                nodes_text_comments,
                 Some(&cancellation_flag),
             )?;
 

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -134,7 +134,7 @@ pub fn parse_file_at_path(
                                 write!(
                                     &mut stdout,
                                     "  \x1b[38;5;242m; {}\x1b[0m",
-                                    node_text
+                                    str::replace(node_text, "\n", "\\n")
                                 )?;
                                 node_text = "";
                             }

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -42,7 +42,7 @@ pub fn parse_file_at_path(
     debug: bool,
     debug_graph: bool,
     debug_xml: bool,
-    nodes_text_comment: bool,
+    nodes_text_comments: bool,
     cancellation_flag: Option<&AtomicUsize>,
 ) -> Result<bool> {
     let mut _log_session = None;
@@ -113,7 +113,7 @@ pub fn parse_file_at_path(
                     if is_named {
                         needs_newline = true;
                         stdout.write(b")")?;
-                        if nodes_text_comment && node_text.len() == 0 {
+                        if nodes_text_comments && node_text.len() == 0 {
                             s = format!("`{}`", node.utf8_text(&source_code).unwrap_or(""));
                             node_text = s.as_str();
                         }
@@ -129,7 +129,7 @@ pub fn parse_file_at_path(
                 } else {
                     if is_named {
                         if needs_newline {
-                            if nodes_text_comment && node_text.len() > 0 {
+                            if nodes_text_comments && node_text.len() > 0 {
                                 write!(
                                     &mut stdout,
                                     "  {} {}",
@@ -167,7 +167,7 @@ pub fn parse_file_at_path(
                     }
                 }
             }
-            if nodes_text_comment && node_text.len() > 0 {
+            if nodes_text_comments && node_text.len() > 0 {
                 write!(
                     &mut stdout,
                     "  {} {}",

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -113,13 +113,9 @@ pub fn parse_file_at_path(
                     if is_named {
                         needs_newline = true;
                         stdout.write(b")")?;
-                    }
-                    if nodes_text_comment && node_text.len() == 0 {
-                        if is_named {
+                        if nodes_text_comment && node_text.len() == 0 {
                             s = format!("`{}`", node.utf8_text(&source_code).unwrap_or(""));
                             node_text = s.as_str();
-                        } else {
-                            node_text = node.kind();
                         }
                     }
                     if cursor.goto_next_sibling() {

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -167,6 +167,14 @@ pub fn parse_file_at_path(
                     }
                 }
             }
+            if nodes_text_comment && node_text.len() > 0 {
+                write!(
+                    &mut stdout,
+                    "  {} {}",
+                    c.paint(";"),
+                    c.paint(str::replace(node_text, "\n", "\\n")),
+                )?;
+            }
             cursor.reset(tree.root_node());
             println!("");
         }


### PR DESCRIPTION
When working on a grammar I found that it's hard to realize with standard `tree-sitter parse` command that tokens match right pieces of text. I know about the `--xml` flag but it's output is less readable IMO and doesn't have token ranges what is also useful information.

**Now it looks like:**

_Note: Command line option was renamed: `-c, --node-text-comments`_


![screenshot1](https://user-images.githubusercontent.com/14666676/111088190-a3eadc80-852e-11eb-816d-a200cab23752.png)

What corresponds to the following C code excerpt:
```c
 0  #include <tree_sitter/parser.h>
 1
 2  #if defined(__GNUC__) || defined(__clang__)
 3  #pragma GCC diagnostic push
 4  #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 5  #endif
 6
 7  #define LANGUAGE_VERSION 13
 8  #define STATE_COUNT 1331
 9  #define LARGE_STATE_COUNT 365
10  #define SYMBOL_COUNT 253
11  #define ALIAS_COUNT 3
```


What's interesting even on the above screenshot there are visible issues with `preproc_arg` tokens they all include preceding space that may be not what is expected.

### Plans:
- [ ] Comments color fallback: RGB -> 256 -> ANSI 8 colors
- [ ] No colors if stdout isn't a tty
- [ ] Show text pieces even on non leaf nodes like starter piece and like additional trailers on leaf node comments
- [ ] Improve s-exp syntax to allow a line trailing comments. Following the work done in #871

_Any feedback or suggestion improvements are welcome!_