### PR TITLE
feat(cli/query): Improve and unify query sub command output

### DIFF
--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -48,10 +48,12 @@ pub fn query_files_at_paths(
                 let capture_name = &query.capture_names()[capture.index as usize];
                 writeln!(
                     &mut stdout,
-                    "    pattern: {}, capture: {}, row: {}, text: {:?}",
+                    "    pattern: {:>2}, capture: {} - {}, start: {}, end: {}, text: `{}`",
                     mat.pattern_index,
+                    capture.index,
                     capture_name,
-                    capture.node.start_position().row,
+                    capture.node.start_position(),
+                    capture.node.end_position(),
                     capture.node.utf8_text(&source_code).unwrap_or("")
                 )?;
                 results.push(query_testing::CaptureInfo {
@@ -70,9 +72,11 @@ pub fn query_files_at_paths(
                     if end.row == start.row {
                         writeln!(
                             &mut stdout,
-                            "    capture: {}, start: {}, text: {:?}",
+                            "    capture: {} - {}, start: {}, end: {}, text: `{}`",
+                            capture.index,
                             capture_name,
                             start,
+                            end,
                             capture.node.utf8_text(&source_code).unwrap_or("")
                         )?;
                     } else {


### PR DESCRIPTION
This PR unifies output for `tree-sitter query` sub command and proposes to show indices for patterns and captures, this may be useful in debugging and coding processes when the CLI provides detailed information.

_Before:_
```
# ts q example/query3.edit.scm example/example.java
example/example.java
  pattern: 0
    capture: literal-value, start: (1, 18), text: "\"literal value\""
  pattern: 0
    capture: pair-key, start: (5, 18), text: "name"
    capture: pair-value, start: (5, 25), text: "\"the name\""
  pattern: 0
    capture: pair-key, start: (5, 37), text: "value"
    capture: pair-value, start: (5, 45), text: "\"key-pair value\""
#
# ts q -c example/query3.edit.scm example/example.java
example/example.java
    pattern: 0, capture: literal-value, row: 1, text: "\"literal value\""
    pattern: 0, capture: pair-key, row: 5, text: "name"
    pattern: 0, capture: pair-value, row: 5, text: "\"the name\""
    pattern: 0, capture: pair-key, row: 5, text: "value"
    pattern: 0, capture: pair-value, row: 5, text: "\"key-pair value\""
#
```

_After:_
```
# ts q example/query3.edit.scm example/example.java
example/example.java
  pattern: 0
    capture: 0 - literal-value, start: (1, 18), end: (1, 33), text: `"literal value"`
  pattern: 0
    capture: 1 - pair-key, start: (5, 18), end: (5, 22), text: `name`
    capture: 2 - pair-value, start: (5, 25), end: (5, 35), text: `"the name"`
  pattern: 0
    capture: 1 - pair-key, start: (5, 37), end: (5, 42), text: `value`
    capture: 2 - pair-value, start: (5, 45), end: (5, 61), text: `"key-pair value"`
#
# ts q -c example/query3.edit.scm example/example.java
example/example.java
    pattern:  0, capture: 0 - literal-value, start: (1, 18), end: (1, 33), text: `"literal value"`
    pattern:  0, capture: 1 - pair-key, start: (5, 18), end: (5, 22), text: `name`
    pattern:  0, capture: 2 - pair-value, start: (5, 25), end: (5, 35), text: `"the name"`
    pattern:  0, capture: 1 - pair-key, start: (5, 37), end: (5, 42), text: `value`
    pattern:  0, capture: 2 - pair-value, start: (5, 45), end: (5, 61), text: `"key-pair value"`
#
```
