### PR TITLE
feat(cli): Set TREE_SITTER_DEBUG env var on 'tree-sitter parse -d'

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -282,6 +282,11 @@ fn run() -> Result<()> {
                 .map_or(Vec::new(), |e| e.collect());
             let cancellation_flag = util::cancel_on_stdin();
 
+            if debug {
+                // For augmenting debug logging in external scanners
+                env::set_var("TREE_SITTER_DEBUG", "1");
+            }
+
             let timeout = matches
                 .value_of("timeout")
                 .map_or(0, |t| u64::from_str_radix(t, 10).unwrap());


### PR DESCRIPTION
This PR adds `TREE_SITTER_DEBUG` environment variable internally set by `tree-sitter parse` command when used with the `-d` flag.
This allows to check this environment variable in the external scanner code and additionally augment debug logging conditionally and print it simultaneously only with tree-sitter parser own logging.

_Example:_
```c++
void *tree_sitter_NAME_external_scanner_create() {
    return new Scanner(std::getenv("TREE_SITTER_DEBUG"));
}
```