### PR TITLE
fix(dsl): Allow to use console.log() in grammar files, resolve #703

### DIFF
--- a/cli/src/generate/dsl.js
+++ b/cli/src/generate/dsl.js
@@ -414,5 +414,7 @@ global.token = token;
 global.grammar = grammar;
 global.field = field;
 
+console.log = console.debug = console.info = console.error = console.warn;
 const result = require(process.env.TREE_SITTER_GRAMMAR_PATH);
-console.log(JSON.stringify(result, null, 2));
+process.stdout.write(JSON.stringify(result, null, 2));
+process.stdout.write('\n');


### PR DESCRIPTION
This PR fixes issue with `console.log()` usage in grammar files. It would be awesome to use a dedicated file descriptor for communication between CLI and an underling node.js sub process but such approach is not portable. So redirecting `console.log()` to stderr I think is enough solution.

Fixes #703

### Edit:
_There're other options on how to fix this if current solution wouldn't be appropriate for some reasons that I could miss:_
1.  _Don't use indented JSON and interpret only the last line of stdout as JSON grammar._
2. _Generate a long random token that would be unique and long enough, transfer it over environment variable and interpret only a part of the output that follows the token line._