### PR TITLE
Adding API to get field name of a named TSNode

### DIFF
--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -274,6 +274,39 @@ fn test_node_field_name_for_child() {
 }
 
 #[test]
+fn test_node_field_name_for_named_child() {
+    let mut parser = Parser::new();
+    parser.set_language(get_language("c")).unwrap();
+    let tree = parser.parse("x + y;", None).unwrap();
+    let translation_unit_node = tree.root_node();
+    let binary_expression_node = translation_unit_node
+        .named_child(0)
+        .unwrap()
+        .named_child(0)
+        .unwrap();
+
+    assert_eq!(binary_expression_node.field_name_for_named_child(0), Some("left"));
+    // Operator is not a named child, so although operator is a child of binary expression,
+    // it is not a named child.
+    assert_ne!(
+        binary_expression_node.field_name_for_named_child(1),
+        Some("operator")
+    );
+    // Check operator's presence with unnamed child API.
+    assert_eq!(
+        binary_expression_node.field_name_for_child(1),
+        Some("operator")
+    );
+    // Child with field name "right" is a named child at index 1.
+    assert_eq!(
+        binary_expression_node.field_name_for_named_child(1),
+        Some("right")
+    );
+    // Negative test - Not a valid child index
+    assert_eq!(binary_expression_node.field_name_for_named_child(3), None);
+}
+
+#[test]
 fn test_node_child_by_field_name_with_extra_hidden_children() {
     let mut parser = Parser::new();
     parser.set_language(get_language("python")).unwrap();

--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -285,7 +285,11 @@ fn test_node_field_name_for_named_child() {
         .named_child(0)
         .unwrap();
 
-    assert_eq!(binary_expression_node.field_name_for_named_child(0), Some("left"));
+    assert_eq!(
+        binary_expression_node.field_name_for_named_child(0),
+        Some("left")
+    );
+
     // Operator is not a named child, so although operator is a child of binary expression,
     // it is not a named child.
     assert_ne!(

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -440,6 +440,14 @@ extern "C" {
     pub fn ts_node_field_name_for_child(arg1: TSNode, arg2: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Get the field name for node's named child at the given index, where zero"]
+    #[doc = " represents the first named child. Returns NULL, if no field is found."]
+    pub fn ts_node_field_name_for_named_child(
+        arg1: TSNode,
+        arg2: u32,
+    ) -> *const ::std::os::raw::c_char;
+}
+extern "C" {
     #[doc = " Get the node's number of children."]
     pub fn ts_node_child_count(arg1: TSNode) -> u32;
 }

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -897,6 +897,18 @@ impl<'tree> Node<'tree> {
         }
     }
 
+    /// Get the field name of this node's named child at the given index.
+    pub fn field_name_for_named_child(&self, child_index: u32) -> Option<&'static str> {
+        unsafe {
+            let ptr = ffi::ts_node_field_name_for_named_child(self.0, child_index);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(ptr).to_str().unwrap())
+            }
+        }
+    }
+
     /// Iterate over this node's children.
     ///
     /// A [TreeCursor] is used to retrieve the children efficiently. Obtain

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -494,6 +494,12 @@ TSNode ts_node_child(TSNode, uint32_t);
 const char *ts_node_field_name_for_child(TSNode, uint32_t);
 
 /**
+ * Get the field name for node's named child at the given index, where zero
+ * represents the first named child. Returns NULL, if no field is found.
+ */
+const char *ts_node_field_name_for_named_child(TSNode, uint32_t);
+
+/**
  * Get the node's number of children.
  */
 uint32_t ts_node_child_count(TSNode);

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -586,6 +586,33 @@ const char *ts_node_field_name_for_child(TSNode self, uint32_t child_index) {
   return NULL;
 }
 
+const char *ts_node_field_name_for_named_child(
+    TSNode self, uint32_t named_child_index) {
+  // Obtain index of child in the list of children from the index of
+  // named child.
+  TSNode child;
+  uint32_t child_index = 0;
+  NodeChildIterator iterator = ts_node_iterate_children(&self);
+  while (ts_node_child_iterator_next(&iterator, &child)) {
+    if (ts_node_is_named(child)) {
+      if (named_child_index == 0) {
+        break;
+      } else {
+        child_index++;
+        named_child_index--;
+      }
+    } else {
+      child_index++;
+    }
+  }
+
+  // If no named child is found for the given index, return NULL.
+  if (named_child_index != 0) {
+    return NULL;
+  }
+  return ts_node_field_name_for_child(self, child_index);
+}
+
 TSNode ts_node_child_by_field_name(
   TSNode self,
   const char *name,


### PR DESCRIPTION
This PR adds an API to get name of the field of TSNode's named child.
It uses same set of arguments as that of ts_node_field_name_for_child, but returns
field name if it is found, otherwise it returns NULL.

This API is useful to implement custom printing of S-expressions such
as following:

```
(binary_expression
  (binary_expression_left (identifier))
  (binary_expression_operator ("+"))
  (binary_expression_right (identifier))
)
```

The added API's purpose is same as that of ts_node_field_name_for_child,
but differs in the handling of named child. ts_node_field_name_for_child
does not support named child.