### PR TITLE
Add tree-sitter-p4 to the parser list

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -97,6 +97,7 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 * [Objective-C](https://github.com/jiyee/tree-sitter-objc)
 * [OCaml](https://github.com/tree-sitter/tree-sitter-ocaml)
 * [Org](https://github.com/milisims/tree-sitter-org)
+* [P4](https://github.com/ace-design/tree-sitter-p4)
 * [Pascal](https://github.com/Isopod/tree-sitter-pascal)
 * [Perl](https://github.com/ganezdragon/tree-sitter-perl)
 * [Perl](https://github.com/tree-sitter-perl/tree-sitter-perl)


### PR DESCRIPTION
The grammar was translated from the [P4_16 specification](https://p4.org/p4-spec/docs/P4-16-v-1.2.3.html).