### PR TITLE
Add `go.work` grammar

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,7 @@ Parsers for these languages are in development:
 * [Erlang](https://github.com/AbstractMachinesLab/tree-sitter-erlang/)
 * [Dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile)
 * [Go mod](https://github.com/camdencheek/tree-sitter-go-mod)
+* [Go work](https://github.com/omertuc/tree-sitter-go-work)
 * [Hack](https://github.com/slackhq/tree-sitter-hack)
 * [Haskell](https://github.com/tree-sitter/tree-sitter-haskell)
 * [Julia](https://github.com/tree-sitter/tree-sitter-julia)


### PR DESCRIPTION
The new golang 1.18 version (currently in beta) [introduced](https://github.com/golang/go/issues/45713) a new file type called `go.work`.

This commit adds a mention to https://github.com/omertuc/tree-sitter-go-work in
the documentation.

That repository is heavily based on previous work in the https://github.com/camdencheek/tree-sitter-go-mod repository, with a few
minor changes to make it work on the very similar `go.work` files.