### PR TITLE
fix(cli): Remove tree-sitter grammar ./... call limitation

### DIFF
--- a/cli/src/generate/mod.rs
+++ b/cli/src/generate/mod.rs
@@ -169,6 +169,7 @@ fn load_grammar_file(grammar_path: &Path) -> Result<String> {
 }
 
 fn load_js_grammar_file(grammar_path: &Path) -> Result<String> {
+    let grammar_path = fs::canonicalize(grammar_path)?;
     let mut node_process = Command::new("node")
         .env("TREE_SITTER_GRAMMAR_PATH", grammar_path)
         .stdin(Stdio::piped())


### PR DESCRIPTION
Currently the `tree-sitter generate` command allows to pass the path argument in relative form only prefixed with `./` because underling node.js `require()` function expect such form. This PR removes such limitation.

_Error sample:_
```console
tree-sitter-typescript # ts g ./typescript/grammar.js
tree-sitter-typescript # ts g typescript/grammar.js
internal/modules/cjs/loader.js:968
  throw err;
  ^

Error: Cannot find module 'typescript/grammar.js'
Require stack:
- /home/user1/Code/tree-sitter-typescript/[stdin]
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:965:15)
    at Function.Module._load (internal/modules/cjs/loader.js:841:27)
    at Module.require (internal/modules/cjs/loader.js:1025:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at [stdin]:482:16
    at Script.runInThisContext (vm.js:120:18)
    at Object.runInThisContext (vm.js:309:38)
    at Object.<anonymous> ([stdin]-wrapper:10:26)
    at Module._compile (internal/modules/cjs/loader.js:1137:30)
    at evalScript (internal/process/execution.js:94:25) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/user1/Code/tree-sitter-typescript/[stdin]'
  ]
}
Node process exited with status 1
```