### PR TITLE
cli: Bump tree-sitter dependency to 0.20.3

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -41,7 +41,7 @@ webbrowser = "0.5.1"
 which = "4.1.0"
 
 [dependencies.tree-sitter]
-version = "0.20"
+version = "0.20.3"
 path = "../lib"
 
 [dependencies.tree-sitter-config]


### PR DESCRIPTION
tree-sitter/tree-sitter#1504 added the capture_quantifiers API and its
usage in tree-sitter-cli, so the version should express the dependency.