### PR TITLE
Avoid extracting default alias for extras

### DIFF
--- a/cli/src/generate/prepare_grammar/extract_default_aliases.rs
+++ b/cli/src/generate/prepare_grammar/extract_default_aliases.rs
@@ -62,6 +62,18 @@ pub(super) fn extract_default_aliases(
         }
     }
 
+    for symbol in syntax_grammar.extra_symbols.iter() {
+        let mut status = match symbol.kind {
+            SymbolType::External => &mut external_status_list[symbol.index],
+            SymbolType::NonTerminal => &mut non_terminal_status_list[symbol.index],
+            SymbolType::Terminal => &mut terminal_status_list[symbol.index],
+            SymbolType::End | SymbolType::EndOfNonTerminalExtra => {
+                panic!("Unexpected end token")
+            }
+        };
+        status.appears_unaliased = true;
+    }
+
     let symbols_with_statuses = (terminal_status_list
         .iter_mut()
         .enumerate()

--- a/test/fixtures/test_grammars/aliased_rules/corpus.txt
+++ b/test/fixtures/test_grammars/aliased_rules/corpus.txt
@@ -7,7 +7,7 @@ Method calls
 ---
 
 (statement
-  (star_aliased)
+  (star)
   (call_expression
     (member_expression
       (variable_name)

--- a/test/fixtures/test_grammars/aliased_rules/corpus.txt
+++ b/test/fixtures/test_grammars/aliased_rules/corpus.txt
@@ -2,11 +2,12 @@
 Method calls
 ======================================
 
-a.b(c(d.e));
+*a.b(c(d.e));
 
 ---
 
 (statement
+  (star_aliased)
   (call_expression
     (member_expression
       (variable_name)

--- a/test/fixtures/test_grammars/aliased_rules/grammar.js
+++ b/test/fixtures/test_grammars/aliased_rules/grammar.js
@@ -1,7 +1,10 @@
 module.exports = grammar({
     name: 'aliased_rules',
 
-    extras: $ => [/\s/],
+    extras: $ => [
+      /\s/,
+      $.star,
+    ],
 
     rules: {
         statement: $ => seq($._expression, ';'),
@@ -25,6 +28,15 @@ module.exports = grammar({
             alias($.identifier, $.property_name)
         )),
 
-        identifier: $ => /[a-z]+/
+        identifier: $ => /[a-z]+/,
+
+        // Tests for https://github.com/tree-sitter/tree-sitter/issues/1834
+        //
+        // Even though the alias is unused, that issue causes all instances of
+        // the extra that appear in the tree to be renamed to `star_aliased`.
+        //
+        // Instead, this alias should have no effect because it is unused.
+        star: $ => '*',
+        unused: $ => alias($.star, $.star_aliased),
     }
 });


### PR DESCRIPTION
Tree sitter extracts default aliases for rules that only appear in aliases. The reasoning is explained in the comments in `extract_default_aliases.rs`. The default alias is used in place of the original name during parsing. However, the logic to determine whether it appears only in aliases overlooks the fact that extras may appear in the tree despite not being mentioned in any rules.

This adds an additional step which traverses the list of extras and notes that they all appear unaliased. This prevents the extraction of a default alias for such rules.

The code to get a reference to the symbol status was copy/pasted from above. I tried pulling it out into a closure or helper function but quickly got bogged down by the borrow checker. I'm not sure if there's an idiomatic way to do something like this, but if there is, it didn't seem like it was going to result in clearer code than just copying and pasting this small block.

Fixes #1834