### PR TITLE
remove unused iterate_assertions function in test_highlight

### DIFF
--- a/cli/src/test_highlight.rs
+++ b/cli/src/test_highlight.rs
@@ -83,72 +83,6 @@ pub fn test_highlights(loader: &Loader, directory: &Path) -> Result<()> {
         Ok(())
     }
 }
-pub fn iterate_assertions(
-    assertions: &Vec<Assertion>,
-    highlights: &Vec<(Point, Point, Highlight)>,
-    highlight_names: &Vec<String>,
-) -> Result<usize> {
-    // Iterate through all of the highlighting assertions, checking each one against the
-    // actual highlights.
-    let mut i = 0;
-    let mut actual_highlights = Vec::<&String>::new();
-    for Assertion {
-        position,
-        expected_capture_name: expected_highlight,
-    } in assertions
-    {
-        let mut passed = false;
-        actual_highlights.clear();
-
-        'highlight_loop: loop {
-            // The assertions are ordered by position, so skip past all of the highlights that
-            // end at or before this assertion's position.
-            if let Some(highlight) = highlights.get(i) {
-                if highlight.1 <= *position {
-                    i += 1;
-                    continue;
-                }
-
-                // Iterate through all of the highlights that start at or before this assertion's,
-                // position, looking for one that matches the assertion.
-                let mut j = i;
-                while let (false, Some(highlight)) = (passed, highlights.get(j)) {
-                    if highlight.0 > *position {
-                        break 'highlight_loop;
-                    }
-
-                    // If the highlight matches the assertion, this test passes. Otherwise,
-                    // add this highlight to the list of actual highlights that span the
-                    // assertion's position, in order to generate an error message in the event
-                    // of a failure.
-                    let highlight_name = &highlight_names[(highlight.2).0];
-                    if *highlight_name == *expected_highlight {
-                        passed = true;
-                        break 'highlight_loop;
-                    } else {
-                        actual_highlights.push(highlight_name);
-                    }
-
-                    j += 1;
-                }
-            } else {
-                break;
-            }
-        }
-
-        if !passed {
-            return Err(Failure {
-                row: position.row,
-                column: position.column,
-                expected_highlight: expected_highlight.clone(),
-                actual_highlights: actual_highlights.into_iter().cloned().collect(),
-            }
-            .into());
-        }
-    }
-
-    Ok(assertions.len())
-}
 
 pub fn test_highlight(
     loader: &Loader,
@@ -161,8 +95,6 @@ pub fn test_highlight(
     let highlights = get_highlight_positions(loader, highlighter, highlight_config, source)?;
     let assertions =
         parse_position_comments(highlighter.parser(), highlight_config.language, source)?;
-
-    iterate_assertions(&assertions, &highlights, &highlight_names)?;
 
     // Iterate through all of the highlighting assertions, checking each one against the
     // actual highlights.


### PR DESCRIPTION
While working on #1547 I noted that this block is duplicated in `iterate_assertions` and `test_highlight` and the return value is discarded. Maybe it makes more sense to keep this `iterate_assertions` function and remove the block in the `test_highlight` function instead?