### PR TITLE
fix: assertion in highlight::tests::test_parse_style test

### DIFF
--- a/cli/src/highlight.rs
+++ b/cli/src/highlight.rs
@@ -438,6 +438,7 @@ mod tests {
         assert_eq!(style.css, None);
 
         // darkcyan is an ANSI color and is preserved
+        env::set_var("COLORTERM", "");
         parse_style(&mut style, Value::String(DARK_CYAN.to_string()));
         assert_eq!(style.ansi.foreground, Some(Color::Fixed(36)));
         assert_eq!(style.css, Some("style=\'color: #0af87\'".to_string()));


### PR DESCRIPTION
I got an error when running tests on current master branch:
```
test highlight::tests::test_parse_style ... thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `Some(RGB(0, 175, 135))`,
 right: `Some(Fixed(36))`', cli/src/highlight.rs:442:9
```
It seems that a test assertion tests correct fallback to ANSI color but there was missing `env::set_var("COLORTERM", "");` that is marker of no support for RGB colors in the current implementation.

_I suppose that the test doesn't failed in the CI due to missing the `COLORTERM` env var there._