### PR TITLE
Update ref to swift parser

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,8 +62,9 @@ Parsers for these languages are fairly complete:
 * [R](https://github.com/r-lib/tree-sitter-r)
 * [S-expressions](https://github.com/AbstractMachinesLab/tree-sitter-sexp)
 * [SPARQL](https://github.com/BonaBeavis/tree-sitter-sparql)
-* [SystemRDL](https://github.com/SystemRDL/tree-sitter-systemrdl)
 * [Svelte](https://github.com/Himujjal/tree-sitter-svelte)
+* [Swift](https://github.com/alex-pinkus/tree-sitter-swift)
+* [SystemRDL](https://github.com/SystemRDL/tree-sitter-systemrdl)
 * [TOML](https://github.com/ikatyang/tree-sitter-toml)
 * [Turtle](https://github.com/BonaBeavis/tree-sitter-turtle)
 * [TypeScript](https://github.com/tree-sitter/tree-sitter-typescript)
@@ -91,7 +92,6 @@ Parsers for these languages are in development:
 * [Protocol Buffers](https://github.com/mitchellh/tree-sitter-proto)
 * [Scala](https://github.com/tree-sitter/tree-sitter-scala)
 * [Sourcepawn](https://github.com/nilshelmig/tree-sitter-sourcepawn)
-* [Swift](https://github.com/tree-sitter/tree-sitter-swift)
 * [SQL](https://github.com/m-novikov/tree-sitter-sql)
 
 


### PR DESCRIPTION
I just realized that the docs point to the now-abandoned Swift parser. The currently-maintained one is quite complete.

(Also, moved one that wasn't in the right ordering)