### PR TITLE
Allow equals sign `=` in test title

### DIFF
--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -16,7 +16,7 @@ use tree_sitter::{Language, LogType, Parser, Query};
 use walkdir::WalkDir;
 
 lazy_static! {
-    static ref HEADER_REGEX: ByteRegex = ByteRegexBuilder::new(r"^===+\r?\n(.*)\r?\n===+\r?\n")
+    static ref HEADER_REGEX: ByteRegex = ByteRegexBuilder::new(r"^===+\r?\n((?s).*?)\r?\n===+\r?\n")
         .multi_line(true)
         .build()
         .unwrap();
@@ -568,6 +568,42 @@ abc
                 children: vec![
                     TestEntry::Example {
                         name: "Test = title = with = equals".to_string(),
+                        input: "abc\n".as_bytes().to_vec(),
+                        output: "(abc)".to_string(),
+                        has_fields: false,
+                    },
+                ],
+                file_path: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_test_content_with_multiple_lines_in_title() {
+        let entry = parse_test_content(
+            "the-filename".to_string(),
+            r#"
+==================
+Hello
+world
+==================
+abc
+
+-------------------
+
+(abc)"#
+            .trim()
+            .to_string(),
+            None,
+        );
+
+        assert_eq!(
+            entry,
+            TestEntry::Group {
+                name: "the-filename".to_string(),
+                children: vec![
+                    TestEntry::Example {
+                        name: "Hello\nworld".to_string(),
                         input: "abc\n".as_bytes().to_vec(),
                         output: "(abc)".to_string(),
                         has_fields: false,

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -16,10 +16,11 @@ use tree_sitter::{Language, LogType, Parser, Query};
 use walkdir::WalkDir;
 
 lazy_static! {
-    static ref HEADER_REGEX: ByteRegex = ByteRegexBuilder::new(r"^===+\r?\n((?s).*?)\r?\n===+\r?\n")
-        .multi_line(true)
-        .build()
-        .unwrap();
+    static ref HEADER_REGEX: ByteRegex =
+        ByteRegexBuilder::new(r"^===+\r?\n((?s).*?)\r?\n===+\r?\n")
+            .multi_line(true)
+            .build()
+            .unwrap();
     static ref DIVIDER_REGEX: ByteRegex = ByteRegexBuilder::new(r"^---+\r?\n")
         .multi_line(true)
         .build()
@@ -556,8 +557,8 @@ abc
 -------------------
 
 (abc)"#
-            .trim()
-            .to_string(),
+                .trim()
+                .to_string(),
             None,
         );
 
@@ -565,14 +566,12 @@ abc
             entry,
             TestEntry::Group {
                 name: "the-filename".to_string(),
-                children: vec![
-                    TestEntry::Example {
-                        name: "Test = title = with = equals".to_string(),
-                        input: "abc\n".as_bytes().to_vec(),
-                        output: "(abc)".to_string(),
-                        has_fields: false,
-                    },
-                ],
+                children: vec![TestEntry::Example {
+                    name: "Test = title = with = equals".to_string(),
+                    input: "abc\n".as_bytes().to_vec(),
+                    output: "(abc)".to_string(),
+                    has_fields: false,
+                },],
                 file_path: None,
             }
         );
@@ -592,8 +591,8 @@ abc
 -------------------
 
 (abc)"#
-            .trim()
-            .to_string(),
+                .trim()
+                .to_string(),
             None,
         );
 
@@ -601,14 +600,12 @@ abc
             entry,
             TestEntry::Group {
                 name: "the-filename".to_string(),
-                children: vec![
-                    TestEntry::Example {
-                        name: "Hello\nworld".to_string(),
-                        input: "abc\n".as_bytes().to_vec(),
-                        output: "(abc)".to_string(),
-                        has_fields: false,
-                    },
-                ],
+                children: vec![TestEntry::Example {
+                    name: "Hello\nworld".to_string(),
+                    input: "abc\n".as_bytes().to_vec(),
+                    output: "(abc)".to_string(),
+                    has_fields: false,
+                },],
                 file_path: None,
             }
         );

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -16,7 +16,7 @@ use tree_sitter::{Language, LogType, Parser, Query};
 use walkdir::WalkDir;
 
 lazy_static! {
-    static ref HEADER_REGEX: ByteRegex = ByteRegexBuilder::new(r"^===+\r?\n([^=]*)\r?\n===+\r?\n")
+    static ref HEADER_REGEX: ByteRegex = ByteRegexBuilder::new(r"^===+\r?\n(.*)\r?\n===+\r?\n")
         .multi_line(true)
         .build()
         .unwrap();
@@ -535,6 +535,41 @@ abc
                         name: "Code ending with dashes".to_string(),
                         input: "abc\n-----------".as_bytes().to_vec(),
                         output: "(c (d))".to_string(),
+                        has_fields: false,
+                    },
+                ],
+                file_path: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_test_content_with_equals_in_title() {
+        let entry = parse_test_content(
+            "the-filename".to_string(),
+            r#"
+==================
+Test = title = with = equals
+==================
+abc
+
+-------------------
+
+(abc)"#
+            .trim()
+            .to_string(),
+            None,
+        );
+
+        assert_eq!(
+            entry,
+            TestEntry::Group {
+                name: "the-filename".to_string(),
+                children: vec![
+                    TestEntry::Example {
+                        name: "Test = title = with = equals".to_string(),
+                        input: "abc\n".as_bytes().to_vec(),
+                        output: "(abc)".to_string(),
                         has_fields: false,
                     },
                 ],


### PR DESCRIPTION
Change the regex for parsing the test header, so that equals sign is allowed in
the test title.

This breaks support for multiline test names. I think that's OK.

Closes #1047.