### PR TITLE
Docs: Add tree-sitter-just to the parser list

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,7 @@ By convention, bindings are named with the language first, eg. ruby-tree-sitter.
 * [JSON5](https://github.com/Joakker/tree-sitter-json5)
 * [JSON](https://github.com/tree-sitter/tree-sitter-json)
 * [Julia](https://github.com/tree-sitter/tree-sitter-julia)
+* [Just](https://github.com/IndianBoy42/tree-sitter-just)
 * [Kotlin](https://github.com/fwcd/tree-sitter-kotlin)
 * [LALRPOP](https://github.com/traxys/tree-sitter-lalrpop)
 * [Latex](https://github.com/latex-lsp/tree-sitter-latex)


### PR DESCRIPTION
This PR adds [tree-sitter-just](https://github.com/IndianBoy42/tree-sitter-just) to the list of parser.

`just` is the format used by `justfile`s: https://github.com/casey/just/

This parser is also mentioned in the `README.md` of `casey/just`, so it is also "blessed" by the project itself.

Since highlighting for `just`-code-blocks seems to already work on github, I'm wondering if this/another parser for `justfile`s is already known? But maybe github just uses a parser that's not yet listed in the docs.