### PR TITLE
Fixed warning/error when compiling with `clang -Os`.

### DIFF
--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -1367,6 +1367,7 @@ static void ts_parser__handle_error(
   for (unsigned i = previous_version_count; i < version_count; i++) {
     bool did_merge = ts_stack_merge(self->stack, version, previous_version_count);
     assert(did_merge);
+    (void)did_merge;	//	fix warning/error with clang -Os
   }
 
   ts_stack_record_summary(self->stack, version, MAX_SUMMARY_DEPTH);


### PR DESCRIPTION
DISCUSSION:

When compiling with `-Os` for "smallest, fastest", an error is reported in `parser.c`:

```
/Users/siegel/git/tree-sitter/lib/src/./parser.c:1368:10: error: unused variable 'did_merge' [-Werror,-Wunused-variable]
    bool did_merge = ts_stack_merge(self->stack, version, previous_version_count);
         ^
1 error generated.
```

This is because with `NDEBUG` set,  `assert(e)` collapses to `(void)0`,
which in turn means that `did_merge` does not actually get consumed.
This seems to get caught when compiling with `-Os`, but not otherwise.

Compiler version:
```
Apple clang version 13.0.0 (clang-1300.0.29.30)
Target: arm64-apple-darwin21.3.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```