### PR TITLE
binding(rust): Mark set_cancellation_flag self as mutable

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -630,7 +630,7 @@ impl Parser {
     /// If a pointer is assigned, then the parser will periodically read from
     /// this pointer during parsing. If it reads a non-zero value, it will halt early,
     /// returning `None`. See [parse](Parser::parse) for more information.
-    pub unsafe fn set_cancellation_flag(&self, flag: Option<&AtomicUsize>) {
+    pub unsafe fn set_cancellation_flag(&mut self, flag: Option<&AtomicUsize>) {
         if let Some(flag) = flag {
             ffi::ts_parser_set_cancellation_flag(
                 self.0.as_ptr(),


### PR DESCRIPTION
C lib definition is not **const**:
https://github.com/tree-sitter/tree-sitter/blob/a63c09375f76ed6dfe5e9a4f8384c805c009fb31/lib/include/tree_sitter/api.h#L312
So the Rust equivalent of the `&self ` receiver seems should be marked as mutable.