### PR TITLE
cli: Warn about queries that exceed match limit

### DIFF
--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -91,6 +91,12 @@ pub fn query_files_at_paths(
                 }
             }
         }
+        if query_cursor.did_exceed_match_limit() {
+            writeln!(
+                &mut stdout,
+                "  WARNING: Query exceeded maximum number of in-progress captures!"
+            )?;
+        }
         if should_test {
             query_testing::assert_expected_captures(results, path, &mut parser, language)?
         }


### PR DESCRIPTION
This makes it easier to debug particular queries and source files to see if they exhibit the match-limit problem.