### PR TITLE
Fix compiling C library with Clang on Windows

### DIFF
--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -1776,7 +1776,11 @@ void ts_parser_print_dot_graphs(TSParser *self, int fd) {
   }
 
   if (fd >= 0) {
+    #ifdef _WIN32
+    self->dot_graph_file = _fdopen(fd, "a");
+    #else
     self->dot_graph_file = fdopen(fd, "a");
+    #endif
   } else {
     self->dot_graph_file = NULL;
   }

--- a/lib/src/stack.c
+++ b/lib/src/stack.c
@@ -302,7 +302,7 @@ static void ts_stack__add_slice(
   array_push(&self->slices, slice);
 }
 
-inline StackSliceArray stack__iter(
+static StackSliceArray stack__iter(
   Stack *self,
   StackVersion version,
   StackCallback callback,


### PR DESCRIPTION
Fixes a part of #1889
