### PR TITLE
Change cursor `goto_first_child_for_{byte,point}` methods to treat nodes' ranges inclusively

### DIFF
--- a/cli/src/tests/tree_test.rs
+++ b/cli/src/tests/tree_test.rs
@@ -280,16 +280,16 @@ fn test_tree_cursor_child_for_point() {
     assert_eq!(c.node().kind(), "program");
 
     assert_eq!(c.goto_first_child_for_point(Point::new(7, 0)), None);
-    assert_eq!(c.goto_first_child_for_point(Point::new(6, 6)), None);
+    assert_eq!(c.goto_first_child_for_point(Point::new(6, 7)), None);
     assert_eq!(c.node().kind(), "program");
 
     // descend to expression statement
-    assert_eq!(c.goto_first_child_for_point(Point::new(6, 5)), Some(0));
+    assert_eq!(c.goto_first_child_for_point(Point::new(6, 6)), Some(0));
     assert_eq!(c.node().kind(), "expression_statement");
 
     // step into ';' and back up
     assert_eq!(c.goto_first_child_for_point(Point::new(7, 0)), None);
-    assert_eq!(c.goto_first_child_for_point(Point::new(6, 5)), Some(1));
+    assert_eq!(c.goto_first_child_for_point(Point::new(6, 6)), Some(1));
     assert_eq!(
         (c.node().kind(), c.node().start_position()),
         (";", Point::new(6, 5))
@@ -312,7 +312,7 @@ fn test_tree_cursor_child_for_point() {
     assert!(c.goto_parent());
 
     // step into identifier 'one' and back up
-    assert_eq!(c.goto_first_child_for_point(Point::new(0, 5)), Some(1));
+    assert_eq!(c.goto_first_child_for_point(Point::new(1, 0)), Some(1));
     assert_eq!(
         (c.node().kind(), c.node().start_position()),
         ("identifier", Point::new(1, 8))
@@ -326,7 +326,7 @@ fn test_tree_cursor_child_for_point() {
     assert!(c.goto_parent());
 
     // step into first ',' and back up
-    assert_eq!(c.goto_first_child_for_point(Point::new(1, 11)), Some(2));
+    assert_eq!(c.goto_first_child_for_point(Point::new(1, 12)), Some(2));
     assert_eq!(
         (c.node().kind(), c.node().start_position()),
         (",", Point::new(1, 11))
@@ -334,7 +334,7 @@ fn test_tree_cursor_child_for_point() {
     assert!(c.goto_parent());
 
     // step into identifier 'four' and back up
-    assert_eq!(c.goto_first_child_for_point(Point::new(4, 10)), Some(5));
+    assert_eq!(c.goto_first_child_for_point(Point::new(5, 0)), Some(5));
     assert_eq!(
         (c.node().kind(), c.node().start_position()),
         ("identifier", Point::new(5, 8))
@@ -354,7 +354,7 @@ fn test_tree_cursor_child_for_point() {
         ("]", Point::new(6, 4))
     );
     assert!(c.goto_parent());
-    assert_eq!(c.goto_first_child_for_point(Point::new(5, 23)), Some(10));
+    assert_eq!(c.goto_first_child_for_point(Point::new(6, 0)), Some(10));
     assert_eq!(
         (c.node().kind(), c.node().start_position()),
         ("]", Point::new(6, 4))

--- a/lib/src/point.h
+++ b/lib/src/point.h
@@ -37,6 +37,10 @@ static inline bool point_gt(TSPoint a, TSPoint b) {
   return (a.row > b.row) || (a.row == b.row && a.column > b.column);
 }
 
+static inline bool point_gte(TSPoint a, TSPoint b) {
+  return (a.row > b.row) || (a.row == b.row && a.column >= b.column);
+}
+
 static inline bool point_eq(TSPoint a, TSPoint b) {
   return a.row == b.row && a.column == b.column;
 }

--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -139,7 +139,7 @@ int64_t ts_tree_cursor_goto_first_child_for_byte(TSTreeCursor *_self, uint32_t g
     CursorChildIterator iterator = ts_tree_cursor_iterate_children(self);
     while (ts_tree_cursor_child_iterator_next(&iterator, &entry, &visible)) {
       uint32_t end_byte = entry.position.bytes + ts_subtree_size(*entry.subtree).bytes;
-      bool at_goal = end_byte > goal_byte;
+      bool at_goal = end_byte >= goal_byte;
       uint32_t visible_child_count = ts_subtree_visible_child_count(*entry.subtree);
 
       if (at_goal) {
@@ -179,7 +179,7 @@ int64_t ts_tree_cursor_goto_first_child_for_point(TSTreeCursor *_self, TSPoint g
     CursorChildIterator iterator = ts_tree_cursor_iterate_children(self);
     while (ts_tree_cursor_child_iterator_next(&iterator, &entry, &visible)) {
       TSPoint end_point = point_add(entry.position.extent, ts_subtree_size(*entry.subtree).extent);
-      bool at_goal = point_gt(end_point, goal_point);
+      bool at_goal = point_gte(end_point, goal_point);
       uint32_t visible_child_count = ts_subtree_visible_child_count(*entry.subtree);
       if (at_goal) {
         if (visible) {


### PR DESCRIPTION
Previously, `ts_tree_cursor_go_to_first_child_for_byte` would advance the cursor to the first child node whose end byte was *strictly* greater than the given byte offset. This PR changes the behavior so that instead, it finds the first child node whose end byte is greater than *or equal* to the given byte offset. This is more useful, since you can always advance the cursor to the next sibling after the fact, but you can't walk the cursor backwards.