### PR TITLE
fix(cli): init-config experience, it shouldn't silently overwrite existing config file

### DIFF
--- a/cli/config/src/lib.rs
+++ b/cli/config/src/lib.rs
@@ -20,7 +20,7 @@ pub struct Config {
 }
 
 impl Config {
-    fn find_config_file() -> Result<Option<PathBuf>> {
+    pub fn find_config_file() -> Result<Option<PathBuf>> {
         if let Ok(path) = env::var("TREE_SITTER_DIR") {
             let mut path = PathBuf::from(path);
             path.push("config.json");

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -36,11 +36,12 @@ fn run() -> Result<()> {
     };
 
     let matches = App::new("tree-sitter")
-        .version(version.as_str())
-        .setting(AppSettings::SubcommandRequiredElseHelp)
         .author("Max Brunsfeld <maxbrunsfeld@gmail.com>")
         .about("Generates and tests parsers")
+        .version(version.as_str())
+        .setting(AppSettings::SubcommandRequiredElseHelp)
         .global_setting(AppSettings::ColoredHelp)
+        .global_setting(AppSettings::DeriveDisplayOrder)
         .global_setting(AppSettings::DisableHelpSubcommand)
         .subcommand(SubCommand::with_name("init-config").about("Generate a default config file"))
         .subcommand(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -194,6 +194,12 @@ fn run() -> Result<()> {
 
     match matches.subcommand() {
         ("init-config", Some(_)) => {
+            if let Ok(Some(config_path)) = Config::find_config_file() {
+                return Err(anyhow!(
+                    "Remove your existing config file first: {}",
+                    config_path.to_string_lossy()
+                ));
+            }
             let mut config = Config::initial()?;
             config.add(tree_sitter_loader::Config::initial())?;
             config.add(tree_sitter_cli::highlight::ThemeConfig::default())?;


### PR DESCRIPTION
Add a fuse to decline silently overwrite of existing config file cause users may have there own grammar lookup paths and custom highlighting configuration.
Also this PR adds the `DeriveDisplayOrder` Clap's setting to show sub commands in the defined order that looks more accurate and have more meaning for sub commands use order.