### PR TITLE
:skull: OOB access in query compiler

### DIFF
--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -1379,8 +1379,8 @@ static void ts_query__perform_analysis(
 
           // Pop from the stack when this state reached the end of its current syntax node.
           while (next_state.depth > 0 && next_state_top->done) {
-            next_state.depth--;
             next_state_top = analysis_state__top(&next_state);
+            next_state.depth--;
           }
 
           // If this hypothetical child did match the current step of the query pattern,


### PR DESCRIPTION
In the case that `depth == 1`, the loop decrements depth to 0 & then accesses `self->stack[-1]` in `analysis_state__top`. I'm not sure if the fix I applied was correct, but it stopped it crashing for me & seems to work for me now.

Thought I'd send a PR just so this doesn't go unnoticed - someone who knows their way around probably wants a deeper look rather than just merging this.