### PR TITLE
tree-sitter: fix build with emscripten 3.1.11

### DIFF
--- a/lib/binding_web/exports.json
+++ b/lib/binding_web/exports.json
@@ -5,7 +5,6 @@
   "_realloc",
 
   "__ZNKSt3__212basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE4copyEPcmm",
-  "__ZNKSt3__220__vector_base_commonILb1EE20__throw_length_errorEv",
   "__ZNSt3__212basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE6__initEPKcm",
   "__ZNSt3__212basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE7reserveEm",
   "__ZNSt3__212basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE9__grow_byEmmmmmm",


### PR DESCRIPTION
- relates to https://github.com/Homebrew/homebrew-core/pull/102099

```
emcc: error: undefined exported symbol: "__ZNKSt3__220__vector_base_commonILb1EE20__throw_length_errorEv" [-Wundefined] [-Werror]
```