### PR TITLE
feat(cli): Independent binding files generation

### DIFF
--- a/cli/src/generate/binding_files.rs
+++ b/cli/src/generate/binding_files.rs
@@ -57,7 +57,7 @@ pub fn generate_binding_files(repo_path: &Path, language_name: &str) -> Result<(
             eprintln!("Updating binding.gyp with new binding path");
             let binding_gyp =
                 fs::read_to_string(path).with_context(|| "Failed to read binding.gyp")?;
-            let binding_gyp = binding_gyp.replace("src/binding.cc", "bindings/node/binding.cc");
+            let binding_gyp = binding_gyp.replace("\"src/binding.cc\"", "\"bindings/node/binding.cc\"");
             write_file(path, binding_gyp)
         },
     )?;


### PR DESCRIPTION
Closes #1195

This PR introduces approach that binding files and related folders restore independently but in proper order so tree-sitter will always restore a full shape of all components for all bindings.