### PR TITLE
Add API for applying a positional offset when accessing a tree's nodes

### DIFF
--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -530,6 +530,34 @@ fn test_node_edit() {
 }
 
 #[test]
+fn test_root_node_with_offset() {
+    let mut parser = Parser::new();
+    parser.set_language(get_language("javascript")).unwrap();
+    let tree = parser.parse("  if (a) b", None).unwrap();
+
+    let node = tree.root_node_with_offset(6, Point::new(2, 2));
+    assert_eq!(node.byte_range(), 8..16);
+    assert_eq!(node.start_position(), Point::new(2, 4));
+    assert_eq!(node.end_position(), Point::new(2, 12));
+
+    let child = node.child(0).unwrap().child(2).unwrap();
+    assert_eq!(child.kind(), "expression_statement");
+    assert_eq!(child.byte_range(), 15..16);
+    assert_eq!(child.start_position(), Point::new(2, 11));
+    assert_eq!(child.end_position(), Point::new(2, 12));
+
+    let mut cursor = node.walk();
+    cursor.goto_first_child();
+    cursor.goto_first_child();
+    cursor.goto_next_sibling();
+    let child = cursor.node();
+    assert_eq!(child.kind(), "parenthesized_expression");
+    assert_eq!(child.byte_range(), 11..14);
+    assert_eq!(child.start_position(), Point::new(2, 7));
+    assert_eq!(child.end_position(), Point::new(2, 10));
+}
+
+#[test]
 fn test_node_is_extra() {
     let mut parser = Parser::new();
     parser.set_language(get_language("javascript")).unwrap();

--- a/cli/src/tests/tree_test.rs
+++ b/cli/src/tests/tree_test.rs
@@ -89,14 +89,11 @@ fn test_tree_edit() {
         let child2 = expr.child(1).unwrap();
 
         assert!(expr.has_changes());
-        assert_eq!(expr.start_byte(), 4);
-        assert_eq!(expr.end_byte(), 17);
+        assert_eq!(expr.byte_range(), 4..17);
         assert!(child1.has_changes());
-        assert_eq!(child1.start_byte(), 4);
-        assert_eq!(child1.end_byte(), 7);
+        assert_eq!(child1.byte_range(), 4..7);
         assert!(!child2.has_changes());
-        assert_eq!(child2.start_byte(), 9);
-        assert_eq!(child2.end_byte(), 12);
+        assert_eq!(child2.byte_range(), 9..12);
     }
 
     // replacement starting at the edge of the tree's padding:
@@ -117,14 +114,11 @@ fn test_tree_edit() {
         let child2 = expr.child(1).unwrap();
 
         assert!(expr.has_changes());
-        assert_eq!(expr.start_byte(), 4);
-        assert_eq!(expr.end_byte(), 17);
+        assert_eq!(expr.byte_range(), 4..17);
         assert!(child1.has_changes());
-        assert_eq!(child1.start_byte(), 4);
-        assert_eq!(child1.end_byte(), 7);
+        assert_eq!(child1.byte_range(), 4..7);
         assert!(!child2.has_changes());
-        assert_eq!(child2.start_byte(), 9);
-        assert_eq!(child2.end_byte(), 12);
+        assert_eq!(child2.byte_range(), 9..12);
     }
 
     // deletion that spans more than one child node:
@@ -146,17 +140,13 @@ fn test_tree_edit() {
         let child3 = expr.child(2).unwrap();
 
         assert!(expr.has_changes());
-        assert_eq!(expr.start_byte(), 4);
-        assert_eq!(expr.end_byte(), 8);
+        assert_eq!(expr.byte_range(), 4..8);
         assert!(child1.has_changes());
-        assert_eq!(child1.start_byte(), 4);
-        assert_eq!(child1.end_byte(), 4);
+        assert_eq!(child1.byte_range(), 4..4);
         assert!(child2.has_changes());
-        assert_eq!(child2.start_byte(), 4);
-        assert_eq!(child2.end_byte(), 4);
+        assert_eq!(child2.byte_range(), 4..4);
         assert!(child3.has_changes());
-        assert_eq!(child3.start_byte(), 5);
-        assert_eq!(child3.end_byte(), 8);
+        assert_eq!(child3.byte_range(), 5..8);
     }
 
     // insertion at the end of the tree:
@@ -178,14 +168,67 @@ fn test_tree_edit() {
         let child3 = expr.child(2).unwrap();
 
         assert!(expr.has_changes());
-        assert_eq!(expr.start_byte(), 2);
-        assert_eq!(expr.end_byte(), 16);
+        assert_eq!(expr.byte_range(), 2..16);
         assert!(!child1.has_changes());
-        assert_eq!(child1.end_byte(), 5);
+        assert_eq!(child1.byte_range(), 2..5);
         assert!(!child2.has_changes());
-        assert_eq!(child2.end_byte(), 10);
+        assert_eq!(child2.byte_range(), 7..10);
         assert!(child3.has_changes());
-        assert_eq!(child3.end_byte(), 16);
+        assert_eq!(child3.byte_range(), 12..16);
+    }
+
+    // replacement that starts within a token and extends beyond the end of the tree:
+    // resize the token and empty out any subsequent child nodes.
+    {
+        let mut tree = tree.clone();
+        tree.edit(&InputEdit {
+            start_byte: 3,
+            old_end_byte: 90,
+            new_end_byte: 4,
+            start_position: Point::new(0, 3),
+            old_end_position: Point::new(0, 90),
+            new_end_position: Point::new(0, 4),
+        });
+
+        let expr = tree.root_node().child(0).unwrap().child(0).unwrap();
+        let child1 = expr.child(0).unwrap();
+        let child2 = expr.child(1).unwrap();
+        let child3 = expr.child(2).unwrap();
+        assert_eq!(expr.byte_range(), 2..4);
+        assert!(expr.has_changes());
+        assert_eq!(child1.byte_range(), 2..4);
+        assert!(child1.has_changes());
+        assert_eq!(child2.byte_range(), 4..4);
+        assert!(child2.has_changes());
+        assert_eq!(child3.byte_range(), 4..4);
+        assert!(child3.has_changes());
+    }
+
+    // replacement that starts in whitespace and extends beyond the end of the tree:
+    // shift the token's start position and empty out its content.
+    {
+        let mut tree = tree.clone();
+        tree.edit(&InputEdit {
+            start_byte: 6,
+            old_end_byte: 90,
+            new_end_byte: 8,
+            start_position: Point::new(0, 6),
+            old_end_position: Point::new(0, 90),
+            new_end_position: Point::new(0, 8),
+        });
+
+        let expr = tree.root_node().child(0).unwrap().child(0).unwrap();
+        let child1 = expr.child(0).unwrap();
+        let child2 = expr.child(1).unwrap();
+        let child3 = expr.child(2).unwrap();
+        assert_eq!(expr.byte_range(), 2..8);
+        assert!(expr.has_changes());
+        assert_eq!(child1.byte_range(), 2..5);
+        assert!(!child1.has_changes());
+        assert_eq!(child2.byte_range(), 8..8);
+        assert!(child2.has_changes());
+        assert_eq!(child3.byte_range(), 8..8);
+        assert!(child3.has_changes());
     }
 }
 

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -333,6 +333,15 @@ extern "C" {
     pub fn ts_tree_root_node(self_: *const TSTree) -> TSNode;
 }
 extern "C" {
+    #[doc = " Get the root node of the syntax tree, but with its position"]
+    #[doc = " shifted forward by the given offset."]
+    pub fn ts_tree_root_node_with_offset(
+        self_: *const TSTree,
+        offset_bytes: u32,
+        offset_point: TSPoint,
+    ) -> TSNode;
+}
+extern "C" {
     #[doc = " Get the language that was used to parse the syntax tree."]
     pub fn ts_tree_language(arg1: *const TSTree) -> *const TSLanguage;
 }

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -708,6 +708,20 @@ impl Tree {
         Node::new(unsafe { ffi::ts_tree_root_node(self.0.as_ptr()) }).unwrap()
     }
 
+    /// Get the root node of the syntax tree, but with its position shifted
+    /// forward by the given offset.
+    #[doc(alias = "ts_tree_root_node_with_offset")]
+    pub fn root_node_with_offset(&self, offset_bytes: usize, offset_extent: Point) -> Node {
+        Node::new(unsafe {
+            ffi::ts_tree_root_node_with_offset(
+                self.0.as_ptr(),
+                offset_bytes as u32,
+                offset_extent.into(),
+            )
+        })
+        .unwrap()
+    }
+
     /// Get the language that was used to parse the syntax tree.
     #[doc(alias = "ts_tree_language")]
     pub fn language(&self) -> Language {

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -367,6 +367,16 @@ void ts_tree_delete(TSTree *self);
 TSNode ts_tree_root_node(const TSTree *self);
 
 /**
+ * Get the root node of the syntax tree, but with its position
+ * shifted forward by the given offset.
+ */
+TSNode ts_tree_root_node_with_offset(
+  const TSTree *self,
+  uint32_t offset_bytes,
+  TSPoint offset_point
+);
+
+/**
  * Get the language that was used to parse the syntax tree.
  */
 const TSLanguage *ts_tree_language(const TSTree *);

--- a/lib/src/length.h
+++ b/lib/src/length.h
@@ -41,4 +41,12 @@ static inline Length length_zero(void) {
   return result;
 }
 
+static inline Length length_saturating_sub(Length len1, Length len2) {
+  if (len1.bytes > len2.bytes) {
+    return length_sub(len1, len2);
+  } else {
+    return length_zero();
+  }
+}
+
 #endif

--- a/lib/src/tree.c
+++ b/lib/src/tree.c
@@ -1,6 +1,7 @@
 #include "tree_sitter/api.h"
 #include "./array.h"
 #include "./get_changed_ranges.h"
+#include "./length.h"
 #include "./subtree.h"
 #include "./tree_cursor.h"
 #include "./tree.h"
@@ -35,6 +36,15 @@ void ts_tree_delete(TSTree *self) {
 
 TSNode ts_tree_root_node(const TSTree *self) {
   return ts_node_new(self, &self->root, ts_subtree_padding(self->root), 0);
+}
+
+TSNode ts_tree_root_node_with_offset(
+  const TSTree *self,
+  uint32_t offset_bytes,
+  TSPoint offset_extent
+) {
+  Length offset = {offset_bytes, offset_extent};
+  return ts_node_new(self, &self->root, length_add(offset, ts_subtree_padding(self->root)), 0);
 }
 
 const TSLanguage *ts_tree_language(const TSTree *self) {


### PR DESCRIPTION
This PR adds a single new function, `ts_tree_root_node_with_offset`, which allows you to retrieve the root node of a tree, but with its position shifted by a given number of bytes, rows, and columns.

This allows you to parse a subset of a document as if it were a self-contained document, but then later, access the syntax tree in the coordinate space of the larger document.