### PR TITLE
feat(rust): Load languages as untied from the Rust type system

### DIFF
--- a/cli/src/generate/templates/cargo.toml
+++ b/cli/src/generate/templates/cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 keywords = ["incremental", "parsing", "PARSER_NAME"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/tree-sitter/tree-sitter-PARSER_NAME"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 build = "bindings/rust/build.rs"
@@ -19,8 +19,8 @@ include = [
 [lib]
 path = "bindings/rust/lib.rs"
 
-[dependencies]
-tree-sitter = "~RUST_BINDING_VERSION"
+[dev-dependencies]
+tree-sitter = ">= RUST_BINDING_VERSION"
 
 [build-dependencies]
 cc = "1.0"

--- a/cli/src/generate/templates/lib.rs
+++ b/cli/src/generate/templates/lib.rs
@@ -1,17 +1,20 @@
 //! This crate provides PARSER_NAME language support for the [tree-sitter][] parsing library.
 //!
-//! Typically, you will use the [language][language func] function to add this language to a
-//! tree-sitter [Parser][], and then use the parser to parse some code:
+//! Typically, you will use the [library][library func] function to access the language library
+//! and make from it the [Language] instance with the [Language::new][new func] method
+//! to add this language to a tree-sitter [Parser][], and then use the parser to parse some code:
 //!
 //! ```
 //! let code = "";
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_PARSER_NAME::language()).expect("Error loading PARSER_NAME grammar");
+//! let language = tree_sitter::Language::new(tree_sitter_PARSER_NAME::library()).expect("Error loading language library");
+//! parser.set_language(language).expect("Error loading PARSER_NAME grammar");
 //! let tree = parser.parse(code, None).unwrap();
 //! ```
 //!
 //! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-//! [language func]: fn.language.html
+//! [new func]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html#method.new
+//! [library func]: fn.library.html
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
@@ -20,7 +23,7 @@ extern "C" {
 }
 
 /// Get a pointer to the tree-sitter [Language][] library for this grammar.
-/// The library needs to be loaded with the `Language::load` method.
+/// The library needs to be loaded with the `Language::new` method.
 ///
 /// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
 pub fn library() -> *const () {

--- a/cli/src/generate/templates/lib.rs
+++ b/cli/src/generate/templates/lib.rs
@@ -15,16 +15,15 @@
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
-
 extern "C" {
-    fn tree_sitter_PARSER_NAME() -> Language;
+    fn tree_sitter_PARSER_NAME() -> *const ();
 }
 
-/// Get the tree-sitter [Language][] for this grammar.
+/// Get a pointer to the tree-sitter [Language][] library for this grammar.
+/// The library needs to be loaded with the `Language::load` method.
 ///
 /// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
+pub fn library() -> *const () {
     unsafe { tree_sitter_PARSER_NAME() }
 }
 
@@ -45,8 +44,9 @@ mod tests {
     #[test]
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
+        let language = tree_sitter::Language::new(super::library()).unwrap();
         parser
-            .set_language(super::language())
+            .set_language(language)
             .expect("Error loading PARSER_NAME language");
     }
 }

--- a/highlight/README.md
+++ b/highlight/README.md
@@ -8,9 +8,9 @@ Add this crate, and the language-specific crates for whichever languages you wan
 
 ```toml
 [dependencies]
-tree-sitter-highlight = "0.19"
-tree-sitter-html = "0.19"
-tree-sitter-javascript = "0.19"
+tree-sitter-highlight = "0.20"
+tree-sitter-html = "0.20"
+tree-sitter-javascript = "0.20"
 ```
 
 Define the list of highlight names that you will recognize:
@@ -49,20 +49,21 @@ let highlighter = Highlighter::new();
 Load some highlighting queries from the `queries` directory of some language repositories:
 
 ```rust
+use tree_sitter::Language;
 use tree_sitter_highlight::HighlightConfiguration;
 
-let html_language = unsafe { tree_sitter_html() };
-let javascript_language = unsafe { tree_sitter_javascript() };
+let html_language = Language::new(tree_sitter_html::library()).unwrap();
+let javascript_language = Language::new(tree_sitter_javascript::library()).unwrap();
 
 let html_config = HighlightConfiguration::new(
-    tree_sitter_html::language(),
+    html_language,
     tree_sitter_html::HIGHLIGHTS_QUERY,
     tree_sitter_html::INJECTIONS_QUERY,
     "",
 ).unwrap();
 
 let javascript_config = HighlightConfiguration::new(
-    tree_sitter_javascript::language(),
+    javascript_language,
     tree_sitter_javascript::HIGHLIGHTS_QUERY,
     tree_sitter_javascript::INJECTIONS_QUERY,
     tree_sitter_javascript::LCOALS_QUERY,

--- a/lib/binding_rust/README.md
+++ b/lib/binding_rust/README.md
@@ -37,14 +37,16 @@ Add the `cc` crate to your `Cargo.toml` under `[build-dependencies]`:
 cc="*"
 ```
 
-To then use languages from rust, you must declare them as `extern "C"` functions and invoke them with `unsafe`. Then you can assign them to the parser.
+To then use languages from rust, you must declare them as `extern "C"` functions and load them with `Language::new` method. Then you can assign them to the parser.
 
 ```rust
-extern "C" { fn tree_sitter_c() -> Language; }
-extern "C" { fn tree_sitter_rust() -> Language; }
-extern "C" { fn tree_sitter_javascript() -> Language; }
+use tree_sitter::Language;
 
-let language = unsafe { tree_sitter_rust() };
+extern "C" { fn tree_sitter_c() -> *const (); }
+extern "C" { fn tree_sitter_rust() -> *const (); }
+extern "C" { fn tree_sitter_javascript() -> *const (); }
+
+let language = Language::new(tree_sitter_rust()).unwrap();
 parser.set_language(language).unwrap();
 ```
 

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -250,6 +250,16 @@ pub struct LossyUtf8<'a> {
 }
 
 impl Language {
+    pub fn new(library: *const ()) -> Result<Self, LanguageError> {
+        let language = unsafe { std::mem::transmute::<*const (), Self>(library) };
+        let version = language.version();
+        if version < MIN_COMPATIBLE_LANGUAGE_VERSION || version > LANGUAGE_VERSION {
+            Err(LanguageError { version })
+        } else {
+            Ok(language)
+        }
+    }
+
     /// Get the ABI version number that indicates which version of the Tree-sitter CLI
     /// that was used to generate this `Language`.
     #[doc(alias = "ts_language_version")]
@@ -355,14 +365,11 @@ impl Parser {
     /// [MIN_COMPATIBLE_LANGUAGE_VERSION](MIN_COMPATIBLE_LANGUAGE_VERSION) constants.
     #[doc(alias = "ts_parser_set_language")]
     pub fn set_language(&mut self, language: Language) -> Result<(), LanguageError> {
-        let version = language.version();
-        if version < MIN_COMPATIBLE_LANGUAGE_VERSION || version > LANGUAGE_VERSION {
-            Err(LanguageError { version })
-        } else {
-            unsafe {
-                ffi::ts_parser_set_language(self.0.as_ptr(), language.0);
-            }
+        if unsafe { ffi::ts_parser_set_language(self.0.as_ptr(), language.0) } {
             Ok(())
+        } else {
+            let version = language.version();
+            Err(LanguageError { version })
         }
     }
 

--- a/tags/README.md
+++ b/tags/README.md
@@ -6,9 +6,9 @@ Add this crate, and the language-specific crates for whichever languages you wan
 
 ```toml
 [dependencies]
-tree-sitter-tags = "0.19"
-tree-sitter-javascript = "0.19"
-tree-sitter-python = "0.19"
+tree-sitter-tags = "0.20"
+tree-sitter-javascript = "0.20"
+tree-sitter-python = "0.20"
 ```
 
 Create a tag context. You need one of these for each thread that you're using for tag computation:
@@ -22,16 +22,17 @@ let context = TagsContext::new();
 Load some tagging queries from the `queries` directory of some language repositories:
 
 ```rust
+use tree_sitter::Language;
 use tree_sitter_tags::TagsConfiguration;
 
 let python_config = TagsConfiguration::new(
-    tree_sitter_python::language(),
+    Language::new(tree_sitter_python::library()).unwrap(),
     tree_sitter_python::TAGGING_QUERY,
     "",
 ).unwrap();
 
 let javascript_config = TagsConfiguration::new(
-    tree_sitter_javascript::language(),
+    Language::new(tree_sitter_javascript::library()).unwrap(),
     tree_sitter_javascript::TAGGING_QUERY,
     tree_sitter_javascript::LOCALS_QUERY,
 ).unwrap();


### PR DESCRIPTION
This PR fixes errors like:
```    
    error[E0308]: mismatched types
       --> src/main.rs:9:27
        |
        |             .set_language(tree_sitter_java::language())
        |              ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `tree_sitter::Language`, found a different struct `tree_sitter::Language`
        |              |
        |              arguments to this function are incorrect
        |
        = note: perhaps two different versions of crate `tree_sitter` are being used?
```

Such errors happen pretty often when user wants to use latest or some specific version of tree-sitter library in the Rust language but some language library uses other version in its `Cargo.toml` file.

This updates Rust binding wrapper around C API and it starts to return `*const ()` instead of `Language` instance tied to some specific version of tree-sitter library. The `*const ()` needs to be converted to a `Language` instance by using `Language::new()` method.
Also this PR completely removes language libraries dependency from the tree-sitter library, because language libraries may not require it at all. Currently such dependency exist for importing just one type, the `Language` symbol.
Another note is that language compatibility managed on runtime on the C level so Rust type system doesn't need to be involved for.

__It's the breaking change that would require from all languages to regenerate Rust bindings in the language repositories by previously manually remove related files like:__
```
rm bindings/rust/*.rs Cargo.*
```
__And run `tree-sitter generate` after that.__