### PR TITLE
cli: Improve const-correctness of the generated parsers (part 2 of 2).

### DIFF
--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -355,7 +355,7 @@ impl Generator {
     }
 
     fn add_symbol_names_list(&mut self) {
-        add_line!(self, "static const char *ts_symbol_names[] = {{");
+        add_line!(self, "static const char * const ts_symbol_names[] = {{");
         indent!(self);
         for symbol in self.parse_table.symbols.iter() {
             let name = self.sanitize_string(
@@ -417,7 +417,7 @@ impl Generator {
     }
 
     fn add_field_name_names_list(&mut self) {
-        add_line!(self, "static const char *ts_field_names[] = {{");
+        add_line!(self, "static const char * const ts_field_names[] = {{");
         indent!(self);
         add_line!(self, "[0] = NULL,");
         for field_name in &self.field_names {

--- a/lib/include/tree_sitter/parser.h
+++ b/lib/include/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char **symbol_names;
-  const char **field_names;
+  const char * const *symbol_names;
+  const char * const *field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;


### PR DESCRIPTION
This is a follow-up to my previous commit 1badd131f91

I've made this an extra patch as it requires a minor API change in `<tree_sitter/parser.h>`.

This commit moves the remaining generated tables into the read-only segment.

```
Before:
  $ for f in bash c cpp go html java javascript jsdoc json php python ruby rust; do \
       gcc -o $f.o -O2 -Ilib/include -c test/fixtures/grammars/$f/src/parser.c; \
    done
  $ size --totals *.o
      text    data     bss     dec     hex filename
   5353477   24472       0 5377949  520f9d (TOTALS)

After:
  $ for f in bash c cpp go html java javascript jsdoc json php python ruby rust; do \
       gcc -o $f.o -O2 -Ilib/include -c test/fixtures/grammars/$f/src/parser.c; \
    done
  $ size --totals *.o
   5378147       0       0 5378147  521063 (TOTALS)
```