### PR TITLE
Add clojure to list of available parsers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ Parsers for these languages are fairly complete:
 * [C](https://github.com/tree-sitter/tree-sitter-c)
 * [C#](https://github.com/tree-sitter/tree-sitter-c-sharp)
 * [C++](https://github.com/tree-sitter/tree-sitter-cpp)
+* [Clojure](https://github.com/sogaiu/tree-sitter-clojure)
 * [Common Lisp](https://github.com/theHamsta/tree-sitter-commonlisp)
 * [CSS](https://github.com/tree-sitter/tree-sitter-css)
 * [CUDA](https://github.com/theHamsta/tree-sitter-cuda)


### PR DESCRIPTION
After some discussion in 
https://github.com/sogaiu/tree-sitter-clojure/issues/28

I decided to submit an issue to the tree-sitter organization  to include [tree-sitter-clojure](https://github.com/sogaiu/tree-sitter-clojure) in their list of available parsers. This repository is used by a couple of editors and tools, and  I am using it to build a tree-sitter based programming mode for Clojure in Emacs.
Since there are a couple of tools that depend on it, it seems  worthy of inclusion in an official list of tree-sitter grammars.