### PR TITLE
fix(cli): Improve error messages on config.json loading, closes #1227

### DIFF
--- a/cli/config/src/lib.rs
+++ b/cli/config/src/lib.rs
@@ -1,6 +1,6 @@
 //! Manages tree-sitter's configuration file.
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::PathBuf;
@@ -64,8 +64,10 @@ impl Config {
             Some(location) => location,
             None => return Config::initial(),
         };
-        let content = fs::read_to_string(&location)?;
-        let config = serde_json::from_str(&content)?;
+        let content = fs::read_to_string(&location)
+            .with_context(|| format!("Failed to read {}", &location.to_string_lossy()))?;
+        let config = serde_json::from_str(&content)
+            .with_context(|| format!("Bad JSON config {}", &location.to_string_lossy()))?;
         Ok(Config { location, config })
     }
 


### PR DESCRIPTION
Closes #1227

Now it looks like:
```console
# tree-sitter highlight foobar
Failed to read /home/user1/.config/tree-sitter/config.json

Caused by:
    Permission denied (os error 13)
```
OR
```console
# tree-sitter highlight foobar
Bad JSON config /home/user1/.config/tree-sitter/config.json

Caused by:
    trailing comma at line 55 column 3
```