### PR TITLE
Release: v0.20.8 - recovered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,9 +366,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "libloading"


### PR DESCRIPTION
This a **v0.20.8** release recovered after issues fixed in:
* #2135 
* #2167 

Closes #2125

Additional manual tasks:
- [ ] Publish updated packages to _[crates.io](https://crates.io/)_
- [ ] Publish updated CLI package to _[npmjs.com](https://www.npmjs.com/)_