### PR TITLE
Publish automatically the tree-sitter lib on crates.io

### DIFF
--- a/.github/workflows/publish_cratesio.yml
+++ b/.github/workflows/publish_cratesio.yml
@@ -1,0 +1,32 @@
+name: Publish on crates.io
+
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Publish lib
+        uses: katyo/publish-crates@v1
+        with:
+          path: './lib'
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This PR allows to publish automatically the `tree-sitter` lib  on `crates.io` when a new tag is set. It is necessary to define the `CARGO_REGISTRY_TOKEN` as secret. 

I also tried to publish the cli, but without any effect, I don't know why.

Thanks in advance for your review! :)