### PR TITLE
fix(parser): count rows in the debug log from 0

### DIFF
--- a/cli/src/tests/parser_test.rs
+++ b/cli/src/tests/parser_test.rs
@@ -63,9 +63,14 @@ fn test_parsing_with_logging() {
     )));
     assert!(messages.contains(&(LogType::Lex, "skip character:' '".to_string())));
 
+    let mut row_starts_from_0 = false;
     for (_, m) in &messages {
-        assert!(!m.contains("row:0"));
+        if m.contains("row:0") {
+            row_starts_from_0 = true;
+            break;
+        }
     }
+    assert!(row_starts_from_0);
 }
 
 #[test]

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -417,7 +417,7 @@ static Subtree ts_parser__lex(
       LOG(
         "lex_external state:%d, row:%u, column:%u",
         lex_mode.external_lex_state,
-        current_position.extent.row + 1,
+        current_position.extent.row,
         current_position.extent.column
       );
       ts_lexer_start(&self->lexer);
@@ -456,7 +456,7 @@ static Subtree ts_parser__lex(
     LOG(
       "lex_internal state:%d, row:%u, column:%u",
       lex_mode.lex_state,
-      current_position.extent.row + 1,
+      current_position.extent.row,
       current_position.extent.column
     );
     ts_lexer_start(&self->lexer);
@@ -1884,7 +1884,7 @@ TSTree *ts_parser_parse(
         LOG("process version:%d, version_count:%u, state:%d, row:%u, col:%u",
             version, ts_stack_version_count(self->stack),
             ts_stack_state(self->stack, version),
-            ts_stack_position(self->stack, version).extent.row + 1,
+            ts_stack_position(self->stack, version).extent.row,
             ts_stack_position(self->stack, version).extent.column);
 
         if (!ts_parser__advance(self, version, allow_node_reuse)) return NULL;


### PR DESCRIPTION
Currently in the `tree-sitter parse -d` debug log the rows counting starts from 1, this PR changes it to 0.

**Pros:**
- Rows for the tree-sitter node ranges starts from 0 and I think this should be the main source of truth for all other logs, outputs, etc.
- I suppose many users when use the `-d` flag for `tree-sitter parse` command trying to find log records related to the `ERROR` error nodes to lookup what preceded for the errors.
- I'm not sure about many editors / IDEs but for ex. VSCode internally for all highlighting tokens uses the ranges row counting started from 0. So counting from the 1 in the UI is just a visual representation.

**Cons:**
- The debug log rows wouldn't be equal to editors' UI row numbers, but these are always on an adjacent row and it's pretty easy visually identify proper row in the UI, _than the incorrectly numbered debug log records **if it's important that those to be in-sync with parsing tree node ranges.**_ 

**Also good to note:**
On many Unix-like systems there is the `nl` tool from a widely present `coreutils` package and it can be used like:
```console
nl -ba -v0 <filepath>
```
It shows a file content with the row numbering started from zero.