### PR TITLE
No flaky tests - make all tests run in a reliable way; V2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc_macro"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rand",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +756,7 @@ dependencies = [
  "lazy_static",
  "log",
  "pretty_assertions",
+ "proc_macro",
  "rand",
  "regex",
  "regex-syntax",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -69,6 +69,8 @@ version = "0.4.6"
 features = ["std"]
 
 [dev-dependencies]
+proc_macro = { path = "src/tests/proc_macro" }
+
 rand = "0.8"
 tempfile = "3"
 pretty_assertions = "0.7.2"

--- a/cli/src/tests/helpers/mod.rs
+++ b/cli/src/tests/helpers/mod.rs
@@ -6,7 +6,8 @@ pub(super) mod random;
 pub(super) mod scope_sequence;
 
 use lazy_static::lazy_static;
-use std::{env, time, usize};
+use rand::Rng;
+use std::env;
 
 lazy_static! {
     pub static ref LOG_ENABLED: bool = env::var("TREE_SITTER_LOG").is_ok();
@@ -16,15 +17,18 @@ lazy_static! {
 }
 
 lazy_static! {
-    pub static ref START_SEED: usize =
-        int_env_var("TREE_SITTER_SEED").unwrap_or_else(|| time::SystemTime::now()
-            .duration_since(time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as usize,);
+    pub static ref START_SEED: usize = new_seed();
     pub static ref EDIT_COUNT: usize = int_env_var("TREE_SITTER_EDITS").unwrap_or(3);
     pub static ref ITERATION_COUNT: usize = int_env_var("TREE_SITTER_ITERATIONS").unwrap_or(10);
 }
 
 fn int_env_var(name: &'static str) -> Option<usize> {
     env::var(name).ok().and_then(|e| e.parse().ok())
+}
+
+pub(crate) fn new_seed() -> usize {
+    int_env_var("TREE_SITTER_SEED").unwrap_or_else(|| {
+        let mut rng = rand::thread_rng();
+        rng.gen::<usize>()
+    })
 }

--- a/cli/src/tests/parser_test.rs
+++ b/cli/src/tests/parser_test.rs
@@ -8,6 +8,7 @@ use crate::{
     generate::generate_parser_for_grammar,
     parse::{perform_edit, Edit},
 };
+use proc_macro::retry;
 use std::{
     sync::atomic::{AtomicUsize, Ordering},
     thread, time,
@@ -638,6 +639,7 @@ fn test_parsing_cancelled_by_another_thread() {
 // Timeouts
 
 #[test]
+#[retry(10)]
 fn test_parsing_with_a_timeout() {
     let mut parser = Parser::new();
     parser.set_language(get_language("json")).unwrap();

--- a/cli/src/tests/proc_macro/Cargo.toml
+++ b/cli/src/tests/proc_macro/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "proc_macro"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+rand = "0.8.5"
+syn = { version = "1", features = ["full"] }

--- a/cli/src/tests/proc_macro/src/lib.rs
+++ b/cli/src/tests/proc_macro/src/lib.rs
@@ -1,0 +1,137 @@
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input, Error, Expr, Ident, ItemFn, LitInt, Token,
+};
+
+#[proc_macro_attribute]
+pub fn retry(args: TokenStream, input: TokenStream) -> TokenStream {
+    let count = parse_macro_input!(args as LitInt);
+    let input = parse_macro_input!(input as ItemFn);
+    let attrs = input.attrs.clone();
+    let name = input.sig.ident.clone();
+
+    TokenStream::from(quote! {
+        #(#attrs),*
+        fn #name() {
+            #input
+
+            for i in 0..=#count {
+                let result = std::panic::catch_unwind(|| {
+                    #name();
+                });
+
+                if result.is_ok() {
+                    return;
+                }
+
+                if i == #count {
+                    std::panic::resume_unwind(result.unwrap_err());
+                }
+            }
+        }
+    })
+}
+
+#[proc_macro_attribute]
+pub fn test_with_seed(args: TokenStream, input: TokenStream) -> TokenStream {
+    struct Args {
+        retry: LitInt,
+        seed: Expr,
+        seed_fn: Option<Ident>,
+    }
+
+    impl Parse for Args {
+        fn parse(input: ParseStream) -> syn::Result<Self> {
+            let mut retry = None;
+            let mut seed = None;
+            let mut seed_fn = None;
+
+            while !input.is_empty() {
+                let name = input.parse::<Ident>()?;
+                match name.to_string().as_str() {
+                    "retry" => {
+                        input.parse::<Token![=]>()?;
+                        retry.replace(input.parse()?);
+                    }
+                    "seed" => {
+                        input.parse::<Token![=]>()?;
+                        seed.replace(input.parse()?);
+                    }
+                    "seed_fn" => {
+                        input.parse::<Token![=]>()?;
+                        seed_fn.replace(input.parse()?);
+                    }
+                    x => {
+                        return Err(Error::new(
+                            name.span(),
+                            format!("Unsupported parameter `{x}`"),
+                        ))
+                    }
+                }
+
+                if !input.is_empty() {
+                    input.parse::<Token![,]>()?;
+                }
+            }
+
+            if retry.is_none() {
+                retry.replace(LitInt::new("0", Span::mixed_site()));
+            }
+
+            Ok(Args {
+                retry: retry.expect("`retry` parameter is requred"),
+                seed: seed.expect("`initial_seed` parameter is required"),
+                seed_fn,
+            })
+        }
+    }
+
+    let Args {
+        retry,
+        seed,
+        seed_fn,
+    } = parse_macro_input!(args as Args);
+
+    let seed_fn = seed_fn.iter();
+
+    let func = parse_macro_input!(input as ItemFn);
+    let attrs = func.attrs.clone();
+    let name = func.sig.ident.clone();
+
+    // dbg!(quote::ToTokens::into_token_stream(&func));
+
+    TokenStream::from(quote! {
+        #[test]
+        #(#attrs),*
+        fn #name() {
+            #func
+
+            let mut seed = #seed;
+
+            for i in 0..=#retry {
+                let result = std::panic::catch_unwind(|| {
+                    #name(seed);
+                });
+
+                if result.is_ok() {
+                    return;
+                }
+
+                if i == #retry {
+                    std::panic::resume_unwind(result.unwrap_err());
+                }
+
+                #(
+                    seed = #seed_fn();
+                )*
+
+                if i < #retry {
+                    println!("\nRetry {}/{} with a new seed {}", i + 1, #retry, seed);
+                }
+            }
+        }
+    })
+}


### PR DESCRIPTION
There is a set of tests that depend on a timeout or a random seed that controls edits in corpus tests. All such tests are flaky and from time to time fail CI in unexpected places on random PR branches or on the master branch or even during a release process :exploding_head:.

There was an attempt to fix tests reliability:
* https://github.com/tree-sitter/tree-sitter/pull/2032
But it was based on a custom runner and didn't properly resolve the issue.

This PR completely solves the issue by introducing several proc macros that run all flaky tests with 10 retries.

---
**Changes:**
ddb0af95 *test: use random SEED numbers*
This is needed to omit occurrences of the same seed in a sequence of
following seeds due to the reason of that two initial seeds are very
close if based on unix epoch seconds.

3aeef44e *test: run all corpus tests with 10 retries*
588549c0 *test: run `test_parsing_with_a_timeout` with 10 retries*
62f8c431 *test: add `retry` and `test_with_seed` proc macros*