### PR TITLE
Fix versioning in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.6.3
+VERSION := 0.20.7
 
 # install directory layout
 PREFIX ?= /usr/local
@@ -22,8 +22,8 @@ CFLAGS ?= -O3 -Wall -Wextra -Werror
 override CFLAGS += -std=gnu99 -fPIC -Ilib/src -Ilib/include
 
 # ABI versioning
-SONAME_MAJOR := 0
-SONAME_MINOR := 0
+SONAME_MAJOR := 20
+SONAME_MINOR := 7
 
 # OS-specific bits
 ifeq ($(shell uname),Darwin)


### PR DESCRIPTION
Currently tree-sitter libraries are versioned 0.6.3 in pkg-config files and 0.0 in /usr/local/lib. This prevented us from requiring for a specific version of tree-sitter, specifically any version >= 0.20.2, which is the first version that can change malloc on runtime.

Closes #1158