### PR TITLE
binding_web: Call correct function to reset parser

### DIFF
--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -123,7 +123,7 @@ class Parser {
   }
 
   reset() {
-    C._ts_parser_parse_wasm(this[0]);
+    C._ts_parser_reset(this[0]);
   }
 
   setTimeoutMicros(timeout) {

--- a/lib/binding_web/exports.json
+++ b/lib/binding_web/exports.json
@@ -69,6 +69,7 @@
   "_ts_parser_enable_logger_wasm",
   "_ts_parser_new_wasm",
   "_ts_parser_parse_wasm",
+  "_ts_parser_reset",
   "_ts_parser_set_language",
   "_ts_parser_set_timeout_micros",
   "_ts_parser_timeout_micros",


### PR DESCRIPTION
Fixes #1088 