### PR TITLE
Fix crash in ts_node_field_name_for_child for inline nodes

### DIFF
--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -571,6 +571,10 @@ recur:
 
 const char *ts_node_field_name_for_child(TSNode self, uint32_t child_index) {
   const TSFieldMapEntry *field_map_start = NULL, *field_map_end = NULL;
+  if (!ts_node_child_count(self)) {
+    return NULL;
+  }
+
   ts_language_field_map(
     self.tree->language,
     ts_node__subtree(self).ptr->production_id,


### PR DESCRIPTION
The function only worked when `self.data.is_inline` is false.