### PR TITLE
config: Bump minimum serde_json version to 1.0.45

### DIFF
--- a/cli/config/Cargo.toml
+++ b/cli/config/Cargo.toml
@@ -16,5 +16,5 @@ dirs = "3.0"
 serde = { version = "1.0.130", features = ["derive"] }
 
 [dependencies.serde_json]
-version = "1.0"
+version = "1.0.45"
 features = ["preserve_order"]


### PR DESCRIPTION
This is the version which introduced Map's append function, used in `Config::add`.