### PR TITLE
Generate bindings during build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,10 +77,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bindgen"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453c49e5950bb0eb63bb3df640e31618846c89d5b7faa54040d76e98e0134375"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "clap",
+ "env_logger",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which 3.1.1",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bitvec"
+version = "0.19.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "blake2b_simd"
@@ -106,6 +141,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
+name = "cexpr"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db507a7679252d2276ed0dd8113c6875ec56d3089f9225b2b42c30cc1f8e5c89"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +173,17 @@ name = "chunked_transfer"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
+
+[[package]]
+name = "clang-sys"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -211,6 +266,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +287,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "getrandom"
@@ -273,6 +347,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "idna"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +395,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +438,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
+name = "nom"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+dependencies = [
+ "bitvec",
+ "funty",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +482,12 @@ checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -426,6 +530,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -586,6 +696,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
 name = "smallbitvec"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +725,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +742,15 @@ dependencies = [
  "redox_syscall 0.2.5",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -711,6 +842,7 @@ dependencies = [
 name = "tree-sitter"
 version = "0.20.2"
 dependencies = [
+ "bindgen",
  "cc",
  "lazy_static",
  "regex",
@@ -750,7 +882,7 @@ dependencies = [
  "tree-sitter-tags",
  "walkdir",
  "webbrowser",
- "which",
+ "which 4.1.0",
 ]
 
 [[package]]
@@ -854,6 +986,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
 name = "walkdir"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +1091,15 @@ dependencies = [
 
 [[package]]
 name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "which"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
@@ -997,3 +1144,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"

--- a/cli/src/tests/highlight_test.rs
+++ b/cli/src/tests/highlight_test.rs
@@ -1,6 +1,7 @@
 use super::helpers::fixtures::{get_highlight_config, get_language, get_language_queries_path};
 use lazy_static::lazy_static;
 use std::ffi::CString;
+use std::os::raw::c_char;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{fs, ptr, slice, str};
 use tree_sitter_highlight::{
@@ -489,15 +490,15 @@ fn test_highlighting_via_c_api() {
     ];
     let highlight_names = highlights
         .iter()
-        .map(|h| h["class=".len()..].as_ptr() as *const i8)
+        .map(|h| h["class=".len()..].as_ptr() as *const c_char)
         .collect::<Vec<_>>();
     let highlight_attrs = highlights
         .iter()
-        .map(|h| h.as_bytes().as_ptr() as *const i8)
+        .map(|h| h.as_bytes().as_ptr() as *const c_char)
         .collect::<Vec<_>>();
     let highlighter = c::ts_highlighter_new(
-        &highlight_names[0] as *const *const i8,
-        &highlight_attrs[0] as *const *const i8,
+        &highlight_names[0] as *const *const c_char,
+        &highlight_attrs[0] as *const *const c_char,
         highlights.len() as u32,
     );
 
@@ -515,9 +516,9 @@ fn test_highlighting_via_c_api() {
         js_scope.as_ptr(),
         js_injection_regex.as_ptr(),
         language,
-        highlights_query.as_ptr() as *const i8,
-        injections_query.as_ptr() as *const i8,
-        locals_query.as_ptr() as *const i8,
+        highlights_query.as_ptr() as *const c_char,
+        injections_query.as_ptr() as *const c_char,
+        locals_query.as_ptr() as *const c_char,
         highlights_query.len() as u32,
         injections_query.len() as u32,
         locals_query.len() as u32,
@@ -534,8 +535,8 @@ fn test_highlighting_via_c_api() {
         html_scope.as_ptr(),
         html_injection_regex.as_ptr(),
         language,
-        highlights_query.as_ptr() as *const i8,
-        injections_query.as_ptr() as *const i8,
+        highlights_query.as_ptr() as *const c_char,
+        injections_query.as_ptr() as *const c_char,
         ptr::null(),
         highlights_query.len() as u32,
         injections_query.len() as u32,

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -26,8 +26,12 @@ lazy_static = { version = "1.2.0", optional = true }
 regex = "1"
 
 [build-dependencies]
-bindgen = "0.59.1"
+bindgen = { version="0.59.1", optional=true }
 cc = "^1.0.58"
 
 [lib]
 path = "binding_rust/lib.rs"
+
+[features]
+# Generate bindings during build instead of using pre-generated code
+generate-bindings = ["bindgen"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -26,6 +26,7 @@ lazy_static = { version = "1.2.0", optional = true }
 regex = "1"
 
 [build-dependencies]
+bindgen = "0.59.1"
 cc = "^1.0.58"
 
 [lib]

--- a/lib/binding_rust/build.rs
+++ b/lib/binding_rust/build.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
+#[cfg(feature = "generate-bindings")]
 fn generate_bindings() {
     const HEADER_FILE: &'static str = "include/tree_sitter/api.h";
 
@@ -39,6 +40,7 @@ fn main() {
         }
     }
 
+    #[cfg(feature = "generate-bindings")]
     generate_bindings();
 
     let src_path = Path::new("src");

--- a/lib/binding_rust/ffi.rs
+++ b/lib/binding_rust/ffi.rs
@@ -2,7 +2,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 
-include!("./bindings.rs");
+include!(concat!(env!("OUT_DIR"),"/bindings.rs"));
 
 extern "C" {
     pub(crate) fn dup(fd: std::os::raw::c_int) -> std::os::raw::c_int;

--- a/lib/binding_rust/ffi.rs
+++ b/lib/binding_rust/ffi.rs
@@ -2,7 +2,11 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 
-include!(concat!(env!("OUT_DIR"),"/bindings.rs"));
+#[cfg(feature = "generate-bindings")]
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+#[cfg(not(feature = "generate-bindings"))]
+include!("./bindings.rs");
 
 extern "C" {
     pub(crate) fn dup(fd: std::os::raw::c_int) -> std::os::raw::c_int;

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -25,11 +25,12 @@ use std::{
 /// assigned an ABI version number that corresponds to the current CLI version.
 /// The Tree-sitter library is generally backwards-compatible with languages
 /// generated using older CLI versions, but is not forwards-compatible.
-pub const LANGUAGE_VERSION: usize = ffi::TREE_SITTER_LANGUAGE_VERSION;
+pub const LANGUAGE_VERSION: usize = ffi::TREE_SITTER_LANGUAGE_VERSION as usize;
 
 /// The earliest ABI version that is supported by the current version of the
 /// library.
-pub const MIN_COMPATIBLE_LANGUAGE_VERSION: usize = ffi::TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION;
+pub const MIN_COMPATIBLE_LANGUAGE_VERSION: usize =
+    ffi::TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION as usize;
 
 pub const PARSER_HEADER: &'static str = include_str!("../include/tree_sitter/parser.h");
 

--- a/tags/src/c_lib.rs
+++ b/tags/src/c_lib.rs
@@ -215,9 +215,9 @@ pub extern "C" fn ts_tags_buffer_tags_len(this: *const TSTagsBuffer) -> u32 {
 }
 
 #[no_mangle]
-pub extern "C" fn ts_tags_buffer_docs(this: *const TSTagsBuffer) -> *const i8 {
+pub extern "C" fn ts_tags_buffer_docs(this: *const TSTagsBuffer) -> *const c_char {
     let buffer = unwrap_ptr(this);
-    buffer.docs.as_ptr() as *const i8
+    buffer.docs.as_ptr() as *const c_char
 }
 
 #[no_mangle]
@@ -237,7 +237,7 @@ pub extern "C" fn ts_tagger_syntax_kinds_for_scope_name(
     this: *mut TSTagger,
     scope_name: *const c_char,
     len: *mut u32,
-) -> *const *const i8 {
+) -> *const *const c_char {
     let tagger = unwrap_mut_ptr(this);
     let scope_name = unsafe { unwrap(CStr::from_ptr(scope_name).to_str()) };
     let len = unwrap_mut_ptr(len);
@@ -245,7 +245,7 @@ pub extern "C" fn ts_tagger_syntax_kinds_for_scope_name(
     *len = 0;
     if let Some(config) = tagger.languages.get(scope_name) {
         *len = config.c_syntax_type_names.len() as u32;
-        return config.c_syntax_type_names.as_ptr() as *const *const i8;
+        return config.c_syntax_type_names.as_ptr() as *const *const c_char;
     }
     std::ptr::null()
 }


### PR DESCRIPTION
It was pointed to me during a package review that the `bindgen` output is platform- and architecture-dependent. Type mismatches may cause subtle bugs, especially when the platform bitness differs.
The officially recommended way of using `bindgen` is to embed it into the build script and run at the build time, as implemented in this PR.
Last 2 commits are fixing the build on non-Intel platforms, where `c_char` is defined as `u8`.

`cargo test` is passing on Linux i686, x86_64, armhfp, aarch64 and ppc64le. I don't have Windows or MacOS development machines, but I hope CI will cover that :)

***
There are two reasons for sending the PR; one is the technical stated above, and another is that our Rust packaging policy insists on regenerating such code when possible. So we're going to apply the patch downstream in Fedora in any case, but I can try reworking it to depend on environment or feature flags if you think that's necessary.