### PR TITLE
Add support for usage from Swift code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
           RUSTFLAGS="-D warnings"
           cargo build --release
 
+      - name: Build as Swift package
+        run: swift build
+
       - name: Set up fixture parsers
         run: |
           script/fetch-fixtures

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ docs/assets/js/tree-sitter.js
 *.exp
 *.lib
 *.wasm
+
+.build

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitter",
+    products: [
+        .library(
+            name: "TreeSitter",
+            targets: ["TreeSitter"]
+        ),
+    ],
+    dependencies: [ ],
+    targets: [
+        .target(
+            name: "TreeSitter",
+            dependencies: [],
+            path: "lib",
+            exclude: [
+               "src/lib.c",
+               "binding_web",
+               "binding_rust",
+            ]
+        ),
+    ]
+)
+

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -9,18 +9,20 @@ let package = Package(
             targets: ["TreeSitter"]
         ),
     ],
-    dependencies: [ ],
+    dependencies: [],
     targets: [
         .target(
             name: "TreeSitter",
             dependencies: [],
             path: "lib",
             exclude: [
-               "src/lib.c",
-               "binding_web",
-               "binding_rust",
+                "src/lib.c",
+                "binding_web",
+                "binding_rust",
+            ],
+            cSettings: [
+                .headerSearchPath("./src"),
             ]
         ),
     ]
 )
-


### PR DESCRIPTION
### :tophat: What is the goal?

Make TreeSitter available on Swift projects using the Swift package manager. 

### :page_facing_up: How is it being implemented?

Since version 3.0, Swift Package Manager supports building [C Language Targets. ](https://github.com/apple/swift-evolution/blob/master/proposals/0038-swiftpm-c-language-targets.md), making it possible to use these projects from Swift with just the addition of a few files. 

I've created a `Package.swift` file that configures a project name and a list of files to compile. I've excluded `lib.c`, avoiding duplicate symbols and `bindings` for `web` and `rust`. Swift Package Manager will automatically collect and compile all the C files in the provided `path`, and will automatically include everything in the `include` directory.

I've also added support for running the swift build in CI for making sure the project compiles. 

### :white_check_mark: How can it be tested?

I've created a [small repo](https://github.com/AntonioCandinho/TreeSitterSwiftExample) showing how the code can be used from Swift code. Please take a look. 