### PR TITLE
Generate header file

### DIFF
--- a/cli/src/generate/mod.rs
+++ b/cli/src/generate/mod.rs
@@ -101,7 +101,7 @@ pub fn generate_parser_in_directory(
     Ok(())
 }
 
-pub fn generate_parser_for_grammar(grammar_json: &str) -> Result<(String, String)> {
+pub fn generate_parser_for_grammar(grammar_json: &str) -> Result<(String, String, String)> {
     let grammar_json = JSON_COMMENT_REGEX.replace_all(grammar_json, "\n");
     let input_grammar = parse_grammar(&grammar_json)?;
     let (syntax_grammar, lexical_grammar, inlines, simple_aliases) =
@@ -115,7 +115,7 @@ pub fn generate_parser_for_grammar(grammar_json: &str) -> Result<(String, String
         true,
         None,
     )?;
-    Ok((input_grammar.name, parser.c_code))
+    Ok((input_grammar.name, parser.c_code, parser.header_code))
 }
 
 fn generate_parser_for_grammar_with_opts(

--- a/cli/src/generate/mod.rs
+++ b/cli/src/generate/mod.rs
@@ -87,7 +87,7 @@ pub fn generate_parser_in_directory(
     )?;
 
     write_file(&src_path.join("parser.c"), c_code)?;
-    write_file(&src_path.join("enums.h"), header_code)?;
+    write_file(&src_path.join("parser.h"), header_code)?;
     write_file(&src_path.join("node-types.json"), node_types_json)?;
 
     if next_abi {

--- a/cli/src/generate/mod.rs
+++ b/cli/src/generate/mod.rs
@@ -34,6 +34,7 @@ lazy_static! {
 
 struct GeneratedParser {
     c_code: String,
+    header_code: String,
     node_types_json: String,
 }
 
@@ -73,6 +74,7 @@ pub fn generate_parser_in_directory(
     // Generate the parser and related files.
     let GeneratedParser {
         c_code,
+        header_code,
         node_types_json,
     } = generate_parser_for_grammar_with_opts(
         &language_name,
@@ -85,6 +87,7 @@ pub fn generate_parser_in_directory(
     )?;
 
     write_file(&src_path.join("parser.c"), c_code)?;
+    write_file(&src_path.join("enums.h"), header_code)?;
     write_file(&src_path.join("node-types.json"), node_types_json)?;
 
     if next_abi {
@@ -140,7 +143,7 @@ fn generate_parser_for_grammar_with_opts(
         &inlines,
         report_symbol_name,
     )?;
-    let c_code = render_c_code(
+    let (c_code, header_code) = render_c_code(
         name,
         parse_table,
         main_lex_table,
@@ -153,6 +156,7 @@ fn generate_parser_for_grammar_with_opts(
     );
     Ok(GeneratedParser {
         c_code,
+        header_code,
         node_types_json: serde_json::to_string_pretty(&node_types_json).unwrap(),
     })
 }

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -1305,6 +1305,7 @@ impl Generator {
 
     fn add_parser_export(&mut self, header_file: &mut GeneratorFile, gen_file: &mut GeneratorFile) {
         let language_function_name = format!("tree_sitter_{}", self.language_name);
+        let language_function_signature = format!("extern const TSLanguage *{}(void)", language_function_name);
         let external_scanner_name = format!("{}_external_scanner", language_function_name);
 
         add_line!(gen_file, "#ifdef __cplusplus");
@@ -1337,13 +1338,9 @@ impl Generator {
         add_line!(gen_file, "#endif");
         add_line!(gen_file, "");
 
-        add_line!(header_file, "const TSLanguage *{}();", language_function_name);
+        add_line!(header_file, "{};", language_function_signature);
         add_line!(header_file, "");
-        add_line!(
-            gen_file,
-            "extern const TSLanguage *{}(void) {{",
-            language_function_name
-        );
+        add_line!(gen_file, "{} {{", language_function_signature);
         indent!(gen_file);
         add_line!(gen_file, "static const TSLanguage language = {{");
         indent!(gen_file);

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -1305,8 +1305,9 @@ impl Generator {
 
     fn add_parser_export(&mut self, header_file: &mut GeneratorFile, gen_file: &mut GeneratorFile) {
         let language_function_name = format!("tree_sitter_{}", self.language_name);
-        let language_function_signature = format!("extern const TSLanguage *{}(void)", language_function_name);
         let external_scanner_name = format!("{}_external_scanner", language_function_name);
+        let extern_macro_name = format!("TS{}EXTERN", self.language_name.to_uppercase());
+        let language_function_signature = format!("{} const TSLanguage *{}(void)", extern_macro_name, language_function_name);
 
         add_line!(gen_file, "#ifdef __cplusplus");
         add_line!(gen_file, r#"extern "C" {{"#);
@@ -1333,13 +1334,15 @@ impl Generator {
             add_line!(gen_file, "");
         }
 
-        add_line!(gen_file, "#ifdef _WIN32");
-        add_line!(gen_file, "#define extern __declspec(dllexport)");
-        add_line!(gen_file, "#endif");
-        add_line!(gen_file, "");
-
+        add_line!(header_file, "#ifdef _WIN32");
+        add_line!(header_file, "#define {} __declspec(dllexport)", extern_macro_name);
+        add_line!(header_file, "#else");
+        add_line!(header_file, "#define {} extern", extern_macro_name);
+        add_line!(header_file, "#endif");
+        add_line!(header_file, "");
         add_line!(header_file, "{};", language_function_signature);
         add_line!(header_file, "");
+
         add_line!(gen_file, "{} {{", language_function_signature);
         indent!(gen_file);
         add_line!(gen_file, "static const TSLanguage language = {{");

--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -256,8 +256,8 @@ fn test_feature_corpus_files() {
             }
 
             let corpus_path = test_path.join("corpus.txt");
-            let c_code = generate_result.unwrap().1;
-            let language = get_test_language(language_name, &c_code, Some(&test_path));
+            let (_, c_code, header_code) = generate_result.unwrap();
+            let language = get_test_language(language_name, &c_code, &header_code, Some(&test_path));
             let test = parse_tests(&corpus_path).unwrap();
             let tests = flatten_tests(test);
 

--- a/cli/src/tests/helpers/fixtures.rs
+++ b/cli/src/tests/helpers/fixtures.rs
@@ -54,14 +54,22 @@ pub fn get_highlight_config(
     result
 }
 
-pub fn get_test_language(name: &str, parser_code: &str, path: Option<&Path>) -> Language {
-    let parser_c_path = SCRATCH_DIR.join(&format!("{}-parser.c", name));
-    if !fs::read_to_string(&parser_c_path)
-        .map(|content| content == parser_code)
+fn write_code(path: &PathBuf, code: &str) {
+    if !fs::read_to_string(&path)
+        .map(|content| content == code)
         .unwrap_or(false)
     {
-        fs::write(&parser_c_path, parser_code).unwrap();
+        fs::write(&path, code).unwrap();
     }
+}
+
+pub fn get_test_language(name: &str, parser_code: &str, header_code: &str, path: Option<&Path>) -> Language {
+    let parser_dir = SCRATCH_DIR.join(name);
+    fs::create_dir_all(&parser_dir).unwrap();
+    let parser_c_path = parser_dir.join("parser.c");
+    let header_path = parser_dir.join("parser.h");
+    write_code(&parser_c_path, parser_code);
+    write_code(&header_path, header_code);
     let scanner_path = path.and_then(|p| {
         let result = p.join("scanner.c");
         if result.exists() {

--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -366,12 +366,12 @@ fn test_node_named_child() {
 
 #[test]
 fn test_node_named_child_with_aliases_and_extras() {
-    let (parser_name, parser_code) =
+    let (parser_name, parser_code, header_code) =
         generate_parser_for_grammar(GRAMMAR_WITH_ALIASES_AND_EXTRAS).unwrap();
 
     let mut parser = Parser::new();
     parser
-        .set_language(get_test_language(&parser_name, &parser_code, None))
+        .set_language(get_test_language(&parser_name, &parser_code, &header_code, None))
         .unwrap();
 
     let tree = parser.parse("b ... b ... c", None).unwrap();
@@ -563,7 +563,7 @@ fn test_node_sexp() {
 
 #[test]
 fn test_node_field_names() {
-    let (parser_name, parser_code) = generate_parser_for_grammar(
+    let (parser_name, parser_code, header_code) = generate_parser_for_grammar(
         r#"
         {
             "name": "test_grammar_with_fields",
@@ -635,7 +635,7 @@ fn test_node_field_names() {
     .unwrap();
 
     let mut parser = Parser::new();
-    let language = get_test_language(&parser_name, &parser_code, None);
+    let language = get_test_language(&parser_name, &parser_code, &header_code, None);
     parser.set_language(language).unwrap();
 
     let tree = parser
@@ -673,7 +673,7 @@ fn test_node_field_names() {
 
 #[test]
 fn test_node_field_calls_in_language_without_fields() {
-    let (parser_name, parser_code) = generate_parser_for_grammar(
+    let (parser_name, parser_code, header_code) = generate_parser_for_grammar(
         r#"
         {
             "name": "test_grammar_with_no_fields",
@@ -705,7 +705,7 @@ fn test_node_field_calls_in_language_without_fields() {
     .unwrap();
 
     let mut parser = Parser::new();
-    let language = get_test_language(&parser_name, &parser_code, None);
+    let language = get_test_language(&parser_name, &parser_code, &header_code, None);
     parser.set_language(language).unwrap();
 
     let tree = parser.parse("b c d", None).unwrap();
@@ -722,7 +722,7 @@ fn test_node_field_calls_in_language_without_fields() {
 
 #[test]
 fn test_node_is_named_but_aliased_as_anonymous() {
-    let (parser_name, parser_code) = generate_parser_for_grammar(
+    let (parser_name, parser_code, header_code) = generate_parser_for_grammar(
         &fs::read_to_string(
             &fixtures_dir()
                 .join("test_grammars")
@@ -734,7 +734,7 @@ fn test_node_is_named_but_aliased_as_anonymous() {
     .unwrap();
 
     let mut parser = Parser::new();
-    let language = get_test_language(&parser_name, &parser_code, None);
+    let language = get_test_language(&parser_name, &parser_code, &header_code, None);
     parser.set_language(language).unwrap();
 
     let tree = parser.parse("B C B", None).unwrap();

--- a/cli/src/tests/parser_test.rs
+++ b/cli/src/tests/parser_test.rs
@@ -409,13 +409,14 @@ fn test_parsing_empty_file_with_reused_tree() {
 #[test]
 fn test_parsing_after_editing_tree_that_depends_on_column_values() {
     let (grammar, path) = get_test_grammar("uses_current_column");
-    let (grammar_name, parser_code) = generate_parser_for_grammar(&grammar).unwrap();
+    let (grammar_name, parser_code, header_code) = generate_parser_for_grammar(&grammar).unwrap();
 
     let mut parser = Parser::new();
     parser
         .set_language(get_test_language(
             &grammar_name,
             &parser_code,
+            &header_code,
             path.as_ref().map(AsRef::as_ref),
         ))
         .unwrap();
@@ -1170,7 +1171,7 @@ fn test_parsing_with_a_newly_included_range() {
 
 #[test]
 fn test_parsing_with_included_ranges_and_missing_tokens() {
-    let (parser_name, parser_code) = generate_parser_for_grammar(
+    let (parser_name, parser_code, header_code) = generate_parser_for_grammar(
         r#"{
             "name": "test_leading_missing_token",
             "rules": {
@@ -1196,7 +1197,7 @@ fn test_parsing_with_included_ranges_and_missing_tokens() {
 
     let mut parser = Parser::new();
     parser
-        .set_language(get_test_language(&parser_name, &parser_code, None))
+        .set_language(get_test_language(&parser_name, &parser_code, &header_code, None))
         .unwrap();
 
     // There's a missing `a` token at the beginning of the code. It must be inserted


### PR DESCRIPTION
This allows us to check node types more efficiently by using `ts_node_symbol()` instead of `ts_node_type()`. For example, this:

```c
assert(strcmp(ts_node_type(root_node), "program") == 0);
```

can be replaced with this:

```c
assert(ts_node_symbol(root_node) == sym_program);
```

Currently, the value of `sym_program` can be retrieved by doing this:

```c
TSSymbol sym_program = ts_language_symbol_for_name(language, "program", 7, true);
```

However, this isn't as efficient as doing `#include "enums.h"`