### PR TITLE
Use emcc modularize option

### DIFF
--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -1206,3 +1206,4 @@ function marshalEdit(edit) {
 
 Parser.Language = Language;
 Parser.Parser = Parser;
+C.Parser = Parser;

--- a/lib/binding_web/check-artifacts-fresh.js
+++ b/lib/binding_web/check-artifacts-fresh.js
@@ -8,7 +8,6 @@ const inputFiles = [
   'binding.js',
   'exports.json',
   'imports.js',
-  'prefix.js',
   ...list('../include/tree_sitter'),
   ...list('../src')
 ]

--- a/lib/binding_web/prefix.js
+++ b/lib/binding_web/prefix.js
@@ -1,9 +1,0 @@
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define([], factory);
-  } else if (typeof exports === 'object') {
-    module.exports = factory();
-  } else {
-    window.TreeSitter = factory();
-  }
-}(this, function () {

--- a/lib/binding_web/suffix.js
+++ b/lib/binding_web/suffix.js
@@ -1,2 +1,0 @@
-return Parser;
-}));

--- a/lib/binding_web/test/helper.js
+++ b/lib/binding_web/test/helper.js
@@ -1,11 +1,11 @@
-const Parser = require(`..`);
+const TreeSitter = require(`..`);
 
 function languageURL(name) {
   return require.resolve(`../../../target/release/tree-sitter-${name}.wasm`);
 }
 
-module.exports = Parser.init().then(async () => ({
-  Parser,
+module.exports = TreeSitter().then(async (module) => ({
+  Parser: module.Parser,
   languageURL,
-  JavaScript: await Parser.Language.load(languageURL('javascript')),
+  JavaScript: await module.Parser.Language.load(languageURL('javascript')),
 }));

--- a/lib/binding_web/tree-sitter-web.d.ts
+++ b/lib/binding_web/tree-sitter-web.d.ts
@@ -1,6 +1,6 @@
 declare module 'web-tree-sitter' {
 
-  declare namespace TreeSitter {
+  namespace TreeSitter {
 
     class Parser {
       static init(): Promise<void>;
@@ -178,7 +178,7 @@ declare module 'web-tree-sitter' {
     [key: string]: any;
   }
 
-  declare function TreeSitter(module?: object): Promise<TreeSitterModule>;
+  function TreeSitter(module?: object): Promise<TreeSitterModule>;
 
   export = TreeSitter
 

--- a/lib/binding_web/tree-sitter-web.d.ts
+++ b/lib/binding_web/tree-sitter-web.d.ts
@@ -1,171 +1,185 @@
 declare module 'web-tree-sitter' {
-  class Parser {
-    static init(): Promise<void>;
-    delete(): void;
-    parse(input: string | Parser.Input, previousTree?: Parser.Tree, options?: Parser.Options): Parser.Tree;
-    getLanguage(): any;
-    setLanguage(language: any): void;
-    getLogger(): Parser.Logger;
-    setLogger(logFunc: Parser.Logger): void;
-  }
 
-  namespace Parser {
-    export type Options = {
-      includedRanges?: Range[];
-    };
+  declare namespace TreeSitter {
 
-    export type Point = {
-      row: number;
-      column: number;
-    };
-
-    export type Range = {
-      startPosition: Point;
-      endPosition: Point;
-      startIndex: number;
-      endIndex: number;
-    };
-
-    export type Edit = {
-      startIndex: number;
-      oldEndIndex: number;
-      newEndIndex: number;
-      startPosition: Point;
-      oldEndPosition: Point;
-      newEndPosition: Point;
-    };
-
-    export type Logger = (
-      message: string,
-      params: { [param: string]: string },
-      type: "parse" | "lex"
-    ) => void;
-
-    export type Input = (
-      startIndex: number,
-      startPoint?: Point,
-      endIndex?: number,
-    ) => string | null;
-
-    export interface SyntaxNode {
-      id: number;
-      tree: Tree;
-      type: string;
-      text: string;
-      startPosition: Point;
-      endPosition: Point;
-      startIndex: number;
-      endIndex: number;
-      parent: SyntaxNode | null;
-      children: Array<SyntaxNode>;
-      namedChildren: Array<SyntaxNode>;
-      childCount: number;
-      namedChildCount: number;
-      firstChild: SyntaxNode | null;
-      firstNamedChild: SyntaxNode | null;
-      lastChild: SyntaxNode | null;
-      lastNamedChild: SyntaxNode | null;
-      nextSibling: SyntaxNode | null;
-      nextNamedSibling: SyntaxNode | null;
-      previousSibling: SyntaxNode | null;
-      previousNamedSibling: SyntaxNode | null;
-
-      hasChanges(): boolean;
-      hasError(): boolean;
-      equals(other: SyntaxNode): boolean;
-      isMissing(): boolean;
-      isNamed(): boolean;
-      toString(): string;
-      child(index: number): SyntaxNode | null;
-      namedChild(index: number): SyntaxNode | null;
-      childForFieldId(fieldId: number): SyntaxNode | null;
-      childForFieldName(fieldName: string): SyntaxNode | null;
-
-      descendantForIndex(index: number): SyntaxNode;
-      descendantForIndex(startIndex: number, endIndex: number): SyntaxNode;
-      descendantsOfType(type: string | Array<string>, startPosition?: Point, endPosition?: Point): Array<SyntaxNode>;
-      namedDescendantForIndex(index: number): SyntaxNode;
-      namedDescendantForIndex(startIndex: number, endIndex: number): SyntaxNode;
-      descendantForPosition(position: Point): SyntaxNode;
-      descendantForPosition(startPosition: Point, endPosition: Point): SyntaxNode;
-      namedDescendantForPosition(position: Point): SyntaxNode;
-      namedDescendantForPosition(startPosition: Point, endPosition: Point): SyntaxNode;
-
-      walk(): TreeCursor;
-    }
-
-    export interface TreeCursor {
-      nodeType: string;
-      nodeText: string;
-      nodeIsNamed: boolean;
-      startPosition: Point;
-      endPosition: Point;
-      startIndex: number;
-      endIndex: number;
-
-      reset(node: SyntaxNode): void;
+    class Parser {
+      static init(): Promise<void>;
       delete(): void;
-      currentNode(): SyntaxNode;
-      currentFieldId(): number;
-      currentFieldName(): string;
-      gotoParent(): boolean;
-      gotoFirstChild(): boolean;
-      gotoFirstChildForIndex(index: number): boolean;
-      gotoNextSibling(): boolean;
-    }
-
-    export interface Tree {
-      readonly rootNode: SyntaxNode;
-
-      copy(): Tree;
-      delete(): void;
-      edit(delta: Edit): Tree;
-      walk(): TreeCursor;
-      getChangedRanges(other: Tree): Range[];
-      getEditedRange(other: Tree): Range;
+      parse(input: string | Parser.Input, previousTree?: Parser.Tree, options?: Parser.Options): Parser.Tree;
       getLanguage(): any;
+      setLanguage(language: any): void;
+      getLogger(): Parser.Logger;
+      setLogger(logFunc: Parser.Logger): void;
+      setTimeoutMicros(value: number): void;
+      getTimeoutMicros(): number;
     }
 
-    class Language {
-      static load(input: string | Uint8Array): Promise<Language>;
+    namespace Parser {
+      export type Options = {
+        includedRanges?: Range[];
+      };
 
-      readonly version: number;
-      readonly fieldCount: number;
-      readonly nodeTypeCount: number;
+      export type Point = {
+        row: number;
+        column: number;
+      };
 
-      fieldNameForId(fieldId: number): string | null;
-      fieldIdForName(fieldName: string): number | null;
-      idForNodeType(type: string, named: boolean): number;
-      nodeTypeForId(typeId: number): string | null;
-      nodeTypeIsNamed(typeId: number): boolean;
-      nodeTypeIsVisible(typeId: number): boolean;
-      query(source: string): Query;
-    }
+      export type Range = {
+        startPosition: Point;
+        endPosition: Point;
+        startIndex: number;
+        endIndex: number;
+      };
 
-    interface QueryCapture {
-      name: string;
-      node: SyntaxNode;
-    }
+      export type Edit = {
+        startIndex: number;
+        oldEndIndex: number;
+        newEndIndex: number;
+        startPosition: Point;
+        oldEndPosition: Point;
+        newEndPosition: Point;
+      };
 
-    interface QueryMatch {
-      pattern: number;
-      captures: QueryCapture[];
-    }
+      export type Logger = (
+        message: string,
+        params: { [param: string]: string },
+        type: "parse" | "lex"
+      ) => void;
 
-    interface PredicateResult {
-      operator: string;
-      operands: { name: string; type: string }[];
-    }
+      export type Input = (
+        startIndex: number,
+        startPoint?: Point,
+        endIndex?: number,
+      ) => string | null;
 
-    class Query {
-      captureNames: string[];
+      export interface SyntaxNode {
+        id: number;
+        tree: Tree;
+        type: string;
+        text: string;
+        startPosition: Point;
+        endPosition: Point;
+        startIndex: number;
+        endIndex: number;
+        parent: SyntaxNode | null;
+        children: Array<SyntaxNode>;
+        namedChildren: Array<SyntaxNode>;
+        childCount: number;
+        namedChildCount: number;
+        firstChild: SyntaxNode | null;
+        firstNamedChild: SyntaxNode | null;
+        lastChild: SyntaxNode | null;
+        lastNamedChild: SyntaxNode | null;
+        nextSibling: SyntaxNode | null;
+        nextNamedSibling: SyntaxNode | null;
+        previousSibling: SyntaxNode | null;
+        previousNamedSibling: SyntaxNode | null;
 
-      delete(): void;
-      matches(node: SyntaxNode, startPosition?: Point, endPosition?: Point): QueryMatch[];
-      captures(node: SyntaxNode, startPosition?: Point, endPosition?: Point): QueryCapture[];
-      predicatesForPattern(patternIndex: number): PredicateResult[];
+        hasChanges(): boolean;
+        hasError(): boolean;
+        equals(other: SyntaxNode): boolean;
+        isMissing(): boolean;
+        isNamed(): boolean;
+        toString(): string;
+        child(index: number): SyntaxNode | null;
+        namedChild(index: number): SyntaxNode | null;
+        childForFieldId(fieldId: number): SyntaxNode | null;
+        childForFieldName(fieldName: string): SyntaxNode | null;
+
+        descendantForIndex(index: number): SyntaxNode;
+        descendantForIndex(startIndex: number, endIndex: number): SyntaxNode;
+        descendantsOfType(type: string | Array<string>, startPosition?: Point, endPosition?: Point): Array<SyntaxNode>;
+        namedDescendantForIndex(index: number): SyntaxNode;
+        namedDescendantForIndex(startIndex: number, endIndex: number): SyntaxNode;
+        descendantForPosition(position: Point): SyntaxNode;
+        descendantForPosition(startPosition: Point, endPosition: Point): SyntaxNode;
+        namedDescendantForPosition(position: Point): SyntaxNode;
+        namedDescendantForPosition(startPosition: Point, endPosition: Point): SyntaxNode;
+
+        walk(): TreeCursor;
+      }
+
+      export interface TreeCursor {
+        nodeType: string;
+        nodeText: string;
+        nodeIsNamed: boolean;
+        startPosition: Point;
+        endPosition: Point;
+        startIndex: number;
+        endIndex: number;
+
+        reset(node: SyntaxNode): void;
+        delete(): void;
+        currentNode(): SyntaxNode;
+        currentFieldId(): number;
+        currentFieldName(): string;
+        gotoParent(): boolean;
+        gotoFirstChild(): boolean;
+        gotoFirstChildForIndex(index: number): boolean;
+        gotoNextSibling(): boolean;
+      }
+
+      export interface Tree {
+        readonly rootNode: SyntaxNode;
+
+        copy(): Tree;
+        delete(): void;
+        edit(delta: Edit): Tree;
+        walk(): TreeCursor;
+        getChangedRanges(other: Tree): Range[];
+        getEditedRange(other: Tree): Range;
+        getLanguage(): any;
+      }
+
+      class Language {
+        static load(input: string | Uint8Array): Promise<Language>;
+
+        readonly version: number;
+        readonly fieldCount: number;
+        readonly nodeTypeCount: number;
+
+        fieldNameForId(fieldId: number): string | null;
+        fieldIdForName(fieldName: string): number | null;
+        idForNodeType(type: string, named: boolean): number;
+        nodeTypeForId(typeId: number): string | null;
+        nodeTypeIsNamed(typeId: number): boolean;
+        nodeTypeIsVisible(typeId: number): boolean;
+        query(source: string): Query;
+      }
+
+      interface QueryCapture {
+        name: string;
+        node: SyntaxNode;
+      }
+
+      interface QueryMatch {
+        pattern: number;
+        captures: QueryCapture[];
+      }
+
+      interface PredicateResult {
+        operator: string;
+        operands: { name: string; type: string }[];
+      }
+
+      class Query {
+        captureNames: string[];
+
+        delete(): void;
+        matches(node: SyntaxNode, startPosition?: Point, endPosition?: Point): QueryMatch[];
+        captures(node: SyntaxNode, startPosition?: Point, endPosition?: Point): QueryCapture[];
+        predicatesForPattern(patternIndex: number): PredicateResult[];
+      }
     }
   }
 
-  export = Parser
+  interface TreeSitterModule {
+    Parser: typeof TreeSitter.Parser;
+    [key: string]: any;
+  }
+
+  declare function TreeSitter(module?: object): Promise<TreeSitterModule>;
+
+  export = TreeSitter
+
 }

--- a/script/build-wasm
+++ b/script/build-wasm
@@ -87,6 +87,7 @@ $emcc                                            \
   -s NO_FILESYSTEM=1                             \
   -s NODEJS_CATCH_EXIT=0                         \
   -s NODEJS_CATCH_REJECTION=0                    \
+  -s MODULARIZE=1 -s EXPORT_NAME='TreeSitter'    \
   -s EXPORTED_FUNCTIONS=@${web_dir}/exports.json \
   $emscripten_flags                              \
   -std=c99                                       \
@@ -95,9 +96,7 @@ $emcc                                            \
   -I lib/src                                     \
   -I lib/include                                 \
   --js-library ${web_dir}/imports.js             \
-  --pre-js ${web_dir}/prefix.js                  \
   --post-js ${web_dir}/binding.js                \
-  --post-js ${web_dir}/suffix.js                 \
   lib/src/lib.c                                  \
   ${web_dir}/binding.c                           \
   -o target/scratch/tree-sitter.js


### PR DESCRIPTION
tl;dr: fixes https://github.com/tree-sitter/tree-sitter/issues/559

This PR uses the [`MODULARIZE `](https://github.com/emscripten-core/emscripten/blob/667d416d84b33b5bdbf47de10a9780b85589117b/src/settings.js#L1161) and `EXPORT_NAME` options when invoking `emcc`. This makes emcc emit a top-level function which exports itself, thereby making prefix.js and suffix.js obsolete. 

The wanted effect of these changes is that the top-level function can be invoked with the emcc `Module` object. This allows to tweak some things, namely how the wasm-binary is located. E.g this is how I can now use tree-sitter:

```ts
import TreeSitter, { Parser } from 'web-tree-sitter';

TreeSitter({
  locateFile: (path) => {
    // massage `path` and return actual path
    return _applyPathMagic(path);
  }
}).then(module => {
  const parser = new module.Parser();
  // happy parsing!
});
```

Also, `Parser.init()` is becoming obsolete with these changes because the `TreeSitter` function returns a promise that resolves when things are ready. Tho, I didn't remove it yet as it also doesn't cause harm. 

The obvious down-side is that this is a breaking change which existing consumers need to adopt.