### PR TITLE
Add link to chess Portable Game Notation grammar

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ Parsers for these languages are fairly complete:
 * [Markdown](https://github.com/ikatyang/tree-sitter-markdown)
 * [OCaml](https://github.com/tree-sitter/tree-sitter-ocaml)
 * [PHP](https://github.com/tree-sitter/tree-sitter-php)
+* [Portable Game Notation](https://github.com/rolandwalker/tree-sitter-pgn)
 * [Python](https://github.com/tree-sitter/tree-sitter-python)
 * [Ruby](https://github.com/tree-sitter/tree-sitter-ruby)
 * [Rust](https://github.com/tree-sitter/tree-sitter-rust)


### PR DESCRIPTION
You may find this link irrelevant, or you may find it amusing.

Portable Game Notation (PGN) is the standard format for storage and interchange of chess games.

While tree-sitter cannot enforce the rules of chess, it can express the constraints of the notation nicely.

In writing this, I did find myself wishing for some type of dialect support, though I realize that's not easy.