### PR TITLE
Suppress snprintf truncation warning for gcc 7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,12 @@ OBJ := $(SRC:.c=.o)
 CFLAGS ?= -O3 -Wall -Wextra -Werror
 override CFLAGS += -std=gnu99 -fPIC -Ilib/src -Ilib/include
 
+# workaround cflags for old gcc versions
+CC_VERSION := $(shell $(CC) -dumpversion)
+ifeq ($(CC_VERSION), $(filter $(CC_VERSION),7 8))
+override CFLAGS += -Wno-format-truncation
+endif
+
 # ABI versioning
 SONAME_MAJOR := 0
 SONAME_MINOR := 0


### PR DESCRIPTION
The default compiler for Ubuntu 18.04 LTS is gcc 7.5.0.

Commit f78ad716 setting a nonzero limit to snprintf triggers
`directive output truncated writing ... bytes into a region of size 1`
for gcc 7, possibly gcc 8.