### PR TITLE
fix(cli): Correct fallback on docker compilation for all platforms, fixes #1124

### DIFF
--- a/cli/src/wasm.rs
+++ b/cli/src/wasm.rs
@@ -3,7 +3,6 @@ use super::generate::parse_grammar::GrammarJSON;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::Path;
-use std::path::PathBuf;
 use std::process::Command;
 use which::which;
 
@@ -23,15 +22,15 @@ pub fn compile_language_to_wasm(language_dir: &Path, force_docker: bool) -> Resu
     let grammar_name = get_grammar_name(&src_dir)?;
     let output_filename = format!("tree-sitter-{}.wasm", grammar_name);
 
+    let emcc_bin = if cfg!(windows) { "emcc.bat" } else { "emcc" };
+    let emcc_path = which(emcc_bin)
+        .ok()
+        .and_then(|p| Command::new(&p).output().and(Ok(p)).ok());
+
     let mut command;
-    if !force_docker {
-        let emcc_path = get_emcc_path();
-        if emcc_path.is_ok() {
-            command = Command::new(emcc_path.unwrap());
-            command.current_dir(&language_dir);
-        } else {
-            return Err(emcc_path.unwrap_err());
-        }
+    if !force_docker && emcc_path.is_some() {
+        command = Command::new(emcc_path.unwrap());
+        command.current_dir(&language_dir);
     } else if Command::new("docker").output().is_ok() {
         command = Command::new("docker");
         command.args(&["run", "--rm"]);
@@ -122,24 +121,4 @@ pub fn compile_language_to_wasm(language_dir: &Path, force_docker: bool) -> Resu
     ))?;
 
     Ok(())
-}
-
-fn get_emcc_path() -> Result<PathBuf> {
-    let emcc_bin;
-    if cfg!(windows) {
-        emcc_bin = "emcc.bat";
-    } else {
-        emcc_bin = "emcc";
-    };
-    let emcc_which = which(emcc_bin);
-    let emcc_path;
-    if emcc_which.is_ok() {
-        emcc_path = emcc_which.unwrap();
-    } else {
-        return Error::err("emcc was not found on PATH".to_string());
-    }
-    if Command::new(&emcc_path).output().is_ok() {
-        return Ok(emcc_path);
-    }
-    return Error::err("emcc binary doesn't work properly".to_string());
 }


### PR DESCRIPTION
This PR fixes regression introduced in #1044 PR by mostly restoring logic before it but also takes into account an issue that that PR tried to fix. All error messages that were introduced in #1044 for absent emcc don't make sense cause there is a fallback to building in docker.
Closes #1124