### PR TITLE
change integer type in ts_parser__set_cached_token

### DIFF
--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -605,7 +605,7 @@ static Subtree ts_parser__get_cached_token(
 
 static void ts_parser__set_cached_token(
   TSParser *self,
-  size_t byte_index,
+  uint32_t byte_index,
   Subtree last_external_token,
   Subtree token
 ) {


### PR DESCRIPTION
The use of `size_t` here causes a warning. Pretty much everywhere else, byte offsets are explicitly `uint32_t`, so this seems like the better type choice here.