### PR TITLE
Don't use zero maxlen for snprintf in ts_subtree__write_to_string

### DIFF
--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -874,7 +874,7 @@ static size_t ts_subtree__write_to_string(
   if (!self.ptr) return snprintf(string, limit, "(NULL)");
 
   char *cursor = string;
-  char **writer = (limit > 0) ? &cursor : &string;
+  char **writer = (limit > 1) ? &cursor : &string;
   bool is_root = field_name == ROOT_FIELD;
   bool is_visible =
     include_all ||
@@ -973,7 +973,7 @@ char *ts_subtree_string(
 ) {
   char scratch_string[1];
   size_t size = ts_subtree__write_to_string(
-    self, scratch_string, 0,
+    self, scratch_string, 1,
     language, include_all,
     0, false, ROOT_FIELD
   ) + 1;


### PR DESCRIPTION
It seems that (some implementations of?) `snprintf` returns -1 and sets `errno` to `EINVAL` if a `maxlen` of zero is passed. This causes the count to underflow and `ts_subtree__write_to_string` returns a gigantic size which the succeeding malloc will refuse to allocate.