### PR TITLE
Avoid using x86 architecture for ARM Macs

### DIFF
--- a/cli/npm/install.js
+++ b/cli/npm/install.js
@@ -19,11 +19,6 @@ let archName = {
   'ia32': 'x86'
 }[process.arch];
 
-// ARM macs can run x64 binaries via Rosetta. Rely on that for now.
-if (platformName === 'macos' && process.arch === 'arm64') {
-  archName = 'x64';
-}
-
 if (!platformName || !archName) {
   console.error(
     `Cannot install tree-sitter-cli for platform ${process.platform}, architecture ${process.arch}`

--- a/cli/npm/install.js
+++ b/cli/npm/install.js
@@ -14,6 +14,7 @@ const platformName = {
 }[process.platform];
 
 let archName = {
+  'arm64': 'arm64',
   'x64': 'x64',
   'x86': 'x86',
   'ia32': 'x86'


### PR DESCRIPTION
This check was causing incompatible architecture errors on ARM macs since arm64e mach-o files are expected instead of the x86_64 architecture.

On my M1 Mac, I was seeing this error before I tested out removing this conditional:
```
Error opening dynamic library "/Users/[REDACTED]/Library/Caches/tree-sitter/lib/java.so"

Caused by:
    dlopen(/Users/[REDACTED]/Library/Caches/tree-sitter/lib/java.so, 0x0005): tried: 
'/Users/[REDACTED]/Library/Caches/tree-sitter/lib/java.so' (mach-o file, but is an
 incompatible architecture (have (x86_64), need (arm64e)))
```

I read some speculation in the issue linked below that this check may have been added for the macos-latest actions runner. If that check fails, I'll look into updating the conditional such that it only performs in the runner.

Fixes https://github.com/tree-sitter/tree-sitter/issues/1737