### PR TITLE
feat(query): add first_retun flag to TSQueryMatch

### DIFF
--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -111,6 +111,7 @@ typedef struct {
   uint16_t pattern_index;
   uint16_t capture_count;
   const TSQueryCapture *captures;
+  bool first_return;
 } TSQueryMatch;
 
 typedef enum {


### PR DESCRIPTION
Allows for users of the API to determine if the match is returned for the first time, for example to run the predicates only once.

We encountered this little problem when working on tree-sitter intergration on neovim.

cc @bfredl
