### PR TITLE
cli: Improve init-config with respect to TREE_SITTER_DIR

### DIFF
--- a/cli/config/src/lib.rs
+++ b/cli/config/src/lib.rs
@@ -25,6 +25,9 @@ impl Config {
         if let Ok(path) = env::var("TREE_SITTER_DIR") {
             let mut path = PathBuf::from(path);
             path.push("config.json");
+            if !path.exists() {
+                return Ok(None);
+            }
             if path.is_file() {
                 return Ok(Some(path));
             }

--- a/cli/config/src/lib.rs
+++ b/cli/config/src/lib.rs
@@ -81,7 +81,13 @@ impl Config {
     ///
     /// (Note that this is typically only done by the `tree-sitter init-config` command.)
     pub fn initial() -> Result<Config> {
-        let location = Self::xdg_config_file()?;
+        let location = if let Ok(path) = env::var("TREE_SITTER_DIR") {
+            let mut path = PathBuf::from(path);
+            path.push("config.json");
+            path
+        } else {
+            Self::xdg_config_file()?
+        };
         let config = serde_json::json!({});
         Ok(Config { location, config })
     }


### PR DESCRIPTION
This PR is an attempt to address #2030 and #2033.

With these changes, `tree-sitter`'s `init-config` subcommand should honor the `TREE_SITTER_DIR` environment variable a bit more appropriately.

I've made a single PR because the changes are closely related and the overall behavior seems better with both applied.  I hope that's ok.

Below is a log of some manual verification.

---

```
$ cd /tmp

# start with no config.json files

$ rm -rf .tree-sitter/

$ rm -rf ~/.config/tree-sitter/

# make fresh config.json files

$ ./tree-sitter.issue-2033/target/release/tree-sitter init-config
Saved initial configuration to /home/user/.config/tree-sitter/config.json

$ ls ~/.config/tree-sitter/config.json 
/home/user/.config/tree-sitter/config.json

$ TREE_SITTER_DIR=$(pwd)/.tree-sitter ./tree-sitter.issue-2033/target/release/tree-sitter init-config
Saved initial configuration to /tmp/.tree-sitter/config.json

$ ls .tree-sitter/config.json 
.tree-sitter/config.json

# existing config.json files are protected

$ ./tree-sitter.issue-2033/target/release/tree-sitter init-config
Remove your existing config file first: /home/user/.config/tree-sitter/config.json

$ ls ~/.config/tree-sitter/config.json 
/home/user/.config/tree-sitter/config.json

$ TREE_SITTER_DIR=$(pwd)/.tree-sitter ./tree-sitter.issue-2033/target/release/tree-sitter init-config
Remove your existing config file first: /tmp/.tree-sitter/config.json

$ ls .tree-sitter/config.json 
.tree-sitter/config.json
```