### PR TITLE
cli: deduplicate query results in 'tree-sitter query --test'

### DIFF
--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -101,6 +101,7 @@ pub fn query_files_at_paths(
             )?;
         }
         if should_test {
+            results.dedup_by(|a, b| a.start == b.start && a.end == b.end);
             query_testing::assert_expected_captures(results, path, &mut parser, language)?
         }
     }


### PR DESCRIPTION
I noticed that `tree-sitter query --test` will give failures when the queries return multiple results, such as when you test highlight queries outside of `tree-sitter test` (see https://github.com/elixir-lang/tree-sitter-elixir/pull/18#issuecomment-996851772)

Somewhat minimally I have a grammar [tree-sitter-git-config](https://github.com/the-mikedavis/tree-sitter-git-config) and a foo.gitconfig file like so:

```gitconfig
[core]
# ^ tag
    path = /path/to/foo.inc ; include by absolute path
    ;       ^ string.special.path
    foo = bar
```

with [these highlight queries](https://github.com/the-mikedavis/tree-sitter-git-config/blob/5a12b9ebe685c9c546e244ff01bbe24d9f16d8dd/queries/highlights.scm). Running `tree-sitter query --test queries/highlights.scm foo.gitconfig` gives an error like so:

```
foo.gitconfig
  pattern: 8
    capture: 7 - punctuation.bracket, start: (0, 0), end: (0, 1), text: `[`
  pattern: 2
    capture: 1 - tag, start: (0, 1), end: (0, 5), text: `core`
  pattern: 8
    capture: 7 - punctuation.bracket, start: (0, 5), end: (0, 6), text: `]`
  pattern: 10
    capture: comment, start: (1, 0), end: (2, 0)
  pattern: 3
    capture: 2 - property, start: (2, 1), end: (2, 5), text: `path`
  pattern: 9
    capture: 8 - punctuation.delimiter, start: (2, 6), end: (2, 7), text: `=`
  pattern: 6
    capture: 5 - string.special.path, start: (2, 7), end: (2, 25), text: ` /path/to/foo.inc `
  pattern: 7
    capture: 6 - string, start: (2, 7), end: (2, 25), text: ` /path/to/foo.inc `
  pattern: 10
    capture: comment, start: (2, 25), end: (3, 0)
  pattern: 10
    capture: comment, start: (3, 4), end: (4, 0)
  pattern: 3
    capture: 2 - property, start: (4, 4), end: (4, 7), text: `foo`
  pattern: 9
    capture: 8 - punctuation.delimiter, start: (4, 8), end: (4, 9), text: `=`
  pattern: 7
    capture: 6 - string, start: (4, 9), end: (4, 13), text: ` bar`
Assertion failed: at (2, 7), found string.special.path, expected string
```

Because the query results overlap.

I think it makes sense to deduplicate these query results when testing to bring the behavior of `tree-sitter query --test` in line with `tree-sitter test` for highlights (and tags as in #1547). But maybe this is the expected behavior? What do you think?

