### PR TITLE
Explicit integer sizes for array capacity

### DIFF
--- a/lib/src/array.h
+++ b/lib/src/array.h
@@ -154,7 +154,7 @@ static inline void array__reserve(VoidArray *self, size_t element_size, uint32_t
     } else {
       self->contents = ts_malloc(new_capacity * element_size);
     }
-    self->capacity = (uint32_t)new_capacity;
+    self->capacity = new_capacity;
   }
 }
 

--- a/lib/src/array.h
+++ b/lib/src/array.h
@@ -154,7 +154,7 @@ static inline void array__reserve(VoidArray *self, size_t element_size, uint32_t
     } else {
       self->contents = ts_malloc(new_capacity * element_size);
     }
-    self->capacity = new_capacity;
+    self->capacity = (uint32_t)new_capacity;
   }
 }
 
@@ -170,10 +170,10 @@ static inline void array__swap(VoidArray *self, VoidArray *other) {
   *self = swap;
 }
 
-static inline void array__grow(VoidArray *self, size_t count, size_t element_size) {
-  size_t new_size = self->size + count;
+static inline void array__grow(VoidArray *self, uint32_t count, size_t element_size) {
+  uint32_t new_size = self->size + count;
   if (new_size > self->capacity) {
-    size_t new_capacity = self->capacity * 2;
+    uint32_t new_capacity = self->capacity * 2;
     if (new_capacity < 8) new_capacity = 8;
     if (new_capacity < new_size) new_capacity = new_size;
     array__reserve(self, element_size, new_capacity);

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -1918,11 +1918,11 @@ static TSQueryError ts_query__parse_string_literal(
       prev_position = stream->input + stream->next_size;
     } else {
       if (stream->next == '\\') {
-        array_extend(&self->string_buffer, (stream->input - prev_position), prev_position);
+        array_extend(&self->string_buffer, (uint32_t)(stream->input - prev_position), prev_position);
         prev_position = stream->input + 1;
         is_escaped = true;
       } else if (stream->next == '"') {
-        array_extend(&self->string_buffer, (stream->input - prev_position), prev_position);
+        array_extend(&self->string_buffer, (uint32_t)(stream->input - prev_position), prev_position);
         stream_advance(stream);
         return TSQueryErrorNone;
       } else if (stream->next == '\n') {
@@ -3669,7 +3669,7 @@ static inline bool ts_query_cursor__advance(
             } else {
               LOG("  finish pattern %u\n", state->pattern_index);
               array_push(&self->finished_states, *state);
-              array_erase(&self->states, state - self->states.contents);
+              array_erase(&self->states, (uint32_t)(state - self->states.contents));
               did_match = true;
               i--;
             }

--- a/lib/src/stack.c
+++ b/lib/src/stack.c
@@ -326,7 +326,7 @@ inline StackSliceArray stack__iter(
   bool include_subtrees = false;
   if (goal_subtree_count >= 0) {
     include_subtrees = true;
-    array_reserve(&iterator.subtrees, ts_subtree_alloc_size(goal_subtree_count) / sizeof(Subtree));
+    array_reserve(&iterator.subtrees, (uint32_t)ts_subtree_alloc_size(goal_subtree_count) / sizeof(Subtree));
   }
 
   array_push(&self->iterators, iterator);


### PR DESCRIPTION
Addresses some integer precision losses related to the `Array` type. Slight API change to make explicit the `uint32_t` capacity limitation.

Discussion: https://github.com/tree-sitter/tree-sitter/issues/1880