### PR TITLE
Add WGSL WebGPU Shading Language

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,7 @@ Parsers for these languages are fairly complete:
 * [Vue](https://github.com/ikatyang/tree-sitter-vue)
 * [YAML](https://github.com/ikatyang/tree-sitter-yaml)
 * [WASM](https://github.com/wasm-lsp/tree-sitter-wasm)
+* [WGSL WebGPU Shading Language](https://github.com/mehmetoguzderin/tree-sitter-wgsl)
 
 Parsers for these languages are in development:
 


### PR DESCRIPTION
This PR adds WebGPU Shading Language to the list of available grammars, the linked repository's grammar is periodically automatically extracted from the WGSL specification itself, which is actually extracted every single time where the specification gets a modification in itself to check the validity of both the syntax and the examples. Thank you very much for developing and maintaining tree-sitter, fantastic project!