### PR TITLE
Fix bug with first child group anchor (anchor had no effect)

### DIFF
--- a/cli/src/tests/github_issue_test.rs
+++ b/cli/src/tests/github_issue_test.rs
@@ -6,11 +6,37 @@
 // cargo test --target $(rustc -vV | sed -nr 's/^host: //p') -- --test-threads 1
 // ```
 
+use super::helpers::query_helpers::assert_query_matches;
 use crate::tests::helpers::fixtures::get_language;
+use indoc::indoc;
 use tree_sitter::Query;
 
 #[test]
 fn issue_2162_out_of_bound() {
     let language = get_language("java");
     assert!(Query::new(language, "(package_declaration _ (_) @name _)").is_ok());
+}
+
+#[test]
+fn issue_2107_first_child_group_anchor_had_no_effect() {
+    let language = get_language("c");
+    let source_code = indoc! {r#"
+        void fun(int a, char b, int c) { };
+    "#};
+    let query = indoc! {r#"
+        (parameter_list
+            .
+            (
+                (parameter_declaration) @constant
+                (#match? @constant "^int")
+            )
+        )
+    "#};
+    let query = Query::new(language, query).unwrap();
+    assert_query_matches(
+        language,
+        &query,
+        source_code,
+        &[(0, vec![("constant", "int a")])],
+    );
 }

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -2260,7 +2260,7 @@ static TSQueryError ts_query__parse_pattern(
 
     // If this parenthesis is followed by a node, then it represents a grouped sequence.
     if (stream->next == '(' || stream->next == '"' || stream->next == '[') {
-      bool child_is_immediate = false;
+      bool child_is_immediate = is_immediate;
       CaptureQuantifiers child_capture_quantifiers = capture_quantifiers_new();
       for (;;) {
         if (stream->next == '.') {


### PR DESCRIPTION
I'm not sure if this is intended behavior, but it feels to me that this is likely a bug (took me some time to figure that out, as  I was just learning about anchors with that first query so...)

Honestly I have no idea about the query codebase and this fix was just a hit and miss (but a hit it seems). But no tests have degraded and my issue is resolved with this change, see:

![tree-sitter-group-anchors-bug](https://user-images.githubusercontent.com/9267430/222029027-d5be8d63-e14b-4a0c-a323-9ee979117351.png)

with the following query:
```scheme
(list .
  ((symbol) @string
	  (#match? @string "^(defwindow|defwidget|defvar|defpoll|deflisten|geometry|children|struts)$")))
```

and this parser: https://github.com/Philipp-M/tree-sitter-yuck/tree/607bf03cc78912cbaa85a3d373af21ddeaef5b41

on the following yuck code:

```yuck
(defwidget)
(defwidget other-symbol defwidget 23)
```