### PR TITLE
Expose ts_tree_cursor_copy for web bindings

### DIFF
--- a/lib/binding_web/binding.c
+++ b/lib/binding_web/binding.c
@@ -322,6 +322,11 @@ void ts_tree_cursor_current_node_wasm(const TSTree *tree) {
   marshal_node(TRANSFER_BUFFER, ts_tree_cursor_current_node(&cursor));
 }
 
+TSTreeCursor ts_tree_cursor_copy_wasm(const TSTree *tree) {
+  TSTreeCursor cursor = unmarshal_cursor(TRANSFER_BUFFER, tree);
+  return ts_tree_cursor_copy(&cursor);
+}
+
 /******************/
 /* Section - Node */
 /******************/

--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -593,6 +593,11 @@ class TreeCursor {
     unmarshalTreeCursor(this);
     return result === 1;
   }
+
+  copy() {
+    marshalTreeCursor(this);
+    return C._ts_tree_cursor_copy_wasm(this.tree[0]);
+  }
 }
 
 class Language {

--- a/lib/binding_web/exports.json
+++ b/lib/binding_web/exports.json
@@ -100,6 +100,7 @@
   "_ts_tree_cursor_reset_wasm",
   "_ts_tree_cursor_start_index_wasm",
   "_ts_tree_cursor_start_position_wasm",
+  "_ts_tree_cursor_copy_wasm",
   "_ts_tree_delete",
   "_ts_tree_edit_wasm",
   "_ts_tree_get_changed_ranges_wasm",

--- a/lib/binding_web/test/tree-test.js
+++ b/lib/binding_web/test/tree-test.js
@@ -257,6 +257,8 @@ describe("Tree", () => {
       // assert(!cursor.gotoNextSibling());
       // assert(cursor.gotoParent());
 
+      const copiedCursor = cursor.copy();
+
       assert(cursor.gotoParent());
       assert.equal(cursor.nodeType, 'binary_expression')
       assert(cursor.gotoParent());
@@ -264,6 +266,14 @@ describe("Tree", () => {
       assert(cursor.gotoParent());
       assert.equal(cursor.nodeType, 'program')
       assert(!cursor.gotoParent());
+
+      assert(copiedCursor.gotoParent());
+      assert.equal(copiedCursor.nodeType, 'binary_expression')
+      assert(copiedCursor.gotoParent());
+      assert.equal(copiedCursor.nodeType, 'expression_statement')
+      assert(copiedCursor.gotoParent());
+      assert.equal(copiedCursor.nodeType, 'program')
+      assert(!copiedCursor.gotoParent());
     });
 
     it('keeps track of the field name associated with each node', () => {

--- a/lib/binding_web/tree-sitter-web.d.ts
+++ b/lib/binding_web/tree-sitter-web.d.ts
@@ -113,6 +113,7 @@ declare module 'web-tree-sitter' {
       startIndex: number;
       endIndex: number;
 
+      copy(): TreeCursor;
       reset(node: SyntaxNode): void;
       delete(): void;
       currentNode(): SyntaxNode;


### PR DESCRIPTION
This PR exposes the `ts_tree_cursor_copy` for the web bindings.

However, I noticed something strange in how it behaves when I attempted to add an example of using it to the `TreeCursor` tests in `lib/binding_web/test/tree-test.js`.

It appears that calling `cursor.copy()` results in `cursor` becoming corrupted somehow and ending up in an `ERROR` state.

The copied cursor also does not behave correctly when attempting to ascend to the parent.

In fact, I also noticed that if the cursor is copied immediately after it is created, I get a crash during testing with a bus error.

I don't really understand how the bindings through emscripten work so I'm not sure if my implementation is wrong or if maybe there is something going wrong with the underlying implementation of `ts_tree_cursor_copy` in `tree_cursor.c`.