### PR TITLE
Update generated Cargo.toml's tree-sitter dependency

### DIFF
--- a/cli/src/generate/templates/cargo.toml
+++ b/cli/src/generate/templates/cargo.toml
@@ -20,7 +20,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.17"
+tree-sitter = "0.19.3"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
tree-sitter 0.19.0 bumped the language version from 12 to 13. `npm install tree-sitter-cli` gets a recent version of tree-sitter, which generates languages with language version 13. However, the Cargo.toml generated from `tree-sitter generate` still has a an old tree-sitter as a dependency. This causes the rust bindings to not work out of the box, as the tree-sitter library expects language version 12.

It would be nice to add a test for this in CI.  `tree-sitter generate` already creates a test for the rust binding, and that test fails out of the box due to the language mismatch.