### PR TITLE
Remove interior mutability for parent-node caching in Tree

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1942,7 +1942,8 @@ impl error::Error for QueryError {}
 unsafe impl Send for Language {}
 unsafe impl Send for Parser {}
 unsafe impl Send for Query {}
-unsafe impl Send for Tree {}
 unsafe impl Send for QueryCursor {}
+unsafe impl Send for Tree {}
 unsafe impl Sync for Language {}
 unsafe impl Sync for Query {}
+unsafe impl Sync for Tree {}

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -150,9 +150,6 @@ static inline TSNode ts_node__child(
     while (ts_node_child_iterator_next(&iterator, &child)) {
       if (ts_node__is_relevant(child, include_anonymous)) {
         if (index == child_index) {
-          if (ts_node__is_relevant(self, true)) {
-            ts_tree_set_cached_parent(self.tree, &child, &self);
-          }
           return child;
         }
         index++;
@@ -355,7 +352,6 @@ static inline TSNode ts_node__descendant_for_byte_range(
 
       node = child;
       if (ts_node__is_relevant(node, include_anonymous)) {
-        ts_tree_set_cached_parent(self.tree, &child, &last_visible_node);
         last_visible_node = node;
       }
       did_descend = true;
@@ -395,7 +391,6 @@ static inline TSNode ts_node__descendant_for_point_range(
 
       node = child;
       if (ts_node__is_relevant(node, include_anonymous)) {
-        ts_tree_set_cached_parent(self.tree, &child, &last_visible_node);
         last_visible_node = node;
       }
       did_descend = true;
@@ -464,10 +459,7 @@ bool ts_node_has_error(TSNode self) {
 }
 
 TSNode ts_node_parent(TSNode self) {
-  TSNode node = ts_tree_get_cached_parent(self.tree, &self);
-  if (node.id) return node;
-
-  node = ts_tree_root_node(self.tree);
+  TSNode node = ts_tree_root_node(self.tree);
   uint32_t end_byte = ts_node_end_byte(self);
   if (node.id == self.id) return ts_node__null();
 
@@ -486,7 +478,6 @@ TSNode ts_node_parent(TSNode self) {
       if (iterator.position.bytes >= end_byte) {
         node = child;
         if (ts_node__is_relevant(child, true)) {
-          ts_tree_set_cached_parent(self.tree, &node, &last_visible_node);
           last_visible_node = node;
         }
         did_descend = true;

--- a/lib/src/tree.c
+++ b/lib/src/tree.c
@@ -5,8 +5,6 @@
 #include "./tree_cursor.h"
 #include "./tree.h"
 
-static const unsigned PARENT_CACHE_CAPACITY = 32;
-
 TSTree *ts_tree_new(
   Subtree root, const TSLanguage *language,
   const TSRange *included_ranges, unsigned included_range_count
@@ -14,9 +12,6 @@ TSTree *ts_tree_new(
   TSTree *result = ts_malloc(sizeof(TSTree));
   result->root = root;
   result->language = language;
-  result->parent_cache = NULL;
-  result->parent_cache_start = 0;
-  result->parent_cache_size = 0;
   result->included_ranges = ts_calloc(included_range_count, sizeof(TSRange));
   memcpy(result->included_ranges, included_ranges, included_range_count * sizeof(TSRange));
   result->included_range_count = included_range_count;
@@ -35,7 +30,6 @@ void ts_tree_delete(TSTree *self) {
   ts_subtree_release(&pool, self->root);
   ts_subtree_pool_delete(&pool);
   ts_free(self->included_ranges);
-  if (self->parent_cache) ts_free(self->parent_cache);
   ts_free(self);
 }
 
@@ -78,8 +72,6 @@ void ts_tree_edit(TSTree *self, const TSInputEdit *edit) {
 
   SubtreePool pool = ts_subtree_pool_new(0);
   self->root = ts_subtree_edit(self->root, edit, &pool);
-  self->parent_cache_start = 0;
-  self->parent_cache_size = 0;
   ts_subtree_pool_delete(&pool);
 }
 
@@ -110,39 +102,4 @@ TSRange *ts_tree_get_changed_ranges(const TSTree *self, const TSTree *other, uin
 
 void ts_tree_print_dot_graph(const TSTree *self, FILE *file) {
   ts_subtree_print_dot_graph(self->root, self->language, file);
-}
-
-TSNode ts_tree_get_cached_parent(const TSTree *self, const TSNode *node) {
-  for (uint32_t i = 0; i < self->parent_cache_size; i++) {
-    uint32_t index = (self->parent_cache_start + i) % PARENT_CACHE_CAPACITY;
-    ParentCacheEntry *entry = &self->parent_cache[index];
-    if (entry->child == node->id) {
-      return ts_node_new(self, entry->parent, entry->position, entry->alias_symbol);
-    }
-  }
-  return ts_node_new(NULL, NULL, length_zero(), 0);
-}
-
-void ts_tree_set_cached_parent(const TSTree *_self, const TSNode *node, const TSNode *parent) {
-  TSTree *self = (TSTree *)_self;
-  if (!self->parent_cache) {
-    self->parent_cache = ts_calloc(PARENT_CACHE_CAPACITY, sizeof(ParentCacheEntry));
-  }
-
-  uint32_t index = (self->parent_cache_start + self->parent_cache_size) % PARENT_CACHE_CAPACITY;
-  self->parent_cache[index] = (ParentCacheEntry) {
-    .child = node->id,
-    .parent = (const Subtree *)parent->id,
-    .position = {
-      parent->context[0],
-      {parent->context[1], parent->context[2]}
-    },
-    .alias_symbol = parent->context[3],
-  };
-
-  if (self->parent_cache_size == PARENT_CACHE_CAPACITY) {
-    self->parent_cache_start++;
-  } else {
-    self->parent_cache_size++;
-  }
 }

--- a/lib/src/tree.h
+++ b/lib/src/tree.h
@@ -15,17 +15,12 @@ typedef struct {
 struct TSTree {
   Subtree root;
   const TSLanguage *language;
-  ParentCacheEntry *parent_cache;
-  uint32_t parent_cache_start;
-  uint32_t parent_cache_size;
   TSRange *included_ranges;
   unsigned included_range_count;
 };
 
 TSTree *ts_tree_new(Subtree root, const TSLanguage *language, const TSRange *, unsigned);
 TSNode ts_node_new(const TSTree *, const Subtree *, Length, TSSymbol);
-TSNode ts_tree_get_cached_parent(const TSTree *, const TSNode *);
-void ts_tree_set_cached_parent(const TSTree *, const TSNode *, const TSNode *);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Background

A long time ago, in #172, after removing parent pointers from syntax trees, I added a system for caching nodes' parents, in order to optimize client code that repeatedly called `ts_node_parent`. This system relied on *interior mutation* of syntax trees - non-mutating `TSNode` APIs would secretly write to a "parent cache" on the `TSTree`.

The downside of this optimization was that it meant that trees' could not be shared between threads at all, *not even in a read-only fashion*.

### Problem

I think we no longer need the optimization I described above. The slow code path in Atom's `bracket-matcher` packages was later overhauled in https://github.com/atom/bracket-matcher/pull/367. None of GitHub's production systems use APIs like `ts_node_parent` - they all use efficient tree traversals with `TSTreeCursor` or `TSQuery`.

### Change

In this PR, I'm basically reverting all of #172. Trees no longer have a "parent node cache" construct. This means that in Rust's terminology, a syntax tree is `Sync` - it can be shared in a read-only way between multiple threads. So I've implemented the `Sync` trait for `Tree`.