### PR TITLE
Resolve syntax warnings for cargo build

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -351,7 +351,7 @@ impl Parser {
                     };
                     callback(log_type, message);
                 }
-            };
+            }
 
             let raw_container = Box::into_raw(container);
 
@@ -462,7 +462,7 @@ impl Parser {
             let slice = text.as_ref().unwrap().as_ref();
             *bytes_read = slice.len() as u32;
             return slice.as_ptr() as *const c_char;
-        };
+        }
 
         let c_input = ffi::TSInput {
             payload: &mut payload as *mut (&mut F, Option<T>) as *mut c_void,
@@ -518,7 +518,7 @@ impl Parser {
             let slice = text.as_ref().unwrap().as_ref();
             *bytes_read = slice.len() as u32 * 2;
             slice.as_ptr() as *const c_char
-        };
+        }
 
         let c_input = ffi::TSInput {
             payload: &mut payload as *mut (&mut F, Option<T>) as *mut c_void,


### PR DESCRIPTION
- cargo 1.51.0 (43b129a20 2021-03-16)
- rustc 1.51.0 (2fd73fabe 2021-03-23)