### PR TITLE
fix: possible rollover of nanoseconds in clock.h

### DIFF
--- a/lib/src/clock.h
+++ b/lib/src/clock.h
@@ -82,6 +82,10 @@ static inline TSClock clock_after(TSClock base, TSDuration duration) {
   TSClock result = base;
   result.tv_sec += duration / 1000000;
   result.tv_nsec += (duration % 1000000) * 1000;
+  if (result.tv_nsec >= 1000000000) {
+    result.tv_nsec -= 1000000000;
+    ++(result.tv_sec);
+  }
   return result;
 }
 


### PR DESCRIPTION
Setting a timeout on a parser can result in a non-deterministic behavior, where parsers time out when they should not. An incorrect timeout is more likely for timeout intervals closer to (but less than) 1s. We noticed that the distribution of these incorrect timeouts didn't seem to be correlated with the complexity of the inputs.

The cause seems to be this possible rollover of the nanoseconds component of `timespec` in `clock.h`. Patching this fixes the timeout issue.

I'm not sure how I would go about adding tests for this, but if you think they are necessary and can provide some pointers, I'd be happy to include them.

Thanks!