### PR TITLE
Add tree-sitter-rasi

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,7 @@ Parsers for these languages are fairly complete:
 * [OCaml](https://github.com/tree-sitter/tree-sitter-ocaml)
 * [PHP](https://github.com/tree-sitter/tree-sitter-php)
 * [Python](https://github.com/tree-sitter/tree-sitter-python)
+* [Rasi](https://github.com/Fymyte/tree-sitter-rasi)
 * [Ruby](https://github.com/tree-sitter/tree-sitter-ruby)
 * [Rust](https://github.com/tree-sitter/tree-sitter-rust)
 * [R](https://github.com/r-lib/tree-sitter-r)


### PR DESCRIPTION
I have created a new grammar for the `rasi` language at [Fymyte/tree-sitter-rasi](https://github.com/Fymyte/tree-sitter-rasi).
It is highly inspired by the `css` grammar but adds some tweaks to properly parse rofi config file.