### PR TITLE
Ignore duplicate states when initializing subgraphs in `ts_query__analyze_patterns`

### DIFF
--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -855,5 +855,5 @@ extern "C" {
     );
 }
 
-pub const TREE_SITTER_LANGUAGE_VERSION: usize = 13;
+pub const TREE_SITTER_LANGUAGE_VERSION: usize = 14;
 pub const TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION: usize = 13;

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -21,7 +21,7 @@ extern "C" {
  * The Tree-sitter library is generally backwards-compatible with languages
  * generated using older CLI versions, but is not forwards-compatible.
  */
-#define TREE_SITTER_LANGUAGE_VERSION 13
+#define TREE_SITTER_LANGUAGE_VERSION 14
 
 /**
  * The earliest ABI version that is supported by the current version of the

--- a/lib/include/tree_sitter/parser.h
+++ b/lib/include/tree_sitter/parser.h
@@ -110,6 +110,7 @@ struct TSLanguage {
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
+  const TSStateId *ts_primary_state_ids;
   const TSLexMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);

--- a/lib/src/language.h
+++ b/lib/src/language.h
@@ -200,6 +200,19 @@ static inline TSStateId ts_language_next_state(
   }
 }
 
+// Whether the state is a "primary state". If this returns false, it indicates that there exists
+// another state that behaves identically to this one with respect to query analysis.
+static inline bool ts_language_state_is_primary(
+  const TSLanguage *self,
+  TSStateId state
+) {
+  if (self->version >= 14) {
+    return state == self->ts_primary_state_ids[state];
+  } else {
+    return true;
+  }
+}
+
 static inline const bool *ts_language_enabled_external_tokens(
   const TSLanguage *self,
   unsigned external_scanner_state

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -960,28 +960,30 @@ static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
         if (lookahead_iterator.next_state != state) {
           state_predecessor_map_add(&predecessor_map, lookahead_iterator.next_state, state);
         }
-        const TSSymbol *aliases, *aliases_end;
-        ts_language_aliases_for_symbol(
-          self->language,
-          lookahead_iterator.symbol,
-          &aliases,
-          &aliases_end
-        );
-        for (const TSSymbol *symbol = aliases; symbol < aliases_end; symbol++) {
-          array_search_sorted_by(
-            &subgraphs,
-            .symbol,
-            *symbol,
-            &subgraph_index,
-            &exists
+        if (ts_language_state_is_primary(self->language, state)) {
+          const TSSymbol *aliases, *aliases_end;
+          ts_language_aliases_for_symbol(
+            self->language,
+            lookahead_iterator.symbol,
+            &aliases,
+            &aliases_end
           );
-          if (exists) {
-            AnalysisSubgraph *subgraph = &subgraphs.contents[subgraph_index];
-            if (
-              subgraph->start_states.size == 0 ||
-              *array_back(&subgraph->start_states) != state
-            )
-            array_push(&subgraph->start_states, state);
+          for (const TSSymbol *symbol = aliases; symbol < aliases_end; symbol++) {
+            array_search_sorted_by(
+              &subgraphs,
+              .symbol,
+              *symbol,
+              &subgraph_index,
+              &exists
+            );
+            if (exists) {
+              AnalysisSubgraph *subgraph = &subgraphs.contents[subgraph_index];
+              if (
+                subgraph->start_states.size == 0 ||
+                *array_back(&subgraph->start_states) != state
+              )
+              array_push(&subgraph->start_states, state);
+            }
           }
         }
       }


### PR DESCRIPTION
This change exposes a new `primary_state_ids` field on the `TSLanguage` struct, and populates it by tracking the first encountered state with a given `core_id`. (For posterity: the initial change just exposed `core_id` and deduplicated within `ts_analyze_query`)

With this `primary_state_ids` field in place, the `ts_query__analyze_patterns` function only needs to populate its subgraphs with starting states that are _primary_, since non-primary states behave identically to primary ones. This leads to large savings across the board, since most states are not primary (more narrative after these graphs):

_Swift_:
States: 7797
Primary states: 2273

![stats-swift](https://user-images.githubusercontent.com/62194897/149670411-ee72e6a4-21be-4c1a-b598-9b960dc82bd3.png)

_Kotlin_:
States: 9424
Primary states: 897
![stats-kotlin](https://user-images.githubusercontent.com/62194897/149670416-fb79a8c2-d287-4b9f-a3ea-4a925b232a26.png)

_Elixir_:
States: 5658
Primary states: 529
![stats-elixir](https://user-images.githubusercontent.com/62194897/149670422-815bc925-c9f4-4a46-8290-0d93880db0c7.png)

_C++_:
States: 5460
Primary states: 1236
![stats-cpp](https://user-images.githubusercontent.com/62194897/149670431-7c25d498-f06c-4d42-b00a-39d90c1a99e7.png)

It appears that pruning out non-primary states causes a mostly linear reduction in runtime, although the overhead for analysis becomes more impactful. Put another way, the runtime per (primary) state is usually close to 60% higher than it was before the reduction. In the Swift grammar, after pruning all but 29% of the states. query analysis takes 45% as long as it used to. Similarly, in the C++ grammar, having 22% of the states leads to 37% of the original runtime. The outlier here is Kotlin, where 9.5% of states are primary and analysis takes 11% of the time (only 17% additional overhead). This doesn’t mean we’re doing _more work_ per state that we weren’t before, it just suggests that the overhead has started to dominate.

The flamegraphs for Swift show that the remaining work happens in roughly the same proportions that it did before.

_Before_:  
![flamegraph-master](https://user-images.githubusercontent.com/62194897/149671945-59b8de62-0ca2-4bc1-ba2a-05d9841c1298.png)  
_After_:  
![flamegraph-after-dedup](https://user-images.githubusercontent.com/62194897/149671957-ef26b2c3-4847-4ac4-9200-f8ded7fe9a01.png)

Note that since the runtime for the actual work has gone down, the benchmark machinery (`rayon::*`, `criterion::*`) takes up a larger proportion of the analysis.

## Benchmarks from `tree-sitter/tree-sitter`
Full benchmarks are available at: [benchmark-old.txt](https://github.com/tree-sitter/tree-sitter/files/7877635/benchmark-old.txt) [benchmark-new.txt](https://github.com/tree-sitter/tree-sitter/files/7877636/benchmark-new.txt). Confusingly, I'm going to perform my comparisons using throughput in the subsequent analysis since these benchmark files don't do well with small-ms time per iteration.

**1. If we ignore sampling noise, the only meaningful changes are in the "Constructing Queries" step (unsurprising)**:  
Look, for instance, at the `tree-sitter-cpp` diff:
```
 Language: cpp
   Constructing Queries
-    highlights.scm                                     time 13 ms      speed 82 bytes/ms
+    highlights.scm                                     time 5 ms       speed 192 bytes/ms
   Parsing Valid Code:
     rule.cc                                            time 0 ms       speed 8448 bytes/ms
     marker-index.h                                     time 0 ms       speed 4832 bytes/ms
@@ -111,7 +112,7 @@ Language: cpp
     test.sh                                            time 4 ms       speed 496 bytes/ms
     install.sh                                         time 7 ms       speed 779 bytes/ms
     release.sh                                         time 0 ms       speed 657 bytes/ms
-    atom.sh                                            time 4 ms       speed 682 bytes/ms
+    atom.sh                                            time 5 ms       speed 568 bytes/ms
     doc-build.sh                                       time 5 ms       speed 543 bytes/ms
     relocate.sh                                        time 0 ms       speed 665 bytes/ms
     malloc.c                                           time 1 ms       speed 6049 bytes/ms
@@ -119,12 +120,12 @@ Language: cpp
     parser.c                                           time 3 ms       speed 11119 bytes/ms
     no_newline_at_eof.go                               time 0 ms       speed 280 bytes/ms
     proc.go                                            time 85 ms      speed 1381 bytes/ms
-    letter_test.go                                     time 5 ms       speed 2073 bytes/ms
+    letter_test.go                                     time 6 ms       speed 1776 bytes/ms
     value.go                                           time 48 ms      speed 1508 bytes/ms
     deeply-nested.html                                 time 8 ms       speed 668 bytes/ms
     deeply-nested-custom.html                          time 4 ms       speed 1214 bytes/ms
-    text-editor-component.js                           time 87 ms      speed 1721 bytes/ms
-    jquery.js                                          time 96 ms      speed 2550 bytes/ms
+    text-editor-component.js                           time 88 ms      speed 1702 bytes/ms
+    jquery.js                                          time 97 ms      speed 2523 bytes/ms
     Logger.kt                                          time 3 ms       speed 1130 bytes/ms
     python3.8_grammar.py                               time 64 ms      speed 775 bytes/ms
     tabs.py                                            time 1 ms       speed 618 bytes/ms
@@ -141,13 +142,13 @@ Language: cpp
     ast.rs                                             time 23 ms      speed 2729 bytes/ms
   Average Speed (normal): 6640 bytes/ms
   Worst Speed (normal):   4832 bytes/ms
-  Average Speed (errors): 1742 bytes/ms
+  Average Speed (errors): 1728 bytes/ms
   Worst Speed (errors):   16 bytes/ms
```

**2. The language that sees the _least_ improvement in its "Constructing Queries" step is `python`, with only a 33% improvement in throughput:**  
```
 Language: python
   Constructing Queries
-    highlights.scm                                     time 3 ms       speed 458 bytes/ms
-    tags.scm                                           time 1 ms       speed 129 bytes/ms
+    highlights.scm                                     time 2 ms       speed 611 bytes/ms
+    tags.scm                                           time 0 ms       speed 258 bytes/ms
```

**3. The only language to take _more than 100ms_ (on my Linux box) after this change is Swift:**
```
 Language: swift
   Constructing Queries
-    highlights.scm                                     time 983 ms     speed 2 bytes/ms
-    locals.scm                                         time 144 ms     speed 2 bytes/ms
+    highlights.scm                                     time 458 ms     speed 6 bytes/ms
+    locals.scm                                         time 153 ms     speed 2 bytes/ms
```

## Conclusion
When we exclude non-primary states from subgraph initialization, we see huge reductions in `ts_query__analyze_patterns` runtime across the board. Although this is imperceptible for the faster grammars (`rust` going from 9ms to 6ms, for instance), it makes a significant difference for others, bringing `kotlin`, `ruby`, and `elixir` under the commonly-accepted 100ms threshold of perceptibility of delay.

At this point, I expect further optimization for `swift` to come from changes to that grammar itself, since its primary state count is a clear outlier among the grammars. Of course, primary state count isn't the only variable here: the C++ parser is 14x faster than Elixir (5ms vs 71ms), but has 133% more primary states. It may be worth documenting the properties of grammars that are more or less performant so that authors like me can find ways to restructure our own grammar definitions.