### PR TITLE
Stylistic fix for #1135 - Panic on broken pipe

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -106,11 +106,10 @@ impl From<serde_json::Error> for Error {
 
 impl From<io::Error> for Error {
     fn from(error: io::Error) -> Self {
-        match error {
-            x if x.kind() == ErrorKind::BrokenPipe => return Error::new_ignored(),
-            _ => (),
+        match error.kind() {
+            ErrorKind::BrokenPipe => Error::new_ignored(),
+            _ => Error::new(error.to_string()),
         }
-        Error::new(error.to_string())
     }
 }
 


### PR DESCRIPTION
I somehow overlooked that it's possible to clearly express error handling only with the match arms.