### PR TITLE
Apply 'cargo fmt' for the whole Rust code base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
           toolchain: stable
           profile: minimal
 
+      - name: Check Rust code formatting
+        run: cargo fmt -- --check
+
       - name: Install emscripten
         uses: mymindstorm/setup-emsdk@v7
         with:

--- a/cli/src/generate/binding_files.rs
+++ b/cli/src/generate/binding_files.rs
@@ -95,7 +95,11 @@ pub fn generate_binding_files(repo_path: &Path, language_name: &str) -> Result<(
                 write_file(&package_json_path, package_json_str)?;
             }
         } else {
-            generate_file(&package_json_path, PACKAGE_JSON_TEMPLATE, dashed_language_name)?;
+            generate_file(
+                &package_json_path,
+                PACKAGE_JSON_TEMPLATE,
+                dashed_language_name,
+            )?;
         }
 
         // Remove files from old node binding paths.

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -543,7 +543,10 @@ impl Generator {
         let mut alias_ids_by_symbol = alias_ids_by_symbol.iter().collect::<Vec<_>>();
         alias_ids_by_symbol.sort_unstable_by_key(|e| e.0);
 
-        add_line!(self, "static const uint16_t ts_non_terminal_alias_map[] = {{");
+        add_line!(
+            self,
+            "static const uint16_t ts_non_terminal_alias_map[] = {{"
+        );
         indent!(self);
         for (symbol, alias_ids) in alias_ids_by_symbol {
             let symbol_id = &self.symbol_ids[symbol];
@@ -962,7 +965,10 @@ impl Generator {
     }
 
     fn add_lex_modes_list(&mut self) {
-        add_line!(self, "static const TSLexMode ts_lex_modes[STATE_COUNT] = {{");
+        add_line!(
+            self,
+            "static const TSLexMode ts_lex_modes[STATE_COUNT] = {{"
+        );
         indent!(self);
         for (i, state) in self.parse_table.states.iter().enumerate() {
             if state.is_end_of_non_terminal_extra() {
@@ -1200,7 +1206,10 @@ impl Generator {
             add_line!(self, "}};");
             add_line!(self, "");
 
-            add_line!(self, "static const uint32_t ts_small_parse_table_map[] = {{");
+            add_line!(
+                self,
+                "static const uint32_t ts_small_parse_table_map[] = {{"
+            );
             indent!(self);
             for i in self.large_state_count..self.parse_table.states.len() {
                 add_line!(
@@ -1219,7 +1228,10 @@ impl Generator {
     }
 
     fn add_parse_action_list(&mut self, parse_table_entries: Vec<(usize, ParseTableEntry)>) {
-        add_line!(self, "static const TSParseActionEntry ts_parse_actions[] = {{");
+        add_line!(
+            self,
+            "static const TSParseActionEntry ts_parse_actions[] = {{"
+        );
         indent!(self);
         for (i, entry) in parse_table_entries {
             add!(
@@ -1334,14 +1346,8 @@ impl Generator {
         // Parse table
         add_line!(self, ".parse_table = &ts_parse_table[0][0],");
         if self.large_state_count < self.parse_table.states.len() {
-            add_line!(
-                self,
-                ".small_parse_table = ts_small_parse_table,"
-            );
-            add_line!(
-                self,
-                ".small_parse_table_map = ts_small_parse_table_map,"
-            );
+            add_line!(self, ".small_parse_table = ts_small_parse_table,");
+            add_line!(self, ".small_parse_table_map = ts_small_parse_table_map,");
         }
         add_line!(self, ".parse_actions = ts_parse_actions,");
 
@@ -1349,23 +1355,14 @@ impl Generator {
         add_line!(self, ".symbol_names = ts_symbol_names,");
         if !self.field_names.is_empty() {
             add_line!(self, ".field_names = ts_field_names,");
-            add_line!(
-                self,
-                ".field_map_slices = ts_field_map_slices,"
-            );
-            add_line!(
-                self,
-                ".field_map_entries = ts_field_map_entries,"
-            );
+            add_line!(self, ".field_map_slices = ts_field_map_slices,");
+            add_line!(self, ".field_map_entries = ts_field_map_entries,");
         }
         add_line!(self, ".symbol_metadata = ts_symbol_metadata,");
         add_line!(self, ".public_symbol_map = ts_symbol_map,");
         add_line!(self, ".alias_map = ts_non_terminal_alias_map,");
         if !self.parse_table.production_infos.is_empty() {
-            add_line!(
-                self,
-                ".alias_sequences = &ts_alias_sequences[0][0],"
-            );
+            add_line!(self, ".alias_sequences = &ts_alias_sequences[0][0],");
         }
 
         // Lexing

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -122,7 +122,12 @@ fn run() -> error::Result<()> {
                         .takes_value(true)
                         .help("Only run corpus test cases whose name includes the given string"),
                 )
-                .arg(Arg::with_name("update").long("update").short("u").help("Update all syntax trees in corpus files with current parser output"))
+                .arg(
+                    Arg::with_name("update")
+                        .long("update")
+                        .short("u")
+                        .help("Update all syntax trees in corpus files with current parser output"),
+                )
                 .arg(Arg::with_name("debug").long("debug").short("d"))
                 .arg(Arg::with_name("debug-graph").long("debug-graph").short("D")),
         )

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -197,7 +197,8 @@ pub fn parse_file_at_path(
                         did_visit_children = true;
                         let start = node.start_byte();
                         let end = node.end_byte();
-                        let value = std::str::from_utf8(&source_code[start..end]).expect("has a string");
+                        let value =
+                            std::str::from_utf8(&source_code[start..end]).expect("has a string");
                         write!(&mut stdout, "{}", html_escape::encode_text(value))?;
                     }
                 }

--- a/cli/src/tests/helpers/random.rs
+++ b/cli/src/tests/helpers/random.rs
@@ -13,7 +13,7 @@ impl Rand {
     }
 
     pub fn unsigned(&mut self, max: usize) -> usize {
-        self.0.gen_range(0 .. max + 1)
+        self.0.gen_range(0..max + 1)
     }
 
     pub fn words(&mut self, max_count: usize) -> Vec<u8> {

--- a/cli/src/tests/helpers/scope_sequence.rs
+++ b/cli/src/tests/helpers/scope_sequence.rs
@@ -47,7 +47,10 @@ impl ScopeSequence {
         if self.0.len() != text.len() {
             panic!(
                 "Inconsistent scope sequence: {:?}",
-                self.0.iter().zip(text.iter().map(|c| *c as char)).collect::<Vec<_>>()
+                self.0
+                    .iter()
+                    .zip(text.iter().map(|c| *c as char))
+                    .collect::<Vec<_>>()
             );
         }
 


### PR DESCRIPTION
This PR fixes Rust code base formatting by 'cargo fmt' and adds corresponding CI check.