### PR TITLE
docs: alphabetise language bindings on front page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,10 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 
 * [Go](https://github.com/smacker/go-tree-sitter)
 * [Haskell](https://github.com/tree-sitter/haskell-tree-sitter)
+* [Java](https://github.com/serenadeai/java-tree-sitter)
 * [JavaScript (Node.js)](https://github.com/tree-sitter/node-tree-sitter)
 * [JavaScript (Wasm)](https://github.com/tree-sitter/tree-sitter/tree/master/lib/binding_web)
+* [Kotlin](https://github.com/oxisto/kotlintree)
 * [Lua](https://github.com/euclidianAce/ltreesitter)
 * [OCaml](https://github.com/returntocorp/ocaml-tree-sitter-core)
 * [Perl](https://metacpan.org/pod/Text::Treesitter)
@@ -27,8 +29,6 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 * [Ruby](https://github.com/calicoday/ruby-tree-sitter-ffi)
 * [Rust](https://github.com/tree-sitter/tree-sitter/tree/master/lib/binding_rust)
 * [Swift](https://github.com/ChimeHQ/SwiftTreeSitter)
-* [Kotlin](https://github.com/oxisto/kotlintree)
-* [Java](https://github.com/serenadeai/java-tree-sitter)
 
 By convention, bindings are named with the language first, eg. ruby-tree-sitter.
 


### PR DESCRIPTION
This helps with readability when scanning for a particular language. It is, strangely, almost sorted with the exception of Java and Kotlin.