### PR TITLE
Add link to Dockerfile parser

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,7 @@ Parsers for these languages are in development:
 
 * [Agda](https://github.com/tree-sitter/tree-sitter-agda)
 * [Erlang](https://github.com/AbstractMachinesLab/tree-sitter-erlang/)
+* [Dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile)
 * [Go mod](https://github.com/camdencheek/tree-sitter-go-mod)
 * [Haskell](https://github.com/tree-sitter/tree-sitter-haskell)
 * [Julia](https://github.com/tree-sitter/tree-sitter-julia)


### PR DESCRIPTION
This adds a link to a Dockerfile parser I've been working on. It's in a working, useful state, so it felt now is the right time to make it public. 