### PR TITLE
fix(lib): fix segfault on ts_query_new with incompatible grammar version

### DIFF
--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -133,6 +133,7 @@ pub const TSQueryError_TSQueryErrorNodeType: TSQueryError = 2;
 pub const TSQueryError_TSQueryErrorField: TSQueryError = 3;
 pub const TSQueryError_TSQueryErrorCapture: TSQueryError = 4;
 pub const TSQueryError_TSQueryErrorStructure: TSQueryError = 5;
+pub const TSQueryError_TSQueryErrorLanguage: TSQueryError = 6;
 pub type TSQueryError = u32;
 extern "C" {
     #[doc = " Create a new parser."]

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -131,6 +131,7 @@ typedef enum {
   TSQueryErrorField,
   TSQueryErrorCapture,
   TSQueryErrorStructure,
+  TSQueryErrorLanguage,
 } TSQueryError;
 
 /********************/

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -2069,6 +2069,15 @@ TSQuery *ts_query_new(
   uint32_t *error_offset,
   TSQueryError *error_type
 ) {
+  if (
+    !language ||
+    language->version > TREE_SITTER_LANGUAGE_VERSION ||
+    language->version < TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION
+  ) {
+    *error_type = TSQueryErrorLanguage;
+    return NULL;
+  }
+
   TSQuery *self = ts_malloc(sizeof(TSQuery));
   *self = (TSQuery) {
     .steps = array_new(),


### PR DESCRIPTION
With this fix a `tree-sitter highlight` command outputs an error into stderr like:
```console
Failed to load property sheet for injection string 'jsdoc': Incompatible language version 11. Expected minimum 13, maximum 13
```

![Screenshot from 2021-09-03 14-29-21](https://user-images.githubusercontent.com/14666676/131998443-f60c2c3f-013d-4b48-b3e9-c37f9a7b05e6.png)
