### PR TITLE
Improve error message on missing grammar file.

### DIFF
--- a/cli/src/generate/mod.rs
+++ b/cli/src/generate/mod.rs
@@ -167,6 +167,14 @@ pub fn load_grammar_file(grammar_path: &Path) -> Result<String> {
 }
 
 fn load_js_grammar_file(grammar_path: &Path) -> Result<String> {
+    // The error message when canonicalize fails doesn't mention
+    // the path which was looked at, so emit a nicer error here.
+    if !grammar_path.exists() {
+        return Err(anyhow!(
+            "missing grammar file: {}",
+            grammar_path.to_string_lossy()
+        ));
+    }
     let grammar_path = fs::canonicalize(grammar_path)?;
     let mut node_process = Command::new("node")
         .env("TREE_SITTER_GRAMMAR_PATH", grammar_path)


### PR DESCRIPTION
I spent a bunch of time trying to debug a silly Bazel failure where
the error message was `No such file or directory (os error 2)`;
the problem was that I forgot to include the `grammar.js` file
in the files that are copied over. 😬