### PR TITLE
Implemented basic cache for `get_column`

### DIFF
--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -73,6 +73,7 @@ typedef struct {
 typedef enum {
   TSLogTypeParse,
   TSLogTypeLex,
+  TSLogTypeColumnCache
 } TSLogType;
 
 typedef struct {

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -73,7 +73,6 @@ typedef struct {
 typedef enum {
   TSLogTypeParse,
   TSLogTypeLex,
-  TSLogTypeColumnCache
 } TSLogType;
 
 typedef struct {

--- a/lib/src/lexer.c
+++ b/lib/src/lexer.c
@@ -4,7 +4,7 @@
 #include "./length.h"
 #include "./unicode.h"
 
-#define LOG_LEX(message, character)          \
+#define LOG(message, character)          \
   if (self->logger.log) {                    \
     snprintf(                                \
       self->debug_buffer,                    \
@@ -17,22 +17,6 @@
     self->logger.log(                        \
       self->logger.payload,                  \
       TSLogTypeLex,                          \
-      self->debug_buffer                     \
-    );                                       \
-  }
-
-#define LOG_COLUMN_CACHE(hit, col)           \
-  if (self->logger.log) {                    \
-    snprintf(                                \
-      self->debug_buffer,                    \
-      TREE_SITTER_SERIALIZATION_BUFFER_SIZE, \
-      "get_column cache %s; value: %d",      \
-      hit ? "hit" : "miss",                  \
-      col                                    \
-    );                                       \
-    self->logger.log(                        \
-      self->logger.payload,                  \
-      TSLogTypeColumnCache,                  \
       self->debug_buffer                     \
     );                                       \
   }
@@ -260,9 +244,9 @@ static void ts_lexer__advance(TSLexer *_self, bool skip) {
   if (!self->chunk) return;
 
   if (skip) {
-    LOG_LEX("skip", self->data.lookahead);
+    LOG("skip", self->data.lookahead);
   } else {
-    LOG_LEX("consume", self->data.lookahead);
+    LOG("consume", self->data.lookahead);
   }
   
   ts_lexer__do_advance(self, skip);
@@ -315,10 +299,6 @@ static uint32_t ts_lexer__get_column(TSLexer *_self) {
     while (self->current_position.bytes < goal_byte && !ts_lexer__eof(_self) && self->chunk) {
       ts_lexer__do_advance(self, false);
     }
-    
-    LOG_COLUMN_CACHE(false, self->column_cache.value);
-  } else {
-    LOG_COLUMN_CACHE(true, self->column_cache.value);
   }
 
   return self->column_cache.value;
@@ -469,5 +449,4 @@ TSRange *ts_lexer_included_ranges(const Lexer *self, uint32_t *count) {
   return self->included_ranges;
 }
 
-#undef LOG_LEX
-#undef LOG_COLUMN_CACHE
+#undef LOG

--- a/lib/src/lexer.c
+++ b/lib/src/lexer.c
@@ -4,7 +4,7 @@
 #include "./length.h"
 #include "./unicode.h"
 
-#define LOG(message, character)          \
+#define LOG(message, character)              \
   if (self->logger.log) {                    \
     snprintf(                                \
       self->debug_buffer,                    \

--- a/lib/src/lexer.c
+++ b/lib/src/lexer.c
@@ -54,7 +54,7 @@ static bool ts_lexer__try_get_cached_column_value(const Lexer *self, uint32_t *o
  * @param self The lexer state.
  * @param val The new value of the column cache.
  */
-static bool ts_lexer__set_column_cache(Lexer *self, uint32_t val) {
+static void ts_lexer__set_column_cache(Lexer *self, uint32_t val) {
   self->column_cache.valid = true;
   self->column_cache.value = val;
 }

--- a/lib/src/lexer.h
+++ b/lib/src/lexer.h
@@ -11,6 +11,11 @@ extern "C" {
 #include "tree_sitter/parser.h"
 
 typedef struct {
+  uint32_t value;
+  bool valid;
+} ColumnCache;
+
+typedef struct {
   TSLexer data;
   Length current_position;
   Length token_start_position;
@@ -26,7 +31,9 @@ typedef struct {
   uint32_t chunk_start;
   uint32_t chunk_size;
   uint32_t lookahead_size;
+
   bool did_get_column;
+  ColumnCache column_cache;
 
   char debug_buffer[TREE_SITTER_SERIALIZATION_BUFFER_SIZE];
 } Lexer;


### PR DESCRIPTION
Implements the basic cache described in https://github.com/tree-sitter/tree-sitter/issues/1626
Unfortunately I don't see huge performance differences when parsing the ten largest files in the [tlaplus/examples](https://github.com/tlaplus/examples) repo. Here are results for 0.20.0 (byte-based `get_column`), 0.20.4 (codepoint-based `get_column`), and this patch, all of which seem to have variance of +/- 15 ms:
| File | 0.20.0 Parse Time | 0.20.4 Parse Time | This Patch Parse Time |
|-----|--------------------|---------------------|--------------------------|
| aba_asyn_byz.tla | 52 ms | 57 ms | 43 ms |
| AllocatorImplementation.tla | 39 ms | 58 ms | 38 ms |
| AllocatorRefinement.tla | 53 ms | 77 ms |  58 ms |
| SchedulingAllocator.tla | 62 ms | 64 ms | 60 ms |
| SimpleAllocator.tla | 59 ms | 76 ms | 47 ms |
| Bakery.tla | 78 ms | 78 ms | 57 ms |
| Boulanger.tla | 61 ms | 77 ms  | 62 ms |
| bcastByz.tla | 76 ms | 91 ms | 74 ms |
| bcastFolklore.tla | 57 ms | 77 ms | 61 ms |
| bosco.tla | 64 ms | 85 ms | 61 ms |

(previously I thought the differences were quite large but it turned out that's because I wasn't using the `tree-sitter.exe` file directly - important!)

For my future reference, here are the commands I used to quickly get these numbers:
<details><summary>pwsh</summary>
<p>

```pwsh
$specs = Get-ChildItem -Path .\test\examples\external\specifications -Filter "*.tla" -Exclude "Reals.tla","Naturals.tla" -Recurse
$largest = Sort-Object -InputObject $specs -Property "Length" -Descending
$largest | Select-Object -First 10 |% {Write-Host $_.Name; Measure-Command {.\node_modules\tree-sitter-cli\tree-sitter.exe parse -q $_.FullName}} |% {$_.Milliseconds}
```
</p>
</details>

These changes do not implement the `mark_end` nor cache-before-external-scanner optimizations suggested in the linked work item.

If the basic approach is approved I will write tests. Currently all tests pass in my grammar, which makes heavy use of `get_column`.

These changes also fix an extremely minor bug where on the first line of the file the BOM could be counted as a column item.