### PR TITLE
Closes #1336

### DIFF
--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Mutex;
 use std::time::SystemTime;
-use std::{fs, mem};
+use std::{env, fs, mem};
 use tree_sitter::{Language, QueryError, QueryErrorKind};
 use tree_sitter_highlight::HighlightConfiguration;
 use tree_sitter_tags::{Error as TagsError, TagsConfiguration};
@@ -108,9 +108,12 @@ unsafe impl Sync for Loader {}
 
 impl Loader {
     pub fn new() -> Result<Self> {
-        let parser_lib_path = dirs::cache_dir()
-            .ok_or(anyhow!("Cannot determine cache directory"))?
-            .join("tree-sitter/lib");
+        let parser_lib_path = match env::var("TREE_SITTER_LIBDIR") {
+            Ok(path) => PathBuf::from(path),
+            _ => dirs::cache_dir()
+                .ok_or(anyhow!("Cannot determine cache directory"))?
+                .join("tree-sitter/lib"),
+        };
         Ok(Self::with_parser_lib_path(parser_lib_path))
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -107,6 +107,11 @@ fn run() -> Result<()> {
                 )
                 .arg(Arg::with_name("no-bindings").long("no-bindings"))
                 .arg(
+                    Arg::with_name("build").long("build").short("b")
+                    .help("Compile all defined languages in the current dir")
+                )
+                .arg(&debug_build_arg)
+                .arg(
                     Arg::with_name("report-states-for-rule")
                         .long("report-states-for-rule")
                         .value_name("rule-name")
@@ -269,6 +274,8 @@ fn run() -> Result<()> {
 
         ("generate", Some(matches)) => {
             let grammar_path = matches.value_of("grammar-path");
+            let debug_build = matches.is_present("debug-build");
+            let build = matches.is_present("build");
             let report_symbol_name = matches.value_of("report-states-for-rule").or_else(|| {
                 if matches.is_present("report-states") {
                     Some("")
@@ -297,6 +304,10 @@ fn run() -> Result<()> {
                 generate_bindings,
                 report_symbol_name,
             )?;
+            if build {
+                loader.use_debug_build(debug_build);
+                loader.languages_at_path(&current_dir)?;
+            }
         }
 
         ("test", Some(matches)) => {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -111,8 +111,7 @@ fn run() -> Result<()> {
                         .long("report-states-for-rule")
                         .value_name("rule-name")
                         .takes_value(true),
-                )
-                .arg(Arg::with_name("no-minimize").long("no-minimize")),
+                ),
         )
         .subcommand(
             SubCommand::with_name("parse")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use clap::{App, AppSettings, Arg, SubCommand};
 use glob::glob;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::{env, fs, u64};
 use tree_sitter_cli::{
     generate, highlight, logger, parse, playground, query, tags, test, test_highlight, test_tags,
@@ -107,10 +107,18 @@ fn run() -> Result<()> {
                 )
                 .arg(Arg::with_name("no-bindings").long("no-bindings"))
                 .arg(
-                    Arg::with_name("build").long("build").short("b")
-                    .help("Compile all defined languages in the current dir")
+                    Arg::with_name("build")
+                        .long("build")
+                        .short("b")
+                        .help("Compile all defined languages in the current dir"),
                 )
                 .arg(&debug_build_arg)
+                .arg(
+                    Arg::with_name("libdir")
+                        .long("libdir")
+                        .takes_value(true)
+                        .value_name("path"),
+                )
                 .arg(
                     Arg::with_name("report-states-for-rule")
                         .long("report-states-for-rule")
@@ -276,6 +284,7 @@ fn run() -> Result<()> {
             let grammar_path = matches.value_of("grammar-path");
             let debug_build = matches.is_present("debug-build");
             let build = matches.is_present("build");
+            let libdir = matches.value_of("libdir");
             let report_symbol_name = matches.value_of("report-states-for-rule").or_else(|| {
                 if matches.is_present("report-states") {
                     Some("")
@@ -305,6 +314,9 @@ fn run() -> Result<()> {
                 report_symbol_name,
             )?;
             if build {
+                if let Some(path) = libdir {
+                    loader = loader::Loader::with_parser_lib_path(PathBuf::from(path));
+                }
                 loader.use_debug_build(debug_build);
                 loader.languages_at_path(&current_dir)?;
             }


### PR DESCRIPTION
Closes #1336 

There were added:
* `TREE_SITTER_LIBDIR` variable to customize path to generated dynamically loaded libraries.
* Several flags for `tree-sitter generate`:
  * `--build, -b` - to generate a parser and build its dylib with one command.
  * `--libdir` to have ability to specify a library storage path by arg.

_The `LIBDIR` name was used cause this name is widely used in Unix-like systems for the same purpose._