### PR TITLE
package.json generation improvements

### DIFF
--- a/cli/src/generate/binding_files.rs
+++ b/cli/src/generate/binding_files.rs
@@ -17,6 +17,9 @@ const CLI_VERSION: &'static str = env!("CARGO_PKG_VERSION");
 pub fn generate_binding_files(repo_path: &Path, language_name: &str) -> Result<()> {
     let bindings_dir = repo_path.join("bindings");
 
+    let dashed_language_name = language_name.replace("_", "-");
+    let dashed_language_name = dashed_language_name.as_str();
+
     // Generate rust bindings if needed.
     let rust_binding_dir = bindings_dir.join("rust");
     if !rust_binding_dir.exists() {
@@ -33,7 +36,7 @@ pub fn generate_binding_files(repo_path: &Path, language_name: &str) -> Result<(
         )?;
         let cargo_toml_path = repo_path.join("Cargo.toml");
         if !cargo_toml_path.exists() {
-            generate_file(&cargo_toml_path, CARGO_TOML_TEMPLATE, language_name)?;
+            generate_file(&cargo_toml_path, CARGO_TOML_TEMPLATE, dashed_language_name)?;
         }
     }
 
@@ -92,7 +95,7 @@ pub fn generate_binding_files(repo_path: &Path, language_name: &str) -> Result<(
                 write_file(&package_json_path, package_json_str)?;
             }
         } else {
-            generate_file(&package_json_path, PACKAGE_JSON_TEMPLATE, language_name)?;
+            generate_file(&package_json_path, PACKAGE_JSON_TEMPLATE, dashed_language_name)?;
         }
 
         // Remove files from old node binding paths.

--- a/cli/src/generate/binding_files.rs
+++ b/cli/src/generate/binding_files.rs
@@ -11,6 +11,8 @@ const BUILD_RS_TEMPLATE: &'static str = include_str!("./templates/build.rs");
 const CARGO_TOML_TEMPLATE: &'static str = include_str!("./templates/cargo.toml");
 const PACKAGE_JSON_TEMPLATE: &'static str = include_str!("./templates/package.json");
 const PARSER_NAME_PLACEHOLDER: &'static str = "PARSER_NAME";
+const CLI_VERSION_PLACEHOLDER: &'static str = "CLI_VERSION";
+const CLI_VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
 pub fn generate_binding_files(repo_path: &Path, language_name: &str) -> Result<()> {
     let bindings_dir = repo_path.join("bindings");
@@ -110,7 +112,9 @@ pub fn generate_binding_files(repo_path: &Path, language_name: &str) -> Result<(
 fn generate_file(path: &Path, template: &str, language_name: &str) -> Result<()> {
     write_file(
         path,
-        template.replace(PARSER_NAME_PLACEHOLDER, language_name),
+        template
+            .replace(PARSER_NAME_PLACEHOLDER, language_name)
+            .replace(CLI_VERSION_PLACEHOLDER, CLI_VERSION),
     )
 }
 

--- a/cli/src/generate/templates/package.json
+++ b/cli/src/generate/templates/package.json
@@ -11,7 +11,7 @@
     "nan": "^2.12.1"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.17.3"
+    "tree-sitter-cli": "^CLI_VERSION"
   },
   "scripts": {
     "test": "tree-sitter test"


### PR DESCRIPTION
This PR adds generation of:
- An actual tree-sitter-cli version on package.json generation in case on missing file.
- Dashes in a language name inside of package.json and Cargo.toml files to uniform naming style in those files.