### PR TITLE
Rust loader library: Make dependencies optional

### DIFF
--- a/cli/loader/Cargo.toml
+++ b/cli/loader/Cargo.toml
@@ -14,6 +14,9 @@ categories.workspace = true
 
 [features]
 wasm = ["tree-sitter/wasm"]
+# TODO: For backward compatibility these must be enabled by default,
+# consider removing for the next semver incompatible release
+default = ["tree-sitter-highlight", "tree-sitter-tags"]
 
 [dependencies]
 anyhow.workspace = true
@@ -28,6 +31,6 @@ serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 
-tree-sitter.workspace = true
-tree-sitter-highlight.workspace = true
-tree-sitter-tags.workspace = true
+tree-sitter = {workspace = true}
+tree-sitter-highlight = {workspace = true, optional = true}
+tree-sitter-tags = {workspace = true, optional = true}


### PR DESCRIPTION
The `tree-sitter-loader` crate currently always pull `tree-sitter-highlight` and tree-sitter-tags as dependencies.
However, apart from the tree-sitter CLI, most clients will not need both of these libraries.

This commit makes the dependencies optional, but still include them by default in order not to break the backward compatibility.
For the next breaking change, we probably should think of removing them from default.