### PR TITLE
Expose capture suffixes in queries

### DIFF
--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -3824,7 +3824,7 @@ fn test_capture_quantifiers() {
         description: &'static str,
         language: Language,
         pattern: &'static str,
-        capture_quantifiers: &'static [(&'static str, CaptureQuantifier)],
+        capture_quantifiers: &'static [(usize, &'static str, CaptureQuantifier)],
     }
 
     let rows = &[
@@ -3835,7 +3835,7 @@ fn test_capture_quantifiers() {
             pattern: r#"
                 (module) @mod
             "#,
-            capture_quantifiers: &[("mod", CaptureQuantifier::One)],
+            capture_quantifiers: &[(0, "mod", CaptureQuantifier::One)],
         },
         Row {
             description: "Nested list capture capture",
@@ -3844,8 +3844,8 @@ fn test_capture_quantifiers() {
                 (array (_)* @elems) @array
             "#,
             capture_quantifiers: &[
-                ("array", CaptureQuantifier::One),
-                ("elems", CaptureQuantifier::ZeroOrMore),
+                (0, "array", CaptureQuantifier::One),
+                (0, "elems", CaptureQuantifier::ZeroOrMore),
             ],
         },
         Row {
@@ -3855,8 +3855,8 @@ fn test_capture_quantifiers() {
                 (array (_)+ @elems) @array
             "#,
             capture_quantifiers: &[
-                ("array", CaptureQuantifier::One),
-                ("elems", CaptureQuantifier::OneOrMore),
+                (0, "array", CaptureQuantifier::One),
+                (0, "elems", CaptureQuantifier::OneOrMore),
             ],
         },
         // Nested quantifiers
@@ -3867,9 +3867,9 @@ fn test_capture_quantifiers() {
                 (array (call_expression (arguments (_) @arg))? @call) @array
             "#,
             capture_quantifiers: &[
-                ("array", CaptureQuantifier::One),
-                ("call", CaptureQuantifier::ZeroOrOne),
-                ("arg", CaptureQuantifier::ZeroOrOne),
+                (0, "array", CaptureQuantifier::One),
+                (0, "call", CaptureQuantifier::ZeroOrOne),
+                (0, "arg", CaptureQuantifier::ZeroOrOne),
             ],
         },
         Row {
@@ -3879,9 +3879,9 @@ fn test_capture_quantifiers() {
                 (array (call_expression (arguments (_)? @arg))+ @call) @array
             "#,
             capture_quantifiers: &[
-                ("array", CaptureQuantifier::One),
-                ("call", CaptureQuantifier::OneOrMore),
-                ("arg", CaptureQuantifier::ZeroOrMore),
+                (0, "array", CaptureQuantifier::One),
+                (0, "call", CaptureQuantifier::OneOrMore),
+                (0, "arg", CaptureQuantifier::ZeroOrMore),
             ],
         },
         Row {
@@ -3891,9 +3891,9 @@ fn test_capture_quantifiers() {
                 (array (call_expression (arguments (_)+ @args))? @call) @array
             "#,
             capture_quantifiers: &[
-                ("array", CaptureQuantifier::One),
-                ("call", CaptureQuantifier::ZeroOrOne),
-                ("args", CaptureQuantifier::ZeroOrMore),
+                (0, "array", CaptureQuantifier::One),
+                (0, "call", CaptureQuantifier::ZeroOrOne),
+                (0, "args", CaptureQuantifier::ZeroOrMore),
             ],
         },
         // Quantifiers in alternations
@@ -3904,7 +3904,7 @@ fn test_capture_quantifiers() {
                 (function_declaration name:(identifier) @name)
                 (call_expression function:(identifier) @name)
             ]"#,
-            capture_quantifiers: &[("name", CaptureQuantifier::One)],
+            capture_quantifiers: &[(0, "name", CaptureQuantifier::One)],
         },
         Row {
             description: "capture appears in some alternatives",
@@ -3914,8 +3914,8 @@ fn test_capture_quantifiers() {
                 (function)
             ] @fun"#,
             capture_quantifiers: &[
-                ("fun", CaptureQuantifier::One),
-                ("name", CaptureQuantifier::ZeroOrOne),
+                (0, "fun", CaptureQuantifier::One),
+                (0, "name", CaptureQuantifier::ZeroOrOne),
             ],
         },
         Row {
@@ -3926,8 +3926,8 @@ fn test_capture_quantifiers() {
                 (new_expression  arguments:(arguments (_)? @args))
             ] @call"#,
             capture_quantifiers: &[
-                ("call", CaptureQuantifier::One),
-                ("args", CaptureQuantifier::ZeroOrMore),
+                (0, "call", CaptureQuantifier::One),
+                (0, "args", CaptureQuantifier::ZeroOrMore),
             ],
         },
         // Quantifiers in siblings
@@ -3938,9 +3938,9 @@ fn test_capture_quantifiers() {
                 (call_expression (arguments (identifier)? @self (_)* @args)) @call
             "#,
             capture_quantifiers: &[
-                ("call", CaptureQuantifier::One),
-                ("self", CaptureQuantifier::ZeroOrOne),
-                ("args", CaptureQuantifier::ZeroOrMore),
+                (0, "call", CaptureQuantifier::One),
+                (0, "self", CaptureQuantifier::ZeroOrOne),
+                (0, "args", CaptureQuantifier::ZeroOrMore),
             ],
         },
         Row {
@@ -3950,13 +3950,13 @@ fn test_capture_quantifiers() {
                 (call_expression (arguments (identifier) @args (_)* @args)) @call
             "#,
             capture_quantifiers: &[
-                ("call", CaptureQuantifier::One),
-                ("args", CaptureQuantifier::OneOrMore),
+                (0, "call", CaptureQuantifier::One),
+                (0, "args", CaptureQuantifier::OneOrMore),
             ],
         },
-        // Combined nesting,
+        // Combined scenarios
         Row {
-            description: "combined nesting, alterantives, and siblings",
+            description: "combined nesting, alternatives, and siblings",
             language: get_language("javascript"),
             pattern: r#"
                 (array
@@ -3969,10 +3969,38 @@ fn test_capture_quantifiers() {
                 ) @array
             "#,
             capture_quantifiers: &[
-                ("array", CaptureQuantifier::One),
-                ("call", CaptureQuantifier::OneOrMore),
-                ("self", CaptureQuantifier::ZeroOrMore),
-                ("args", CaptureQuantifier::ZeroOrMore),
+                (0, "array", CaptureQuantifier::One),
+                (0, "call", CaptureQuantifier::OneOrMore),
+                (0, "self", CaptureQuantifier::ZeroOrMore),
+                (0, "args", CaptureQuantifier::ZeroOrMore),
+            ],
+        },
+        // Multiple patterns
+        Row {
+            description: "multiple patterns",
+            language: get_language("javascript"),
+            pattern: r#"
+                (function_declaration name: (identifier) @x)
+                (statement_identifier) @y
+                (property_identifier)+ @z
+                (array (identifier)* @x)
+            "#,
+            capture_quantifiers: &[
+                // x
+                (0, "x", CaptureQuantifier::One),
+                (1, "x", CaptureQuantifier::Zero),
+                (2, "x", CaptureQuantifier::Zero),
+                (3, "x", CaptureQuantifier::ZeroOrMore),
+                // y
+                (0, "y", CaptureQuantifier::Zero),
+                (1, "y", CaptureQuantifier::One),
+                (2, "y", CaptureQuantifier::Zero),
+                (3, "y", CaptureQuantifier::Zero),
+                // z
+                (0, "z", CaptureQuantifier::Zero),
+                (1, "z", CaptureQuantifier::Zero),
+                (2, "z", CaptureQuantifier::OneOrMore),
+                (3, "z", CaptureQuantifier::Zero),
             ],
         },
     ];
@@ -3988,9 +4016,9 @@ fn test_capture_quantifiers() {
             }
             eprintln!("  query example: {:?}", row.description);
             let query = Query::new(row.language, row.pattern).unwrap();
-            for (capture, expected_quantifier) in row.capture_quantifiers {
+            for (pattern, capture, expected_quantifier) in row.capture_quantifiers {
                 let index = query.capture_index_for_name(capture).unwrap();
-                let actual_quantifier = query.capture_quantifiers()[index as usize];
+                let actual_quantifier = query.capture_quantifiers(*pattern)[index as usize];
                 assert_eq!(
                     actual_quantifier,
                     *expected_quantifier,

--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -4003,6 +4003,24 @@ fn test_capture_quantifiers() {
                 (3, "z", CaptureQuantifier::Zero),
             ],
         },
+        Row {
+            description: "multiple alternatives",
+            language: get_language("javascript"),
+            pattern: r#"
+            [
+                (array (identifier) @x)
+                (function_declaration name: (identifier)+ @x)
+            ]
+            [
+                (array (identifier) @x)
+                (function_declaration name: (identifier)+ @x)
+            ]
+            "#,
+            capture_quantifiers: &[
+                (0, "x", CaptureQuantifier::OneOrMore),
+                (1, "x", CaptureQuantifier::OneOrMore),
+            ],
+        },
     ];
 
     allocations::record(|| {

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -666,6 +666,15 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Get the suffix of one of the query's captures, or one of the query's"]
+    #[doc = " string literals. Each capture and string is associated with a numeric"]
+    #[doc = " id based on the order that it appeared in the query's source."]
+    pub fn ts_query_capture_suffix_for_id(
+        arg1: *const TSQuery,
+        id: u32,
+    ) -> ::std::os::raw::c_char;
+}
+extern "C" {
     pub fn ts_query_string_value_for_id(
         arg1: *const TSQuery,
         id: u32,

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -107,10 +107,11 @@ pub struct TSQueryCapture {
     pub node: TSNode,
     pub index: u32,
 }
-pub const TSQuantifier_One: TSQuantifier = 0;
-pub const TSQuantifier_OneOrMore: TSQuantifier = 1;
-pub const TSQuantifier_ZeroOrOne: TSQuantifier = 2;
-pub const TSQuantifier_ZeroOrMore: TSQuantifier = 3;
+pub const TSQuantifier_Zero: TSQuantifier = 0;
+pub const TSQuantifier_ZeroOrOne: TSQuantifier = 1;
+pub const TSQuantifier_ZeroOrMore: TSQuantifier = 2;
+pub const TSQuantifier_One: TSQuantifier = 3;
+pub const TSQuantifier_OneOrMore: TSQuantifier = 4;
 pub type TSQuantifier = u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -675,7 +675,11 @@ extern "C" {
     #[doc = " Get the quantifier of the query's captures, or one of the query's string"]
     #[doc = " literals. Each capture and string is associated with a numeric id based"]
     #[doc = " on the order that it appeared in the query's source."]
-    pub fn ts_query_capture_quantifier_for_id(arg1: *const TSQuery, id: u32) -> TSQuantifier;
+    pub fn ts_query_capture_quantifier_for_id(
+        arg1: *const TSQuery,
+        pattern_id: u32,
+        capture_id: u32,
+    ) -> TSQuantifier;
 }
 extern "C" {
     pub fn ts_query_string_value_for_id(

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -107,6 +107,11 @@ pub struct TSQueryCapture {
     pub node: TSNode,
     pub index: u32,
 }
+pub const TSQuantifier_One: TSQuantifier = 0;
+pub const TSQuantifier_OneOrMore: TSQuantifier = 1;
+pub const TSQuantifier_ZeroOrOne: TSQuantifier = 2;
+pub const TSQuantifier_ZeroOrMore: TSQuantifier = 3;
+pub type TSQuantifier = u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct TSQueryMatch {
@@ -666,13 +671,10 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Get the suffix of one of the query's captures, or one of the query's"]
-    #[doc = " string literals. Each capture and string is associated with a numeric"]
-    #[doc = " id based on the order that it appeared in the query's source."]
-    pub fn ts_query_capture_suffix_for_id(
-        arg1: *const TSQuery,
-        id: u32,
-    ) -> ::std::os::raw::c_char;
+    #[doc = " Get the quantifier of the query's captures, or one of the query's string"]
+    #[doc = " literals. Each capture and string is associated with a numeric id based"]
+    #[doc = " on the order that it appeared in the query's source."]
+    pub fn ts_query_capture_quantifier_for_id(arg1: *const TSQuery, id: u32) -> TSQuantifier;
 }
 extern "C" {
     pub fn ts_query_string_value_for_id(

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -672,9 +672,8 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Get the quantifier of the query's captures, or one of the query's string"]
-    #[doc = " literals. Each capture and string is associated with a numeric id based"]
-    #[doc = " on the order that it appeared in the query's source."]
+    #[doc = " Get the quantifier of the query's captures. Each capture is * associated"]
+    #[doc = " with a numeric id based on the order that it appeared in the query's source."]
     pub fn ts_query_capture_quantifier_for_id(
         arg1: *const TSQuery,
         pattern_id: u32,

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -107,12 +107,12 @@ pub struct TSQueryCapture {
     pub node: TSNode,
     pub index: u32,
 }
-pub const TSQuantifier_Zero: TSQuantifier = 0;
-pub const TSQuantifier_ZeroOrOne: TSQuantifier = 1;
-pub const TSQuantifier_ZeroOrMore: TSQuantifier = 2;
-pub const TSQuantifier_One: TSQuantifier = 3;
-pub const TSQuantifier_OneOrMore: TSQuantifier = 4;
-pub type TSQuantifier = u32;
+pub const TSQuantifier_TSQuantifierZero: TSQuantifier = 0;
+pub const TSQuantifier_TSQuantifierZeroOrOne: TSQuantifier = 1;
+pub const TSQuantifier_TSQuantifierZeroOrMore: TSQuantifier = 2;
+pub const TSQuantifier_TSQuantifierOne: TSQuantifier = 3;
+pub const TSQuantifier_TSQuantifierOneOrMore: TSQuantifier = 4;
+pub type TSQuantifier = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct TSQueryMatch {

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -118,11 +118,11 @@ pub enum CaptureQuantifier {
 impl From<ffi::TSQuantifier> for CaptureQuantifier {
     fn from(value: ffi::TSQuantifier) -> Self {
         match value {
-            ffi::TSQuantifier_Zero => CaptureQuantifier::Zero,
-            ffi::TSQuantifier_ZeroOrOne => CaptureQuantifier::ZeroOrOne,
-            ffi::TSQuantifier_ZeroOrMore => CaptureQuantifier::ZeroOrMore,
-            ffi::TSQuantifier_One => CaptureQuantifier::One,
-            ffi::TSQuantifier_OneOrMore => CaptureQuantifier::OneOrMore,
+            ffi::TSQuantifier_TSQuantifierZero => CaptureQuantifier::Zero,
+            ffi::TSQuantifier_TSQuantifierZeroOrOne => CaptureQuantifier::ZeroOrOne,
+            ffi::TSQuantifier_TSQuantifierZeroOrMore => CaptureQuantifier::ZeroOrMore,
+            ffi::TSQuantifier_TSQuantifierOne => CaptureQuantifier::One,
+            ffi::TSQuantifier_TSQuantifierOneOrMore => CaptureQuantifier::OneOrMore,
             _ => panic!("Unrecognized quantifier: {}", value),
         }
     }

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1349,7 +1349,7 @@ impl Query {
             }
         }
 
-        // Build
+        // Build a vector to store capture qunatifiers.
         for i in 0..pattern_count {
             let mut capture_quantifiers = Vec::with_capacity(capture_count as usize);
             for j in 0..capture_count {

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -98,7 +98,7 @@ pub struct TreeCursor<'a>(ffi::TSTreeCursor, PhantomData<&'a ()>);
 pub struct Query {
     ptr: NonNull<ffi::TSQuery>,
     capture_names: Vec<String>,
-    capture_quantifiers: Vec<CaptureQuantifier>,
+    capture_quantifiers: Vec<Vec<CaptureQuantifier>>,
     text_predicates: Vec<Box<[TextPredicate]>>,
     property_settings: Vec<Box<[QueryProperty]>>,
     property_predicates: Vec<Box<[(QueryProperty, bool)]>>,
@@ -108,19 +108,21 @@ pub struct Query {
 /// A quantifier for captures
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum CaptureQuantifier {
-    One,
-    OneOrMore,
+    Zero,
     ZeroOrOne,
     ZeroOrMore,
+    One,
+    OneOrMore,
 }
 
 impl From<ffi::TSQuantifier> for CaptureQuantifier {
     fn from(value: ffi::TSQuantifier) -> Self {
         match value {
-            ffi::TSQuantifier_One => CaptureQuantifier::One,
-            ffi::TSQuantifier_OneOrMore => CaptureQuantifier::OneOrMore,
+            ffi::TSQuantifier_Zero => CaptureQuantifier::Zero,
             ffi::TSQuantifier_ZeroOrOne => CaptureQuantifier::ZeroOrOne,
             ffi::TSQuantifier_ZeroOrMore => CaptureQuantifier::ZeroOrMore,
+            ffi::TSQuantifier_One => CaptureQuantifier::One,
+            ffi::TSQuantifier_OneOrMore => CaptureQuantifier::OneOrMore,
             _ => panic!("Unrecognized quantifier: {}", value),
         }
     }
@@ -1328,7 +1330,7 @@ impl Query {
         let mut result = Query {
             ptr: unsafe { NonNull::new_unchecked(ptr) },
             capture_names: Vec::with_capacity(capture_count as usize),
-            capture_quantifiers: Vec::with_capacity(capture_count as usize),
+            capture_quantifiers: Vec::with_capacity(pattern_count as usize),
             text_predicates: Vec::with_capacity(pattern_count),
             property_predicates: Vec::with_capacity(pattern_count),
             property_settings: Vec::with_capacity(pattern_count),
@@ -1344,9 +1346,19 @@ impl Query {
                 let name = slice::from_raw_parts(name, length as usize);
                 let name = str::from_utf8_unchecked(name);
                 result.capture_names.push(name.to_string());
-                let quantifier = ffi::ts_query_capture_quantifier_for_id(ptr, i);
-                result.capture_quantifiers.push(quantifier.into());
             }
+        }
+
+        // Build
+        for i in 0..pattern_count {
+            let mut capture_quantifiers = Vec::with_capacity(capture_count as usize);
+            for j in 0..capture_count {
+                unsafe {
+                    let quantifier = ffi::ts_query_capture_quantifier_for_id(ptr, i as u32, j);
+                    capture_quantifiers.push(quantifier.into());
+                }
+            }
+            result.capture_quantifiers.push(capture_quantifiers);
         }
 
         // Build a vector of strings to represent literal values used in predicates.
@@ -1550,8 +1562,8 @@ impl Query {
     }
 
     /// Get the quantifiers of the captures used in the query.
-    pub fn capture_quantifiers(&self) -> &[CaptureQuantifier] {
-        &self.capture_quantifiers
+    pub fn capture_quantifiers(&self, index: usize) -> &[CaptureQuantifier] {
+        &self.capture_quantifiers[index]
     }
 
     /// Get the index for a given capture name.

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -98,7 +98,7 @@ pub struct TreeCursor<'a>(ffi::TSTreeCursor, PhantomData<&'a ()>);
 pub struct Query {
     ptr: NonNull<ffi::TSQuery>,
     capture_names: Vec<String>,
-    capture_quantifiers: Vec<Quantifier>,
+    capture_quantifiers: Vec<CaptureQuantifier>,
     text_predicates: Vec<Box<[TextPredicate]>>,
     property_settings: Vec<Box<[QueryProperty]>>,
     property_predicates: Vec<Box<[(QueryProperty, bool)]>>,
@@ -107,20 +107,20 @@ pub struct Query {
 
 /// A quantifier for captures
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum Quantifier {
+pub enum CaptureQuantifier {
     One,
     OneOrMore,
     ZeroOrOne,
     ZeroOrMore,
 }
 
-impl From<ffi::TSQuantifier> for Quantifier {
+impl From<ffi::TSQuantifier> for CaptureQuantifier {
     fn from(value: ffi::TSQuantifier) -> Self {
         match value {
-            ffi::TSQuantifier_One => Quantifier::One,
-            ffi::TSQuantifier_OneOrMore => Quantifier::OneOrMore,
-            ffi::TSQuantifier_ZeroOrOne => Quantifier::ZeroOrOne,
-            ffi::TSQuantifier_ZeroOrMore => Quantifier::ZeroOrMore,
+            ffi::TSQuantifier_One => CaptureQuantifier::One,
+            ffi::TSQuantifier_OneOrMore => CaptureQuantifier::OneOrMore,
+            ffi::TSQuantifier_ZeroOrOne => CaptureQuantifier::ZeroOrOne,
+            ffi::TSQuantifier_ZeroOrMore => CaptureQuantifier::ZeroOrMore,
             _ => panic!("Unrecognized quantifier: {}", value),
         }
     }
@@ -1550,7 +1550,7 @@ impl Query {
     }
 
     /// Get the quantifiers of the captures used in the query.
-    pub fn capture_quantifiers(&self) -> &[Quantifier] {
+    pub fn capture_quantifiers(&self) -> &[CaptureQuantifier] {
         &self.capture_quantifiers
     }
 

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -106,6 +106,13 @@ typedef struct {
   uint32_t index;
 } TSQueryCapture;
 
+typedef enum {
+  One,
+  OneOrMore,
+  ZeroOrOne,
+  ZeroOrMore,
+} TSQuantifier;
+
 typedef struct {
   uint32_t id;
   uint16_t pattern_index;
@@ -740,7 +747,13 @@ const char *ts_query_capture_name_for_id(
   uint32_t id,
   uint32_t *length
 );
-char ts_query_capture_suffix_for_id(
+
+/**
+ * Get the quantifier of the query's captures, or one of the query's string
+ * literals. Each capture and string is associated with a numeric id based
+ * on the order that it appeared in the query's source.
+ */
+TSQuantifier ts_query_capture_quantifier_for_id(
   const TSQuery *,
   uint32_t id
 );

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -107,10 +107,11 @@ typedef struct {
 } TSQueryCapture;
 
 typedef enum {
-  One,
-  OneOrMore,
+  Zero = 0, // must match the array initialization value
   ZeroOrOne,
   ZeroOrMore,
+  One,
+  OneOrMore,
 } TSQuantifier;
 
 typedef struct {

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -750,9 +750,8 @@ const char *ts_query_capture_name_for_id(
 );
 
 /**
- * Get the quantifier of the query's captures, or one of the query's string
- * literals. Each capture and string is associated with a numeric id based
- * on the order that it appeared in the query's source.
+ * Get the quantifier of the query's captures. Each capture is * associated
+ * with a numeric id based on the order that it appeared in the query's source.
  */
 TSQuantifier ts_query_capture_quantifier_for_id(
   const TSQuery *,

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -756,8 +756,10 @@ const char *ts_query_capture_name_for_id(
  */
 TSQuantifier ts_query_capture_quantifier_for_id(
   const TSQuery *,
-  uint32_t id
+  uint32_t pattern_id,
+  uint32_t capture_id
 );
+
 const char *ts_query_string_value_for_id(
   const TSQuery *,
   uint32_t id,

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -740,6 +740,10 @@ const char *ts_query_capture_name_for_id(
   uint32_t id,
   uint32_t *length
 );
+char ts_query_capture_suffix_for_id(
+  const TSQuery *,
+  uint32_t id
+);
 const char *ts_query_string_value_for_id(
   const TSQuery *,
   uint32_t id,

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -107,11 +107,11 @@ typedef struct {
 } TSQueryCapture;
 
 typedef enum {
-  Zero = 0, // must match the array initialization value
-  ZeroOrOne,
-  ZeroOrMore,
-  One,
-  OneOrMore,
+  TSQuantifierZero = 0, // must match the array initialization value
+  TSQuantifierZeroOrOne,
+  TSQuantifierZeroOrMore,
+  TSQuantifierOne,
+  TSQuantifierOneOrMore,
 } TSQuantifier;
 
 typedef struct {

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -482,6 +482,7 @@ static TSQuantifier quantifier_mul(
         case TSQuantifierOneOrMore:
           return TSQuantifierZeroOrMore;
       };
+      break;
     case TSQuantifierZeroOrMore:
       switch (right) {
         case TSQuantifierZero:
@@ -492,6 +493,7 @@ static TSQuantifier quantifier_mul(
         case TSQuantifierOneOrMore:
           return TSQuantifierZeroOrMore;
       };
+      break;
     case TSQuantifierOne:
       return right;
     case TSQuantifierOneOrMore:
@@ -505,6 +507,7 @@ static TSQuantifier quantifier_mul(
         case TSQuantifierOneOrMore:
           return TSQuantifierOneOrMore;
       };
+      break;
   }
   return TSQuantifierZero; // to make compiler happy, but all cases should be covered above!
 }
@@ -526,6 +529,7 @@ static TSQuantifier quantifier_join(
         case TSQuantifierOneOrMore:
           return TSQuantifierZeroOrMore;
       };
+      break;
     case TSQuantifierZeroOrOne:
       switch (right) {
         case TSQuantifierZero:
@@ -538,6 +542,7 @@ static TSQuantifier quantifier_join(
           return TSQuantifierZeroOrMore;
           break;
       };
+      break;
     case TSQuantifierZeroOrMore:
       return TSQuantifierZeroOrMore;
     case TSQuantifierOne:
@@ -552,6 +557,7 @@ static TSQuantifier quantifier_join(
         case TSQuantifierOneOrMore:
           return TSQuantifierOneOrMore;
       };
+      break;
     case TSQuantifierOneOrMore:
       switch (right) {
         case TSQuantifierZero:
@@ -562,6 +568,7 @@ static TSQuantifier quantifier_join(
         case TSQuantifierOneOrMore:
           return TSQuantifierOneOrMore;
       };
+      break;
   }
   return TSQuantifierZero; // to make compiler happy, but all cases should be covered above!
 }
@@ -585,6 +592,7 @@ static TSQuantifier quantifier_add(
         case TSQuantifierOneOrMore:
           return TSQuantifierOneOrMore;
       };
+      break;
     case TSQuantifierZeroOrMore:
       switch (right) {
         case TSQuantifierZero:
@@ -596,6 +604,7 @@ static TSQuantifier quantifier_add(
         case TSQuantifierOneOrMore:
           return TSQuantifierOneOrMore;
       };
+      break;
     case TSQuantifierOne:
       switch (right) {
         case TSQuantifierZero:
@@ -606,6 +615,7 @@ static TSQuantifier quantifier_add(
         case TSQuantifierOneOrMore:
           return TSQuantifierOneOrMore;
       };
+      break;
     case TSQuantifierOneOrMore:
       return TSQuantifierOneOrMore;
   }

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -467,90 +467,82 @@ static TSQuantifier quantifier_mul(
   TSQuantifier left,
   TSQuantifier right
 ) {
+  TSQuantifier result;
   switch (left)
   {
     case Zero:
-      return Zero;
-    case One:
-      return right;
-    case OneOrMore:
-      switch (right) {
-        case Zero:
-          return Zero;
-        case ZeroOrOne:
-        case ZeroOrMore:
-          return ZeroOrMore;
-        case One:
-        case OneOrMore:
-          return OneOrMore;
-      };
+      result = Zero;
       break;
     case ZeroOrOne:
       switch (right) {
         case Zero:
-          return Zero;
+          result = Zero;
+          break;
         case ZeroOrOne:
         case One:
-          return ZeroOrOne;
+          result = ZeroOrOne;
+          break;
         case ZeroOrMore:
         case OneOrMore:
-          return ZeroOrMore;
+          result = ZeroOrMore;
+          break;
       };
       break;
     case ZeroOrMore:
       switch (right) {
         case Zero:
-          return Zero;
+          result = Zero;
+          break;
         case ZeroOrOne:
         case ZeroOrMore:
         case One:
         case OneOrMore:
-          return ZeroOrMore;
+          result = ZeroOrMore;
+          break;
       };
-      return ZeroOrMore;
+      break;
+    case One:
+      result = right;
+      break;
+    case OneOrMore:
+      switch (right) {
+        case Zero:
+          result = Zero;
+          break;
+        case ZeroOrOne:
+        case ZeroOrMore:
+          result = ZeroOrMore;
+          break;
+        case One:
+        case OneOrMore:
+          result = OneOrMore;
+          break;
+      };
+      break;
   }
+  return result;
 }
 
 static TSQuantifier quantifier_join(
   TSQuantifier left,
   TSQuantifier right
 ) {
+  TSQuantifier result;
   switch (left)
   {
     case Zero:
       switch (right) {
         case Zero:
-          return Zero;
+          result = Zero;
+          break;
         case ZeroOrOne:
         case One:
-          return ZeroOrOne;
+          result = ZeroOrOne;
+          break;
         case ZeroOrMore:
         case OneOrMore:
-          return ZeroOrMore;
-      };
-      break;
-    case One:
-      switch (right) {
-        case Zero:
-        case ZeroOrOne:
-          return ZeroOrOne;
-        case ZeroOrMore:
-          return ZeroOrMore;
-        case One:
-          return One;
-        case OneOrMore:
-          return OneOrMore;
-      };
-      break;
-    case OneOrMore:
-      switch (right) {
-        case Zero:
-        case ZeroOrOne:
-        case ZeroOrMore:
-          return ZeroOrMore;
-        case One:
-        case OneOrMore:
-          return OneOrMore;
+          result = ZeroOrMore;
+          break;
       };
       break;
     case ZeroOrOne:
@@ -558,63 +550,109 @@ static TSQuantifier quantifier_join(
         case Zero:
         case ZeroOrOne:
         case One:
-          return ZeroOrOne;
+          result = ZeroOrOne;
+          break;
         case ZeroOrMore:
         case OneOrMore:
-          return ZeroOrMore;
+          result = ZeroOrMore;
+          break;
       };
       break;
     case ZeroOrMore:
-      return ZeroOrMore;
+      result = ZeroOrMore;
+      break;
+    case One:
+      switch (right) {
+        case Zero:
+        case ZeroOrOne:
+          result = ZeroOrOne;
+          break;
+        case ZeroOrMore:
+          result = ZeroOrMore;
+          break;
+        case One:
+          result = One;
+          break;
+        case OneOrMore:
+          result = OneOrMore;
+          break;
+      };
+      break;
+    case OneOrMore:
+      switch (right) {
+        case Zero:
+        case ZeroOrOne:
+        case ZeroOrMore:
+          result = ZeroOrMore;
+          break;
+        case One:
+        case OneOrMore:
+          result = OneOrMore;
+          break;
+      };
+      break;
   }
+  return result;
 }
 
 static TSQuantifier quantifier_add(
   TSQuantifier left,
   TSQuantifier right
 ) {
+  TSQuantifier result;
   switch (left)
   {
     case Zero:
-      return right;
-    case One:
-      switch (right) {
-        case Zero:
-          return One;
-        case ZeroOrOne:
-        case ZeroOrMore:
-        case One:
-        case OneOrMore:
-          return OneOrMore;
-      };
+      result = right;
       break;
-    case OneOrMore:
-      return OneOrMore;
     case ZeroOrOne:
       switch (right) {
         case Zero:
-          return ZeroOrOne;
+          result = ZeroOrOne;
+          break;
         case ZeroOrOne:
         case ZeroOrMore:
-          return ZeroOrMore;
+          result = ZeroOrMore;
+          break;
         case One:
         case OneOrMore:
-          return OneOrMore;
+          result = OneOrMore;
+          break;
       };
       break;
     case ZeroOrMore:
       switch (right) {
         case Zero:
-          return ZeroOrMore;
+          result = ZeroOrMore;
+          break;
         case ZeroOrOne:
         case ZeroOrMore:
-          return ZeroOrMore;
+          result = ZeroOrMore;
+          break;
         case One:
         case OneOrMore:
-          return OneOrMore;
+          result = OneOrMore;
+          break;
       };
       break;
+    case One:
+      switch (right) {
+        case Zero:
+          result = One;
+          break;
+        case ZeroOrOne:
+        case ZeroOrMore:
+        case One:
+        case OneOrMore:
+          result = OneOrMore;
+          break;
+      };
+      break;
+    case OneOrMore:
+      result = OneOrMore;
+      break;
   }
+  return result;
 }
 
 // Create new capture quantifiers structure

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -1990,7 +1990,7 @@ static TSQueryError ts_query__parse_pattern(
         return e;
       }
 
-      if(start_index == 0) {
+      if(start_index == starting_step_index) {
         capture_quantifiers_replace(capture_quantifiers, &branch_capture_quantifiers);
       } else {
         capture_quantifiers_join_all(capture_quantifiers, &branch_capture_quantifiers);

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -123,7 +123,7 @@ typedef struct {
 /**
  * CaptureQuantififers - a data structure holding the quantifiers of pattern captures.
  */
-typedef Array(TSQuantifier) CaptureQuantifiers;
+typedef Array(uint8_t) CaptureQuantifiers;
 
 /*
  * PatternEntry - Information about the starting point for matching a particular
@@ -645,7 +645,7 @@ static TSQuantifier capture_quantifier_for_id(
   const CaptureQuantifiers *self,
   uint16_t id
 ) {
-  return (self->size <= id) ? TSQuantifierZero : *array_get(self, id);
+  return (self->size <= id) ? TSQuantifierZero : (TSQuantifier) *array_get(self, id);
 }
 
 // Add the given quantifier to the current value for id
@@ -657,8 +657,8 @@ static void capture_quantifiers_add_for_id(
   if (self->size <= id) {
     array_grow_by(self, id + 1 - self->size);
   }
-  TSQuantifier *own_quantifier = array_get(self, id);
-  *own_quantifier = quantifier_add(*own_quantifier, quantifier);
+  uint8_t *own_quantifier = array_get(self, id);
+  *own_quantifier = (uint8_t) quantifier_add((TSQuantifier) *own_quantifier, quantifier);
 }
 
 // Point-wise add the given quantifiers to the current values
@@ -670,9 +670,9 @@ static void capture_quantifiers_add_all(
     array_grow_by(self, quantifiers->size - self->size);
   }
   for (uint16_t id = 0; id < quantifiers->size; id++) {
-    TSQuantifier *quantifier = array_get(quantifiers, id);
-    TSQuantifier *own_quantifier = array_get(self, id);
-    *own_quantifier = quantifier_add(*own_quantifier, *quantifier);
+    uint8_t *quantifier = array_get(quantifiers, id);
+    uint8_t *own_quantifier = array_get(self, id);
+    *own_quantifier = (uint8_t) quantifier_add((TSQuantifier) *own_quantifier, (TSQuantifier) *quantifier);
   }
 }
 
@@ -682,8 +682,8 @@ static void capture_quantifiers_mul(
   TSQuantifier quantifier
 ) {
   for (uint16_t id = 0; id < self->size; id++) {
-    TSQuantifier *own_quantifier = array_get(self, id);
-    *own_quantifier = quantifier_mul(*own_quantifier, quantifier);
+    uint8_t *own_quantifier = array_get(self, id);
+    *own_quantifier = (uint8_t) quantifier_mul((TSQuantifier) *own_quantifier, quantifier);
   }
 }
 
@@ -696,13 +696,13 @@ static void capture_quantifiers_join_all(
     array_grow_by(self, quantifiers->size - self->size);
   }
   for (uint32_t id = 0; id < quantifiers->size; id++) {
-    TSQuantifier *quantifier = array_get(quantifiers, id);
-    TSQuantifier *own_quantifier = array_get(self, id);
-    *own_quantifier = quantifier_join(*own_quantifier, *quantifier);
+    uint8_t *quantifier = array_get(quantifiers, id);
+    uint8_t *own_quantifier = array_get(self, id);
+    *own_quantifier = (uint8_t) quantifier_join((TSQuantifier) *own_quantifier, (TSQuantifier) *quantifier);
   }
   for (uint32_t id = quantifiers->size; id < self->size; id++) {
-    TSQuantifier *own_quantifier = array_get(self, id);
-    *own_quantifier = quantifier_join(*own_quantifier, TSQuantifierZero);
+    uint8_t *own_quantifier = array_get(self, id);
+    *own_quantifier = (uint8_t) quantifier_join((TSQuantifier) *own_quantifier, TSQuantifierZero);
   }
 }
 

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -1607,7 +1607,7 @@ static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
   }
 
   // Mark as indefinite any step with captures that are used in predicates.
-  Array(uint16_t) predicate_capture_ids = array_new(); // FIXME
+  Array(uint16_t) predicate_capture_ids = array_new();
   for (unsigned i = 0; i < self->patterns.size; i++) {
     QueryPattern *pattern = &self->patterns.contents[i];
 
@@ -1715,7 +1715,7 @@ static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
   array_delete(&deeper_states);
   array_delete(&final_step_indices);
   array_delete(&parent_step_indices);
-  array_delete(&predicate_capture_ids); // FIXME
+  array_delete(&predicate_capture_ids);
   state_predecessor_map_delete(&predecessor_map);
 
   return all_patterns_are_valid;

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -467,192 +467,149 @@ static TSQuantifier quantifier_mul(
   TSQuantifier left,
   TSQuantifier right
 ) {
-  TSQuantifier result = TSQuantifierZero; // initialized to make compiler happy, but all cases should be covered below!
   switch (left)
   {
     case TSQuantifierZero:
-      result = TSQuantifierZero;
-      break;
+      return TSQuantifierZero;
     case TSQuantifierZeroOrOne:
       switch (right) {
         case TSQuantifierZero:
-          result = TSQuantifierZero;
-          break;
+          return TSQuantifierZero;
         case TSQuantifierZeroOrOne:
         case TSQuantifierOne:
-          result = TSQuantifierZeroOrOne;
-          break;
+          return TSQuantifierZeroOrOne;
         case TSQuantifierZeroOrMore:
         case TSQuantifierOneOrMore:
-          result = TSQuantifierZeroOrMore;
-          break;
+          return TSQuantifierZeroOrMore;
       };
-      break;
     case TSQuantifierZeroOrMore:
       switch (right) {
         case TSQuantifierZero:
-          result = TSQuantifierZero;
-          break;
+          return TSQuantifierZero;
         case TSQuantifierZeroOrOne:
         case TSQuantifierZeroOrMore:
         case TSQuantifierOne:
         case TSQuantifierOneOrMore:
-          result = TSQuantifierZeroOrMore;
-          break;
+          return TSQuantifierZeroOrMore;
       };
-      break;
     case TSQuantifierOne:
-      result = right;
-      break;
+      return right;
     case TSQuantifierOneOrMore:
       switch (right) {
         case TSQuantifierZero:
-          result = TSQuantifierZero;
-          break;
+          return TSQuantifierZero;
         case TSQuantifierZeroOrOne:
         case TSQuantifierZeroOrMore:
-          result = TSQuantifierZeroOrMore;
-          break;
+          return TSQuantifierZeroOrMore;
         case TSQuantifierOne:
         case TSQuantifierOneOrMore:
-          result = TSQuantifierOneOrMore;
-          break;
+          return TSQuantifierOneOrMore;
       };
-      break;
   }
-  return result;
+  return TSQuantifierZero; // to make compiler happy, but all cases should be covered above!
 }
 
 static TSQuantifier quantifier_join(
   TSQuantifier left,
   TSQuantifier right
 ) {
-  TSQuantifier result = TSQuantifierZero; // initialized to make compiler happy, but all cases should be covered below!
   switch (left)
   {
     case TSQuantifierZero:
       switch (right) {
         case TSQuantifierZero:
-          result = TSQuantifierZero;
-          break;
+          return TSQuantifierZero;
         case TSQuantifierZeroOrOne:
         case TSQuantifierOne:
-          result = TSQuantifierZeroOrOne;
-          break;
+          return TSQuantifierZeroOrOne;
         case TSQuantifierZeroOrMore:
         case TSQuantifierOneOrMore:
-          result = TSQuantifierZeroOrMore;
-          break;
+          return TSQuantifierZeroOrMore;
       };
-      break;
     case TSQuantifierZeroOrOne:
       switch (right) {
         case TSQuantifierZero:
         case TSQuantifierZeroOrOne:
         case TSQuantifierOne:
-          result = TSQuantifierZeroOrOne;
+          return TSQuantifierZeroOrOne;
           break;
         case TSQuantifierZeroOrMore:
         case TSQuantifierOneOrMore:
-          result = TSQuantifierZeroOrMore;
+          return TSQuantifierZeroOrMore;
           break;
       };
-      break;
     case TSQuantifierZeroOrMore:
-      result = TSQuantifierZeroOrMore;
-      break;
+      return TSQuantifierZeroOrMore;
     case TSQuantifierOne:
       switch (right) {
         case TSQuantifierZero:
         case TSQuantifierZeroOrOne:
-          result = TSQuantifierZeroOrOne;
-          break;
+          return TSQuantifierZeroOrOne;
         case TSQuantifierZeroOrMore:
-          result = TSQuantifierZeroOrMore;
-          break;
+          return TSQuantifierZeroOrMore;
         case TSQuantifierOne:
-          result = TSQuantifierOne;
-          break;
+          return TSQuantifierOne;
         case TSQuantifierOneOrMore:
-          result = TSQuantifierOneOrMore;
-          break;
+          return TSQuantifierOneOrMore;
       };
-      break;
     case TSQuantifierOneOrMore:
       switch (right) {
         case TSQuantifierZero:
         case TSQuantifierZeroOrOne:
         case TSQuantifierZeroOrMore:
-          result = TSQuantifierZeroOrMore;
-          break;
+          return TSQuantifierZeroOrMore;
         case TSQuantifierOne:
         case TSQuantifierOneOrMore:
-          result = TSQuantifierOneOrMore;
-          break;
+          return TSQuantifierOneOrMore;
       };
-      break;
   }
-  return result;
+  return TSQuantifierZero; // to make compiler happy, but all cases should be covered above!
 }
 
 static TSQuantifier quantifier_add(
   TSQuantifier left,
   TSQuantifier right
 ) {
-  TSQuantifier result = TSQuantifierZero; // initialized to make compiler happy, but all cases should be covered below!
   switch (left)
   {
     case TSQuantifierZero:
-      result = right;
-      break;
+      return right;
     case TSQuantifierZeroOrOne:
       switch (right) {
         case TSQuantifierZero:
-          result = TSQuantifierZeroOrOne;
-          break;
+          return TSQuantifierZeroOrOne;
         case TSQuantifierZeroOrOne:
         case TSQuantifierZeroOrMore:
-          result = TSQuantifierZeroOrMore;
-          break;
+          return TSQuantifierZeroOrMore;
         case TSQuantifierOne:
         case TSQuantifierOneOrMore:
-          result = TSQuantifierOneOrMore;
-          break;
+          return TSQuantifierOneOrMore;
       };
-      break;
     case TSQuantifierZeroOrMore:
       switch (right) {
         case TSQuantifierZero:
-          result = TSQuantifierZeroOrMore;
-          break;
+          return TSQuantifierZeroOrMore;
         case TSQuantifierZeroOrOne:
         case TSQuantifierZeroOrMore:
-          result = TSQuantifierZeroOrMore;
-          break;
+          return TSQuantifierZeroOrMore;
         case TSQuantifierOne:
         case TSQuantifierOneOrMore:
-          result = TSQuantifierOneOrMore;
-          break;
+          return TSQuantifierOneOrMore;
       };
-      break;
     case TSQuantifierOne:
       switch (right) {
         case TSQuantifierZero:
-          result = TSQuantifierOne;
-          break;
+          return TSQuantifierOne;
         case TSQuantifierZeroOrOne:
         case TSQuantifierZeroOrMore:
         case TSQuantifierOne:
         case TSQuantifierOneOrMore:
-          result = TSQuantifierOneOrMore;
-          break;
+          return TSQuantifierOneOrMore;
       };
-      break;
     case TSQuantifierOneOrMore:
-      result = TSQuantifierOneOrMore;
-      break;
+      return TSQuantifierOneOrMore;
   }
-  return result;
+  return TSQuantifierZero; // to make compiler happy, but all cases should be covered above!
 }
 
 // Create new capture quantifiers structure

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -467,7 +467,7 @@ static TSQuantifier quantifier_mul(
   TSQuantifier left,
   TSQuantifier right
 ) {
-  TSQuantifier result;
+  TSQuantifier result = Zero; // initialized to make compiler happy, but all cases should be covered below!
   switch (left)
   {
     case Zero:
@@ -527,7 +527,7 @@ static TSQuantifier quantifier_join(
   TSQuantifier left,
   TSQuantifier right
 ) {
-  TSQuantifier result;
+  TSQuantifier result = Zero; // initialized to make compiler happy, but all cases should be covered below!
   switch (left)
   {
     case Zero:
@@ -599,7 +599,7 @@ static TSQuantifier quantifier_add(
   TSQuantifier left,
   TSQuantifier right
 ) {
-  TSQuantifier result;
+  TSQuantifier result = Zero; // initialized to make compiler happy, but all cases should be covered below!
   switch (left)
   {
     case Zero:

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -2291,12 +2291,9 @@ static TSQueryError ts_query__parse_pattern(
       is_immediate,
       &field_capture_quantifiers
     );
-    if (e == PARENT_DONE) {
-      capture_quantifiers_delete(&field_capture_quantifiers);
-      return TSQueryErrorSyntax;
-    }
     if (e) {
       capture_quantifiers_delete(&field_capture_quantifiers);
+      if (e == PARENT_DONE) e = TSQueryErrorSyntax;
       return e;
     }
 

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -467,55 +467,55 @@ static TSQuantifier quantifier_mul(
   TSQuantifier left,
   TSQuantifier right
 ) {
-  TSQuantifier result = Zero; // initialized to make compiler happy, but all cases should be covered below!
+  TSQuantifier result = TSQuantifierZero; // initialized to make compiler happy, but all cases should be covered below!
   switch (left)
   {
-    case Zero:
-      result = Zero;
+    case TSQuantifierZero:
+      result = TSQuantifierZero;
       break;
-    case ZeroOrOne:
+    case TSQuantifierZeroOrOne:
       switch (right) {
-        case Zero:
-          result = Zero;
+        case TSQuantifierZero:
+          result = TSQuantifierZero;
           break;
-        case ZeroOrOne:
-        case One:
-          result = ZeroOrOne;
+        case TSQuantifierZeroOrOne:
+        case TSQuantifierOne:
+          result = TSQuantifierZeroOrOne;
           break;
-        case ZeroOrMore:
-        case OneOrMore:
-          result = ZeroOrMore;
+        case TSQuantifierZeroOrMore:
+        case TSQuantifierOneOrMore:
+          result = TSQuantifierZeroOrMore;
           break;
       };
       break;
-    case ZeroOrMore:
+    case TSQuantifierZeroOrMore:
       switch (right) {
-        case Zero:
-          result = Zero;
+        case TSQuantifierZero:
+          result = TSQuantifierZero;
           break;
-        case ZeroOrOne:
-        case ZeroOrMore:
-        case One:
-        case OneOrMore:
-          result = ZeroOrMore;
+        case TSQuantifierZeroOrOne:
+        case TSQuantifierZeroOrMore:
+        case TSQuantifierOne:
+        case TSQuantifierOneOrMore:
+          result = TSQuantifierZeroOrMore;
           break;
       };
       break;
-    case One:
+    case TSQuantifierOne:
       result = right;
       break;
-    case OneOrMore:
+    case TSQuantifierOneOrMore:
       switch (right) {
-        case Zero:
-          result = Zero;
+        case TSQuantifierZero:
+          result = TSQuantifierZero;
           break;
-        case ZeroOrOne:
-        case ZeroOrMore:
-          result = ZeroOrMore;
+        case TSQuantifierZeroOrOne:
+        case TSQuantifierZeroOrMore:
+          result = TSQuantifierZeroOrMore;
           break;
-        case One:
-        case OneOrMore:
-          result = OneOrMore;
+        case TSQuantifierOne:
+        case TSQuantifierOneOrMore:
+          result = TSQuantifierOneOrMore;
           break;
       };
       break;
@@ -527,67 +527,67 @@ static TSQuantifier quantifier_join(
   TSQuantifier left,
   TSQuantifier right
 ) {
-  TSQuantifier result = Zero; // initialized to make compiler happy, but all cases should be covered below!
+  TSQuantifier result = TSQuantifierZero; // initialized to make compiler happy, but all cases should be covered below!
   switch (left)
   {
-    case Zero:
+    case TSQuantifierZero:
       switch (right) {
-        case Zero:
-          result = Zero;
+        case TSQuantifierZero:
+          result = TSQuantifierZero;
           break;
-        case ZeroOrOne:
-        case One:
-          result = ZeroOrOne;
+        case TSQuantifierZeroOrOne:
+        case TSQuantifierOne:
+          result = TSQuantifierZeroOrOne;
           break;
-        case ZeroOrMore:
-        case OneOrMore:
-          result = ZeroOrMore;
+        case TSQuantifierZeroOrMore:
+        case TSQuantifierOneOrMore:
+          result = TSQuantifierZeroOrMore;
           break;
       };
       break;
-    case ZeroOrOne:
+    case TSQuantifierZeroOrOne:
       switch (right) {
-        case Zero:
-        case ZeroOrOne:
-        case One:
-          result = ZeroOrOne;
+        case TSQuantifierZero:
+        case TSQuantifierZeroOrOne:
+        case TSQuantifierOne:
+          result = TSQuantifierZeroOrOne;
           break;
-        case ZeroOrMore:
-        case OneOrMore:
-          result = ZeroOrMore;
+        case TSQuantifierZeroOrMore:
+        case TSQuantifierOneOrMore:
+          result = TSQuantifierZeroOrMore;
           break;
       };
       break;
-    case ZeroOrMore:
-      result = ZeroOrMore;
+    case TSQuantifierZeroOrMore:
+      result = TSQuantifierZeroOrMore;
       break;
-    case One:
+    case TSQuantifierOne:
       switch (right) {
-        case Zero:
-        case ZeroOrOne:
-          result = ZeroOrOne;
+        case TSQuantifierZero:
+        case TSQuantifierZeroOrOne:
+          result = TSQuantifierZeroOrOne;
           break;
-        case ZeroOrMore:
-          result = ZeroOrMore;
+        case TSQuantifierZeroOrMore:
+          result = TSQuantifierZeroOrMore;
           break;
-        case One:
-          result = One;
+        case TSQuantifierOne:
+          result = TSQuantifierOne;
           break;
-        case OneOrMore:
-          result = OneOrMore;
+        case TSQuantifierOneOrMore:
+          result = TSQuantifierOneOrMore;
           break;
       };
       break;
-    case OneOrMore:
+    case TSQuantifierOneOrMore:
       switch (right) {
-        case Zero:
-        case ZeroOrOne:
-        case ZeroOrMore:
-          result = ZeroOrMore;
+        case TSQuantifierZero:
+        case TSQuantifierZeroOrOne:
+        case TSQuantifierZeroOrMore:
+          result = TSQuantifierZeroOrMore;
           break;
-        case One:
-        case OneOrMore:
-          result = OneOrMore;
+        case TSQuantifierOne:
+        case TSQuantifierOneOrMore:
+          result = TSQuantifierOneOrMore;
           break;
       };
       break;
@@ -599,57 +599,57 @@ static TSQuantifier quantifier_add(
   TSQuantifier left,
   TSQuantifier right
 ) {
-  TSQuantifier result = Zero; // initialized to make compiler happy, but all cases should be covered below!
+  TSQuantifier result = TSQuantifierZero; // initialized to make compiler happy, but all cases should be covered below!
   switch (left)
   {
-    case Zero:
+    case TSQuantifierZero:
       result = right;
       break;
-    case ZeroOrOne:
+    case TSQuantifierZeroOrOne:
       switch (right) {
-        case Zero:
-          result = ZeroOrOne;
+        case TSQuantifierZero:
+          result = TSQuantifierZeroOrOne;
           break;
-        case ZeroOrOne:
-        case ZeroOrMore:
-          result = ZeroOrMore;
+        case TSQuantifierZeroOrOne:
+        case TSQuantifierZeroOrMore:
+          result = TSQuantifierZeroOrMore;
           break;
-        case One:
-        case OneOrMore:
-          result = OneOrMore;
+        case TSQuantifierOne:
+        case TSQuantifierOneOrMore:
+          result = TSQuantifierOneOrMore;
           break;
       };
       break;
-    case ZeroOrMore:
+    case TSQuantifierZeroOrMore:
       switch (right) {
-        case Zero:
-          result = ZeroOrMore;
+        case TSQuantifierZero:
+          result = TSQuantifierZeroOrMore;
           break;
-        case ZeroOrOne:
-        case ZeroOrMore:
-          result = ZeroOrMore;
+        case TSQuantifierZeroOrOne:
+        case TSQuantifierZeroOrMore:
+          result = TSQuantifierZeroOrMore;
           break;
-        case One:
-        case OneOrMore:
-          result = OneOrMore;
+        case TSQuantifierOne:
+        case TSQuantifierOneOrMore:
+          result = TSQuantifierOneOrMore;
           break;
       };
       break;
-    case One:
+    case TSQuantifierOne:
       switch (right) {
-        case Zero:
-          result = One;
+        case TSQuantifierZero:
+          result = TSQuantifierOne;
           break;
-        case ZeroOrOne:
-        case ZeroOrMore:
-        case One:
-        case OneOrMore:
-          result = OneOrMore;
+        case TSQuantifierZeroOrOne:
+        case TSQuantifierZeroOrMore:
+        case TSQuantifierOne:
+        case TSQuantifierOneOrMore:
+          result = TSQuantifierOneOrMore;
           break;
       };
       break;
-    case OneOrMore:
-      result = OneOrMore;
+    case TSQuantifierOneOrMore:
+      result = TSQuantifierOneOrMore;
       break;
   }
   return result;
@@ -688,7 +688,7 @@ static TSQuantifier capture_quantifier_for_id(
   const CaptureQuantifiers *self,
   uint16_t id
 ) {
-  return (self->size <= id) ? Zero : *array_get(self, id);
+  return (self->size <= id) ? TSQuantifierZero : *array_get(self, id);
 }
 
 // Add the given quantifier to the current value for id
@@ -745,7 +745,7 @@ static void capture_quantifiers_join_all(
   }
   for (uint32_t id = quantifiers->size; id < self->size; id++) {
     TSQuantifier *own_quantifier = array_get(self, id);
-    *own_quantifier = quantifier_join(*own_quantifier, Zero);
+    *own_quantifier = quantifier_join(*own_quantifier, TSQuantifierZero);
   }
 }
 
@@ -2381,11 +2381,11 @@ static TSQueryError ts_query__parse_pattern(
   stream_skip_whitespace(stream);
 
   // Parse suffixes modifiers for this pattern
-  TSQuantifier quantifier = One;
+  TSQuantifier quantifier = TSQuantifierOne;
   for (;;) {
     // Parse the one-or-more operator.
     if (stream->next == '+') {
-      quantifier = quantifier_join(OneOrMore, quantifier);
+      quantifier = quantifier_join(TSQuantifierOneOrMore, quantifier);
 
       stream_advance(stream);
       stream_skip_whitespace(stream);
@@ -2399,7 +2399,7 @@ static TSQueryError ts_query__parse_pattern(
 
     // Parse the zero-or-more repetition operator.
     else if (stream->next == '*') {
-      quantifier = quantifier_join(ZeroOrMore, quantifier);
+      quantifier = quantifier_join(TSQuantifierZeroOrMore, quantifier);
 
       stream_advance(stream);
       stream_skip_whitespace(stream);
@@ -2419,7 +2419,7 @@ static TSQueryError ts_query__parse_pattern(
 
     // Parse the optional operator.
     else if (stream->next == '?') {
-      quantifier = quantifier_join(ZeroOrOne, quantifier);
+      quantifier = quantifier_join(TSQuantifierZeroOrOne, quantifier);
 
       stream_advance(stream);
       stream_skip_whitespace(stream);
@@ -2453,7 +2453,7 @@ static TSQueryError ts_query__parse_pattern(
         query_step__add_capture(step, capture_id);
         // Add only once, not for every branch, lest the quantifier will be '+' instead of '1'
         if (step_index == starting_step_index) {
-          capture_quantifiers_add_for_id(capture_quantifiers, capture_id, One);
+          capture_quantifiers_add_for_id(capture_quantifiers, capture_id, TSQuantifierOne);
         }
         if (
           step->alternative_index != NONE &&

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -2404,14 +2404,13 @@ static TSQueryError ts_query__parse_pattern(
         length
       );
 
+      // Add the capture quantifier
+      capture_quantifiers_add_for_id(capture_quantifiers, capture_id, TSQuantifierOne);
+
       uint32_t step_index = starting_step_index;
       for (;;) {
         QueryStep *step = &self->steps.contents[step_index];
         query_step__add_capture(step, capture_id);
-        // Add only once, not for every branch, lest the quantifier will be '+' instead of '1'
-        if (step_index == starting_step_index) {
-          capture_quantifiers_add_for_id(capture_quantifiers, capture_id, TSQuantifierOne);
-        }
         if (
           step->alternative_index != NONE &&
           step->alternative_index > step_index &&


### PR DESCRIPTION
This PR adds support for exposing the pattern suffixes like `?` and `*` as part of the query object. This is useful information for downstream tools that are consuming a query match. In my use case, an optional pattern should map to an `Option` type, while a list or star pattern should map to `Vec` type.

## Implementation notes

The suffixes are exposed in a separate array `capture_suffixes` that has the same shape as the `capture_names` array. This way, the change should not be breaking for users.

~The C code exposes the suffixes as characters, but in the Rust bindings I convert them to a more semantic enum.~