### PR TITLE
Revert some refactorings from 12d727; fix #1722

### DIFF
--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -17,15 +17,26 @@ var MIN_COMPATIBLE_VERSION;
 var TRANSFER_BUFFER;
 var currentParseCallback;
 var currentLogCallback;
+var initPromise;
 
-class ParserImpl {
-  static init() {
-    TRANSFER_BUFFER = C._ts_init();
-    VERSION = getValue(TRANSFER_BUFFER, 'i32');
-    MIN_COMPATIBLE_VERSION = getValue(TRANSFER_BUFFER + SIZE_OF_INT, 'i32');
+class Parser {
+  static init(moduleOptions) {
+    if (initPromise) return initPromise;
+    Module = Object.assign({}, Module, moduleOptions);
+    return initPromise = new Promise((resolve) => {
+      Module.onRuntimeInitialized = resolve;
+    }).then(() => {
+      TRANSFER_BUFFER = C._ts_init();
+      VERSION = getValue(TRANSFER_BUFFER, "i32");
+      MIN_COMPATIBLE_VERSION = getValue(TRANSFER_BUFFER + SIZE_OF_INT, "i32");
+    });
   }
 
-  initialize() {
+  constructor() {
+    if (TRANSFER_BUFFER == null) {
+      throw new Error('You must first call Parser.init() and wait for it to resolve.');
+    }
+
     C._ts_parser_new_wasm();
     this[0] = getValue(TRANSFER_BUFFER, 'i32');
     this[1] = getValue(TRANSFER_BUFFER + SIZE_OF_INT, 'i32');
@@ -1195,3 +1206,6 @@ function marshalEdit(edit) {
   setValue(address, edit.oldEndIndex, 'i32'); address += SIZE_OF_INT;
   setValue(address, edit.newEndIndex, 'i32'); address += SIZE_OF_INT;
 }
+
+Parser.Language = Language;
+Parser.Parser = Parser;

--- a/lib/binding_web/prefix.js
+++ b/lib/binding_web/prefix.js
@@ -1,19 +1,9 @@
-var TreeSitter = function() {
-  var initPromise;
-  var document = typeof window == 'object'
-    ? {currentScript: window.document.currentScript}
-    : null;
-
-  class Parser {
-    constructor() {
-      this.initialize();
-    }
-
-    initialize() {
-      throw new Error("cannot construct a Parser before calling `init()`");
-    }
-
-    static init(moduleOptions) {
-      if (initPromise) return initPromise;
-      Module = Object.assign({}, Module, moduleOptions);
-      return initPromise = new Promise((resolveInitPromise) => {
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define([], factory);
+  } else if (typeof exports === 'object') {
+    module.exports = factory();
+  } else {
+    window.TreeSitter = factory();
+  }
+}(this, function () {

--- a/lib/binding_web/suffix.js
+++ b/lib/binding_web/suffix.js
@@ -1,23 +1,2 @@
-        for (const name of Object.getOwnPropertyNames(ParserImpl.prototype)) {
-          Object.defineProperty(Parser.prototype, name, {
-            value: ParserImpl.prototype[name],
-            enumerable: false,
-            writable: false,
-          })
-        }
-
-        Parser.Language = Language;
-        Module.onRuntimeInitialized = () => {
-          ParserImpl.init();
-          resolveInitPromise();
-        };
-      });
-    }
-  }
-
-  return Parser;
-}();
-
-if (typeof exports === 'object') {
-  module.exports = TreeSitter;
-}
+return Parser;
+}));


### PR DESCRIPTION
This PR fixes the export issue identified in #1722 which caused breakage for the downstream package [web-tree-sitter-sys](https://crates.io/crates/web-tree-sitter-sys) which has prevented me from updating to versions `>= 0.20.*`.

The fix required rolling back some of the refactoring that were introduced in commit 12d727. However, I believe this version should provide the same functionality that was introduced in that commit. Perhaps @jrieken can verify?

If possible, can an updated release be made including this change? I would appreciate it, thanks.