### PR TITLE
Split query-related lifetimes into query/cursor lifetime and tree lifetime

### DIFF
--- a/highlight/src/lib.rs
+++ b/highlight/src/lib.rs
@@ -101,7 +101,7 @@ where
 struct HighlightIterLayer<'a> {
     _tree: Tree,
     cursor: QueryCursor,
-    captures: iter::Peekable<QueryCaptures<'a, &'a [u8]>>,
+    captures: iter::Peekable<QueryCaptures<'a, 'a, &'a [u8]>>,
     config: &'a HighlightConfiguration,
     highlight_end_stack: Vec<usize>,
     scope_stack: Vec<LocalScope<'a>>,
@@ -1022,10 +1022,10 @@ impl HtmlRenderer {
     }
 }
 
-fn injection_for_match<'a>(
+fn injection_for_match<'a, 'tree>(
     config: &HighlightConfiguration,
     query: &'a Query,
-    query_match: &QueryMatch<'a>,
+    query_match: &QueryMatch<'a, 'a>,
     source: &'a [u8],
 ) -> (Option<&'a str>, Option<Node<'a>>, bool) {
     let content_capture_index = config.injection_content_capture_index;

--- a/tags/src/lib.rs
+++ b/tags/src/lib.rs
@@ -88,7 +88,7 @@ struct LocalScope<'a> {
 
 struct TagsIter<'a, I>
 where
-    I: Iterator<Item = tree_sitter::QueryMatch<'a>>,
+    I: Iterator<Item = tree_sitter::QueryMatch<'a, 'a>>,
 {
     matches: I,
     _tree: Tree,
@@ -291,7 +291,7 @@ impl TagsContext {
 
 impl<'a, I> Iterator for TagsIter<'a, I>
 where
-    I: Iterator<Item = tree_sitter::QueryMatch<'a>>,
+    I: Iterator<Item = tree_sitter::QueryMatch<'a, 'a>>,
 {
     type Item = Result<Tag, Error>;
 


### PR DESCRIPTION
I've noticed that the lifetimes of query matches and captures are overly strict, which makes it impossible e.g. to call a function that takes a node as input, performs a query on it, and then returns the query's matched nodes as output:

```rust
fn do_query<'tree>(source: &str, language: Language, node: Node<'tree>) -> Node<'tree> {
    let query = Query::new(language, "...").unwrap();
    let mut cursor = QueryCursor::new();
    let node = cursor
        .matches(&query, node, move |n| &source.as_bytes()[n.byte_range()])
        .next()
        .unwrap()
        .captures[0]
        .node;
    node
}
```

Here, the rust compiler complains that `node`'s lifetime is tied to `cursor`, because it is.  But it needn't be.

This PR splits the lifetime of `QueryCaptures`, `QueryCapture` and `QueryMatch` into `'a` and `'tree`, the latter being the lifetime of the node passed to `cursor.matches()` or `cursor.captures()`.

(by the way, this library is totally amazing :-) thanks for the awesome work!)