### PR TITLE
Add another (general) SQL parser to documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -125,6 +125,7 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 * [Sourcepawn](https://github.com/nilshelmig/tree-sitter-sourcepawn)
 * [SPARQL](https://github.com/BonaBeavis/tree-sitter-sparql)
 * [SQL - BigQuery](https://github.com/takegue/tree-sitter-sql-bigquery)
+* [SQL - General](https://github.com/DerekStride/tree-sitter-sql)
 * [SQL - PostgreSQL](https://github.com/m-novikov/tree-sitter-sql)
 * [SQL - SQLite](https://github.com/dhcmrlchtdj/tree-sitter-sqlite)
 * [SSH](https://github.com/metio/tree-sitter-ssh-client-config)


### PR DESCRIPTION
I've written & help maintain a general/permissive SQL grammar. It's currently being used for highlighting within [neovim](https://github.com/nvim-treesitter/nvim-treesitter/blob/fc1ca10bfbdee17e29374d0d1bac8ea030539dc3/lua/nvim-treesitter/parsers.lua#L1323-L1330) and is actively maintained by several community members. I'd appreciate it if you add it to the list on the main tree-sitter page.