### PR TITLE
query: Use uint16_t for production_id in AnalysisSubgraphNode struct

### DIFF
--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -242,7 +242,7 @@ typedef Array(AnalysisState *) AnalysisStatePool;
  */
 typedef struct {
   TSStateId state;
-  uint8_t production_id;
+  uint16_t production_id;
   uint8_t child_index: 7;
   bool done: 1;
 } AnalysisSubgraphNode;


### PR DESCRIPTION
Production IDs are represented as `uint16_t` in other places in the codebase.

Fixes https://github.com/tree-sitter/tree-sitter/issues/1818