### PR TITLE
fix: Cut dangling closing bracket in the playground tree

### DIFF
--- a/docs/assets/js/playground.js
+++ b/docs/assets/js/playground.js
@@ -181,7 +181,7 @@ let tree;
           } else {
             fieldName = '';
           }
-          row = `<div>${'  '.repeat(indentLevel)}${fieldName}<a class='plain' href="#" data-id=${id} data-range="${start.row},${start.column},${end.row},${end.column}">${displayName}</a> [${start.row}, ${start.column}] - [${end.row}, ${end.column}])`;
+          row = `<div>${'  '.repeat(indentLevel)}${fieldName}<a class='plain' href="#" data-id=${id} data-range="${start.row},${start.column},${end.row},${end.column}">${displayName}</a> [${start.row}, ${start.column}] - [${end.row}, ${end.column}]`;
           finishedRow = true;
         }
 


### PR DESCRIPTION
This PR removes dangling closing bracket in the playground representation to make it cleaner cause it seems it was migrated from CLI representation where there are opening brackets and closing brackets for every opening bracket.

![image](https://user-images.githubusercontent.com/14666676/120184962-43f4ff80-c21a-11eb-85bb-442ed536d609.png)
