### PR TITLE
Allow TextProvider's iterators to generate owned text

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -8,6 +8,7 @@ pub mod allocations;
 use std::os::unix::io::AsRawFd;
 
 use std::{
+    borrow::Cow,
     char, error,
     ffi::CStr,
     fmt, hash, iter,
@@ -162,7 +163,8 @@ pub struct QueryCaptures<'a, 'tree: 'a, T: TextProvider<'a>> {
 }
 
 pub trait TextProvider<'a> {
-    type I: Iterator<Item = &'a [u8]> + 'a;
+    type I: Iterator<Item = Cow<'a, [u8]>>;
+
     fn text(&mut self, node: Node) -> Self::I;
 }
 
@@ -1799,19 +1801,19 @@ impl<'a, 'tree> QueryMatch<'a, 'tree> {
         buffer2: &mut Vec<u8>,
         text_provider: &mut impl TextProvider<'a>,
     ) -> bool {
-        fn get_text<'a, 'b: 'a, I: Iterator<Item = &'b [u8]>>(
+        fn get_text<'a, 'b: 'a, I: Iterator<Item = Cow<'b, [u8]>>>(
             buffer: &'a mut Vec<u8>,
             mut chunks: I,
-        ) -> &'a [u8] {
-            let first_chunk = chunks.next().unwrap_or(&[]);
+        ) -> Cow<'a, [u8]> {
+            let first_chunk = chunks.next().unwrap_or(Cow::Owned(vec![0u8; 0]));
             if let Some(next_chunk) = chunks.next() {
                 buffer.clear();
-                buffer.extend_from_slice(first_chunk);
-                buffer.extend_from_slice(next_chunk);
+                buffer.extend_from_slice(&first_chunk);
+                buffer.extend_from_slice(&next_chunk);
                 for chunk in chunks {
-                    buffer.extend_from_slice(chunk);
+                    buffer.extend_from_slice(&chunk);
                 }
-                buffer.as_slice()
+                Cow::Borrowed(buffer.as_slice())
             } else {
                 first_chunk
             }
@@ -1835,7 +1837,7 @@ impl<'a, 'tree> QueryMatch<'a, 'tree> {
                 TextPredicate::CaptureMatchString(i, r, is_positive) => {
                     let node = self.nodes_for_capture_index(*i).next().unwrap();
                     let text = get_text(buffer1, text_provider.text(node));
-                    r.is_match(text) == *is_positive
+                    r.is_match(&text) == *is_positive
                 }
             })
     }
@@ -1946,23 +1948,24 @@ impl<'cursor, 'tree> fmt::Debug for QueryMatch<'cursor, 'tree> {
     }
 }
 
-impl<'a, F, I> TextProvider<'a> for F
+impl<'a, F, I, T> TextProvider<'a> for F
 where
     F: FnMut(Node) -> I,
-    I: Iterator<Item = &'a [u8]> + 'a,
+    T: Into<Cow<'a, [u8]>>,
+    I: Iterator<Item = T>,
 {
-    type I = I;
+    type I = iter::Map<I, fn(T) -> Cow<'a, [u8]>>;
 
     fn text(&mut self, node: Node) -> Self::I {
-        (self)(node)
+        (self)(node).map(T::into)
     }
 }
 
 impl<'a> TextProvider<'a> for &'a [u8] {
-    type I = iter::Once<&'a [u8]>;
+    type I = iter::Once<Cow<'a, [u8]>>;
 
     fn text(&mut self, node: Node) -> Self::I {
-        iter::once(&self[node.byte_range()])
+        iter::once(Cow::Borrowed(&self[node.byte_range()]))
     }
 }
 


### PR DESCRIPTION
The switch to `TextProvider` made it no longer possible to use a callback that returns owned text, which was enabled by #488 (for Emacs dynamic modules). 