### PR TITLE
Add link to swift bindings package

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 * [Python](https://github.com/tree-sitter/py-tree-sitter)
 * [Ruby](https://github.com/tree-sitter/ruby-tree-sitter)
 * [Rust](https://github.com/tree-sitter/tree-sitter/tree/master/lib/binding_rust)
+* [Swift](https://github.com/ChimeHQ/SwiftTreeSitter)
 
 ### Available Parsers
 


### PR DESCRIPTION
Hello!

I'm a long-time user of tree-sitter, but just finally got around to open sourcing the bindings I use. They are mostly wrappers, but do also include a few utilities to make interoperating with Swift and its string/data constructs easier.

I thought it would be nice to include it in the docs.