### PR TITLE
Allow to change the allocator dynamically

### DIFF
--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -134,13 +134,6 @@ typedef enum {
   TSQueryErrorLanguage,
 } TSQueryError;
 
-typedef struct {
-  void *(*malloc)(size_t);
-  void *(*calloc)(size_t, size_t);
-  void *(*realloc)(void *, size_t);
-  void (*free)(void *);
-} TSAllocator;
-
 /********************/
 /* Section - Parser */
 /********************/
@@ -148,15 +141,18 @@ typedef struct {
 /**
  * Switch to a new allocator.
  *
- * Returns true iff the switch successes.
+ * This function can be invoked more than once. However, the application needs
+ * to pay attention to the memory allocated by the old allocator but might be
+ * freed by the new one.
  *
- * This function can only be invoked *once*, before tree-sitter has allocated
- * any memory via malloc/calloc/realloc. Otherwise, memory bugs could occur
- * since some memory is allocated by the old allocator, but freed by the new
- * one.
- *
+ * Specifically, the application either,
+ *  1. ensures all parsers and trees are freed before calling it;
+ *  2. provides an allocator that shares its state with the old allocator.
  */
-bool ts_set_allocator(TSAllocator *new_alloc);
+void ts_set_allocator(void *(*new_malloc)(size_t),
+		      void *(*new_calloc)(size_t, size_t),
+		      void *(*new_realloc)(void *, size_t),
+		      void (*new_free)(void *));
 
 /**
  * Create a new parser.

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -145,12 +145,6 @@ typedef struct {
 /* Section - Parser */
 /********************/
 
-
-/**
- * The allocator.
- */
-extern TSAllocator *ts_allocator;
-
 /**
  * Switch to a new allocator.
  *

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -148,10 +148,15 @@ typedef struct {
 /**
  * Switch to a new allocator.
  *
- * Returns the old allocator. The caller needs to take care of any allocated
- * memory managed by the old allocator.
+ * Returns true iff the switch successes.
+ *
+ * This function can only be invoked *once*, before tree-sitter has allocated
+ * any memory via malloc/calloc/realloc. Otherwise, memory bugs could occur
+ * since some memory is allocated by the old allocator, but freed by the new
+ * one.
+ *
  */
-TSAllocator *ts_set_allocator(TSAllocator *new_alloc);
+bool ts_set_allocator(TSAllocator *new_alloc);
 
 /**
  * Create a new parser.

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -134,9 +134,30 @@ typedef enum {
   TSQueryErrorLanguage,
 } TSQueryError;
 
+typedef struct {
+  void *(*malloc)(size_t);
+  void *(*calloc)(size_t, size_t);
+  void *(*realloc)(void *, size_t);
+  void (*free)(void *);
+} TSAllocator;
+
 /********************/
 /* Section - Parser */
 /********************/
+
+
+/**
+ * The allocator.
+ */
+extern TSAllocator *ts_allocator;
+
+/**
+ * Switch to a new allocator.
+ *
+ * Returns the old allocator. The caller needs to take care of any allocated
+ * memory managed by the old allocator.
+ */
+TSAllocator *ts_set_allocator(TSAllocator *new_alloc);
 
 /**
  * Create a new parser.

--- a/lib/src/alloc.c
+++ b/lib/src/alloc.c
@@ -70,10 +70,15 @@ TSAllocator *ts_allocator = &ts_default_allocator;
 
 #endif // defined(TREE_SITTER_ALLOCATION_TRACKING)
 
-TSAllocator *ts_set_allocator(TSAllocator *new_alloc)
+bool ts_set_allocator(TSAllocator *new_alloc)
 {
-	TSAllocator *old = ts_allocator;
-	ts_allocator = new_alloc;
-	return old;
+  static bool using_default_allocator = true;
+  if (!using_default_allocator) {
+    fprintf(stderr, "tree-sitter's allocator can only be set once!");
+    return false;
+  }
+  using_default_allocator = false;
+  ts_allocator = new_alloc;
+  return true;
 }
 

--- a/lib/src/alloc.c
+++ b/lib/src/alloc.c
@@ -21,7 +21,7 @@ struct allocator *ts_allocator = &ts_tracking_allocator;
 
 #include <stdlib.h>
 
-static inline bool ts_toggle_allocation_recording(bool value) {
+bool ts_toggle_allocation_recording(bool value) {
   (void)value;
   return false;
 }

--- a/lib/src/alloc.c
+++ b/lib/src/alloc.c
@@ -1,0 +1,72 @@
+#include "alloc.h"
+
+#if defined(TREE_SITTER_ALLOCATION_TRACKING)
+
+void *ts_record_malloc(size_t);
+void *ts_record_calloc(size_t, size_t);
+void *ts_record_realloc(void *, size_t);
+void ts_record_free(void *);
+bool ts_toggle_allocation_recording(bool);
+
+static struct allocator ts_tracking_allocator = {
+  .malloc = ts_record_malloc,
+  .calloc = ts_record_calloc,
+  .realloc = ts_record_realloc,
+  .free = ts_record_free,
+};
+
+struct allocator *ts_allocator = &ts_tracking_allocator;
+
+#else
+
+#include <stdlib.h>
+
+static inline bool ts_toggle_allocation_recording(bool value) {
+  (void)value;
+  return false;
+}
+
+
+static inline void *ts_malloc_default(size_t size) {
+  void *result = malloc(size);
+  if (size > 0 && !result) {
+    fprintf(stderr, "tree-sitter failed to allocate %zu bytes", size);
+    exit(1);
+  }
+  return result;
+}
+
+static inline void *ts_calloc_default(size_t count, size_t size) {
+  void *result = calloc(count, size);
+  if (count > 0 && !result) {
+    fprintf(stderr, "tree-sitter failed to allocate %zu bytes", count * size);
+    exit(1);
+  }
+  return result;
+}
+
+static inline void *ts_realloc_default(void *buffer, size_t size) {
+  void *result = realloc(buffer, size);
+  if (size > 0 && !result) {
+    fprintf(stderr, "tree-sitter failed to reallocate %zu bytes", size);
+    exit(1);
+  }
+  return result;
+}
+
+static inline void ts_free_default(void *buffer) {
+  free(buffer);
+}
+
+static struct allocator ts_default_allocator = {
+  .malloc = ts_malloc_default,
+  .calloc = ts_calloc_default,
+  .realloc = ts_realloc_default,
+  .free = ts_free_default,
+};
+
+// Allow clients to override allocation functions dynamically
+struct allocator *ts_allocator = &ts_default_allocator;
+
+
+#endif

--- a/lib/src/alloc.c
+++ b/lib/src/alloc.c
@@ -8,14 +8,14 @@ void *ts_record_realloc(void *, size_t);
 void ts_record_free(void *);
 bool ts_toggle_allocation_recording(bool);
 
-static struct allocator ts_tracking_allocator = {
+static TSAllocator ts_tracking_allocator = {
   .malloc = ts_record_malloc,
   .calloc = ts_record_calloc,
   .realloc = ts_record_realloc,
   .free = ts_record_free,
 };
 
-struct allocator *ts_allocator = &ts_tracking_allocator;
+TSAllocator *ts_allocator = &ts_tracking_allocator;
 
 #else
 
@@ -58,7 +58,7 @@ static inline void ts_free_default(void *buffer) {
   free(buffer);
 }
 
-static struct allocator ts_default_allocator = {
+static TSAllocator ts_default_allocator = {
   .malloc = ts_malloc_default,
   .calloc = ts_calloc_default,
   .realloc = ts_realloc_default,
@@ -66,7 +66,14 @@ static struct allocator ts_default_allocator = {
 };
 
 // Allow clients to override allocation functions dynamically
-struct allocator *ts_allocator = &ts_default_allocator;
+TSAllocator *ts_allocator = &ts_default_allocator;
 
+#endif // defined(TREE_SITTER_ALLOCATION_TRACKING)
 
-#endif
+TSAllocator *ts_set_allocator(TSAllocator *new_alloc)
+{
+	TSAllocator *old = ts_allocator;
+	ts_allocator = new_alloc;
+	return old;
+}
+

--- a/lib/src/alloc.h
+++ b/lib/src/alloc.h
@@ -11,20 +11,23 @@ extern "C" {
 #include <stdbool.h>
 #include <stdio.h>
 
-extern TSAllocator *ts_allocator;
+extern void *(*ts_current_malloc)(size_t);
+extern void *(*ts_current_calloc)(size_t, size_t);
+extern void *(*ts_current_realloc)(void *, size_t);
+extern void (*ts_current_free)(void *);
 
 // Allow clients to override allocation functions
 #ifndef ts_malloc
-#define ts_malloc  ts_allocator->malloc
+#define ts_malloc  ts_current_malloc
 #endif
 #ifndef ts_calloc
-#define ts_calloc  ts_allocator->calloc
+#define ts_calloc  ts_current_calloc
 #endif
 #ifndef ts_realloc
-#define ts_realloc ts_allocator->realloc
+#define ts_realloc ts_current_realloc
 #endif
 #ifndef ts_free
-#define ts_free    ts_allocator->free
+#define ts_free    ts_current_free
 #endif
 
 bool ts_toggle_allocation_recording(bool);

--- a/lib/src/alloc.h
+++ b/lib/src/alloc.h
@@ -32,6 +32,8 @@ extern struct allocator *ts_allocator;
 #define ts_free    ts_allocator->free
 #endif
 
+bool ts_toggle_allocation_recording(bool);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/src/alloc.h
+++ b/lib/src/alloc.h
@@ -1,6 +1,8 @@
 #ifndef TREE_SITTER_ALLOC_H_
 #define TREE_SITTER_ALLOC_H_
 
+#include "tree_sitter/api.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -9,14 +11,7 @@ extern "C" {
 #include <stdbool.h>
 #include <stdio.h>
 
-struct allocator {
-  void *(*malloc)(size_t);
-  void *(*calloc)(size_t, size_t);
-  void *(*realloc)(void *, size_t);
-  void (*free)(void *);
-};
-
-extern struct allocator *ts_allocator;
+extern TSAllocator *ts_allocator;
 
 // Allow clients to override allocation functions
 #ifndef ts_malloc

--- a/lib/src/lib.c
+++ b/lib/src/lib.c
@@ -5,6 +5,7 @@
 
 #define _POSIX_C_SOURCE 200112L
 
+#include "./alloc.c"
 #include "./get_changed_ranges.c"
 #include "./language.c"
 #include "./lexer.c"


### PR DESCRIPTION
This is a draft implementation for #1535. Two things need mentioning:

1. Each malloc/free call will become a function call through the function pointer, which might make the program slightly (perhaps negligible) slower.
2. The clients have two approaches to use alternative allocators:
    1) define the macros at compilation time;
    2) reassign the global allocation function pointers (`ts_current_malloc`, `ts_current_calloc`, `ts_current_realloc`, and `ts_current_free`) by invoking `ts_set_allocator` at runtime. The function can be invoked more than once, as long as the applications take care of the memory allocated by the old allocator.
