### PR TITLE
Add tree-sitter-gleam to list of available parsers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ Parsers for these languages are fairly complete:
 * [Eno](https://github.com/eno-lang/tree-sitter-eno)
 * [ERB / EJS](https://github.com/tree-sitter/tree-sitter-embedded-template)
 * [Fennel](https://github.com/travonted/tree-sitter-fennel)
+* [Gleam](https://github.com/gleam-lang/tree-sitter-gleam)
 * [GLSL (OpenGL Shading Language)](https://github.com/theHamsta/tree-sitter-glsl)
 * [Go](https://github.com/tree-sitter/tree-sitter-go)
 * [HCL](https://github.com/MichaHoffmann/tree-sitter-hcl)


### PR DESCRIPTION
Hello!  I'm the original author and maintainer of [tree-sitter-gleam](https://github.com/gleam-lang/tree-sitter-gleam).  At this stage it's relatively battle tested as it's used by GitHub for Gleam syntax highlighting as well as by the [official gleam-mode for Emacs](https://github.com/gleam-lang/gleam-mode), so I would like to add it to the list of "Available Parsers" in the docs.