### PR TITLE
fix(cli): Don't print 'Error:' prefix

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,17 +12,20 @@ use tree_sitter_loader as loader;
 const BUILD_VERSION: &'static str = env!("CARGO_PKG_VERSION");
 const BUILD_SHA: Option<&'static str> = option_env!("BUILD_SHA");
 
-fn main() -> Result<()> {
+fn main() {
     let result = run();
-    // Ignore BrokenPipe errors
     if let Err(err) = &result {
+        // Ignore BrokenPipe errors
         if let Some(error) = err.downcast_ref::<std::io::Error>() {
             if error.kind() == std::io::ErrorKind::BrokenPipe {
-                return Ok(());
+                return;
             }
         }
+        if !err.to_string().is_empty() {
+            eprintln!("{:?}", err);
+        }
+        std::process::exit(1);
     }
-    result
 }
 
 fn run() -> Result<()> {


### PR DESCRIPTION
Follow up for #1152

Currently `tree-sitter parse` command shows weird empty error prefix cause there is a code:
https://github.com/tree-sitter/tree-sitter/blob/6ed42747a4e0faee9b65edbbacc86ed0caeae05c/cli/src/main.rs#L303-L305
That should set some system error code without printing any error messages, but the `anyhow` library prints the `Error: ` prefix even for empty error messages:
```console
# tree-sitter parse lib/include/tree_sitter/api.corrupted_file.h
lib/include/tree_sitter/api.corrupted_file.h	2 ms	(ERROR [897, 0] - [897, 47])
Error:
```
This PR removes printing of the prefix for empty messages.