### PR TITLE
Fixed some test failures due to CRLF line endings

### DIFF
--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -231,10 +231,21 @@ fn test_feature_corpus_files() {
 
             let expected_message = fs::read_to_string(&error_message_path).unwrap();
             if let Err(e) = generate_result {
-                if e.to_string() != expected_message {
+                let actual_message = e.to_string();
+                let first_diff = expected_message
+                    .lines()
+                    .zip(actual_message.lines())
+                    .enumerate()
+                    .filter(|(_, (expected, actual))| expected != actual)
+                    .next();
+                if let Some((line_number,(expected_line, actual_line))) = first_diff {
                     eprintln!(
                         "Unexpected error message.\n\nExpected:\n\n{}\nActual:\n\n{}\n",
-                        expected_message, e
+                        expected_message, actual_message
+                    );
+                    eprintln!(
+                        "First difference on line {}; expected:\n{}\nActual:\n{}\n",
+                        line_number, expected_line, actual_line
                     );
                     failure_count += 1;
                 }

--- a/test/fixtures/test_grammars/external_and_internal_tokens/scanner.c
+++ b/test/fixtures/test_grammars/external_and_internal_tokens/scanner.c
@@ -35,7 +35,7 @@ bool tree_sitter_external_and_internal_tokens_external_scanner_scan(
 ) {
   // If a line-break is a valid lookahead token, only skip spaces.
   if (whitelist[LINE_BREAK]) {
-    while (lexer->lookahead == ' ') {
+    while (lexer->lookahead == ' ' || lexer->lookahead == '\r') {
       lexer->advance(lexer, true);
     }
 
@@ -49,7 +49,7 @@ bool tree_sitter_external_and_internal_tokens_external_scanner_scan(
   // If a line-break is not a valid lookahead token, skip line breaks as well
   // as spaces.
   if (whitelist[STRING]) {
-    while (lexer->lookahead == ' ' || lexer->lookahead == '\n') {
+    while (lexer->lookahead == ' ' || lexer->lookahead == '\r' || lexer->lookahead == '\n') {
       lexer->advance(lexer, true);
     }
 

--- a/test/fixtures/test_grammars/external_tokens/scanner.c
+++ b/test/fixtures/test_grammars/external_tokens/scanner.c
@@ -46,7 +46,8 @@ bool tree_sitter_external_tokens_external_scanner_scan(
   if (whitelist[percent_string]) {
     while (lexer->lookahead == ' ' ||
            lexer->lookahead == '\t' ||
-           lexer->lookahead == '\n') {
+           lexer->lookahead == '\n' ||
+           lexer->lookahead == '\r') {
       lexer->advance(lexer, true);
     }
 

--- a/test/fixtures/test_grammars/inverted_external_token/scanner.c
+++ b/test/fixtures/test_grammars/inverted_external_token/scanner.c
@@ -23,7 +23,7 @@ void tree_sitter_inverted_external_token_external_scanner_deserialize(
 
 bool tree_sitter_inverted_external_token_external_scanner_scan(
   void *payload, TSLexer *lexer, const bool *whitelist) {
-  while (lexer->lookahead == ' ') {
+  while (lexer->lookahead == ' ' || lexer->lookahead == '\r') {
     lexer->advance(lexer, true);
   }
 
@@ -34,7 +34,7 @@ bool tree_sitter_inverted_external_token_external_scanner_scan(
     lexer->mark_end(lexer);
 
     // Skip whitespace *after* having marked the end.
-    while (lexer->lookahead == ' ' || lexer->lookahead == '\n') {
+    while (lexer->lookahead == ' ' || lexer->lookahead == '\n' || lexer->lookahead == '\r') {
       lexer->advance(lexer, true);
     }
 


### PR DESCRIPTION
Normalize line endings when comparing expected `tree-sitter generate` error output to actual output
Add `\r` skipping to some external scanners
Fixes https://github.com/tree-sitter/tree-sitter/issues/940
Partially addresses https://github.com/tree-sitter/tree-sitter/issues/913
The following issues in the bash and ruby grammars still must be resolved for all tests to pass on Windows:
- https://github.com/tree-sitter/tree-sitter-bash/issues/94
- https://github.com/tree-sitter/tree-sitter-ruby/issues/164