### PR TITLE
Simplify script/fetch-fixtures, it clones the right reference by the git clone

### DIFF
--- a/script/fetch-fixtures
+++ b/script/fetch-fixtures
@@ -11,14 +11,8 @@ fetch_grammar() {
   echo "Updating ${grammar} grammar..."
 
   if [ ! -d $grammar_dir ]; then
-    git clone $grammar_url $grammar_dir --depth=1
+    git clone -b $ref $grammar_url $grammar_dir --depth=1
   fi
-
-  (
-    cd $grammar_dir
-    git fetch origin $ref --depth=1
-    git reset --hard FETCH_HEAD
-  )
 }
 
 fetch_grammar bash              master


### PR DESCRIPTION
This PR simplifies and a bit speed ups the `script/fetch-fixtures`.
Also it fixes that in a `javascript` fixure repo the actual local `master` branch forcibly moves to required reference instead of to clone required reference directly.