### PR TITLE
Fix check in ts_language_symbol_type (#997)

### DIFF
--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -95,7 +95,7 @@ TSSymbolType ts_language_symbol_type(
   TSSymbol symbol
 ) {
   TSSymbolMetadata metadata = ts_language_symbol_metadata(self, symbol);
-  if (metadata.named) {
+  if (metadata.named && metadata.visible) {
     return TSSymbolTypeRegular;
   } else if (metadata.visible) {
     return TSSymbolTypeAnonymous;


### PR DESCRIPTION
As per Max's advice, this function should only return
`TSSymbolTypeRegular` when the metadata is both visible and named.