### PR TITLE
docs: Add entries of various available SQL parsers 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -94,7 +94,10 @@ Parsers for these languages are in development:
 * [Racket](https://github.com/6cdh/tree-sitter-racket)
 * [Scala](https://github.com/tree-sitter/tree-sitter-scala)
 * [Sourcepawn](https://github.com/nilshelmig/tree-sitter-sourcepawn)
-* [SQL](https://github.com/m-novikov/tree-sitter-sql)
+* SQL
+    * [PostgreSQL-flavor](https://github.com/m-novikov/tree-sitter-sql)
+    * [BigQuery-flavor](https://github.com/takegue/tree-sitter-sql-bigquery)
+    * [SQLite-flavor](https://github.com/dhcmrlchtdj/tree-sitter-sqlite)
 
 
 ### Talks on Tree-sitter


### PR DESCRIPTION
Hi, maintainers. Thank you for reading my PR!
I have added a couple of links to SQL-dialect parsers such as PostgreSQL, SQLite and BigQuery.

This is useful for users to find available SQL parsers.