### PR TITLE
cicd: switch main workflow to work on any branch except `release/v*` prefixed

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches:
-      - master
-      - check/*
+    branches-ignore:
+      - release/v*
 
 concurrency:
   group: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.name }} (${{ matrix.target }}) (${{ matrix.os }})
+    name: ${{ matrix.runtime }} (${{ matrix.target }}) (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        name:
+        runtime:
         - linux-aarch64 #
         - linux-arm     #
         - linux-x64     #
@@ -31,23 +31,23 @@ jobs:
         - macos-x64     #
 
         include:
-        - { name: linux-aarch64 , target: aarch64-unknown-linux-gnu   , os: ubuntu-latest  , use-cross: true }
-        - { name: linux-arm     , target: arm-unknown-linux-gnueabihf , os: ubuntu-latest  , use-cross: true }
-        - { name: linux-x64     , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest                    }
-        - { name: linux-x86     , target: i686-unknown-linux-gnu      , os: ubuntu-latest  , use-cross: true }
-        - { name: windows-x64   , target: x86_64-pc-windows-msvc      , os: windows-latest                   }
-        - { name: windows-x86   , target: i686-pc-windows-msvc        , os: windows-latest                   }
-        - { name: macos-arm64   , target: aarch64-apple-darwin        , os: macos-latest                     }
-        - { name: macos-x64     , target: x86_64-apple-darwin         , os: macos-latest                     }
+        - { runtime: linux-aarch64 , target: aarch64-unknown-linux-gnu   , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-arm     , target: arm-unknown-linux-gnueabihf , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-x64     , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest                    }
+        - { runtime: linux-x86     , target: i686-unknown-linux-gnu      , os: ubuntu-latest  , use-cross: true }
+        - { runtime: windows-x64   , target: x86_64-pc-windows-msvc      , os: windows-latest                   }
+        - { runtime: windows-x86   , target: i686-pc-windows-msvc        , os: windows-latest                   }
+        - { runtime: macos-arm64   , target: aarch64-apple-darwin        , os: macos-latest                     }
+        - { runtime: macos-x64     , target: x86_64-apple-darwin         , os: macos-latest                     }
 
         # Cross compilers for C library
-        - { name: linux-aarch64 , cc: aarch64-linux-gnu-gcc           , ar: aarch64-linux-gnu-ar               }
-        - { name: linux-arm     , cc: arm-unknown-linux-gnueabihf-gcc , ar: arm-unknown-linux-gnueabihf-gcc-ar }
-        - { name: linux-x86     , cc: i686-linux-gnu-gcc              , ar: i686-linux-gnu-ar                  }
+        - { runtime: linux-aarch64 , cc: aarch64-linux-gnu-gcc           , ar: aarch64-linux-gnu-ar               }
+        - { runtime: linux-arm     , cc: arm-unknown-linux-gnueabihf-gcc , ar: arm-unknown-linux-gnueabihf-gcc-ar }
+        - { runtime: linux-x86     , cc: i686-linux-gnu-gcc              , ar: i686-linux-gnu-ar                  }
 
         # See #2041 tree-sitter issue
-        - { name: windows-x64   , rust_test_threads: 1 }
-        - { name: windows-x86   , rust_test_threads: 1 }
+        - { runtime: windows-x64   , rust_test_threads: 1 }
+        - { runtime: windows-x86   , rust_test_threads: 1 }
 
     env:
       BUILD_CMD: cargo
@@ -137,46 +137,46 @@ jobs:
       run: make.sh CFLAGS="-Werror" -j
 
     - name: Build wasm library
-      if: ${{ !matrix.use-cross && matrix.name != 'macos-arm64' }} # Not used
+      if: ${{ !matrix.use-cross && matrix.runtime != 'macos-arm64' }} # Not used
       run: script/build-wasm
 
     - name: Build CLI
       run: $BUILD_CMD build --release --target=${{ matrix.target }}
 
     - name: Fetch fixtures
-      if: ${{ matrix.name != 'macos-arm64' }} # Not used
+      if: ${{ matrix.runtime != 'macos-arm64' }} # Not used
       run: script/fetch-fixtures
 
     - name: Generate fixtures
-      if: ${{ matrix.name != 'macos-arm64' }} # Can't natively run CLI on runner's host
+      if: ${{ matrix.runtime != 'macos-arm64' }} # Can't natively run CLI on runner's host
       run: script/generate-fixtures
 
     - name: Generate WASM fixtures
-      if: ${{ !matrix.use-cross && matrix.name != 'macos-arm64' }} # Not used
+      if: ${{ !matrix.use-cross && matrix.runtime != 'macos-arm64' }} # Not used
       run: script/generate-fixtures-wasm
 
     - name: Run main tests
-      if: ${{ matrix.name != 'macos-arm64' }} # Can't natively run CLI on runner's host
+      if: ${{ matrix.runtime != 'macos-arm64' }} # Can't natively run CLI on runner's host
       run: $BUILD_CMD test --target=${{ matrix.target }}
 
     - name: Run wasm tests
-      if: ${{ !matrix.use-cross && matrix.name != 'macos-arm64' }} # Not used
+      if: ${{ !matrix.use-cross && matrix.runtime != 'macos-arm64' }} # Not used
       run: script/test-wasm
 
     - name: Run benchmarks
-      if: ${{ !matrix.use-cross && matrix.name != 'macos-arm64' }} # Cross-compiled benchmarks make no sense
+      if: ${{ !matrix.use-cross && matrix.runtime != 'macos-arm64' }} # Cross-compiled benchmarks make no sense
       run: $BUILD_CMD bench benchmark -p tree-sitter-cli --target=${{ matrix.target }}
 
     - name: Upload CLI artifact
       uses: actions/upload-artifact@v3
       with:
-        name: tree-sitter.${{ matrix.name }}
+        name: tree-sitter.${{ matrix.runtime }}
         path: target/${{ matrix.target }}/release/tree-sitter${{ contains(matrix.target, 'windows') && '.exe' || '' }}
         if-no-files-found: error
         retention-days: 7
 
     - name: Upload WASM artifacts
-      if: ${{ matrix.name == 'linux-x64' }}
+      if: ${{ matrix.runtime == 'linux-x64' }}
       uses: actions/upload-artifact@v3
       with:
         name: tree-sitter.wasm


### PR DESCRIPTION
This PR switches main workflow to work on any branch except `release/v*` prefixed.

The `release/v*` prefixed branches can be used only with a PR opened on such branches. The release branches only accepted in the main repo and not from forks.

Also this workflow enables runining on every `push` unconditionaly. This leads to parallel runs on `push` and `pull_request` events and that would seen in PR checks also in parallel, but this is useful because checks that run on the `push` event runs on head ref while checks on the `pull_request` event runs on an additional `refs/pull/<PR>/merge` ref what is created by Github on every push to a PR to check that it can be merged to a target branch without conflicts and passed checks.

_I suppose parallel runs for `push` and `pull_request` events will happen only for branches pushed directly to this repo._