### PR TITLE
Resolving a crash when freeing a null pointer when cancelling parses

### DIFF
--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -1461,7 +1461,9 @@ static bool ts_parser__advance(
       ((self->cancellation_flag && atomic_load(self->cancellation_flag)) ||
        (!clock_is_null(self->end_clock) && clock_is_gt(clock_now(), self->end_clock)))
     ) {
-      ts_subtree_release(&self->tree_pool, lookahead);
+      if (lookahead.ptr) {
+        ts_subtree_release(&self->tree_pool, lookahead);
+      }
       return false;
     }
 


### PR DESCRIPTION
This pull request resolves a potential crash we've seen in parser.c.

If a parse is in progress, in certain cases, the `lookahead.ptr` pointer can be `NULL` when the code reaches [src/parser.c#L](https://github.com/tree-sitter/tree-sitter/blob/master/lib/src/parser.c#L1464). This will only actually crash if the cancellation token happens to have been set to a non-zero value.

This request contains a check to ensure that `lookahead.ptr` is not `NULL` before releasing the subtree.

I'm not _entirely_ up on all of the potential branch cases and other code with which this might interact, so I'm happy for a review to ensure this is an acceptable fix!

Thank you!