### PR TITLE
ci(windows): exit in script when failing

### DIFF
--- a/script/benchmark.cmd
+++ b/script/benchmark.cmd
@@ -1,3 +1,4 @@
 @echo off
 
 cargo bench benchmark -p tree-sitter-cli
+exit /b %errorlevel%

--- a/script/test.cmd
+++ b/script/test.cmd
@@ -4,4 +4,7 @@ setlocal
 set RUST_TEST_THREADS=1
 set RUST_BACKTRACE=full
 cargo test "%~1"
+if %errorlevel% NEQ 0 (
+  exit /b %errorlevel%
+)
 endlocal


### PR DESCRIPTION
In Windows, cmd file does not exit if commands in the file failed.

`exit /b %errorlevel%` is needed.

Tests

- https://github.com/LumaKernel/tree-sitter/actions/runs/2214618556
  - Disturbed the test to fail but it passes. (CI except win is commented out)
- https://github.com/LumaKernel/tree-sitter/actions/runs/2214567546
  - Disturbed the test to fail and write above then it fails. (CI except win is commented out)
- https://github.com/LumaKernel/tree-sitter/actions/runs/2214647394
  - Revert the test and write above then it passes. (Same as this PR)


I think the files I didn't modify is not needed to exit when failing.