### PR TITLE
feat: script/test improvements

### DIFF
--- a/script/test
+++ b/script/test
@@ -105,5 +105,6 @@ if [[ "${mode}" == "debug" ]]; then
   )
   lldb "${test_binary}" -- $top_level_filter
 else
-  cargo test $test_flags --jobs 1 $top_level_filter -- --nocapture
+  [ -t 1 ] && color=always || color=never
+  cargo test $test_flags --jobs 1 $top_level_filter -- --nocapture --color "$color"
 fi

--- a/script/test
+++ b/script/test
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # vim:ts=2:sw=2:et
 
+shopts=$-
 set -Eeuo pipefail
 
 function usage {
@@ -96,6 +97,23 @@ if [[ \
   -n "$TREE_SITTER_TEST_TRIAL_FILTER" \
 ]]; then
   : ${top_level_filter:=corpus}
+fi
+
+# Allow to source this script to just set
+# shell environment variables and use `cargo test` directly
+if [ "$0" != "$BASH_SOURCE" ]; then
+    eval set +${-//[is]/}
+    eval set -${shopts//[is]/}
+    cargo() {
+      case "$1" in
+        t|test)
+            command cargo test $test_flags "${@:2}"
+            ;;
+        *)  command cargo "$@"
+            ;;
+      esac
+    }
+    return
 fi
 
 if [[ "${mode}" == "debug" ]]; then

--- a/script/test
+++ b/script/test
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
+# vim:ts=2:sw=2:et
 
-set -e
+set -Eeuo pipefail
 
 function usage {
   cat <<-EOF
@@ -37,6 +38,9 @@ export RUST_BACKTRACE=full
 mode=normal
 test_flags="-p tree-sitter-cli"
 
+TREE_SITTER_TEST_LANGUAGE_FILTER=
+TREE_SITTER_TEST_EXAMPLE_FILTER=
+TREE_SITTER_TEST_TRIAL_FILTER=
 
 while getopts "adDghl:e:s:t:" option; do
   case ${option} in
@@ -53,10 +57,10 @@ while getopts "adDghl:e:s:t:" option; do
       if [[ $toolchain =~ $toolchain_regex ]]; then
         release=${BASH_REMATCH[1]}
         current_target=${BASH_REMATCH[2]}
+        test_flags="${test_flags} --target ${current_target}"
       else
         echo "Failed to parse toolchain '${toolchain}'"
       fi
-      test_flags="${test_flags} --target ${current_target}"
       ;;
     l)
       export TREE_SITTER_TEST_LANGUAGE_FILTER=${OPTARG}
@@ -84,12 +88,12 @@ done
 
 shift $(expr $OPTIND - 1)
 
-top_level_filter=$1
+top_level_filter=${1-}
 
 if [[ \
-  -n $TREE_SITTER_TEST_LANGUAGE_FILTER || \
-  -n $TREE_SITTER_TEST_EXAMPLE_FILTER || \
-  -n $TREE_SITTER_TEST_TRIAL_FILTER \
+  -n "$TREE_SITTER_TEST_LANGUAGE_FILTER" || \
+  -n "$TREE_SITTER_TEST_EXAMPLE_FILTER" || \
+  -n "$TREE_SITTER_TEST_TRIAL_FILTER" \
 ]]; then
   : ${top_level_filter:=corpus}
 fi


### PR DESCRIPTION
This PR:
* Enables maximally strong bash mode to make the script less error prone, `set -Eeuo pipefail` command.
* Fixes conditions check on the [90](https://github.com/tree-sitter/tree-sitter/compare/master...ahlinc:feat/script-test-improvements?expand=1#diff-2ade384ce3c8dda6cc27f888849ab9af75d1870698b5d6e5b7d2e5d1ba86d064L90) line, that turns into `[ -n || -n ... ]` for any missing var, this wasn't triggered cause the `getopts` also emits cases for missing options with empty arguments. But it's better to don't rely on this occasion.
* Fixes coloring by moving it's control to the script level cause the `--nocapture` disables it without any reasons for this script.
* Allows to do `source script/test` and use the `cargo test` directly.