### PR TITLE
fix(cli): allow dead code in Logger; fixes CI failure

### DIFF
--- a/cli/src/logger.rs
+++ b/cli/src/logger.rs
@@ -1,5 +1,6 @@
 use log::{LevelFilter, Log, Metadata, Record};
 
+#[allow(dead_code)]
 struct Logger {
     pub filter: Option<String>,
 }


### PR DESCRIPTION
This PR fixes a failure in the CI due to a dead code for some unfinished feature in the CLI `Logger`.
It seems `rustc` 1.54.0 improved its dead code detection.