### PR TITLE
Add EXTERNAL specifier to check types of them and setup test for type definitinos.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,11 @@ jobs:
       - name: Run main tests
         run: cargo test
 
+      - name: Run typecheck tests
+        run: |
+          npm --prefix ./test/typecheck install
+          npm --prefix ./test/typecheck run typecheck
+
       - name: Run wasm tests
         run: script/test-wasm
 
@@ -147,3 +152,8 @@ jobs:
 
       - name: Run main tests
         run: script/test
+
+      - name: Run typecheck tests
+        run: |
+          npm --prefix ./test/typecheck --cwd ./test/typecheck install
+          npm --prefix ./test/typecheck --cwd ./test/typecheck run typecheck

--- a/cli/npm/dsl.d.ts
+++ b/cli/npm/dsl.d.ts
@@ -33,6 +33,8 @@ type Rule =
   | SymbolRule<string>
   | TokenRule;
 
+declare const EXTERNAL: unique symbol;
+
 type RuleOrLiteral = Rule | RegExp | string;
 
 type GrammarSymbols<RuleName extends string> = {
@@ -48,7 +50,7 @@ type RuleBuilders<
   RuleName extends string,
   BaseGrammarRuleName extends string
 > = {
-  [name in RuleName]: RuleBuilder<RuleName | BaseGrammarRuleName>;
+  [name in RuleName]: RuleBuilder<RuleName | BaseGrammarRuleName> | typeof EXTERNAL;
 };
 
 interface Grammar<

--- a/cli/src/generate/dsl.js
+++ b/cli/src/generate/dsl.js
@@ -1,3 +1,5 @@
+const EXTERNAL = Symbol("external rule");
+
 function alias(rule, value) {
   const result = {
     type: "ALIAS",
@@ -226,6 +228,13 @@ function grammar(baseGrammar, options) {
       precedences: [],
     };
   }
+  options = Object.assign({}, options);
+  options.rules = Object.assign({}, options.rules);
+  for (const key in options.rules) {
+    if (options.rules[key] === EXTERNAL) {
+      delete options.rules[key];
+    }
+  }
 
   let externals = baseGrammar.externals;
   if (options.externals) {
@@ -401,6 +410,7 @@ function checkPrecedence(value) {
   }
 }
 
+global.EXTERNAL = EXTERNAL;
 global.alias = alias;
 global.blank = blank;
 global.choice = choice;

--- a/test/fixtures/test_grammars/rule_with_external/corpus.txt
+++ b/test/fixtures/test_grammars/rule_with_external/corpus.txt
@@ -1,0 +1,9 @@
+=========================================
+single-line statements - internal tokens
+=========================================
+
+a b
+
+---
+
+(statement (variable) (variable) (line_break))

--- a/test/fixtures/test_grammars/rule_with_external/grammar.js
+++ b/test/fixtures/test_grammars/rule_with_external/grammar.js
@@ -1,0 +1,34 @@
+// Copy of external_and_internal_tokens
+// @ts-check
+/// <reference path="../../../../cli/npm/dsl.d.ts" />
+
+module.exports = grammar({
+    name: 'rule_with_external',
+
+    externals: $ => [
+        $.string,
+        $.line_break,
+    ],
+
+    extras: $ => [/\s/],
+
+    rules: {
+        string: EXTERNAL,
+
+        statement: $ => seq(
+            $._expression,
+            $._expression,
+            $.line_break,
+        ),
+
+        _expression: $ => choice(
+            $.string,
+            $.variable,
+            $.number,
+        ),
+
+        variable: $ => /[a-z]+/,
+        number: $ => /\d+/,
+        line_break: $ => '\n',
+    }
+});

--- a/test/fixtures/test_grammars/rule_with_external/scanner.c
+++ b/test/fixtures/test_grammars/rule_with_external/scanner.c
@@ -1,0 +1,70 @@
+#include <tree_sitter/parser.h>
+
+enum {
+  STRING,
+  LINE_BREAK
+};
+
+void *tree_sitter_rule_with_external_external_scanner_create() {
+  return NULL;
+}
+
+void tree_sitter_rule_with_external_external_scanner_destroy(
+  void *payload
+) {}
+
+void tree_sitter_rule_with_external_external_scanner_reset(
+  void *payload
+) {}
+
+unsigned tree_sitter_rule_with_external_external_scanner_serialize(
+  void *payload,
+  char *buffer
+) { return 0; }
+
+void tree_sitter_rule_with_external_external_scanner_deserialize(
+  void *payload,
+  const char *buffer,
+  unsigned length
+) {}
+
+bool tree_sitter_rule_with_external_external_scanner_scan(
+  void *payload,
+  TSLexer *lexer,
+  const bool *whitelist
+) {
+  // If a line-break is a valid lookahead token, only skip spaces.
+  if (whitelist[LINE_BREAK]) {
+    while (lexer->lookahead == ' ' || lexer->lookahead == '\r') {
+      lexer->advance(lexer, true);
+    }
+
+    if (lexer->lookahead == '\n') {
+      lexer->advance(lexer, false);
+      lexer->result_symbol = LINE_BREAK;
+      return true;
+    }
+  }
+
+  // If a line-break is not a valid lookahead token, skip line breaks as well
+  // as spaces.
+  if (whitelist[STRING]) {
+    while (lexer->lookahead == ' ' || lexer->lookahead == '\r' || lexer->lookahead == '\n') {
+      lexer->advance(lexer, true);
+    }
+
+    if (lexer->lookahead == '\'') {
+      lexer->advance(lexer, false);
+
+      while (lexer->lookahead != '\'') {
+        lexer->advance(lexer, false);
+      }
+
+      lexer->advance(lexer, false);
+      lexer->result_symbol = STRING;
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/test/fixtures/test_grammars/tsconfig.json
+++ b/test/fixtures/test_grammars/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2019"],
+    "strict": true,
+    "noEmit": true,
+    "allowJs": true
+  },
+  "include": ["**/*.js", "./typecheck.d.ts"],
+  "exclude": ["node_modules"]
+}

--- a/test/fixtures/test_grammars/typecheck.d.ts
+++ b/test/fixtures/test_grammars/typecheck.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../../../cli/npm/dsl.d.ts" />

--- a/test/typecheck/package.json
+++ b/test/typecheck/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@tree-sitter-cli/typecheck",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "typecheck": "tsc --noEmit -p ../fixtures/test_grammars/tsconfig.json"
+  },
+  "devDependencies": {
+    "typescript": "latest"
+  }
+}

--- a/test/typecheck/readme.md
+++ b/test/typecheck/readme.md
@@ -1,0 +1,8 @@
+Typecheck
+=========
+
+This npm project is for testing dsl.d.ts definition.
+
+To run the test, run command `npm run typecheck`.
+
+Currently only checking if `// @ts-check` included in top of the file. If all files are ready for typechecking, remove these directives and add `"checkJs": true` to `test/fixtures/test_grammars/tsconfig.json`.


### PR DESCRIPTION
Resolves https://github.com/tree-sitter/tree-sitter/issues/1718

Details for decisions:

- Change type def of externals.
- Add type def for EXTERNAL.
- Drop EXTERNAL in grammar
  - grammar is currently throwing error for values other than functions, so it is backward-compatible change.
- Add export for EXTERNAL.

- Setup tests for type definition the project own .
- Setup CI for types as well.