### PR TITLE
fix: fix detection of the compiler on windows (allow Clang + MinGW)

### DIFF
--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -377,7 +377,8 @@ impl Loader {
                 command.env(key, value);
             }
 
-            if cfg!(windows) {
+            let compiler = config.get_compiler();
+            if compiler.is_like_msvc() {
                 command.args(&["/nologo", "/LD", "/I"]).arg(header_path);
                 if self.debug_build {
                     command.arg("/Od");

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -395,13 +395,16 @@ impl Loader {
             } else {
                 command
                     .arg("-shared")
-                    .arg("-fPIC")
                     .arg("-fno-exceptions")
                     .arg("-g")
                     .arg("-I")
                     .arg(header_path)
                     .arg("-o")
                     .arg(&library_path);
+
+                if !cfg!(windows) {
+                    command.arg("-fPIC");
+                }
 
                 if self.debug_build {
                     command.arg("-O0");

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -377,7 +377,6 @@ impl Loader {
                 command.env(key, value);
             }
 
-            let compiler = config.get_compiler();
             if compiler.is_like_msvc() {
                 command.args(&["/nologo", "/LD", "/I"]).arg(header_path);
                 if self.debug_build {


### PR DESCRIPTION
Fixes a part of #1889

The previous detection assumed that the compiler on Windows is MSVC, which is not correct all the time.

Also, related to #1411 
