### PR TITLE
Add Kotlin, Swift, and Elixir to benchmarks

### DIFF
--- a/script/fetch-fixtures
+++ b/script/fetch-fixtures
@@ -3,10 +3,11 @@
 GRAMMARS_DIR=$(dirname $0)/../test/fixtures/grammars
 
 fetch_grammar() {
-  local grammar=$1
-  local ref=$2
+  local organization=$1
+  local grammar=$2
+  local ref=$3
   local grammar_dir=${GRAMMARS_DIR}/${grammar}
-  local grammar_url=https://github.com/tree-sitter/tree-sitter-${grammar}
+  local grammar_url=https://github.com/${organization}/tree-sitter-${grammar}
 
   echo "Updating ${grammar} grammar..."
 
@@ -21,18 +22,21 @@ fetch_grammar() {
   )
 }
 
-fetch_grammar bash              master
-fetch_grammar c                 master
-fetch_grammar cpp               master
-fetch_grammar embedded-template master
-fetch_grammar go                master
-fetch_grammar html              master
-fetch_grammar java              master
-fetch_grammar javascript        partial-order-precedences
-fetch_grammar jsdoc             master
-fetch_grammar json              master
-fetch_grammar php               master
-fetch_grammar python            master
-fetch_grammar ruby              master
-fetch_grammar rust              master
-fetch_grammar typescript        master
+fetch_grammar tree-sitter bash              master
+fetch_grammar tree-sitter c                 master
+fetch_grammar tree-sitter cpp               master
+fetch_grammar tree-sitter embedded-template master
+fetch_grammar tree-sitter go                master
+fetch_grammar tree-sitter html              master
+fetch_grammar tree-sitter java              master
+fetch_grammar tree-sitter javascript        partial-order-precedences
+fetch_grammar tree-sitter jsdoc             master
+fetch_grammar tree-sitter json              master
+fetch_grammar tree-sitter php               master
+fetch_grammar tree-sitter python            master
+fetch_grammar tree-sitter ruby              master
+fetch_grammar tree-sitter rust              master
+fetch_grammar tree-sitter typescript        master
+fetch_grammar elixir-lang elixir            de20391afe5cb03ef1e8a8e43167e7b58cc52869
+fetch_grammar fwcd        kotlin            0.2.11
+fetch_grammar alex-pinkus swift             0.1.1-with-static-grammar.json

--- a/script/fetch-fixtures.cmd
+++ b/script/fetch-fixtures.cmd
@@ -1,32 +1,36 @@
 @echo off
 
-call:fetch_grammar bash              master
-call:fetch_grammar c                 master
-call:fetch_grammar cpp               master
-call:fetch_grammar embedded-template master
-call:fetch_grammar go                master
-call:fetch_grammar html              master
-call:fetch_grammar java              master
-call:fetch_grammar javascript        partial-order-precedences
-call:fetch_grammar jsdoc             master
-call:fetch_grammar json              master
-call:fetch_grammar php               master
-call:fetch_grammar python            master
-call:fetch_grammar ruby              master
-call:fetch_grammar rust              master
-call:fetch_grammar typescript        master
+call:fetch_grammar tree-sitter bash              master
+call:fetch_grammar tree-sitter c                 master
+call:fetch_grammar tree-sitter cpp               master
+call:fetch_grammar tree-sitter embedded-template master
+call:fetch_grammar tree-sitter go                master
+call:fetch_grammar tree-sitter html              master
+call:fetch_grammar tree-sitter java              master
+call:fetch_grammar tree-sitter javascript        partial-order-precedences
+call:fetch_grammar tree-sitter jsdoc             master
+call:fetch_grammar tree-sitter json              master
+call:fetch_grammar tree-sitter php               master
+call:fetch_grammar tree-sitter python            master
+call:fetch_grammar tree-sitter ruby              master
+call:fetch_grammar tree-sitter rust              master
+call:fetch_grammar tree-sitter typescript        master
+call:fetch_grammar elixir-lang elixir            de20391afe5cb03ef1e8a8e43167e7b58cc52869
+call:fetch_grammar fwcd        kotlin            0.2.11
+call:fetch_grammar alex-pinkus swift             0.1.1-with-static-grammar.json
 exit /B 0
 
 :fetch_grammar
 setlocal
-set grammar_dir=test\fixtures\grammars\%~1
-set grammar_url=https://github.com/tree-sitter/tree-sitter-%~1
-set grammar_branch=%~2
+set organization=%~1
+set grammar_dir=test\fixtures\grammars\%~2
+set grammar_url=https://github.com/%organization%/tree-sitter-%~2
+set grammar_ref=%~3
 @if not exist %grammar_dir% (
   git clone %grammar_url% %grammar_dir% --depth=1
 )
 pushd %grammar_dir%
-git fetch origin %2 --depth=1
+git fetch origin %grammar_ref% --depth=1
 git reset --hard FETCH_HEAD
 popd
 exit /B 0


### PR DESCRIPTION
Initially suggested in https://github.com/tree-sitter/tree-sitter/pull/1578#issuecomment-1008512836. I decided to split this out from #1589 for the purpose of discussion.

~Because the Swift grammar generates its `grammar.json` from source every time, this also modifies the `generate-fixtures` scripts so that they attempt an `npm install` when they need to.~ Edit: this is no longer the case because the Swift grammar won’t build from source on the Appveyor 32-bit host. Instead this just points at a tag that has a checked-in `grammar.json`.

This change does not add these repositories into `corpus_test` because `elixir` seems to have a spurious failure there and `swift` runs forever without terminating.