### PR TITLE
cli: produce smaller release binary by stripping debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 default-members = ["cli"]
 
 members = ["cli", "lib"]
+
+[profile.release]
+strip = true


### PR DESCRIPTION
This shrinks `tree-sitter` CLI size from _17Mb_ to _12Mb_.