### PR TITLE
Only use rule strings for fuzz dictionary

### DIFF
--- a/test/fuzz/gen-dict.py
+++ b/test/fuzz/gen-dict.py
@@ -21,7 +21,7 @@ def main():
     grammar = json.load(f)
 
   literals = set()
-  find_literals(literals, grammar)
+  find_literals(literals, grammar['rules'])
 
   for lit in sorted(literals):
     if lit:


### PR DESCRIPTION
The `find_literals` function can also pick up tokens in `precedences`