### PR TITLE
Generate parsers with ABI version 14 by default

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,7 +12,7 @@ use tree_sitter_loader as loader;
 
 const BUILD_VERSION: &'static str = env!("CARGO_PKG_VERSION");
 const BUILD_SHA: Option<&'static str> = option_env!("BUILD_SHA");
-const DEFAULT_GENERATE_ABI_VERSION: usize = 13;
+const DEFAULT_GENERATE_ABI_VERSION: usize = 14;
 
 fn main() {
     let result = run();


### PR DESCRIPTION
This makes `tree-sitter generate` use the newest ABI version by default. This will include the new `primary_state_ids` field introduced in https://github.com/tree-sitter/tree-sitter/pull/1589, which significantly speeds up construction of queries in some languages.

I had initially held off on bumping the generated ABI version, because I didn't want generated parsers to become incompatible with applications using older versions of the library. But the newer version of the library supporting ABI version 14 has been out for several months now.

Note that you can still do `tree-sitter generate --abi=13` if you need to regenerate a parser, but keep it compatible with an older version of the library.