### PR TITLE
Allow to pass Module object to init-function

### DIFF
--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -17,24 +17,15 @@ var MIN_COMPATIBLE_VERSION;
 var TRANSFER_BUFFER;
 var currentParseCallback;
 var currentLogCallback;
-var initPromise = new Promise(resolve => {
-  Module.onRuntimeInitialized = resolve
-}).then(() => {
-  TRANSFER_BUFFER = C._ts_init();
-  VERSION = getValue(TRANSFER_BUFFER, 'i32');
-  MIN_COMPATIBLE_VERSION = getValue(TRANSFER_BUFFER + SIZE_OF_INT, 'i32');
-});
 
-class Parser {
+class ParserImpl {
   static init() {
-    return initPromise;
+    TRANSFER_BUFFER = C._ts_init();
+    VERSION = getValue(TRANSFER_BUFFER, 'i32');
+    MIN_COMPATIBLE_VERSION = getValue(TRANSFER_BUFFER + SIZE_OF_INT, 'i32');
   }
 
-  constructor() {
-    if (TRANSFER_BUFFER == null) {
-      throw new Error('You must first call Parser.init() and wait for it to resolve.');
-    }
-
+  initialize() {
     C._ts_parser_new_wasm();
     this[0] = getValue(TRANSFER_BUFFER, 'i32');
     this[1] = getValue(TRANSFER_BUFFER + SIZE_OF_INT, 'i32');
@@ -1203,6 +1194,3 @@ function marshalEdit(edit) {
   setValue(address, edit.oldEndIndex, 'i32'); address += SIZE_OF_INT;
   setValue(address, edit.newEndIndex, 'i32'); address += SIZE_OF_INT;
 }
-
-Parser.Language = Language;
-Parser.Parser = Parser;

--- a/lib/binding_web/prefix.js
+++ b/lib/binding_web/prefix.js
@@ -11,5 +11,5 @@ var TreeSitter = function() {
 
     static init(moduleOptions) {
       if (initPromise) return initPromise;
-      Module = { ...Module, ...moduleOptions };
+      Module = Object.assign({ }, Module, moduleOptions);
       return initPromise = new Promise((resolveInitPromise) => {

--- a/lib/binding_web/prefix.js
+++ b/lib/binding_web/prefix.js
@@ -1,9 +1,15 @@
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define([], factory);
-  } else if (typeof exports === 'object') {
-    module.exports = factory();
-  } else {
-    window.TreeSitter = factory();
-  }
-}(this, function () {
+var TreeSitter = function() {
+  var initPromise;
+  class Parser {
+    constructor() {
+      this.initialize();
+    }
+
+    initialize() {
+      throw new Error("cannot construct a Parser before calling `init()`");
+    }
+
+    static init(moduleOptions) {
+      if (initPromise) return initPromise;
+      Module = { ...Module, ...moduleOptions };
+      return initPromise = new Promise((resolveInitPromise) => {

--- a/lib/binding_web/suffix.js
+++ b/lib/binding_web/suffix.js
@@ -1,2 +1,23 @@
-return Parser;
-}));
+        for (const name of Object.getOwnPropertyNames(ParserImpl.prototype)) {
+          Object.defineProperty(Parser.prototype, name, {
+            value: ParserImpl.prototype[name],
+            enumerable: false,
+            writable: false,
+          })
+        }
+
+        Parser.Language = Language;
+        Module.onRuntimeInitialized = () => {
+          ParserImpl.init();
+          resolveInitPromise();
+        };
+      });
+    }
+  }
+
+  return Parser;
+}();
+
+if (typeof exports === 'object') {
+  module.exports = TreeSitter;
+}

--- a/lib/binding_web/tree-sitter-web.d.ts
+++ b/lib/binding_web/tree-sitter-web.d.ts
@@ -1,6 +1,10 @@
 declare module 'web-tree-sitter' {
   class Parser {
-    static init(): Promise<void>;
+    /**
+     * 
+     * @param moduleOptions Optional emscripten module-object, see https://emscripten.org/docs/api_reference/module.html
+     */
+    static init(moduleOptions?: object): Promise<void>;
     delete(): void;
     parse(input: string | Parser.Input, previousTree?: Parser.Tree, options?: Parser.Options): Parser.Tree;
     getLanguage(): any;


### PR DESCRIPTION
Builds on top of https://github.com/tree-sitter/tree-sitter/pull/1250#issuecomment-907421445

Adds the ability to optionally pass the Emscription Module-object to `Parser.init` so that things like `locateFile` can be controlled. 

Real world usage: https://github.com/microsoft/vscode-anycode/commit/1a6b8818177635cb911e8f085ccf03219992a320