### PR TITLE
prevent future captures for `#is-not? local` matches

### DIFF
--- a/highlight/src/lib.rs
+++ b/highlight/src/lib.rs
@@ -111,7 +111,7 @@ struct HighlightIterLayer<'a> {
     scope_stack: Vec<LocalScope<'a>>,
     ranges: Vec<Range>,
     depth: usize,
-    ignore_match_ids: Vec<u32>,
+    ignore_match_id: i32,
 }
 
 impl Highlighter {
@@ -414,7 +414,7 @@ impl<'a> HighlightIterLayer<'a> {
                     captures,
                     config,
                     ranges,
-                    ignore_match_ids: Vec::new(),
+                    ignore_match_id: -1,
                 });
             }
 
@@ -685,7 +685,7 @@ where
             let (mut match_, capture_index) = layer.captures.next().unwrap();
             let mut capture = match_.captures[capture_index];
 
-            if layer.ignore_match_ids.contains(&match_.id()) {
+            if layer.ignore_match_id >= match_.id() as i32 {
                 continue 'main;
             }
 
@@ -841,7 +841,7 @@ where
             // highlighting patterns that are disabled for local variables.
             if definition_highlight.is_some() || reference_highlight.is_some() {
                 while layer.config.non_local_variable_patterns[match_.pattern_index] {
-                    layer.ignore_match_ids.push(match_.id());
+                    layer.ignore_match_id = match_.id() as i32;
                     if let Some((next_match, next_capture_index)) = layer.captures.peek() {
                         let next_capture = next_match.captures[*next_capture_index];
                         if next_capture.node == capture.node {

--- a/highlight/src/lib.rs
+++ b/highlight/src/lib.rs
@@ -111,7 +111,6 @@ struct HighlightIterLayer<'a> {
     scope_stack: Vec<LocalScope<'a>>,
     ranges: Vec<Range>,
     depth: usize,
-    ignore_match_id: i32,
 }
 
 impl Highlighter {
@@ -414,7 +413,6 @@ impl<'a> HighlightIterLayer<'a> {
                     captures,
                     config,
                     ranges,
-                    ignore_match_id: -1,
                 });
             }
 
@@ -685,10 +683,6 @@ where
             let (mut match_, capture_index) = layer.captures.next().unwrap();
             let mut capture = match_.captures[capture_index];
 
-            if layer.ignore_match_id >= match_.id() as i32 {
-                continue 'main;
-            }
-
             // If this capture represents an injection, then process the injection.
             if match_.pattern_index < layer.config.locals_pattern_index {
                 let (language_name, content_node, include_children) =
@@ -841,7 +835,7 @@ where
             // highlighting patterns that are disabled for local variables.
             if definition_highlight.is_some() || reference_highlight.is_some() {
                 while layer.config.non_local_variable_patterns[match_.pattern_index] {
-                    layer.ignore_match_id = match_.id() as i32;
+                    match_.remove();
                     if let Some((next_match, next_capture_index)) = layer.captures.peek() {
                         let next_capture = next_match.captures[*next_capture_index];
                         if next_capture.node == capture.node {

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -3725,6 +3725,20 @@ void ts_query_cursor_remove_match(
       return;
     }
   }
+
+  // Remove unfinished query states as well to prevent future
+  // captures for a match being removed.
+  for (unsigned i = 0; i < self->states.size; i++) {
+    const QueryState *state = &self->states.contents[i];
+    if (state->id == match_id) {
+      capture_list_pool_release(
+        &self->capture_list_pool,
+        state->capture_list_id
+      );
+      array_erase(&self->states, i);
+      return;
+    }
+  }
 }
 
 bool ts_query_cursor_next_capture(


### PR DESCRIPTION
closes #1597

~In this case I thought it would make sense to use `match.remove()`, but that appears to only clear out existing matches and does not prevent future captures for the removed match. It might make sense to change the C query api to ignore future captures for a removed match, but fixing it in the rust binding was so much easier :sweat_smile:~

~Here we store a set of match IDs to ignore when a capture for each match finds that it is not local. I suppose this could be used by other mechanism like injections, so I've left it named generically, but I'm open to suggestions on that.~