### PR TITLE
feat(cli/loader): Add TREE_SITTER_INTERNAL_BUILD C/C++ compiler definition

### DIFF
--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -391,6 +391,11 @@ impl Loader {
                     .arg("-o")
                     .arg(&library_path)
                     .arg("-O2");
+
+                // For conditional compilation of external scanner code when
+                // used internally by `tree-siteer parse` and other sub commands.
+                command.arg("-DTREE_SITTER_INTERNAL_BUILD");
+
                 if let Some(scanner_path) = scanner_path.as_ref() {
                     if scanner_path.extension() == Some("c".as_ref()) {
                         command.arg("-xc").arg("-std=c99").arg(scanner_path);


### PR DESCRIPTION
Follow up for use case from #1186.
This PR adds C/C++ compiler macro definition that allows to detect that the external scanner was compiled directly by `tree-sitter parse` or other sub command and allows conditionally enable additional debug logic.

_Example:_
```c++
void *tree_sitter_NAME_external_scanner_create() {
  #ifdef TREE_SITTER_INTERNAL_BUILD
    return new Scanner(std::getenv("TREE_SITTER_DEBUG"));
  #else
    return new Scanner();
  #endif
}
```
```c++
struct Scanner {

#ifdef TREE_SITTER_INTERNAL_BUILD
  bool debug;
  Scanner(bool debug) {
    this->debug = debug;
  }
#endif

  void print_lookahead(TSLexer* lexer) {
    #ifdef TREE_SITTER_INTERNAL_BUILD
      if (debug) {
        string s;
        switch (lexer->lookahead) {
        case 0x20: s = "\\s"; break;
        case '\t': s = "\\t"; break;
        case '\n': s = "\\n"; break;
        case '\v': s = "\\v"; break;
        case '\f': s = "\\f"; break;
        case '\r': s = "\\r"; break;
        default: s = lexer->lookahead; break;
        }
        std::cout << "la " << s << " " << lexer->lookahead << std::endl;
      }
    #endif
  }

  void print_column(TSLexer* lexer) {
    #ifdef TREE_SITTER_INTERNAL_BUILD
      if (debug) {
        std::cout << "col " << lexer->get_column(lexer) << std::endl;
      }
    #endif
  }

};
```
