### PR TITLE
Reliable CI tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ test_script:
   # Fetch and regenerate the fixture parsers
   - script\fetch-fixtures.cmd
   - cargo build --release
-  - script\generate-fixtures.cmd
+  - script\generate-fixtures.cmd --build
 
   # Run main tests
   - cargo nextest run --workspace --lib --tests --bins --examples

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,8 +8,10 @@ install:
   - IF "%PLATFORM%" == "x86" rustup-init -y --default-toolchain stable --default-host i686-pc-windows-msvc
   - IF "%PLATFORM%" == "x64" rustup-init -y --default-toolchain stable --default-host x86_64-pc-windows-msvc
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - cargo install cargo-nextest
   - rustc -vV
   - cargo -vV
+  - cargo nextest -vV
 
   # Install dependencies
   - git submodule update --init
@@ -24,8 +26,13 @@ test_script:
   - cargo build --release
   - script\generate-fixtures.cmd
 
-  # Run tests
-  - script\test.cmd
+  # Run main tests
+  - cargo nextest run --workspace --lib --tests --bins --examples
+
+  # Run main flaky tests
+  - cargo nextest run --workspace --lib --tests --bins --examples --retries 10 -- --ignored
+
+  # Run benchmarks
   - script\benchmark.cmd
 
 before_deploy:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,9 @@
+environment:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: 1
+  TREE_SITTER_LIBDIR: "%APPVEYOR_BUILD_FOLDER%\\target\\scratch"
+
 build: false
 install:
   # Terminate early unless building either a tag or a PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,5 +152,11 @@ jobs:
           script/fetch-fixtures.cmd
           script/generate-fixtures.cmd
 
+      - name: Install latest nextest release
+        uses: taiki-e/install-action@nextest
+
       - name: Run main tests
-        run: script/test
+        run: cargo nextest run --workspace --lib --tests --bins --examples
+
+      - name: Run main flaky tests
+        run: cargo nextest run --workspace --lib --tests --bins --examples --retries 10 -- --ignored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Set up fixture parsers
         run: |
           script/fetch-fixtures
-          script/generate-fixtures
+          script/generate-fixtures --build
           script/generate-fixtures-wasm
 
       - name: Install latest nextest release
@@ -150,7 +150,7 @@ jobs:
       - name: Set up fixture parsers
         run: |
           script/fetch-fixtures.cmd
-          script/generate-fixtures.cmd
+          script/generate-fixtures.cmd --build
 
       - name: Install latest nextest release
         uses: taiki-e/install-action@nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,14 @@ jobs:
           script/generate-fixtures
           script/generate-fixtures-wasm
 
+      - name: Install latest nextest release
+        uses: taiki-e/install-action@nextest
+
       - name: Run main tests
-        run: cargo test
+        run: cargo nextest run --workspace --lib --tests --bins --examples
+
+      - name: Run main flaky tests
+        run: cargo nextest run --workspace --lib --tests --bins --examples --retries 10 -- --ignored
 
       - name: Run wasm tests
         run: script/test-wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   RUST_BACKTRACE: 1
+  RUSTFLAGS: -D warnings
 
 jobs:
   unix-tests:
@@ -80,9 +81,7 @@ jobs:
         run: script/build-wasm
 
       - name: Build CLI
-        run: |
-          RUSTFLAGS="-D warnings"
-          cargo build --release
+        run: cargo build --release
 
       - name: Set up fixture parsers
         run: |
@@ -159,9 +158,7 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Build CLI
-        run: |
-          $env:RUSTFLAGS="-D warnings"
-          cargo build --release
+        run: cargo build --release
 
       - name: Set up fixture parsers
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Set TREE_SITTER_LIBDIR to a scratch dir
         run: |
           echo TREE_SITTER_LIBDIR=${{ github.workspace }}/target/scratch >> $GITHUB_ENV
+      - run: |
+          env
 
       # Work around https://github.com/actions/cache/issues/403.
       - name: Use GNU tar
@@ -133,6 +135,8 @@ jobs:
       - name: Set TREE_SITTER_LIBDIR to a scratch dir
         run: |
           echo TREE_SITTER_LIBDIR=${{ github.workspace }}\target\scratch | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - run: |
+          dir env:
 
       - name: Cache artifacts
         id: cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: 1
 
 jobs:
   unix-tests:
@@ -27,6 +28,12 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+
+      # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#env
+      # >> Variables in the env map cannot be defined in terms of other variables in the map.
+      - name: Set TREE_SITTER_LIBDIR to a scratch dir
+        run: |
+          echo TREE_SITTER_LIBDIR=${{ github.workspace }}/target/scratch >> $GITHUB_ENV
 
       # Work around https://github.com/actions/cache/issues/403.
       - name: Use GNU tar
@@ -121,6 +128,11 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+
+      # https://github.com/actions/runner-images/issues/5251#issuecomment-1071030822
+      - name: Set TREE_SITTER_LIBDIR to a scratch dir
+        run: |
+          echo TREE_SITTER_LIBDIR=${{ github.workspace }}\target\scratch | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Cache artifacts
         id: cache

--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -17,61 +17,73 @@ use std::fs;
 use tree_sitter::{LogType, Node, Parser, Point, Range, Tree};
 
 #[test]
+#[ignore = "flaky due to seed"]
 fn test_bash_corpus() {
     test_language_corpus("bash");
 }
 
 #[test]
+#[ignore = "flaky due to seed"]
 fn test_c_corpus() {
     test_language_corpus("c");
 }
 
 #[test]
+#[ignore = "flaky due to seed"]
 fn test_cpp_corpus() {
     test_language_corpus("cpp");
 }
 
 #[test]
+#[ignore = "flaky due to seed"]
 fn test_embedded_template_corpus() {
     test_language_corpus("embedded-template");
 }
 
 #[test]
+#[ignore = "flaky due to seed"]
 fn test_go_corpus() {
     test_language_corpus("go");
 }
 
 #[test]
+#[ignore = "flaky due to seed"]
 fn test_html_corpus() {
     test_language_corpus("html");
 }
 
 #[test]
+#[ignore = "flaky due to seed"]
 fn test_javascript_corpus() {
     test_language_corpus("javascript");
 }
 
 #[test]
+#[ignore = "flaky due to seed"]
 fn test_json_corpus() {
     test_language_corpus("json");
 }
 
 #[test]
+#[ignore = "flaky due to seed"]
 fn test_php_corpus() {
     test_language_corpus("php");
 }
 
 #[test]
+#[ignore = "flaky due to seed"]
 fn test_python_corpus() {
     test_language_corpus("python");
 }
 
 #[test]
+#[ignore = "flaky due to seed"]
 fn test_ruby_corpus() {
     test_language_corpus("ruby");
 }
 
 #[test]
+#[ignore = "flaky due to seed"]
 fn test_rust_corpus() {
     test_language_corpus("rust");
 }

--- a/cli/src/tests/parser_test.rs
+++ b/cli/src/tests/parser_test.rs
@@ -638,6 +638,7 @@ fn test_parsing_cancelled_by_another_thread() {
 // Timeouts
 
 #[test]
+#[ignore = "flaky due to timeout"]
 fn test_parsing_with_a_timeout() {
     let mut parser = Parser::new();
     parser.set_language(get_language("json")).unwrap();

--- a/script/generate-fixtures
+++ b/script/generate-fixtures
@@ -4,7 +4,16 @@ set -e
 
 cargo build --release
 
+for arg in "$@"; do
+  case "$arg" in
+    --build)
+      build="--build"
+      shift
+  esac
+done
+
 filter_grammar_name=$1
+
 
 root_dir=$PWD
 tree_sitter=${root_dir}/target/release/tree-sitter
@@ -22,6 +31,6 @@ while read -r grammar_file; do
   echo "Regenerating ${grammar_name} parser"
   (
     cd $grammar_dir
-    "$tree_sitter" generate src/grammar.json --no-bindings --abi=latest
+    "$tree_sitter" generate src/grammar.json --no-bindings --abi=latest $build
   )
 done <<< "$grammar_files"

--- a/script/generate-fixtures.cmd
+++ b/script/generate-fixtures.cmd
@@ -3,10 +3,12 @@
 setlocal EnableDelayedExpansion
 set tree_sitter="%cd%\target\release\tree-sitter"
 
+IF "%~1" == "--build" set build="--build"
+
 for /f "tokens=*" %%f in ('dir test\fixtures\grammars\grammar.js /b/s') do (
   pushd "%%f\.."
   echo Regenerating parser !cd!
-  %tree_sitter% generate src\grammar.json --no-bindings --abi=latest
+  %tree_sitter% generate src\grammar.json --no-bindings --abi=latest !build!
   popd
 )
 


### PR DESCRIPTION
Some Tree-sitter tests are flaky and this from time to time affects CI with random fails in unexpected places.
At this moment I know two such cases:
- Tests that use timeouts may fail.
- Corpus tests that test random edits may fail on some random seed that produces an edit that changes parsing tree structure.

This PR marks such tests as `#[ignored]` by default and uses another `nextest` test runner to run such marked test separately with 10 retries.