### PR TITLE
ci: build CLI for macos-arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ env:
   CROSS_DEBUG: 1
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       ref:
@@ -27,6 +28,7 @@ jobs:
           - { name: windows-x64   , target: x86_64-pc-windows-msvc      , os: windows-latest                   }
           - { name: windows-x86   , target: i686-pc-windows-msvc        , os: windows-latest                   }
           - { name: macos-x64     , target: x86_64-apple-darwin         , os: macos-latest                     }
+          - { name: macos-arm64   , target: aarch64-apple-darwin        , os: macos-latest                     }
 
     env:
       BUILD_CMD: cargo
@@ -125,30 +127,34 @@ jobs:
       run: make.sh CFLAGS="-Werror" -j
 
     - name: Build wasm library
+      if: ${{ !matrix.job.use-cross && matrix.job.name != 'macos-arm64' }} # Not used
       run: script/build-wasm
 
     - name: Build CLI
       run: $BUILD_CMD build --release --target=${{ matrix.job.target }}
 
     - name: Fetch fixtures
+      if: ${{ matrix.job.name != 'macos-arm64' }} # Not used
       run: script/fetch-fixtures
 
     - name: Generate fixtures
+      if: ${{ matrix.job.name != 'macos-arm64' }} # Can't run CLI on host
       run: script/generate-fixtures
 
     - name: Generate WASM fixtures
-      if: "!matrix.job.use-cross"
+      if: ${{ !matrix.job.use-cross && matrix.job.name != 'macos-arm64' }} # Not used
       run: script/generate-fixtures-wasm
 
     - name: Run main tests
+      if: ${{ matrix.job.name != 'macos-arm64' }} # Can't run CLI on host
       run: $BUILD_CMD test --target=${{ matrix.job.target }}
 
     - name: Run wasm tests
-      if: "!matrix.job.use-cross" # TODO: Install Emscripten into custom cross images
+      if: ${{ !matrix.job.use-cross && matrix.job.name != 'macos-arm64' }} # Not used
       run: script/test-wasm
 
     - name: Run benchmarks
-      if: "!matrix.job.use-cross" # It doesn't make sense to benchmark something in an emulator
+      if: ${{ !matrix.job.use-cross && matrix.job.name != 'macos-arm64' }} # Cross-compiled benchmarks make no sense
       run: $BUILD_CMD bench benchmark -p tree-sitter-cli --target=${{ matrix.job.target }}
 
     - name: Upload CLI artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ env:
   CROSS_DEBUG: 1
 
 on:
-  workflow_dispatch:
   workflow_call:
     inputs:
       ref:
@@ -27,8 +26,8 @@ jobs:
           - { name: linux-x86     , target: i686-unknown-linux-gnu      , os: ubuntu-latest  , use-cross: true }
           - { name: windows-x64   , target: x86_64-pc-windows-msvc      , os: windows-latest                   }
           - { name: windows-x86   , target: i686-pc-windows-msvc        , os: windows-latest                   }
-          - { name: macos-x64     , target: x86_64-apple-darwin         , os: macos-latest                     }
           - { name: macos-arm64   , target: aarch64-apple-darwin        , os: macos-latest                     }
+          - { name: macos-x64     , target: x86_64-apple-darwin         , os: macos-latest                     }
 
     env:
       BUILD_CMD: cargo
@@ -123,7 +122,7 @@ jobs:
         esac
 
     - name: Build C library
-      if: "!contains(matrix.job.os, 'windows')" # Requires an additional adapted Makefile for `cl.exe` compiler
+      if: ${{ !contains(matrix.job.os, 'windows') }} # Requires an additional adapted Makefile for `cl.exe` compiler
       run: make.sh CFLAGS="-Werror" -j
 
     - name: Build wasm library
@@ -138,7 +137,7 @@ jobs:
       run: script/fetch-fixtures
 
     - name: Generate fixtures
-      if: ${{ matrix.job.name != 'macos-arm64' }} # Can't run CLI on host
+      if: ${{ matrix.job.name != 'macos-arm64' }} # Can't natively run CLI on runner's host
       run: script/generate-fixtures
 
     - name: Generate WASM fixtures
@@ -146,7 +145,7 @@ jobs:
       run: script/generate-fixtures-wasm
 
     - name: Run main tests
-      if: ${{ matrix.job.name != 'macos-arm64' }} # Can't run CLI on host
+      if: ${{ matrix.job.name != 'macos-arm64' }} # Can't natively run CLI on runner's host
       run: $BUILD_CMD test --target=${{ matrix.job.target }}
 
     - name: Run wasm tests

--- a/cli/npm/install.js
+++ b/cli/npm/install.js
@@ -16,13 +16,9 @@ const platformName = {
 let archName = {
   'x64': 'x64',
   'x86': 'x86',
-  'ia32': 'x86'
+  'ia32': 'x86',
+  'arm64': 'arm64'
 }[process.arch];
-
-// ARM macs can run x64 binaries via Rosetta. Rely on that for now.
-if (platformName === 'macos' && process.arch === 'arm64') {
-  archName = 'x64';
-}
 
 if (!platformName || !archName) {
   console.error(


### PR DESCRIPTION
closes #2009 

Caveat: can't run tests on `macos-arm64` as we can't use the built CLI on the host due to the wrong architecture.

Tested the build workflow on my fork; you can checkout the artefacts here: https://github.com/clason/tree-sitter/actions/runs/4629484854

I skipped building WASM for any target where it's not tested (and uploaded) to save resources, but that can of course be reverted (except for `macos-arm64`). More savings are possible by restricting this to only the target for which the build is actually uploaded (`linux-x64`).