### PR TITLE
Add tree-sitter-cobol to the parser list

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 * [C#](https://github.com/tree-sitter/tree-sitter-c-sharp)
 * [Clojure](https://github.com/sogaiu/tree-sitter-clojure)
 * [CMake](https://github.com/uyha/tree-sitter-cmake)
+* [COBOL](https://github.com/yutaro-sakamoto/tree-sitter-cobol)
 * [Comment](https://github.com/stsewd/tree-sitter-comment)
 * [Common Lisp](https://github.com/theHamsta/tree-sitter-commonlisp)
 * [CSS](https://github.com/tree-sitter/tree-sitter-css)


### PR DESCRIPTION
I released [tree-sitter-cobol](https://github.com/yutaro-sakamoto/tree-sitter-cobol).
The parser can parse almost all of source files of [NIST tests](https://www.itl.nist.gov/div897/ctg/cobol_form.htm), which is the standard tests for COBOL compilers.
Please add [tree-sitter-cobol](https://github.com/yutaro-sakamoto/tree-sitter-cobol) to the parser list.