### PR TITLE
Add link to m68k grammar

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,7 @@ Parsers for these languages are fairly complete:
 * [Lua](https://github.com/Azganoth/tree-sitter-lua)
 * [Make](https://github.com/alemuller/tree-sitter-make)
 * [Markdown](https://github.com/ikatyang/tree-sitter-markdown)
+* [Motorola 68000 Assembly](https://github.com/grahambates/tree-sitter-m68k)
 * [OCaml](https://github.com/tree-sitter/tree-sitter-ocaml)
 * [PHP](https://github.com/tree-sitter/tree-sitter-php)
 * [Python](https://github.com/tree-sitter/tree-sitter-python)


### PR DESCRIPTION
Link to [m68k](https://github.com/grahambates/tree-sitter-m68k) (Motorola 68000 assembly) grammar in docs.