### PR TITLE
Update documentation on creating a parser: minor inconsitency on the generated files

### DIFF
--- a/docs/section-3-creating-parsers.md
+++ b/docs/section-3-creating-parsers.md
@@ -100,8 +100,10 @@ The most important command you'll use is `tree-sitter generate`. This command re
 The first time you run `tree-sitter generate`, it will also generate a few other files:
 
 * `binding.gyp` - This file tells Node.js how to compile your language.
-* `index.js` - This is the file that Node.js initially loads when using your language.
-* `src/binding.cc` - This file wraps your language in a JavaScript object when used in Node.js
+* `bindings/node/index.js` - This is the file that Node.js initially loads when using your language.
+* `bindings/node/binding.cc` - This file wraps your language in a JavaScript object when used in Node.js.
+* `bindings/rust/lib.rs` - This file wraps your language in a Rust crate when used in Rust.
+* `bindings/rust/build.rs` - This file wraps the building process for the Rust crate.
 * `src/tree_sitter/parser.h` - This file provides some basic C definitions that are used in your generated `parser.c` file.
 
 If there is an ambiguity or *local ambiguity* in your grammar, Tree-sitter will detect it during parser generation, and it will exit with a `Unresolved conflict` error message. See below for more information on these errors.
@@ -702,7 +704,7 @@ if (valid_symbols[INDENT] || valid_symbol[DEDENT]) {
 [cst]: https://en.wikipedia.org/wiki/Parse_tree
 [dfa]: https://en.wikipedia.org/wiki/Deterministic_finite_automaton
 [ebnf]: https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form
-[ecmascript-spec]: https://www.ecma-international.org/ecma-262/6.0
+[ecmascript-spec]: https://262.ecma-international.org/6.0/
 [ejs]: https://ejs.co
 [enum]: https://en.wikipedia.org/wiki/Enumerated_type#C
 [glr-parsing]: https://en.wikipedia.org/wiki/GLR_parser


### PR DESCRIPTION
Hello 👋 

I was going through the documentation about creating a parser on the website and spotted a few differences on the generated files in between what I got and what the doc talks about. Thus this is a very minor change, feel free to close this PR if that's not worth it. 

⚠️ Being a totally new user with no previous knowlegde of Tree-Sitter, it'd be better to proof-read my guesses at writing a description for the new files, as they may not be the clearest definition. 

There's also a broken link, but that's a rather straightforward change. 