### PR TITLE
Fix: cast pointers to `void *` when printing

### DIFF
--- a/lib/src/stack.c
+++ b/lib/src/stack.c
@@ -737,7 +737,7 @@ bool ts_stack_print_dot_graph(Stack *self, const TSLanguage *language, FILE *f) 
     if (head->status == StackStatusHalted) continue;
 
     fprintf(f, "node_head_%u [shape=none, label=\"\"]\n", i);
-    fprintf(f, "node_head_%u -> node_%p [", i, head->node);
+    fprintf(f, "node_head_%u -> node_%p [", i, (void *)head->node);
 
     if (head->status == StackStatusPaused) {
       fprintf(f, "color=red ");
@@ -782,7 +782,7 @@ bool ts_stack_print_dot_graph(Stack *self, const TSLanguage *language, FILE *f) 
       if (!node) continue;
       all_iterators_done = false;
 
-      fprintf(f, "node_%p [", node);
+      fprintf(f, "node_%p [", (void *)node);
       if (node->state == ERROR_STATE) {
         fprintf(f, "label=\"?\"");
       } else if (
@@ -807,7 +807,7 @@ bool ts_stack_print_dot_graph(Stack *self, const TSLanguage *language, FILE *f) 
 
       for (int j = 0; j < node->link_count; j++) {
         StackLink link = node->links[j];
-        fprintf(f, "node_%p -> node_%p [", node, link.node);
+        fprintf(f, "node_%p -> node_%p [", (void *)node, (void *)link.node);
         if (link.is_pending) fprintf(f, "style=dashed ");
         if (link.subtree.ptr && ts_subtree_extra(link.subtree)) fprintf(f, "fontcolor=gray ");
 

--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -992,7 +992,7 @@ void ts_subtree__print_dot_graph(const Subtree *self, uint32_t start_offset,
   TSSymbol subtree_symbol = ts_subtree_symbol(*self);
   TSSymbol symbol = alias_symbol ? alias_symbol : subtree_symbol;
   uint32_t end_offset = start_offset + ts_subtree_total_bytes(*self);
-  fprintf(f, "tree_%p [label=\"", self);
+  fprintf(f, "tree_%p [label=\"", (void *)self);
   ts_subtree__write_dot_string(f, ts_language_symbol_name(language, symbol));
   fprintf(f, "\"");
 
@@ -1034,7 +1034,7 @@ void ts_subtree__print_dot_graph(const Subtree *self, uint32_t start_offset,
       child_info_offset++;
     }
     ts_subtree__print_dot_graph(child, child_start_offset, language, alias_symbol, f);
-    fprintf(f, "tree_%p -> tree_%p [tooltip=%u]\n", self, child, i);
+    fprintf(f, "tree_%p -> tree_%p [tooltip=%u]\n", (void *)self, (void *)child, i);
     child_start_offset += ts_subtree_total_bytes(*child);
   }
 }


### PR DESCRIPTION
In `lib/src/stack.c` and `lib/src/subtree.c`, there were a couple of instances where pointers were being printed, but where not of type `void *`. This may cause undefined behaviour, and is not supported by the `gnu99` standard, which is being used in compilation.

These were all the instances of `%p` I was able to find (with `git grep "%p"`).