### PR TITLE
feat(rust): Add an id() method for QueryMatch

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1753,6 +1753,10 @@ impl QueryCursor {
 }
 
 impl<'a, 'tree> QueryMatch<'a, 'tree> {
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
     pub fn remove(self) {
         unsafe { ffi::ts_query_cursor_remove_match(self.cursor, self.id) }
     }


### PR DESCRIPTION
This is follow up PR for https://github.com/tree-sitter/tree-sitter/commit/22a5cfbe102056ff3d51b2b44a8666fd8f85fdc0 commit and reasons described in https://github.com/tree-sitter/tree-sitter/pull/1372#issuecomment-918492254. It makes sense to make ids accessible for QueryMatch instances in the Rust binding.