### PR TITLE
cli: Bump tree-sitter dependency to 0.20.10

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -41,7 +41,7 @@ webbrowser = "0.5.1"
 which = "4.1.0"
 
 [dependencies.tree-sitter]
-version = "0.20.3"
+version = "0.20.10"
 path = "../lib"
 
 [dependencies.tree-sitter-config]


### PR DESCRIPTION
tree-sitter/tree-sitter#2085 added the ts_query_is_pattern_non_local API and its
usage in tree-sitter-cli, so bump version accordingly.
