### PR TITLE
adding perl parser under development section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,7 @@ Parsers for these languages are in development:
 * [Haskell](https://github.com/tree-sitter/tree-sitter-haskell)
 * [Julia](https://github.com/tree-sitter/tree-sitter-julia)
 * [Nix](https://github.com/cstrahan/tree-sitter-nix)
+* [Perl](https://github.com/ganezdragon/tree-sitter-perl)
 * [Scala](https://github.com/tree-sitter/tree-sitter-scala)
 * [Sourcepawn](https://github.com/nilshelmig/tree-sitter-sourcepawn)
 * [Swift](https://github.com/tree-sitter/tree-sitter-swift)


### PR DESCRIPTION
hi tree sitter maintainer/developers, I'm currently developing a parser for perl using your awesome tree-sitter. Please accept this PR, to show the perl parser under development section of https://tree-sitter.github.io/tree-sitter/

Thanks!