### PR TITLE
Fix build and tests on alternative architectures

### DIFF
--- a/cli/src/tests/highlight_test.rs
+++ b/cli/src/tests/highlight_test.rs
@@ -1,6 +1,7 @@
 use super::helpers::fixtures::{get_highlight_config, get_language, get_language_queries_path};
 use lazy_static::lazy_static;
 use std::ffi::CString;
+use std::os::raw::c_char;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{fs, ptr, slice, str};
 use tree_sitter_highlight::{
@@ -489,15 +490,15 @@ fn test_highlighting_via_c_api() {
     ];
     let highlight_names = highlights
         .iter()
-        .map(|h| h["class=".len()..].as_ptr() as *const i8)
+        .map(|h| h["class=".len()..].as_ptr() as *const c_char)
         .collect::<Vec<_>>();
     let highlight_attrs = highlights
         .iter()
-        .map(|h| h.as_bytes().as_ptr() as *const i8)
+        .map(|h| h.as_bytes().as_ptr() as *const c_char)
         .collect::<Vec<_>>();
     let highlighter = c::ts_highlighter_new(
-        &highlight_names[0] as *const *const i8,
-        &highlight_attrs[0] as *const *const i8,
+        &highlight_names[0] as *const *const c_char,
+        &highlight_attrs[0] as *const *const c_char,
         highlights.len() as u32,
     );
 
@@ -515,9 +516,9 @@ fn test_highlighting_via_c_api() {
         js_scope.as_ptr(),
         js_injection_regex.as_ptr(),
         language,
-        highlights_query.as_ptr() as *const i8,
-        injections_query.as_ptr() as *const i8,
-        locals_query.as_ptr() as *const i8,
+        highlights_query.as_ptr() as *const c_char,
+        injections_query.as_ptr() as *const c_char,
+        locals_query.as_ptr() as *const c_char,
         highlights_query.len() as u32,
         injections_query.len() as u32,
         locals_query.len() as u32,
@@ -534,8 +535,8 @@ fn test_highlighting_via_c_api() {
         html_scope.as_ptr(),
         html_injection_regex.as_ptr(),
         language,
-        highlights_query.as_ptr() as *const i8,
-        injections_query.as_ptr() as *const i8,
+        highlights_query.as_ptr() as *const c_char,
+        injections_query.as_ptr() as *const c_char,
         ptr::null(),
         highlights_query.len() as u32,
         injections_query.len() as u32,

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -705,14 +705,14 @@ impl Tree {
     /// after calling one of the [Parser::parse] functions. Call it on the old tree that
     /// was passed to parse, and pass the new tree that was returned from `parse`.
     pub fn changed_ranges(&self, other: &Tree) -> impl ExactSizeIterator<Item = Range> {
-        let mut count = 0;
+        let mut count = 0u32;
         unsafe {
             let ptr = ffi::ts_tree_get_changed_ranges(
                 self.0.as_ptr(),
                 other.0.as_ptr(),
-                &mut count as *mut _ as *mut u32,
+                &mut count as *mut u32,
             );
-            util::CBufferIter::new(ptr, count).map(|r| r.into())
+            util::CBufferIter::new(ptr, count as usize).map(|r| r.into())
         }
     }
 }

--- a/tags/src/c_lib.rs
+++ b/tags/src/c_lib.rs
@@ -215,9 +215,9 @@ pub extern "C" fn ts_tags_buffer_tags_len(this: *const TSTagsBuffer) -> u32 {
 }
 
 #[no_mangle]
-pub extern "C" fn ts_tags_buffer_docs(this: *const TSTagsBuffer) -> *const i8 {
+pub extern "C" fn ts_tags_buffer_docs(this: *const TSTagsBuffer) -> *const c_char {
     let buffer = unwrap_ptr(this);
-    buffer.docs.as_ptr() as *const i8
+    buffer.docs.as_ptr() as *const c_char
 }
 
 #[no_mangle]
@@ -237,7 +237,7 @@ pub extern "C" fn ts_tagger_syntax_kinds_for_scope_name(
     this: *mut TSTagger,
     scope_name: *const c_char,
     len: *mut u32,
-) -> *const *const i8 {
+) -> *const *const c_char {
     let tagger = unwrap_mut_ptr(this);
     let scope_name = unsafe { unwrap(CStr::from_ptr(scope_name).to_str()) };
     let len = unwrap_mut_ptr(len);
@@ -245,7 +245,7 @@ pub extern "C" fn ts_tagger_syntax_kinds_for_scope_name(
     *len = 0;
     if let Some(config) = tagger.languages.get(scope_name) {
         *len = config.c_syntax_type_names.len() as u32;
-        return config.c_syntax_type_names.as_ptr() as *const *const i8;
+        return config.c_syntax_type_names.as_ptr() as *const *const c_char;
     }
     std::ptr::null()
 }


### PR DESCRIPTION
Fix build and most of the tests on aarch64, ppc64le and s390x (big-endian).

Note: this is a minimal set of changes just to make things compile and tests pass. There are more mismatched types, but none of those break the build or affect the ABI. Case in point: `tags/include/tree_sitter/tags.h` doesn't have a single uint8_t parameter, while there's a plenty of `u8`s in the rust counterpart of the code.


There's one remaining test failure on s390x which I didn't have enough time to debug - #1693 