### PR TITLE
Remember lookahead bytes on error detection

### DIFF
--- a/lib/src/stack.h
+++ b/lib/src/stack.h
@@ -99,9 +99,9 @@ bool ts_stack_merge(Stack *, StackVersion, StackVersion);
 // Determine whether the given two stack versions can be merged.
 bool ts_stack_can_merge(Stack *, StackVersion, StackVersion);
 
-TSSymbol ts_stack_resume(Stack *, StackVersion);
+Subtree ts_stack_resume(Stack *, StackVersion);
 
-void ts_stack_pause(Stack *, StackVersion, TSSymbol);
+void ts_stack_pause(Stack *, StackVersion, Subtree);
 
 void ts_stack_halt(Stack *, StackVersion);
 

--- a/test/fixtures/error_corpus/c_errors.txt
+++ b/test/fixtures/error_corpus/c_errors.txt
@@ -128,8 +128,8 @@ int main() {
       (declaration (primitive_type) (init_declarator
         (identifier)
         (parenthesized_expression
-          (number_literal)
-          (ERROR (number_literal))))))))
+          (ERROR (number_literal))
+          (number_literal)))))))
 
 ========================================
 Extra identifiers in declarations


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter/issues/1645