### PR TITLE
binding_web: Add Query.didExceedMatchLimit

### DIFF
--- a/lib/binding_web/binding.c
+++ b/lib/binding_web/binding.c
@@ -670,3 +670,10 @@ void ts_query_captures_wasm(
   TRANSFER_BUFFER[0] = (const void *)(capture_count);
   TRANSFER_BUFFER[1] = result.contents;
 }
+
+bool ts_query_did_exceed_match_limit_wasm(
+  const TSQuery *self
+) {
+  if (!scratch_query_cursor) return false;
+  return ts_query_cursor_did_exceed_match_limit(scratch_query_cursor);
+}

--- a/lib/binding_web/binding.c
+++ b/lib/binding_web/binding.c
@@ -622,8 +622,11 @@ void ts_query_matches_wasm(
     }
   }
 
+  bool did_exceed_match_limit =
+    ts_query_cursor_did_exceed_match_limit(scratch_query_cursor);
   TRANSFER_BUFFER[0] = (const void *)(match_count);
   TRANSFER_BUFFER[1] = result.contents;
+  TRANSFER_BUFFER[2] = (const void *)(did_exceed_match_limit);
 }
 
 void ts_query_captures_wasm(
@@ -667,13 +670,9 @@ void ts_query_captures_wasm(
     }
   }
 
+  bool did_exceed_match_limit =
+    ts_query_cursor_did_exceed_match_limit(scratch_query_cursor);
   TRANSFER_BUFFER[0] = (const void *)(capture_count);
   TRANSFER_BUFFER[1] = result.contents;
-}
-
-bool ts_query_did_exceed_match_limit_wasm(
-  const TSQuery *self
-) {
-  if (!scratch_query_cursor) return false;
-  return ts_query_cursor_did_exceed_match_limit(scratch_query_cursor);
+  TRANSFER_BUFFER[2] = (const void *)(did_exceed_match_limit);
 }

--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -945,6 +945,7 @@ class Query {
     this.setProperties = setProperties;
     this.assertedProperties = assertedProperties;
     this.refutedProperties = refutedProperties;
+    this.exceededMatchLimit = false;
   }
 
   delete() {
@@ -969,7 +970,9 @@ class Query {
 
     const rawCount = getValue(TRANSFER_BUFFER, 'i32');
     const startAddress = getValue(TRANSFER_BUFFER + SIZE_OF_INT, 'i32');
+    const didExceedMatchLimit = getValue(TRANSFER_BUFFER + 2 * SIZE_OF_INT, 'i32');
     const result = new Array(rawCount);
+    this.exceededMatchLimit = !!didExceedMatchLimit;
 
     let filteredCount = 0;
     let address = startAddress;
@@ -1014,7 +1017,9 @@ class Query {
 
     const count = getValue(TRANSFER_BUFFER, 'i32');
     const startAddress = getValue(TRANSFER_BUFFER + SIZE_OF_INT, 'i32');
+    const didExceedMatchLimit = getValue(TRANSFER_BUFFER + 2 * SIZE_OF_INT, 'i32');
     const result = [];
+    this.exceededMatchLimit = !!didExceedMatchLimit;
 
     const captures = [];
     let address = startAddress;
@@ -1050,7 +1055,7 @@ class Query {
   }
 
   didExceedMatchLimit() {
-    return C._ts_query_did_exceed_match_limit_wasm(this[0]);
+    return this.exceededMatchLimit;
   }
 }
 

--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -1048,6 +1048,10 @@ class Query {
   predicatesForPattern(patternIndex) {
     return this.predicates[patternIndex]
   }
+
+  didExceedMatchLimit() {
+    return C._ts_query_did_exceed_match_limit_wasm(this[0]);
+  }
 }
 
 function getText(tree, startIndex, endIndex) {

--- a/lib/binding_web/exports.json
+++ b/lib/binding_web/exports.json
@@ -76,7 +76,6 @@
   "_ts_query_capture_name_for_id",
   "_ts_query_captures_wasm",
   "_ts_query_delete",
-  "_ts_query_did_exceed_match_limit_wasm",
   "_ts_query_matches_wasm",
   "_ts_query_new",
   "_ts_query_pattern_count",

--- a/lib/binding_web/exports.json
+++ b/lib/binding_web/exports.json
@@ -76,6 +76,7 @@
   "_ts_query_capture_name_for_id",
   "_ts_query_captures_wasm",
   "_ts_query_delete",
+  "_ts_query_did_exceed_match_limit_wasm",
   "_ts_query_matches_wasm",
   "_ts_query_new",
   "_ts_query_pattern_count",

--- a/lib/binding_web/test/query-test.js
+++ b/lib/binding_web/test/query-test.js
@@ -238,6 +238,26 @@ describe("Query", () => {
           refutedProperties: { bar: "baz" },
         },
       ]);
+      assert.ok(!query.didExceedMatchLimit());
+    });
+
+    it("detects queries with too many permutations to track", () => {
+      tree = parser.parse(`
+        [
+          hello, hello, hello, hello, hello, hello, hello, hello, hello, hello,
+          hello, hello, hello, hello, hello, hello, hello, hello, hello, hello,
+          hello, hello, hello, hello, hello, hello, hello, hello, hello, hello,
+          hello, hello, hello, hello, hello, hello, hello, hello, hello, hello,
+          hello, hello, hello, hello, hello, hello, hello, hello, hello, hello,
+        ];
+      `);
+
+      query = JavaScript.query(`
+        (array (identifier) @pre (identifier) @post)
+      `);
+
+      const captures = query.captures(tree.rootNode);
+      assert.ok(query.didExceedMatchLimit());
     });
   });
 


### PR DESCRIPTION
This lets wasm clients check whether a query exceeded its maximum number of in-progress matches.