### PR TITLE
Add Objective-C language parser

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,6 +76,7 @@ Parsers for these languages are in development:
 * [Scala](https://github.com/tree-sitter/tree-sitter-scala)
 * [Sourcepawn](https://github.com/nilshelmig/tree-sitter-sourcepawn)
 * [Swift](https://github.com/tree-sitter/tree-sitter-swift)
+* [Objective-C](https://github.com/jiyee/tree-sitter-objc)
 
 
 ### Talks on Tree-sitter


### PR DESCRIPTION
The parser for Objective-C language is near complete (or possibly even usable) but submitting it anyhow for the list just for visibility in case people who know more come along.