### PR TITLE
Add immediate rule

### DIFF
--- a/cli/npm/dsl.d.ts
+++ b/cli/npm/dsl.d.ts
@@ -11,6 +11,7 @@ type PrecRule = {type: 'PREC'; content: Rule; value: number};
 type Repeat1Rule = {type: 'REPEAT1'; content: Rule};
 type RepeatRule = {type: 'REPEAT'; content: Rule};
 type SeqRule = {type: 'SEQ'; members: Rule[]};
+type ImmediateRule = {type: 'Immediate'; content: Rule};
 type StringRule = {type: 'STRING'; value: string};
 type SymbolRule<Name extends string> = {type: 'SYMBOL'; name: Name};
 type TokenRule = {type: 'TOKEN'; content: Rule};
@@ -28,6 +29,7 @@ type Rule =
   | PrecRule
   | Repeat1Rule
   | RepeatRule
+  | ImmediateRule
   | SeqRule
   | StringRule
   | SymbolRule<string>
@@ -310,6 +312,15 @@ declare function repeat1(rule: RuleOrLiteral): Repeat1Rule;
  * @param rules ordered rules that comprise the sequence
  */
 declare function seq(...rules: RuleOrLiteral[]): SeqRule;
+
+
+/**
+ * Use `immediate(next_rule)` inside `seq` to instruct tree-sitter that this next element
+ * should only be patched if it comes immediately (e.g. with no spaces)
+ *
+ * @param next_rule the next rule that should be checked
+ */
+declare function immediate(next_rule: RuleOrLiteral): ImmediateRule;
 
 /**
  * Creates a symbol rule, representing another rule in the grammar by name.

--- a/cli/src/generate/dsl.js
+++ b/cli/src/generate/dsl.js
@@ -142,6 +142,13 @@ function repeat1(rule) {
   };
 }
 
+function immediate(content) {
+  return {
+    type: "IMMEDIATE",
+    content: normalize(content)
+  };
+}
+
 function seq(...elements) {
   return {
     type: "SEQ",
@@ -408,6 +415,7 @@ global.optional = optional;
 global.prec = prec;
 global.repeat = repeat;
 global.repeat1 = repeat1;
+global.immediate = immediate;
 global.seq = seq;
 global.sym = sym;
 global.token = token;

--- a/cli/src/generate/parse_grammar.rs
+++ b/cli/src/generate/parse_grammar.rs
@@ -30,6 +30,9 @@ enum RuleJSON {
         name: String,
         content: Box<RuleJSON>,
     },
+    IMMEDIATE {
+        content: Box<RuleJSON>,
+    },
     SEQ {
         members: Vec<RuleJSON>,
     },
@@ -148,6 +151,7 @@ fn parse_rule(json: RuleJSON) -> Rule {
         RuleJSON::SYMBOL { name } => Rule::NamedSymbol(name),
         RuleJSON::CHOICE { members } => Rule::choice(members.into_iter().map(parse_rule).collect()),
         RuleJSON::FIELD { content, name } => Rule::field(name, parse_rule(*content)),
+        RuleJSON::IMMEDIATE { content } => Rule::immediate(parse_rule(*content)),
         RuleJSON::SEQ { members } => Rule::seq(members.into_iter().map(parse_rule).collect()),
         RuleJSON::REPEAT1 { content } => Rule::repeat(parse_rule(*content)),
         RuleJSON::REPEAT { content } => {

--- a/cli/src/generate/prepare_grammar/expand_repeats.rs
+++ b/cli/src/generate/prepare_grammar/expand_repeats.rs
@@ -57,7 +57,7 @@ impl Expander {
                 params: params.clone(),
             },
 
-            // For repetitions, introduce an auxiliary rule that contains the the
+            // For repetitions, introduce an auxiliary rule that contains the
             // repeated content, but can also contain a recursive binary tree structure.
             Rule::Repeat(content) => {
                 let inner_rule = self.expand_rule(content);

--- a/cli/src/generate/prepare_grammar/expand_tokens.rs
+++ b/cli/src/generate/prepare_grammar/expand_tokens.rs
@@ -167,6 +167,14 @@ impl NfaBuilder {
                 }
                 Ok(true)
             }
+            Rule::Immediate(element) => {
+                self.is_sep = false;
+                if self.expand_rule(element, next_state_id)? {
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
             Rule::Seq(elements) => {
                 let mut result = false;
                 for element in elements.into_iter().rev() {

--- a/cli/src/generate/prepare_grammar/extract_tokens.rs
+++ b/cli/src/generate/prepare_grammar/extract_tokens.rs
@@ -214,6 +214,7 @@ impl TokenExtractor {
                 }
             }
             Rule::Repeat(content) => Rule::Repeat(Box::new(self.extract_tokens_in_rule(content))),
+            Rule::Immediate(element) => self.extract_tokens_in_rule(element),
             Rule::Seq(elements) => Rule::Seq(
                 elements
                     .iter()

--- a/cli/src/generate/rules.rs
+++ b/cli/src/generate/rules.rs
@@ -66,6 +66,7 @@ pub(crate) enum Rule {
     },
     Repeat(Box<Rule>),
     Seq(Vec<Rule>),
+    Immediate(Box<Rule>),
 }
 
 // Because tokens are represented as small (~400 max) unsigned integers,
@@ -142,6 +143,10 @@ impl Rule {
             choice_helper(&mut elements, rule);
         }
         Rule::Choice(elements)
+    }
+
+    pub fn immediate(rule: Rule) -> Self {
+        Rule::Immediate(Box::new(rule))
     }
 
     pub fn seq(rules: Vec<Rule>) -> Self {


### PR DESCRIPTION
As I discussed in [this comment](https://github.com/tree-sitter/tree-sitter/issues/931#issuecomment-838582264) in #931, having a way to express an immediate rule is highly needed. 

In this PR, I tried to show what I mean. This code doesn't work in its current state but can be used to discuss the issue.


In my RFC, `immediate` function is called inside `seq`:
```js
seq(rule1, immediate(rule2), rule3)

```