### PR TITLE
add unit testing documentation for tags queries

### DIFF
--- a/docs/section-8-code-navigation-systems.md
+++ b/docs/section-8-code-navigation-systems.md
@@ -101,3 +101,20 @@ Invoking `tree-sitter tags test.rb` produces the following console output, repre
 ```
 
 It is expected that tag queries for a given language are located at `queries/tags.scm` in that language's repository.
+
+## Unit Testing
+
+Tags queries may be tested with `tree-sitter test`. Files under `test/tags/` are checked using the same comment system as [highlights queries](https://tree-sitter.github.io/tree-sitter/syntax-highlighting#unit-testing). For example, the above Ruby tags can be tested with these comments:
+
+```ruby
+module Foo
+  #     ^ definition.module
+  class Bar
+    #    ^ definition.class
+
+    def baz
+      #  ^ definition.method
+    end
+  end
+end
+```


### PR DESCRIPTION
Following up from @razzeee's comment (https://github.com/tree-sitter/tree-sitter/pull/1547#issuecomment-1050631839), now that there's a nice section on code-navigation and tags queries, I think this is the perfect place for some docs on unit testing. The docs are pretty thin - they're mostly a pointer to the syntax highlighting unit testing docs with an example.

cc @patrickt