### PR TITLE
Ignore 'extra' nodes when querying for field names of children by index

### DIFF
--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -860,7 +860,9 @@ fn get_field_names(cursor: &mut TreeCursor, data: &mut Vec<FieldTestData>, sourc
         get_field_names(cursor, data, source_text);
 
         child_index += 1;
-        if !cursor.goto_next_sibling() { break; }
+        if !cursor.goto_next_sibling() {
+            break;
+        }
     }
 
     cursor.goto_parent();
@@ -871,12 +873,11 @@ fn test_node_ts_node_field_name_for_child_matches_cursor_field_names() {
     let mut parser = Parser::new();
     parser.set_language(get_language("cpp")).unwrap();
 
-
     // Example 1:
     // The C++ grammar gives the body of a for loop a label. It also defines comments as
     // extra nodes, meaning they could appear between the body and the range statement.
     // Cursors get field names differently than getting them directly from nodes, so we
-    // want to make sure extra nodes are handled approprialty in both methods. 
+    // want to make sure extra nodes are handled approprialty in both methods.
     let source = "for(auto i : c) // help
     i++;";
 
@@ -892,7 +893,11 @@ fn test_node_ts_node_field_name_for_child_matches_cursor_field_names() {
     get_field_names(&mut cursor, &mut field_name_data, source.as_bytes());
 
     for data in field_name_data.iter() {
-        assert_eq!(data.node_field_name, data.cursor_field_name, "source text: {}", data.node_text);
+        assert_eq!(
+            data.node_field_name, data.cursor_field_name,
+            "source text: {}",
+            data.node_text
+        );
     }
 
     // Example 2:

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -571,7 +571,7 @@ recur:
 
 const char *ts_node_field_name_for_child(TSNode self, uint32_t child_index) {
   const TSFieldMapEntry *field_map_start = NULL, *field_map_end = NULL;
-  if (!ts_node_child_count(self)) {
+  if (ts_node_child_count(self) <= child_index) {
     return NULL;
   }
 

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -582,9 +582,20 @@ const char *ts_node_field_name_for_child(TSNode self, uint32_t child_index) {
     &field_map_end
   );
 
-  for (const TSFieldMapEntry *i = field_map_start; i < field_map_end; i++) {
-    if (i->child_index == child_index) {
-      return self.tree->language->field_names[i->field_id];
+  uint32_t extra_child_count = 0;
+  for(uint32_t i = 0; i <= child_index; i++) {
+    TSNode child = ts_node_child(self, i);
+    if (ts_node_is_extra(child)) {
+      extra_child_count++;
+    }
+  }
+
+  if (extra_child_count <= child_index) {
+    uint32_t grammar_child_index = child_index - extra_child_count;
+    for (const TSFieldMapEntry *i = field_map_start; i < field_map_end; i++) {
+      if (i->child_index == grammar_child_index) {
+        return self.tree->language->field_names[i->field_id];
+      }
     }
   }
   return NULL;


### PR DESCRIPTION
`ts_node_field_name_for_child` returns incorrect field names when there are 'extra' nodes preceding the child at the requested index. The index stored in the field map is based on the grammar for the rule, but 'extra' nodes can appear anywhere, and increase the `child_index` of subsequent nodes.

Example:
```cpp
for(auto i : c) // help
i++;
```

labels the `//help` with the `body` field, not the `i++` expression statement when queried using `ts_node_field_name_for_child`:

(format is `[start line, start column] -> [end line, end column] {node name} ({field name})` with indentation before the node name representing nested nodes)
```
for(auto i : c) // help
i++;
[ 0,  0] -> [ 1,  4]     for_range_loop
[ 0,  0] -> [ 0,  3]         for
[ 0,  3] -> [ 0,  4]         (
[ 0,  4] -> [ 0,  8]         placeholder_type_specifier (type)
[ 0,  4] -> [ 0,  8]             auto
[ 0,  9] -> [ 0, 10]         identifier (declarator)
[ 0, 11] -> [ 0, 12]         :
[ 0, 13] -> [ 0, 14]         identifier (right)
[ 0, 14] -> [ 0, 15]         )
[ 0, 16] -> [ 0, 23]         comment (body)
[ 1,  0] -> [ 1,  4]         expression_statement
[ 1,  0] -> [ 1,  3]             update_expression
[ 1,  0] -> [ 1,  1]                 identifier (argument)
[ 1,  1] -> [ 1,  3]                 ++ (operator)
[ 1,  3] -> [ 1,  4]             ;
```

My attempt at a fix is to count the number of 'extra' nodes that come before the child at the requested index, then subtract that number from the index when comparing to the index in the field map. This is similar to how the cursor based version works. Now the above example shows:
```
for(auto i : c) // help
i++;
[ 0,  0] -> [ 1,  4]     for_range_loop
[ 0,  0] -> [ 0,  3]         for
[ 0,  3] -> [ 0,  4]         (
[ 0,  4] -> [ 0,  8]         placeholder_type_specifier (type)
[ 0,  4] -> [ 0,  8]             auto
[ 0,  9] -> [ 0, 10]         identifier (declarator)
[ 0, 11] -> [ 0, 12]         :
[ 0, 13] -> [ 0, 14]         identifier (right)
[ 0, 14] -> [ 0, 15]         )
[ 0, 16] -> [ 0, 23]         comment
[ 1,  0] -> [ 1,  4]         expression_statement (body)
[ 1,  0] -> [ 1,  3]             update_expression
[ 1,  0] -> [ 1,  1]                 identifier (argument)
[ 1,  1] -> [ 1,  3]                 ++ (operator)
[ 1,  3] -> [ 1,  4]             ;
```

https://github.com/tree-sitter/tree-sitter/issues/1642 has similar symptoms, however their examples don't include 'extra' nodes. I get the same incorrect labels on their example, so this PR does not close that issue:
```
struct Foo { static const int bar = 10; };
[ 0,  0] -> [ 0, 41]     struct_specifier
[ 0,  0] -> [ 0,  6]         struct
[ 0,  7] -> [ 0, 10]         type_identifier (name)
[ 0, 11] -> [ 0, 41]         field_declaration_list (body)
[ 0, 11] -> [ 0, 12]             {
[ 0, 13] -> [ 0, 39]             field_declaration
[ 0, 13] -> [ 0, 19]                 storage_class_specifier (type)
[ 0, 13] -> [ 0, 19]                     static
[ 0, 20] -> [ 0, 25]                 type_qualifier (declarator)
[ 0, 20] -> [ 0, 25]                     const
[ 0, 26] -> [ 0, 29]                 primitive_type
[ 0, 30] -> [ 0, 33]                 field_identifier (default_value)
[ 0, 34] -> [ 0, 35]                 =
[ 0, 36] -> [ 0, 38]                 number_literal
[ 0, 38] -> [ 0, 39]                 ;
[ 0, 40] -> [ 0, 41]             }
[ 0, 41] -> [ 0, 42]     ;
```

I am not sure how to write a test for this as there are no tests that check field names. In my own project that uses tree-sitter, this modification means I get correct field names in the presence of 'extra' nodes.

