### PR TITLE
Add "--sample" option to "parse" subcommand

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -132,6 +132,11 @@ fn run() -> Result<()> {
                         .short("s"),
                 )
                 .arg(
+                    Arg::with_name("sample")
+                        .long("sample")
+                        .help("Include sample of matched span in output"),
+                )
+                .arg(
                     Arg::with_name("timeout")
                         .help("Interrupt the parsing process by timeout (µs)")
                         .long("timeout")
@@ -363,6 +368,12 @@ fn run() -> Result<()> {
                 env::set_var("TREE_SITTER_DEBUG", "1");
             }
 
+            let output_sample = if matches.is_present("sample") {
+                Some(32)
+            } else {
+                None
+            };
+
             loader.use_debug_build(debug_build);
 
             let timeout = matches
@@ -396,6 +407,7 @@ fn run() -> Result<()> {
                     debug_graph,
                     debug_xml,
                     Some(&cancellation_flag),
+                    output_sample,
                 )?;
 
                 if should_track_stats {

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -42,6 +42,7 @@ pub fn parse_file_at_path(
     debug_graph: bool,
     debug_xml: bool,
     cancellation_flag: Option<&AtomicUsize>,
+    sample_chars: Option<usize>,
 ) -> Result<bool> {
     let mut _log_session = None;
     let mut parser = Parser::new();
@@ -137,6 +138,15 @@ pub fn parse_file_at_path(
                             end.row,
                             end.column
                         )?;
+                        if let Some(sample_len) = sample_chars {
+                            let start = node.start_byte();
+                            let orig_len = node.end_byte() - start;
+                            let len = orig_len.min(sample_len);
+                            let sample = &source_code[start..(start + len)];
+                            let sample = String::from_utf8_lossy(sample);
+                            let sample = sample.replace("\n", "\\n");
+                            write!(&mut stdout, " \"{}\"", sample,)?;
+                        }
                         needs_newline = true;
                     }
                     if cursor.goto_first_child() {


### PR DESCRIPTION
When iterating on a new grammar it would be helpful to see an example
of the text matched by a node, particularly for error nodes.  This
commit adds a "--sample" option to the "parse" subcommand that will
output up to 32 bytes of matching source for each AST node.
