### PR TITLE
Make HighlightConfiguration::configure use IntoIterator

### DIFF
--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -661,7 +661,7 @@ impl<'a> LanguageConfiguration<'a> {
                             }
                         }
                     }
-                    result.configure(&all_highlight_names);
+                    result.configure(&all_highlight_names.as_slice());
                     Ok(Some(result))
                 }
             })

--- a/cli/src/tests/helpers/fixtures.rs
+++ b/cli/src/tests/helpers/fixtures.rs
@@ -50,7 +50,7 @@ pub fn get_highlight_config(
         &locals_query,
     )
     .unwrap();
-    result.configure(highlight_names);
+    result.configure(&highlight_names);
     result
 }
 

--- a/highlight/README.md
+++ b/highlight/README.md
@@ -18,7 +18,7 @@ tree-sitter-javascript = "0.19"
 Define the list of highlight names that you will recognize:
 
 ```rust
-let highlight_names : Vec<String> = [
+let highlight_names = &[
     "attribute",
     "constant",
     "function.builtin",
@@ -37,11 +37,7 @@ let highlight_names : Vec<String> = [
     "variable",
     "variable.builtin",
     "variable.parameter",
-]
-.iter()
-.cloned()
-.map(String::from)
-.collect();
+];
 ```
 
 Create a highlighter. You need one of these for each thread that you're using for syntax highlighting:

--- a/highlight/src/c_lib.rs
+++ b/highlight/src/c_lib.rs
@@ -112,7 +112,7 @@ pub extern "C" fn ts_highlighter_add_language(
         let mut config =
             HighlightConfiguration::new(language, highlight_query, injection_query, locals_query)
                 .or(Err(ErrorCode::InvalidQuery))?;
-        config.configure(&this.highlight_names);
+        config.configure(&this.highlight_names.as_slice());
         this.languages.insert(scope_name, (injection_regex, config));
 
         Ok(())

--- a/highlight/src/lib.rs
+++ b/highlight/src/lib.rs
@@ -293,7 +293,11 @@ impl HighlightConfiguration {
     ///
     /// When highlighting, results are returned as `Highlight` values, which contain the index
     /// of the matched highlight this list of highlight names.
-    pub fn configure(&mut self, recognized_names: &[String]) {
+    pub fn configure<'a, I, J>(&mut self, recognized_names: &I)
+    where
+        I: IntoIterator<Item = &'a J> + Copy,
+        J: AsRef<str> + 'a,
+    {
         let mut capture_parts = Vec::new();
         self.highlight_indices.clear();
         self.highlight_indices
@@ -303,10 +307,10 @@ impl HighlightConfiguration {
 
                 let mut best_index = None;
                 let mut best_match_len = 0;
-                for (i, recognized_name) in recognized_names.iter().enumerate() {
+                for (i, recognized_name) in recognized_names.into_iter().enumerate() {
                     let mut len = 0;
                     let mut matches = true;
-                    for part in recognized_name.split('.') {
+                    for part in recognized_name.as_ref().split('.') {
                         len += 1;
                         if !capture_parts.contains(&part) {
                             matches = false;

--- a/highlight/src/lib.rs
+++ b/highlight/src/lib.rs
@@ -293,8 +293,7 @@ impl HighlightConfiguration {
     ///
     /// When highlighting, results are returned as `Highlight` values, which contain the index
     /// of the matched highlight this list of highlight names.
-    pub fn configure(&mut self, recognized_names: &[impl AsRef<str>])
-    {
+    pub fn configure(&mut self, recognized_names: &[impl AsRef<str>]) {
         let mut capture_parts = Vec::new();
         self.highlight_indices.clear();
         self.highlight_indices

--- a/highlight/src/lib.rs
+++ b/highlight/src/lib.rs
@@ -293,10 +293,7 @@ impl HighlightConfiguration {
     ///
     /// When highlighting, results are returned as `Highlight` values, which contain the index
     /// of the matched highlight this list of highlight names.
-    pub fn configure<'a, I, J>(&mut self, recognized_names: &I)
-    where
-        I: IntoIterator<Item = &'a J> + Copy,
-        J: AsRef<str> + 'a,
+    pub fn configure(&mut self, recognized_names: &[impl AsRef<str>])
     {
         let mut capture_parts = Vec::new();
         self.highlight_indices.clear();


### PR DESCRIPTION
Make `HighlightConfiguration::configure` use into iterator instead of a `Vec<String>`

I think it's better this way, so you can define a static array of highlight names without having to turn them into a vector of owned values.

Maybe there is some caveat to this that I don't know or this is not useful at all? Let me know please.

With this, you can do the following:

```rust
static HIGHLIGHT_NAMES: &[&str] = &[
    "attribute",
    "label",
    "constant",
    "function.builtin",
    "function.macro",
    ...
];

let mut highlighter = Highlighter::new();

let mut rust_config = HighlightConfiguration::new(
    tree_sitter_rust::language(),
    tree_sitter_rust::HIGHLIGHT_QUERY,
    "",
    "",
)
.unwrap();

rust_config.configure(&HIGHLIGHT_NAMES);
```

Or checkout how I changed the readme.