### PR TITLE
Add CMake support for tree_sitter C library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ node_modules
 docs/assets/js/tree-sitter.js
 
 /target
+build/
+.cache/
 *.rs.bk
 *.a
 *.dylib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,4 +62,4 @@ project_options(
 
 add_subdirectory("./lib")
 
-package_project(PUBLIC_INCLUDES "${TREE_SITTER_INCLUDE_DIR}")
+package_project()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 
 # Add project_options from https://github.com/aminya/project_options
 # Change the version in the following URL to update the package (watch the releases of the repository for future updates)
-set(PROJECT_OPTIONS_VERSION "v0.31.0")
+set(PROJECT_OPTIONS_VERSION "v0.32.2")
 FetchContent_Declare(
   _project_options
   URL https://github.com/aminya/project_options/archive/refs/tags/${PROJECT_OPTIONS_VERSION}.zip)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,13 +11,11 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
 endif()
 
 # Add project_options from https://github.com/aminya/project_options
-# Change the version in the following URL to update the package
-# (watch the releases of the repository for future updates)
-set(PROJECT_OPTIONS_VERSION "v0.29.0")
+# Change the version in the following URL to update the package (watch the releases of the repository for future updates)
+set(PROJECT_OPTIONS_VERSION "v0.31.0")
 FetchContent_Declare(
   _project_options
-  URL https://github.com/aminya/project_options/archive/refs/tags/${PROJECT_OPTIONS_VERSION}.zip
-)
+  URL https://github.com/aminya/project_options/archive/refs/tags/${PROJECT_OPTIONS_VERSION}.zip)
 FetchContent_MakeAvailable(_project_options)
 include(${_project_options_SOURCE_DIR}/Index.cmake)
 
@@ -25,26 +23,26 @@ include(${_project_options_SOURCE_DIR}/Index.cmake)
 project(
   tree-sitter
   LANGUAGES C CXX
-  VERSION 0.20.7)
+  VERSION 0.20.9)
 
-# Initialize project_options variable related to this project This overwrites
-# `project_options` and sets `project_warnings` uncomment the options to enable
-# them:
+# Initialize project_options variable related to this project
+# This overwrites `project_options` and sets `project_warnings`
+# uncomment to enable the options. Some of them accept one or more inputs:
 project_options(
-  PREFIX "tree-sitter"
+  PREFIX "tree_sitter"
   ENABLE_CACHE
-  # ENABLE_CPPCHECK
-  # ENABLE_CLANG_TIDY
-  # ENABLE_VS_ANALYSIS
-  # ENABLE_GCC_ANALYZER
-  # ENABLE_COVERAGE
-  # ENABLE_DOXYGEN
+  # ${ENABLE_CPPCHECK}
+  # ${ENABLE_CLANG_TIDY}
+  # ${ENABLE_VS_ANALYSIS}
+  # ENABLE_CONAN
   # ENABLE_INTERPROCEDURAL_OPTIMIZATION
   # ENABLE_NATIVE_OPTIMIZATION
-  # ENABLE_SANITIZER_ADDRESS
-  # ENABLE_SANITIZER_UNDEFINED_BEHAVIOR
-  # ENABLE_SANITIZER_THREAD
-  # ENABLE_SANITIZER_MEMORY
+  # ${ENABLE_DOXYGEN}
+  # ${ENABLE_COVERAGE}
+  # ${ENABLE_SANITIZER_ADDRESS}
+  # ${ENABLE_SANITIZER_UNDEFINED_BEHAVIOR}
+  # ${ENABLE_SANITIZER_THREAD}
+  # ${ENABLE_SANITIZER_MEMORY}
   # ENABLE_CONTROL_FLOW_PROTECTION
   # ENABLE_STACK_PROTECTION
   # ENABLE_OVERFLOW_PROTECTION
@@ -54,19 +52,14 @@ project_options(
   # ENABLE_PCH
   # PCH_HEADERS
   # WARNINGS_AS_ERRORS
+  # ENABLE_INCLUDE_WHAT_YOU_USE
+  # ENABLE_GCC_ANALYZER
   # ENABLE_BUILD_WITH_TIME_TRACE
+  # ENABLE_UNITY
   # LINKER "lld"
+  # CONAN_PROFILE ${profile_path}
 )
 
-add_library(tree_sitter ./lib/src/lib.c)
-target_include_directories(tree_sitter PRIVATE ./lib/src)
+add_subdirectory("./lib")
 
-set(INCLUDE_DIR "./lib/include")
-target_include_directories(
-  tree_sitter
-  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${INCLUDE_DIR}>"
-         "$<INSTALL_INTERFACE:./${CMAKE_INSTALL_INCLUDEDIR}>")
-
-target_link_libraries(tree_sitter PRIVATE project_options project_warnings)
-
-package_project(PUBLIC_INCLUDES ${INCLUDE_DIR})
+package_project(PUBLIC_INCLUDES "${TREE_SITTER_INCLUDE_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,12 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-# Add project_options v0.22.4
+# Add project_options v0.24.0
 # https://github.com/aminya/project_options
 include(FetchContent)
 FetchContent_Declare(
   _project_options
-  URL https://github.com/aminya/project_options/archive/refs/tags/v0.22.4.zip
+  URL https://github.com/aminya/project_options/archive/refs/tags/v0.24.0.zip
 )
 FetchContent_MakeAvailable(_project_options)
 include(${_project_options_SOURCE_DIR}/Index.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,39 +1,58 @@
-# Configure with: 
-# cmake -S ./ -B ./build -G "Ninja Multi-Config" -DCMAKE_BUILD_TYPE=Release
-# Build with: 
+# To use, run these commands:
+# cmake -S ./ -B ./build -G "Ninja Multi-Config" -DCMAKE_BUILD_TYPE=Release 
 # cmake --build ./build --config Release
+# cmake --install ./build --prefix <install-location>
 
 cmake_minimum_required(VERSION 3.16)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_C_STANDARD 17)
-
-# Add project_options v0.16.0
+# Add project_options v0.17.0
 # https://github.com/cpp-best-practices/project_options
 include(FetchContent)
-FetchContent_Declare(_project_options URL https://github.com/cpp-best-practices/project_options/archive/refs/tags/v0.16.0.zip)
+FetchContent_Declare(
+  _project_options
+  URL https://github.com/cpp-best-practices/project_options/archive/refs/tags/v0.17.0.zip
+)
 FetchContent_MakeAvailable(_project_options)
 include(${_project_options_SOURCE_DIR}/Index.cmake)
 
 # Set the project name and language
-project(tree-sitter LANGUAGES C CXX)
+project(tree-sitter LANGUAGES C CXX VERSION 0.20.3)
 
-# Initialize project_options variable related to this project
-# This overwrites `project_options` and sets `project_warnings`
-# uncomment the options to enable them:
+# Initialize project_options variable related to this project This overwrites
+# `project_options` and sets `project_warnings` uncomment the options to enable
+# them:
 project_options(
       ENABLE_CACHE
       ENABLE_CPPCHECK
       ENABLE_CLANG_TIDY
-      # WARNINGS_AS_ERRORS
-      # ENABLE_IPO
-      # ENABLE_USER_LINKER
+      # ENABLE_INTERPROCEDURAL_OPTIMIZATION
+      # ENABLE_NATIVE_OPTIMIZATION
+      # ENABLE_DOXYGEN
+      # ENABLE_COVERAGE
       # ENABLE_SANITIZER_ADDRESS
       # ENABLE_SANITIZER_LEAK
       # ENABLE_SANITIZER_UNDEFINED_BEHAVIOR
       # ENABLE_SANITIZER_THREAD
       # ENABLE_SANITIZER_MEMORY
+      # ENABLE_PCH
+      # PCH_HEADERS
+      # WARNINGS_AS_ERRORS
+      # ENABLE_INCLUDE_WHAT_YOU_USE
+      # ENABLE_USER_LINKER
+      # ENABLE_BUILD_WITH_TIME_TRACE
+      # ENABLE_UNITY
+      # ENABLE_CONAN
+      # CONAN_OPTIONS
 )
 
-# add lib directory to the project
-add_subdirectory(lib)
+add_library(tree_sitter ./lib/src/lib.c)
+target_include_directories(tree_sitter PRIVATE ./lib/src)
+
+set(INCLUDE_DIR "./lib/include")
+target_include_directories(tree_sitter PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${INCLUDE_DIR}>"
+                                            "$<INSTALL_INTERFACE:./${CMAKE_INSTALL_INCLUDEDIR}>")
+
+target_link_libraries(tree_sitter PRIVATE project_options project_warnings)
+
+
+package_project(PUBLIC_INCLUDES ${INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,16 @@
 # To use, run these commands:
-# cmake -S ./ -B ./build -G "Ninja Multi-Config" -DCMAKE_BUILD_TYPE=Release 
+# cmake -S ./ -B ./build -G "Ninja Multi-Config" -DCMAKE_BUILD_TYPE=Release
 # cmake --build ./build --config Release
 # cmake --install ./build --prefix <install-location>
 
 cmake_minimum_required(VERSION 3.16)
 
-# Add project_options v0.21.0
+# Add project_options v0.22.4
 # https://github.com/aminya/project_options
 include(FetchContent)
 FetchContent_Declare(
   _project_options
-  URL https://github.com/aminya/project_options/archive/refs/tags/v0.21.0.zip
+  URL https://github.com/aminya/project_options/archive/refs/tags/v0.22.4.zip
 )
 FetchContent_MakeAvailable(_project_options)
 include(${_project_options_SOURCE_DIR}/Index.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,12 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-# Add project_options v0.24.0
+# Add project_options v0.25.2
 # https://github.com/aminya/project_options
 include(FetchContent)
 FetchContent_Declare(
   _project_options
-  URL https://github.com/aminya/project_options/archive/refs/tags/v0.24.0.zip
+  URL https://github.com/aminya/project_options/archive/refs/tags/v0.25.2.zip
 )
 FetchContent_MakeAvailable(_project_options)
 include(${_project_options_SOURCE_DIR}/Index.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,59 +4,69 @@
 # cmake --install ./build --prefix <install-location>
 
 cmake_minimum_required(VERSION 3.20)
-# fix DOWNLOAD_EXTRACT_TIMESTAMP warning in FetchContent
+
+include(FetchContent)
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
   cmake_policy(SET CMP0135 NEW)
 endif()
 
-# Add project_options v0.26.3
-# https://github.com/aminya/project_options
-include(FetchContent)
+# Add project_options from https://github.com/aminya/project_options
+# Change the version in the following URL to update the package
+# (watch the releases of the repository for future updates)
+set(PROJECT_OPTIONS_VERSION "v0.29.0")
 FetchContent_Declare(
   _project_options
-  URL https://github.com/aminya/project_options/archive/refs/tags/v0.26.3.zip
+  URL https://github.com/aminya/project_options/archive/refs/tags/${PROJECT_OPTIONS_VERSION}.zip
 )
 FetchContent_MakeAvailable(_project_options)
 include(${_project_options_SOURCE_DIR}/Index.cmake)
 
 # Set the project name and language
-project(tree-sitter LANGUAGES C CXX VERSION 0.20.3)
+project(
+  tree-sitter
+  LANGUAGES C CXX
+  VERSION 0.20.7)
 
 # Initialize project_options variable related to this project This overwrites
 # `project_options` and sets `project_warnings` uncomment the options to enable
 # them:
 project_options(
-      ENABLE_CACHE
-      ENABLE_CPPCHECK
-      ENABLE_CLANG_TIDY
-      # ENABLE_INTERPROCEDURAL_OPTIMIZATION
-      # ENABLE_NATIVE_OPTIMIZATION
-      # ENABLE_DOXYGEN
-      # ENABLE_COVERAGE
-      # ENABLE_SANITIZER_ADDRESS
-      # ENABLE_SANITIZER_LEAK
-      # ENABLE_SANITIZER_UNDEFINED_BEHAVIOR
-      # ENABLE_SANITIZER_THREAD
-      # ENABLE_SANITIZER_MEMORY
-      # ENABLE_PCH
-      # PCH_HEADERS
-      # WARNINGS_AS_ERRORS
-      # ENABLE_INCLUDE_WHAT_YOU_USE
-      # ENABLE_USER_LINKER
-      # ENABLE_BUILD_WITH_TIME_TRACE
-      # ENABLE_UNITY
-      # ENABLE_CONAN
-      # CONAN_OPTIONS
+  PREFIX "tree-sitter"
+  ENABLE_CACHE
+  # ENABLE_CPPCHECK
+  # ENABLE_CLANG_TIDY
+  # ENABLE_VS_ANALYSIS
+  # ENABLE_GCC_ANALYZER
+  # ENABLE_COVERAGE
+  # ENABLE_DOXYGEN
+  # ENABLE_INTERPROCEDURAL_OPTIMIZATION
+  # ENABLE_NATIVE_OPTIMIZATION
+  # ENABLE_SANITIZER_ADDRESS
+  # ENABLE_SANITIZER_UNDEFINED_BEHAVIOR
+  # ENABLE_SANITIZER_THREAD
+  # ENABLE_SANITIZER_MEMORY
+  # ENABLE_CONTROL_FLOW_PROTECTION
+  # ENABLE_STACK_PROTECTION
+  # ENABLE_OVERFLOW_PROTECTION
+  # ENABLE_ELF_PROTECTION
+  # ENABLE_RUNTIME_SYMBOLS_RESOLUTION
+  # ENABLE_COMPILE_COMMANDS_SYMLINK
+  # ENABLE_PCH
+  # PCH_HEADERS
+  # WARNINGS_AS_ERRORS
+  # ENABLE_BUILD_WITH_TIME_TRACE
+  # LINKER "lld"
 )
 
 add_library(tree_sitter ./lib/src/lib.c)
 target_include_directories(tree_sitter PRIVATE ./lib/src)
 
 set(INCLUDE_DIR "./lib/include")
-target_include_directories(tree_sitter PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${INCLUDE_DIR}>"
-                                            "$<INSTALL_INTERFACE:./${CMAKE_INSTALL_INCLUDEDIR}>")
+target_include_directories(
+  tree_sitter
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${INCLUDE_DIR}>"
+         "$<INSTALL_INTERFACE:./${CMAKE_INSTALL_INCLUDEDIR}>")
 
 target_link_libraries(tree_sitter PRIVATE project_options project_warnings)
-
 
 package_project(PUBLIC_INCLUDES ${INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+# Configure with: 
+# cmake -S ./ -B ./build -G "Ninja Multi-Config" -DCMAKE_BUILD_TYPE=Release
+# Build with: 
+# cmake --build ./build --config Release
+
+cmake_minimum_required(VERSION 3.16)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_C_STANDARD 17)
+
+# Add project_options v0.12.3
+# https://github.com/cpp-best-practices/project_options
+include(FetchContent)
+FetchContent_Declare(_project_options URL https://github.com/cpp-best-practices/project_options/archive/refs/tags/v0.12.3.zip)
+FetchContent_MakeAvailable(_project_options)
+include(${_project_options_SOURCE_DIR}/Index.cmake)
+
+# Set the project name and language
+project(tree-sitter LANGUAGES C CXX)
+
+# Initialize project_options variable related to this project
+# This overwrites `project_options` and sets `project_warnings`
+# uncomment the options to enable them:
+project_options(
+      ENABLE_CACHE
+      ENABLE_CPPCHECK
+      ENABLE_CLANG_TIDY
+      # WARNINGS_AS_ERRORS
+      # ENABLE_IPO
+      # ENABLE_USER_LINKER
+      # ENABLE_SANITIZER_ADDRESS
+      # ENABLE_SANITIZER_LEAK
+      # ENABLE_SANITIZER_UNDEFINED_BEHAVIOR
+      # ENABLE_SANITIZER_THREAD
+      # ENABLE_SANITIZER_MEMORY
+)
+
+# add lib directory to the project
+add_subdirectory(lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,14 +3,18 @@
 # cmake --build ./build --config Release
 # cmake --install ./build --prefix <install-location>
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
+# fix DOWNLOAD_EXTRACT_TIMESTAMP warning in FetchContent
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+  cmake_policy(SET CMP0135 NEW)
+endif()
 
-# Add project_options v0.25.2
+# Add project_options v0.26.3
 # https://github.com/aminya/project_options
 include(FetchContent)
 FetchContent_Declare(
   _project_options
-  URL https://github.com/aminya/project_options/archive/refs/tags/v0.25.2.zip
+  URL https://github.com/aminya/project_options/archive/refs/tags/v0.26.3.zip
 )
 FetchContent_MakeAvailable(_project_options)
 include(${_project_options_SOURCE_DIR}/Index.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,12 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-# Add project_options v0.17.0
-# https://github.com/cpp-best-practices/project_options
+# Add project_options v0.21.0
+# https://github.com/aminya/project_options
 include(FetchContent)
 FetchContent_Declare(
   _project_options
-  URL https://github.com/cpp-best-practices/project_options/archive/refs/tags/v0.17.0.zip
+  URL https://github.com/aminya/project_options/archive/refs/tags/v0.21.0.zip
 )
 FetchContent_MakeAvailable(_project_options)
 include(${_project_options_SOURCE_DIR}/Index.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,10 @@ cmake_minimum_required(VERSION 3.16)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 17)
 
-# Add project_options v0.12.3
+# Add project_options v0.16.0
 # https://github.com/cpp-best-practices/project_options
 include(FetchContent)
-FetchContent_Declare(_project_options URL https://github.com/cpp-best-practices/project_options/archive/refs/tags/v0.12.3.zip)
+FetchContent_Declare(_project_options URL https://github.com/cpp-best-practices/project_options/archive/refs/tags/v0.16.0.zip)
 FetchContent_MakeAvailable(_project_options)
 include(${_project_options_SOURCE_DIR}/Index.cmake)
 

--- a/Makefile
+++ b/Makefile
@@ -68,4 +68,8 @@ install: all
 clean:
 	rm -f lib/src/*.o libtree-sitter.a libtree-sitter.$(SOEXT) libtree-sitter.$(SOEXTVER_MAJOR) libtree-sitter.$(SOEXTVER)
 
+cmake: 
+	cmake -S ./ -B ./build -G "Ninja Multi-Config" -DCMAKE_BUILD_TYPE=Release
+	cmake --build ./build --config Release
+	
 .PHONY: all install clean

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,12 +1,5 @@
 add_library(tree_sitter ./src/lib.c)
 target_include_directories(tree_sitter PRIVATE ./src)
 
-set(TREE_SITTER_INCLUDE_DIR "./include")
-target_include_directories(
-  tree_sitter
-  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${TREE_SITTER_INCLUDE_DIR}>"
-         "$<INSTALL_INTERFACE:./${CMAKE_INSTALL_INCLUDEDIR}>")
-
-if(TARGET tree_sitter_project_options)
-    target_link_libraries(tree_sitter PRIVATE tree_sitter_project_options tree_sitter_project_warnings)
-endif()
+target_include_interface_directories(tree_sitter "./include")
+target_link_libraries(tree_sitter PRIVATE tree_sitter_project_options tree_sitter_project_warnings)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(tree_sitter ./src/lib.c)
+target_include_directories(tree_sitter PRIVATE ./src)
+
+set(TREE_SITTER_INCLUDE_DIR "./include")
+target_include_directories(
+  tree_sitter
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${TREE_SITTER_INCLUDE_DIR}>"
+         "$<INSTALL_INTERFACE:./${CMAKE_INSTALL_INCLUDEDIR}>")
+
+if(TARGET tree_sitter_project_options)
+    target_link_libraries(tree_sitter PRIVATE tree_sitter_project_options tree_sitter_project_warnings)
+endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(tree_sitter ./src/lib.c)
+target_include_directories(tree_sitter PRIVATE src)
+target_include_directories(tree_sitter PUBLIC include)
+
+target_link_libraries(tree_sitter PRIVATE project_options project_warnings)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,5 +1,0 @@
-add_library(tree_sitter ./src/lib.c)
-target_include_directories(tree_sitter PRIVATE src)
-target_include_directories(tree_sitter PUBLIC include)
-
-target_link_libraries(tree_sitter PRIVATE project_options project_warnings)


### PR DESCRIPTION
- This adds cross-platform CMake support for the tree_sitter C library. 
- This also helps the IDEs to work correctly (autocomplete, showing the warnings in the code, etc.) by generating the required `compile_command.json` for clangd or MSVC. e.g. automatic refactoring was used in #1618
- Enables the compiler warnings. For example, see the shadowed variables revealed by PR #1618. The CMake is based on the cpp-best-practices project, which helps the project evolve. 
 
- This cmake file generates a tree-sitter package, which allows it to be used from other projects and potentially added to the C++/C package managers like vcpkg and Conan
```cmake
    find_package(tree-sitter CONFIG REQUIRED)
    target_link_libraries(main PRIVATE  tree-sitter::tree_sitter tree-sitter::project_options tree-sitter::project_warnings)
```
![image](https://user-images.githubusercontent.com/16418197/154836831-d49c5779-73b6-41bc-bfb8-87fbb476e10c.png)

- optionally, you can remove the old Makefile as it doesn't have any of the above-mentioned points.