### PR TITLE
Add realloc to wasm exports

### DIFF
--- a/lib/binding_web/exports.json
+++ b/lib/binding_web/exports.json
@@ -2,6 +2,7 @@
   "_calloc",
   "_free",
   "_malloc",
+  "_realloc",
 
   "__ZNKSt3__212basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE4copyEPcmm",
   "__ZNKSt3__220__vector_base_commonILb1EE20__throw_length_errorEv",


### PR DESCRIPTION
`tree-sitter-haskell` uses `realloc` directly, and it seems like a small and crucial enough function to include in wasm builds.