### PR TITLE
Fix ABI 14 back compat by moving primary_field_ids to the end

### DIFF
--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -1390,10 +1390,6 @@ impl Generator {
             add_line!(self, ".alias_sequences = &ts_alias_sequences[0][0],");
         }
 
-        if self.abi_version >= ABI_VERSION_WITH_PRIMARY_STATES {
-            add_line!(self, ".primary_state_ids = ts_primary_state_ids,");
-        }
-
         // Lexing
         add_line!(self, ".lex_modes = ts_lex_modes,");
         add_line!(self, ".lex_fn = ts_lex,");
@@ -1418,6 +1414,10 @@ impl Generator {
             add_line!(self, "{}_deserialize,", external_scanner_name);
             dedent!(self);
             add_line!(self, "}},");
+        }
+
+        if self.abi_version >= ABI_VERSION_WITH_PRIMARY_STATES {
+            add_line!(self, ".primary_state_ids = ts_primary_state_ids,");
         }
 
         dedent!(self);

--- a/lib/include/tree_sitter/parser.h
+++ b/lib/include/tree_sitter/parser.h
@@ -110,7 +110,6 @@ struct TSLanguage {
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSStateId *primary_state_ids;
   const TSLexMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
@@ -124,6 +123,7 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
+  const TSStateId *primary_state_ids;
 };
 
 /*


### PR DESCRIPTION
Due to an oversight in #1589, I added `primary_field_ids` into the `TSLanguage` struct in a place that wasn't the end. This is not actually backwards compatible and causes downstream failures :(
﻿
CC @maxbrunsfeld 