### PR TITLE
Add Ada to the list of available parsers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 
 Parsers for these languages are fairly complete:
 
+* [Ada](https://github.com/briot/tree-sitter-ada)
 * [Bash](https://github.com/tree-sitter/tree-sitter-bash)
 * [C](https://github.com/tree-sitter/tree-sitter-c)
 * [C#](https://github.com/tree-sitter/tree-sitter-c-sharp)


### PR DESCRIPTION
The grammar was built from the official Ada grammar available in the ISO standard, and from an existing similar grammar used for the Emacs ada-mode.
The resulting grammar is able to parse all source files in the GNAT runtime (the kind of "official" compiler for Ada), as well as the 3 million+ lines of code at my company), without ERROR, though of course I could not check all resulting trees.
The testsuite is reasonably complete at this stage.