### PR TITLE
Make SubtreeInlineData work on Big-Endian

### DIFF
--- a/lib/src/host.h
+++ b/lib/src/host.h
@@ -1,0 +1,21 @@
+
+// Determine endian and pointer size based on known defines.
+// TS_BIG_ENDIAN and TS_PTR_SIZE can be set as -D compiler arguments
+// to override this.
+
+#if !defined(TS_BIG_ENDIAN)
+#if (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) \
+  || (defined( __APPLE_CC__) && (defined(__ppc__) || defined(__ppc64__)))
+#define TS_BIG_ENDIAN 1
+#else
+#define TS_BIG_ENDIAN 0
+#endif
+#endif
+
+#if !defined(TS_PTR_SIZE)
+#if UINTPTR_MAX == 0xFFFFFFFF
+#define TS_PTR_SIZE 32
+#else
+#define TS_PTR_SIZE 64
+#endif
+#endif

--- a/lib/src/subtree.h
+++ b/lib/src/subtree.h
@@ -49,10 +49,9 @@ typedef struct {
 typedef struct {
 #define SUBTREE_3_BYTES \
   uint8_t symbol; \
-  uint8_t padding_bytes; \
-  uint8_t size_bytes; \
+  uint16_t parse_state;
 
-#define SUBTREE_6_BITS \
+#define SUBTREE_BITS \
   bool visible : 1; \
   bool named : 1; \
   bool extra : 1; \
@@ -60,36 +59,39 @@ typedef struct {
   bool is_missing : 1; \
   bool is_keyword : 1;
 
-#define SUBTREE_4_BYTES \
+#define SUBTREE_SIZE \
   uint8_t padding_columns; \
   uint8_t padding_rows : 4; \
   uint8_t lookahead_bytes : 4; \
-  uint16_t parse_state;
+  uint8_t padding_bytes; \
+  uint8_t size_bytes;
 
 #if TS_BIG_ENDIAN
 #if TS_PTR_SIZE == 32
-  SUBTREE_3_BYTES
-  SUBTREE_6_BITS
+  uint16_t parse_state;
+  uint8_t symbol;
+  SUBTREE_BITS
   bool unused : 1;
   bool is_inline : 1;
-  SUBTREE_4_BYTES
+  SUBTREE_SIZE
 #else
-  SUBTREE_4_BYTES
-  SUBTREE_3_BYTES
-  SUBTREE_6_BITS
+  SUBTREE_SIZE
+  uint16_t parse_state;
+  uint8_t symbol;
+  SUBTREE_BITS
   bool unused : 1;
   bool is_inline : 1;
 #endif
 #else
   bool is_inline : 1;
-  SUBTREE_6_BITS
-  SUBTREE_3_BYTES
-  SUBTREE_4_BYTES
+  SUBTREE_BITS
+  uint8_t symbol;
+  uint16_t parse_state;
+  SUBTREE_SIZE
 #endif
 
-#undef SUBTREE_3_BYTES
-#undef SUBTREE_6_BITS
-#undef SUBTREE_4_BYTES
+#undef SUBTREE_BITS
+#undef SUBTREE_SIZE
 } SubtreeInlineData;
 
 // A heap-allocated representation of a subtree.

--- a/lib/src/subtree.h
+++ b/lib/src/subtree.h
@@ -11,6 +11,7 @@ extern "C" {
 #include "./length.h"
 #include "./array.h"
 #include "./error_costs.h"
+#include "./host.h"
 #include "tree_sitter/api.h"
 #include "tree_sitter/parser.h"
 
@@ -39,21 +40,56 @@ typedef struct {
 //
 // This representation is used for small leaf nodes that are not
 // errors, and were not created by an external scanner.
+// The idea behind the layout of this struct is that the `is_inline`
+// bit will fall exactly into the same location as the least significant
+// bit of the pointer in `Subtree` or `MutableSubtree`, respectively.
+// Because of alignment, for any valid pointer this will be 0, giving
+// us the opportunity to make use of this bit to signify whether to use
+// the pointer or the inline struct.
 typedef struct {
-  bool is_inline : 1;
-  bool visible : 1;
-  bool named : 1;
-  bool extra : 1;
-  bool has_changes : 1;
-  bool is_missing : 1;
+#define SUBTREE_3_BYTES \
+  uint8_t symbol; \
+  uint8_t padding_bytes; \
+  uint8_t size_bytes; \
+
+#define SUBTREE_6_BITS \
+  bool visible : 1; \
+  bool named : 1; \
+  bool extra : 1; \
+  bool has_changes : 1; \
+  bool is_missing : 1; \
   bool is_keyword : 1;
-  uint8_t symbol;
-  uint8_t padding_bytes;
-  uint8_t size_bytes;
-  uint8_t padding_columns;
-  uint8_t padding_rows : 4;
-  uint8_t lookahead_bytes : 4;
+
+#define SUBTREE_4_BYTES \
+  uint8_t padding_columns; \
+  uint8_t padding_rows : 4; \
+  uint8_t lookahead_bytes : 4; \
   uint16_t parse_state;
+
+#if TS_BIG_ENDIAN
+#if TS_PTR_SIZE == 32
+  SUBTREE_3_BYTES
+  SUBTREE_6_BITS
+  bool unused : 1;
+  bool is_inline : 1;
+  SUBTREE_4_BYTES
+#else
+  SUBTREE_4_BYTES
+  SUBTREE_3_BYTES
+  SUBTREE_6_BITS
+  bool unused : 1;
+  bool is_inline : 1;
+#endif
+#else
+  bool is_inline : 1;
+  SUBTREE_6_BITS
+  SUBTREE_3_BYTES
+  SUBTREE_4_BYTES
+#endif
+
+#undef SUBTREE_3_BYTES
+#undef SUBTREE_6_BITS
+#undef SUBTREE_4_BYTES
 } SubtreeInlineData;
 
 // A heap-allocated representation of a subtree.


### PR DESCRIPTION
Fixes #1466

This orders the members of `SubtreeInlineData` such that the `is_inline` bit falls exactly into the least significant bit of the pointer in `Subtree`, while keeping a maximum size of 8 bytes. There are three cases that need different layouts:

* Little-endian, no matter which pointer size: as before, the bit is simply the first member in the struct
* Big-endian, 32-bit: it has to occupy the highest bit of the 4th byte in the struct
* Big-endian, 64-bit: it has to occupy the highest bit of the 8th byte in the struct

I am not a huge fan of bloating up the definition of the struct so much, but I don't really see another way. I used macros to not repeat all members multiple times.
Also unfortunately there is no standard way to detect the endian in the preprocessor, so I have only added the checks I could actually verify myself and if undetected it falls back to assuming little-endian as before.
The detection for setting `TS_BIG_ENDIAN` and `TS_PTR_SIZE` can be overridden by using `-D` compiler args so any project that embeds tree-sitter can supply this by themselves if they want.

A little program to check the exact layout is here: https://github.com/thestr4ng3r/ts-endian
It zero-initializes a `Subtree`, sets `is_inline` to 1 and then checks if the pointer is exactly 1, e.g.:
```
g5-openbsd:ts-endian$ uname -a
OpenBSD g5-openbsd.fritz.box 7.0 GENERIC#940 macppc
g5-openbsd:ts-endian$ ./ts-endian
sizeof(void *) = 4
TS_PTR_SIZE = 32
TS_BIG_ENDIAN = 1
sizeof(SubtreeInlineData) = 8
sizeof(Subtree) = 8
==> ptr = 0x1
```

I tested this on the following platforms:
* OpenBSD 7.0 macppc (32bit)
* Mac OS X 10.5 ppc 32bit
* Mac OS X 10.5 ppc 64bit
* macOS 12 arm64

As a sidenote, another idea I had was to not use an explicit `is_inline` member, but simply perform the check like `((size_t)ptr) & 1`, since in any case that is what we want to use. Then one would have to just make sure that for any of the above cases, `SubtreeInlineData` would not put any actual payload data at the position of that bit. Including the current `is_inline` there are two unused bits avaliable. But because we need 3 bits and because of other alignment restrictions, this wouldn't work.

Another possibility that could actually work would be something like this:
```c
union {
  uint64_t data;
  void *ptr;
} Subtree;
```
Then one would have to manually pull the members out of the `data` value. But that would require a lot of annoying bit-shifting and anding instead of accessing struct members.