### PR TITLE
fix: fix variable shadows

### DIFF
--- a/lib/src/array.h
+++ b/lib/src/array.h
@@ -109,9 +109,9 @@ extern "C" {
 // callback to determine the order.
 #define array_insert_sorted_with(self, compare, value) \
   do { \
-    unsigned index, exists; \
-    array_search_sorted_with(self, compare, &(value), &index, &exists); \
-    if (!exists) array_insert(self, index, value); \
+    unsigned index__, exists__; \
+    array_search_sorted_with(self, compare, &(value), &index__, &exists__); \
+    if (!exists__) array_insert(self, index__, value); \
   } while (0)
 
 // Insert a given `value` into a sorted array, using integer comparisons of
@@ -120,9 +120,9 @@ extern "C" {
 // See also `array_search_sorted_by`.
 #define array_insert_sorted_by(self, field, value) \
   do { \
-    unsigned index, exists; \
-    array_search_sorted_by(self, field, (value) field, &index, &exists); \
-    if (!exists) array_insert(self, index, value); \
+    unsigned index__, exists__; \
+    array_search_sorted_by(self, field, (value) field, &index__, &exists__); \
+    if (!exists__) array_insert(self, index__, value); \
   } while (0)
 
 // Private

--- a/lib/src/language.h
+++ b/lib/src/language.h
@@ -83,7 +83,7 @@ static inline uint16_t ts_language_lookup(
     for (unsigned i = 0; i < group_count; i++) {
       uint16_t section_value = *(data++);
       uint16_t symbol_count = *(data++);
-      for (unsigned i = 0; i < symbol_count; i++) {
+      for (unsigned i_symbol = 0; i_symbol < symbol_count; i_symbol++) {
         if (*(data++) == symbol) return section_value;
       }
     }

--- a/lib/src/stack.c
+++ b/lib/src/stack.c
@@ -333,15 +333,15 @@ inline StackSliceArray stack__iter(
 
   while (self->iterators.size > 0) {
     for (uint32_t i = 0, size = self->iterators.size; i < size; i++) {
-      StackIterator *iterator = &self->iterators.contents[i];
-      StackNode *node = iterator->node;
+      StackIterator *stack_iterator = &self->iterators.contents[i];
+      StackNode *node = stack_iterator->node;
 
-      StackAction action = callback(payload, iterator);
+      StackAction action = callback(payload, stack_iterator);
       bool should_pop = action & StackActionPop;
       bool should_stop = action & StackActionStop || node->link_count == 0;
 
       if (should_pop) {
-        SubtreeArray subtrees = iterator->subtrees;
+        SubtreeArray subtrees = stack_iterator->subtrees;
         if (!should_stop) {
           ts_subtree_array_copy(subtrees, &subtrees);
         }
@@ -356,7 +356,7 @@ inline StackSliceArray stack__iter(
 
       if (should_stop) {
         if (!should_pop) {
-          ts_subtree_array_delete(self->subtree_pool, &iterator->subtrees);
+          ts_subtree_array_delete(self->subtree_pool, &stack_iterator->subtrees);
         }
         array_erase(&self->iterators, i);
         i--, size--;

--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -365,9 +365,9 @@ void ts_tree_cursor_current_status(
 
       // Look for a field name associated with the current node.
       if (!*field_id) {
-        for (const TSFieldMapEntry *i = field_map; i < field_map_end; i++) {
-          if (!i->inherited && i->child_index == entry->structural_child_index) {
-            *field_id = i->field_id;
+        for (const TSFieldMapEntry *i_field = field_map; i_field < field_map_end; i_field++) {
+          if (!i_field->inherited && i_field->child_index == entry->structural_child_index) {
+            *field_id = i_field->field_id;
             break;
           }
         }
@@ -375,10 +375,10 @@ void ts_tree_cursor_current_status(
 
       // Determine if the current node can have later siblings with the same field name.
       if (*field_id) {
-        for (const TSFieldMapEntry *i = field_map; i < field_map_end; i++) {
+        for (const TSFieldMapEntry *i_field = field_map; i_field < field_map_end; i_field++) {
           if (
-            i->field_id == *field_id &&
-            i->child_index > entry->structural_child_index
+            i_field->field_id == *field_id &&
+            i_field->child_index > entry->structural_child_index
           ) {
             *can_have_later_siblings_with_this_field = true;
             break;
@@ -445,9 +445,9 @@ TSFieldId ts_tree_cursor_current_field_id(const TSTreeCursor *_self) {
       parent_entry->subtree->ptr->production_id,
       &field_map, &field_map_end
     );
-    for (const TSFieldMapEntry *i = field_map; i < field_map_end; i++) {
-      if (!i->inherited && i->child_index == entry->structural_child_index) {
-        return i->field_id;
+    for (const TSFieldMapEntry *i_field = field_map; i_field < field_map_end; i_field++) {
+      if (!i_field->inherited && i_field->child_index == entry->structural_child_index) {
+        return i_field->field_id;
       }
     }
   }


### PR DESCRIPTION
Fixes #1888

This fixes 31 shadow warnings from `-Wshadow` in tree-sitter.


Detected using #1555 

The variables were automatically renamed using the IDE, so they are correct without human error. This became possible because #1555 generates `compile_commands.json` that makes clangd work inside the IDE, and so automatic refactoring becomes available.