### PR TITLE
Support @module as a highlight key.

### DIFF
--- a/cli/src/highlight.rs
+++ b/cli/src/highlight.rs
@@ -157,6 +157,7 @@ impl Default for Theme {
               "function": 26,
               "keyword": 56,
               "number": {"color": 94, "bold": true},
+              "module": 136,
               "property": 124,
               "operator": {"color": 239, "bold": true},
               "punctuation.bracket": 239,


### PR DESCRIPTION
Some languages have the notion of modules, and to represent those
we've started to use a `@module` tag, as discussed in
https://github.com/elixir-lang/tree-sitter-elixir/issues/15.
Because historically we've used the constructor highlight color for
modules in JS/Ruby, it's defined to map to the same color.