### PR TITLE
cli: fix warnings from `cargo doc`

### DIFF
--- a/cli/config/src/lib.rs
+++ b/cli/config/src/lib.rs
@@ -8,12 +8,12 @@ use std::{env, fs};
 
 /// Holds the contents of tree-sitter's configuration file.
 ///
-/// The file typically lives at `~/.config/tree-sitter/config.json`, but see the [`load`][] method
-/// for the full details on where it might be located.
+/// The file typically lives at `~/.config/tree-sitter/config.json`, but see the [`Config::load`][]
+/// method for the full details on where it might be located.
 ///
 /// This type holds the generic JSON content of the configuration file.  Individual tree-sitter
-/// components will use the [`get`][] method to parse that JSON to extract configuration fields
-/// that are specific to that component.
+/// components will use the [`Config::get`][] method to parse that JSON to extract configuration
+/// fields that are specific to that component.
 #[derive(Debug)]
 pub struct Config {
     pub location: PathBuf,
@@ -72,9 +72,10 @@ impl Config {
         Ok(Config { location, config })
     }
 
-    /// Creates an empty initial configuration file.  You can then use the [`add`][] method to add
-    /// the component-specific configuration types for any components that want to add content to
-    /// the default file, and then use [`save`][] to write the configuration to disk.
+    /// Creates an empty initial configuration file.  You can then use the [`Config::add`][] method
+    /// to add the component-specific configuration types for any components that want to add
+    /// content to the default file, and then use [`Config::save`][] to write the configuration to
+    /// disk.
     ///
     /// (Note that this is typically only done by the `tree-sitter init-config` command.)
     pub fn initial() -> Result<Config> {


### PR DESCRIPTION
This PR fixes invalid links in treesitter-config package documents, warned by `cargo doc` as follows:

```
warning: unresolved link to `load`
  --> cli/config/src/lib.rs:11:84
   |
11 | /// The file typically lives at `~/.config/tree-sitter/config.json`, but see the [`load`][] method
   |                                                                                    ^^^^ no item named `load` in scope
   |
   = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `get`
  --> cli/config/src/lib.rs:15:31
   |
15 | /// components will use the [`get`][] method to parse that JSON to extract configuration fields
   |                               ^^^ no item named `get` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `add`
  --> cli/config/src/lib.rs:75:78
   |
75 |     /// Creates an empty initial configuration file.  You can then use the [`add`][] method to add
   |                                                                              ^^^ no item named `add` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `save`
  --> cli/config/src/lib.rs:77:42
   |
77 |     /// the default file, and then use [`save`][] to write the configuration to disk.
   |                                          ^^^^ no item named `save` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: `tree-sitter-config` (lib doc) generated 4 warnings
```