### PR TITLE
Export needed by OCaml grammar

### DIFF
--- a/lib/binding_web/exports.json
+++ b/lib/binding_web/exports.json
@@ -4,6 +4,7 @@
   "_malloc",
   "_realloc",
 
+  "__ZNSt3__212basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE17__assign_externalEPKcm",
   "__ZNSt3__212basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE6__initEPKcm",
   "__ZNSt3__212basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE9__grow_byEmmmmmm",
   "__ZNSt3__212basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE9push_backEc",


### PR DESCRIPTION
This export is needed to make https://github.com/tree-sitter/tree-sitter-ocaml work together with the Tree-sitter Wasm bindings.

Without it, I ran into this error message when using the release build of the Tree-sitter bindings:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'apply')
    at e.<computed> (tree-sitter.js:1:16465)
    at 00aa486e:0x2947
    at tree-sitter.wasm:0x2581d
    at Module._ts_parser_parse_wasm (tree-sitter.js:1:33493)
    at Parser.parse (tree-sitter.js:1:53325)
    at handleCodeChange (playground.js:115:28)
    at handleLanguageChange (playground.js:101:5)
    at async playground.js:78:3
```

When using the debug build, I got a message that `_ZNSt3__212basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE17__assign_externalEPKcm` was missing.