### PR TITLE
fix(cli): Panic on queries containing alternation with predicates

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1821,21 +1821,36 @@ impl<'a, 'tree> QueryMatch<'a, 'tree> {
             .iter()
             .all(|predicate| match predicate {
                 TextPredicate::CaptureEqCapture(i, j, is_positive) => {
-                    let node1 = self.nodes_for_capture_index(*i).next().unwrap();
-                    let node2 = self.nodes_for_capture_index(*j).next().unwrap();
-                    let text1 = get_text(buffer1, text_provider.text(node1));
-                    let text2 = get_text(buffer2, text_provider.text(node2));
-                    (text1 == text2) == *is_positive
+                    let node1 = self.nodes_for_capture_index(*i).next();
+                    let node2 = self.nodes_for_capture_index(*j).next();
+                    match (node1, node2) {
+                        (Some(node1), Some(node2)) => {
+                            let text1 = get_text(buffer1, text_provider.text(node1));
+                            let text2 = get_text(buffer2, text_provider.text(node2));
+                            (text1 == text2) == *is_positive
+                        }
+                        _ => true,
+                    }
                 }
                 TextPredicate::CaptureEqString(i, s, is_positive) => {
-                    let node = self.nodes_for_capture_index(*i).next().unwrap();
-                    let text = get_text(buffer1, text_provider.text(node));
-                    (text == s.as_bytes()) == *is_positive
+                    let node = self.nodes_for_capture_index(*i).next();
+                    match node {
+                        Some(node) => {
+                            let text = get_text(buffer1, text_provider.text(node));
+                            (text == s.as_bytes()) == *is_positive
+                        }
+                        None => true,
+                    }
                 }
                 TextPredicate::CaptureMatchString(i, r, is_positive) => {
-                    let node = self.nodes_for_capture_index(*i).next().unwrap();
-                    let text = get_text(buffer1, text_provider.text(node));
-                    r.is_match(text) == *is_positive
+                    let node = self.nodes_for_capture_index(*i).next();
+                    match node {
+                        Some(node) => {
+                            let text = get_text(buffer1, text_provider.text(node));
+                            r.is_match(text) == *is_positive
+                        }
+                        None => true,
+                    }
                 }
             })
     }

--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -785,6 +785,7 @@ class Language {
                     if (c.name === captureName1) node1 = c.node;
                     if (c.name === captureName2) node2 = c.node;
                   }
+                  if(node1 === undefined || node2 === undefined) return true;
                   return (node1.text === node2.text) === isPositive;
                 });
               } else {
@@ -796,7 +797,7 @@ class Language {
                       return (c.node.text === stringValue) === isPositive;
                     };
                   }
-                  return false;
+                  return true;
                 });
               }
               break;
@@ -819,7 +820,7 @@ class Language {
                 for (const c of captures) {
                   if (c.name === captureName) return regex.test(c.node.text) === isPositive;
                 }
-                return false;
+                return true;
               });
               break;
 


### PR DESCRIPTION
`QuearyMatch::satisfies_text_predicates()` was changed to pass
captures that don't relate to a checked predicate. This allows
predicates in inner alternations for queries.

Resolves #1392

For `java` input:
```java
class MyClass {
    @MyAnnotation("literal value")
    public void method1() {
    }

    @MyAnnotation(name = "the name", value = "key-pair value")
    public void method2() {
    }
}
```

With query:
```wat
(method_declaration 
  (modifiers 
    (annotation 
      arguments: (annotation_argument_list
        [
          (string_literal) @literal-value
          (
            (element_value_pair
              key: (identifier) @pair-key
              value: (string_literal) @pair-value)
            (#eq? @pair-key "value")
          )
        ]
      )
    )
  )
)
```

`tree-sitter query` returns the output:
```
example/example.java
  pattern: 0
    capture: literal-value, start: (1, 18), text: "\"literal value\""
  pattern: 0
    capture: pair-key, start: (5, 37), text: "value"
    capture: pair-value, start: (5, 45), text: "\"key-pair value\""
```

With commented predicate the output looks like:
```
example/example.java
  pattern: 0
    capture: literal-value, start: (1, 18), text: "\"literal value\""
  pattern: 0
    capture: pair-key, start: (5, 18), text: "name"
    capture: pair-value, start: (5, 25), text: "\"the name\""
  pattern: 0
    capture: pair-key, start: (5, 37), text: "value"
    capture: pair-value, start: (5, 45), text: "\"key-pair value\""
```

### Edit 1
_I suppose something similar has to be done in the playground logic too._

### Edit 2
On the master it fails with panic:
```
# RUST_BACKTRACE=1 ts q example/query3.scm example/example.java
example/example.java
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', lib/binding_rust/lib.rs:1831:72
stack backtrace:
   0: rust_begin_unwind
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:515:5
   1: core::panicking::panic_fmt
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/panicking.rs:92:14
   2: core::panicking::panic
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/panicking.rs:50:5
   3: tree_sitter::QueryMatch::satisfies_text_predicates
   4: <tree_sitter::QueryMatches<T> as core::iter::traits::iterator::Iterator>::next
   5: tree_sitter_cli::query::query_files_at_paths
   6: tree_sitter::run
   7: tree_sitter::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

### Edit 3
Also fixed for **wasm** binding and playground:

![Screenshot from 2021-09-21 21-21-53](https://user-images.githubusercontent.com/14666676/134226233-549aa55e-f15b-42fe-ad81-2cfc38e514a7.png)

