### PR TITLE
Add precedences to json schema

### DIFF
--- a/cli/npm/dsl.d.ts
+++ b/cli/npm/dsl.d.ts
@@ -72,7 +72,9 @@ interface Grammar<
    * a *descending* ordering. Names listed earlier in one of these arrays
    * have higher precedence than any names listed later in the same array.
    */
-  precedences?: () => String[][],
+  precedences?: (
+    $: GrammarSymbols<RuleName | BaseGrammarRuleName>
+  ) => Array<string | SymbolRule<string>>[],
 
   /**
    * An array of arrays of rule names. Each inner array represents a set of

--- a/cli/src/generate/grammar-schema.json
+++ b/cli/src/generate/grammar-schema.json
@@ -24,6 +24,19 @@
       "additionalProperties": false
     },
 
+    "precedences": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {"$ref": "#/definitions/symbol-rule"},
+            {"type": "string", "pattern": "^[a-zA-Z_]\\w*$"}
+          ]
+        }
+      }
+    },
+
     "extras": {
       "type": "array",
       "items": {

--- a/cli/src/generate/grammar-schema.json
+++ b/cli/src/generate/grammar-schema.json
@@ -30,8 +30,8 @@
         "type": "array",
         "items": {
           "oneOf": [
-            {"$ref": "#/definitions/symbol-rule"},
-            {"type": "string", "pattern": "^[a-zA-Z_]\\w*$"}
+            { "$ref": "#/definitions/symbol-rule" },
+            { "$ref": "#/defintions/string-rule" }
           ]
         }
       }


### PR DESCRIPTION
As per [this comment](https://github.com/tree-sitter/tree-sitter/pull/939#issuecomment-810164152) from #939, the `grammar-schema.json` file needed to include `precedences`.  In the course of that routine update, I also updated type of `precedences` in `dsl.d.ts` to accept rule-references. 