### PR TITLE
feat(cli): colored help and frequent command aliases

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -169,8 +169,11 @@ fn run() -> Result<()> {
                 .arg(Arg::with_name("path").index(1).multiple(true)),
         )
         .subcommand(
-            SubCommand::with_name("web-ui")
-                .about("Test a parser interactively in the browser")
+            SubCommand::with_name("playground")
+                .alias("play")
+                .alias("pg")
+                .alias("web-ui")
+                .about("Start local playground for a parser in the browser")
                 .arg(
                     Arg::with_name("quiet")
                         .long("quiet")
@@ -437,7 +440,7 @@ fn run() -> Result<()> {
             wasm::compile_language_to_wasm(&grammar_path, matches.is_present("docker"))?;
         }
 
-        ("web-ui", Some(matches)) => {
+        ("playground", Some(matches)) => {
             let open_in_browser = !matches.is_present("quiet");
             web_ui::serve(&current_dir, open_in_browser);
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -40,6 +40,7 @@ fn run() -> Result<()> {
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .author("Max Brunsfeld <maxbrunsfeld@gmail.com>")
         .about("Generates and tests parsers")
+        .global_setting(AppSettings::ColoredHelp)
         .subcommand(SubCommand::with_name("init-config").about("Generate a default config file"))
         .subcommand(
             SubCommand::with_name("generate")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -154,7 +154,7 @@ fn run() -> Result<()> {
                         .required(false),
                 )
                 .arg(Arg::with_name("scope").long("scope").takes_value(true))
-                .arg(Arg::with_name("html").long("html").short("h"))
+                .arg(Arg::with_name("html").long("html").short("H"))
                 .arg(Arg::with_name("time").long("time").short("t"))
                 .arg(Arg::with_name("quiet").long("quiet").short("q")),
         )

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -44,6 +44,8 @@ fn run() -> Result<()> {
         .subcommand(SubCommand::with_name("init-config").about("Generate a default config file"))
         .subcommand(
             SubCommand::with_name("generate")
+                .alias("gen")
+                .alias("g")
                 .about("Generate a parser")
                 .arg(Arg::with_name("grammar-path").index(1))
                 .arg(Arg::with_name("log").long("log"))
@@ -59,6 +61,7 @@ fn run() -> Result<()> {
         )
         .subcommand(
             SubCommand::with_name("parse")
+                .alias("p")
                 .about("Parse files")
                 .arg(Arg::with_name("paths-file").long("paths").takes_value(true))
                 .arg(
@@ -86,6 +89,7 @@ fn run() -> Result<()> {
         )
         .subcommand(
             SubCommand::with_name("query")
+                .alias("q")
                 .about("Search files using a syntax tree query")
                 .arg(Arg::with_name("query-path").index(1).required(true))
                 .arg(Arg::with_name("paths-file").long("paths").takes_value(true))
@@ -120,6 +124,7 @@ fn run() -> Result<()> {
         )
         .subcommand(
             SubCommand::with_name("test")
+                .alias("t")
                 .about("Run a parser's tests")
                 .arg(
                     Arg::with_name("filter")
@@ -154,6 +159,7 @@ fn run() -> Result<()> {
         )
         .subcommand(
             SubCommand::with_name("build-wasm")
+                .alias("bw")
                 .about("Compile a parser to WASM")
                 .arg(
                     Arg::with_name("docker")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -41,6 +41,7 @@ fn run() -> Result<()> {
         .author("Max Brunsfeld <maxbrunsfeld@gmail.com>")
         .about("Generates and tests parsers")
         .global_setting(AppSettings::ColoredHelp)
+        .global_setting(AppSettings::DisableHelpSubcommand)
         .subcommand(SubCommand::with_name("init-config").about("Generate a default config file"))
         .subcommand(
             SubCommand::with_name("generate")


### PR DESCRIPTION
This PR: 
* Enables builtin Clap's coloring for the help output.
* Adds short aliases for frequent sub commands:
  * _generate - gen, g_
  * _parse - p_
  * _query - q_
  * _test - t_
  * _build-wasm - bw_
  * _playground - play, pg_
* Renames `web-ui` sub command to `playground` with a backward compatible `web-ui` alias. This change is controversial but it seems most users know about [Playground](https://tree-sitter.github.io/tree-sitter/playground) in the documentation but don't realize that they have the same but for their local grammar.
* Removes `help` subcommand, it's the same as `--help, -h` flags but among all sub commands doesn't make any real action.
* Change `-h` -> `-H` for the highlight sub command to don't clash with the standard help flag, cause it's unexpected that it's possible to use `-h` to call the help except for `highlight` sub command.