### PR TITLE
cicd: don't cancel runs on master by concurrency condition

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -9,7 +9,13 @@ on:
       - check/*
 
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  group: >
+    ${{ github.workflow }} @ ${{
+      github.ref == 'refs/heads/master' && github.ref_name || ''
+    }}${{
+      github.ref == 'refs/heads/master' && github.sha
+      || github.event.pull_request.head.label || github.head_ref || github.ref
+    }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This PR's change solves a CI/CD badge flickering on the master when there are happened several merges without waiting for completion on master for every merge. This change disables concurrency canceling on the master branch.