### PR TITLE
Adding API to get field name of a TSNode

### DIFF
--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -249,6 +249,25 @@ fn test_node_parent_of_child_by_field_name() {
 }
 
 #[test]
+fn test_node_field_name_for_child() {
+    let mut parser = Parser::new();
+    parser.set_language(get_language("c")).unwrap();
+    let tree = parser.parse("x + y;", None).unwrap();
+    let translation_unit_node = tree.root_node();
+    let binary_expression_node = translation_unit_node
+                                 .named_child(0)
+                                 .unwrap()
+                                 .named_child(0)
+                                 .unwrap();
+
+    assert_eq!(binary_expression_node.field_name_for_child(0), Some("left"));
+    assert_eq!(binary_expression_node.field_name_for_child(1), Some("operator"));
+    assert_eq!(binary_expression_node.field_name_for_child(2), Some("right"));
+		// Negative test - Not a valid child index
+    assert_eq!(binary_expression_node.field_name_for_child(3), None);
+}
+
+#[test]
 fn test_node_child_by_field_name_with_extra_hidden_children() {
     let mut parser = Parser::new();
     parser.set_language(get_language("python")).unwrap();

--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -255,15 +255,21 @@ fn test_node_field_name_for_child() {
     let tree = parser.parse("x + y;", None).unwrap();
     let translation_unit_node = tree.root_node();
     let binary_expression_node = translation_unit_node
-                                 .named_child(0)
-                                 .unwrap()
-                                 .named_child(0)
-                                 .unwrap();
+        .named_child(0)
+        .unwrap()
+        .named_child(0)
+        .unwrap();
 
     assert_eq!(binary_expression_node.field_name_for_child(0), Some("left"));
-    assert_eq!(binary_expression_node.field_name_for_child(1), Some("operator"));
-    assert_eq!(binary_expression_node.field_name_for_child(2), Some("right"));
-		// Negative test - Not a valid child index
+    assert_eq!(
+        binary_expression_node.field_name_for_child(1),
+        Some("operator")
+    );
+    assert_eq!(
+        binary_expression_node.field_name_for_child(2),
+        Some("right")
+    );
+    // Negative test - Not a valid child index
     assert_eq!(binary_expression_node.field_name_for_child(3), None);
 }
 

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -435,6 +435,11 @@ extern "C" {
     pub fn ts_node_child(arg1: TSNode, arg2: u32) -> TSNode;
 }
 extern "C" {
+    #[doc = " Get the field name for node's child at the given index, where zero represents"]
+    #[doc = " the first child. Returns NULL, if no field is found."]
+    pub fn ts_node_field_name_for_child(arg1: TSNode, arg2: u32) -> *const ::std::os::raw::c_char;
+}
+extern "C" {
     #[doc = " Get the node\'s number of children."]
     pub fn ts_node_child_count(arg1: TSNode) -> u32;
 }

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -859,6 +859,18 @@ impl<'tree> Node<'tree> {
         Self::new(unsafe { ffi::ts_node_child_by_field_id(self.0, field_id) })
     }
 
+    /// Get the field name of this node's child at the given index.
+    pub fn field_name_for_child(&self, child_index: u32) -> Option<&'static str> {
+        unsafe {
+            let ptr = ffi::ts_node_field_name_for_child(self.0, child_index);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(ptr).to_str().unwrap())
+            }
+        }
+    }
+
     /// Iterate over this node's children.
     ///
     /// A [TreeCursor] is used to retrieve the children efficiently. Obtain

--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-tree-sitter",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Tree-sitter bindings for the web",
   "main": "tree-sitter.js",
   "types": "tree-sitter-web.d.ts",

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -488,10 +488,10 @@ TSNode ts_node_parent(TSNode);
 TSNode ts_node_child(TSNode, uint32_t);
 
 /**
- * Get the field_name for node's child at the given index, where zero represents
+ * Get the field name for node's child at the given index, where zero represents
  * the first child. Returns NULL, if no field is found.
  */
-const char *ts_node_child_field_name(TSNode, uint32_t);
+const char *ts_node_field_name_for_child(TSNode, uint32_t);
 
 /**
  * Get the node's number of children.

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -488,6 +488,12 @@ TSNode ts_node_parent(TSNode);
 TSNode ts_node_child(TSNode, uint32_t);
 
 /**
+ * Get the field_name for node's child at the given index, where zero represents
+ * the first child. Returns NULL, if no field is found.
+ */
+const char *ts_node_child_field_name(TSNode, uint32_t);
+
+/**
  * Get the node's number of children.
  */
 uint32_t ts_node_child_count(TSNode);

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -578,6 +578,23 @@ recur:
   return ts_node__null();
 }
 
+const char *ts_node_child_field_name(TSNode self, uint32_t child_index) {
+  const TSFieldMapEntry *field_map, *field_map_end;
+  ts_language_field_map(
+    self.tree->language,
+    ts_node__subtree(self).ptr->production_id,
+    &field_map,
+    &field_map_end
+  );
+
+  for (const TSFieldMapEntry *i = field_map; i < field_map_end; i++) {
+    if (i->child_index == child_index) {
+      return self.tree->language->field_names[i->field_id];
+    }
+  }
+  return NULL;
+}
+
 TSNode ts_node_child_by_field_name(
   TSNode self,
   const char *name,

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -578,7 +578,7 @@ recur:
   return ts_node__null();
 }
 
-const char *ts_node_child_field_name(TSNode self, uint32_t child_index) {
+const char *ts_node_field_name_for_child(TSNode self, uint32_t child_index) {
   const TSFieldMapEntry *field_map_start = NULL, *field_map_end = NULL;
   ts_language_field_map(
     self.tree->language,

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -579,15 +579,15 @@ recur:
 }
 
 const char *ts_node_child_field_name(TSNode self, uint32_t child_index) {
-  const TSFieldMapEntry *field_map, *field_map_end;
+  const TSFieldMapEntry *field_map_start = NULL, *field_map_end = NULL;
   ts_language_field_map(
     self.tree->language,
     ts_node__subtree(self).ptr->production_id,
-    &field_map,
+    &field_map_start,
     &field_map_end
   );
 
-  for (const TSFieldMapEntry *i = field_map; i < field_map_end; i++) {
+  for (const TSFieldMapEntry *i = field_map_start; i < field_map_end; i++) {
     if (i->child_index == child_index) {
       return self.tree->language->field_names[i->field_id];
     }


### PR DESCRIPTION
This PR adds an API to get name of the field of TSNode's child.
It uses same set of arguments as that of ts_node_child, but returns
field name if it is found, otherwise it returns NULL.

This API is useful to implement custom printing of S-expressions such
as following:

"(binary_expression
   (binary_expression_left (identifier))
   (binary_expression_operator ("+"))
   (binary_expression_right (identifier)
)"

Currently, ts_node_string does not allow any customization for printing.
This PR addresses question #1090.