### PR TITLE
fix(cli): Panic on broken pipe

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,6 +1,7 @@
 use super::test_highlight;
 use std::fmt::Write;
 use std::io;
+use std::io::ErrorKind;
 use tree_sitter::{QueryError, QueryErrorKind};
 use walkdir;
 
@@ -106,8 +107,8 @@ impl From<serde_json::Error> for Error {
 
 impl From<io::Error> for Error {
     fn from(error: io::Error) -> Self {
-        match error.raw_os_error() {
-            Some(32) => return Error::new_ignored(), // Broken pipe
+        match error {
+            x if x.kind() == ErrorKind::BrokenPipe => return Error::new_ignored(),
             _ => (),
         }
         Error::new(error.to_string())

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -25,8 +25,7 @@ impl Error {
     }
 
     pub fn new(message: String) -> Self {
-        let e = Error(Some(vec![message]));
-        e
+        Error(Some(vec![message]))
     }
 
     pub fn new_ignored() -> Self {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,9 +14,12 @@ const BUILD_VERSION: &'static str = env!("CARGO_PKG_VERSION");
 const BUILD_SHA: Option<&'static str> = option_env!("BUILD_SHA");
 
 fn main() {
-    if let Err(e) = run() {
+    if let Err(ref e) = run() {
+        if e.is_ignored() {
+            exit(0);
+        }
         if !e.message().is_empty() {
-            println!("");
+            eprintln!("");
             eprintln!("{}", e.message());
         }
         exit(1);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,7 +14,7 @@ const BUILD_VERSION: &'static str = env!("CARGO_PKG_VERSION");
 const BUILD_SHA: Option<&'static str> = option_env!("BUILD_SHA");
 
 fn main() {
-    if let Err(ref e) = run() {
+    if let Err(e) = run() {
         if e.is_ignored() {
             exit(0);
         }


### PR DESCRIPTION
This PR:
* Fixes CLI panic if to call tree-sitter-cli in pipe with a tool that closes pipe without reading to the end:
  ```
  tree-sitter parse ... | head
  ```
* Introduces a concept of ignored errors when the `Error` wrapper struct contains `None` instead of `Vec` of `String` messages.
