### PR TITLE
CLI npm installation: strict `platform` / `arch` mapping for provided targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         runtime:
-        - linux-aarch64 #
+        - linux-arm64   #
         - linux-arm     #
         - linux-x64     #
         - linux-x86     #
@@ -31,7 +31,10 @@ jobs:
         - macos-x64     #
 
         include:
-        - { runtime: linux-aarch64 , target: aarch64-unknown-linux-gnu   , os: ubuntu-latest  , use-cross: true }
+        # When adding a new `target`:
+        # 1. Define a runtime alias above
+        # 2. Add a record in a matrix map in `cli/npm/install.js`
+        - { runtime: linux-arm64   , target: aarch64-unknown-linux-gnu   , os: ubuntu-latest  , use-cross: true }
         - { runtime: linux-arm     , target: arm-unknown-linux-gnueabihf , os: ubuntu-latest  , use-cross: true }
         - { runtime: linux-x64     , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest                    }
         - { runtime: linux-x86     , target: i686-unknown-linux-gnu      , os: ubuntu-latest  , use-cross: true }
@@ -41,7 +44,7 @@ jobs:
         - { runtime: macos-x64     , target: x86_64-apple-darwin         , os: macos-latest                     }
 
         # Cross compilers for C library
-        - { runtime: linux-aarch64 , cc: aarch64-linux-gnu-gcc           , ar: aarch64-linux-gnu-ar               }
+        - { runtime: linux-arm64   , cc: aarch64-linux-gnu-gcc           , ar: aarch64-linux-gnu-ar               }
         - { runtime: linux-arm     , cc: arm-unknown-linux-gnueabihf-gcc , ar: arm-unknown-linux-gnueabihf-gcc-ar }
         - { runtime: linux-x86     , cc: i686-linux-gnu-gcc              , ar: i686-linux-gnu-ar                  }
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,7 +1,12 @@
 Tree-sitter CLI
 ===============
 
-[![Crates.io](https://img.shields.io/crates/v/tree-sitter-cli.svg)](https://crates.io/crates/tree-sitter-cli)
+[![crates.io][crates-badge]][crates-package] [![npmjs.com][npmjs-badge]][npmjs-package]
+
+[crates-package]: https://crates.io/crates/tree-sitter-cli
+[npmjs-package]: https://www.npmjs.org/package/tree-sitter-cli
+[crates-badge]: https://img.shields.io/crates/v/tree-sitter-cli.svg?color=%23B48723
+[npmjs-badge]: https://img.shields.io/npm/v/tree-sitter-cli.svg?color=%23BF4A4A
 
 The Tree-sitter CLI allows you to develop, test, and use Tree-sitter grammars from the command line. It works on MacOS, Linux, and Windows.
 

--- a/cli/npm/.gitignore
+++ b/cli/npm/.gitignore
@@ -3,3 +3,4 @@ tree-sitter.exe
 *.gz
 *.tgz
 LICENSE
+README.md

--- a/cli/npm/install.js
+++ b/cli/npm/install.js
@@ -6,21 +6,41 @@ const http = require('http');
 const https = require('https');
 const packageJSON = require('./package.json');
 
+// Look to a results table in https://github.com/tree-sitter/tree-sitter/issues/2196
+const matrix = {
+  platform: {
+    'darwin': {
+      name: 'macos',
+      arch: {
+        'x64': { name: 'x64' },
+        'arm64': { name: 'arm64' },
+      }
+    },
+    'linux': {
+      name: 'linux',
+      arch: {
+        'arm64': { name: 'arm64' },
+        'arm': { name: 'arm' },
+        'x64': { name: 'x64' },
+        'x86': { name: 'x86' },
+      }
+    },
+    'win32': {
+      name: 'windows',
+      arch: {
+        'x64': { name: 'x64' },
+        'x86': { name: 'x86' },
+        'ia32': { name: 'x86' },
+      }
+    },
+  },
+}
+
 // Determine the URL of the file.
-const platformName = {
-  'darwin': 'macos',
-  'linux': 'linux',
-  'win32': 'windows'
-}[process.platform];
+const platform = matrix.platform[process.platform];
+const arch = platform && platform.arch[process.arch];
 
-let archName = {
-  'x64': 'x64',
-  'x86': 'x86',
-  'ia32': 'x86',
-  'arm64': 'arm64'
-}[process.arch];
-
-if (!platformName || !archName) {
+if (!platform.name || !arch.name) {
   console.error(
     `Cannot install tree-sitter-cli for platform ${process.platform}, architecture ${process.arch}`
   );
@@ -28,7 +48,7 @@ if (!platformName || !archName) {
 }
 
 const releaseURL = `https://github.com/tree-sitter/tree-sitter/releases/download/v${packageJSON.version}`;
-const assetName = `tree-sitter-${platformName}-${archName}.gz`;
+const assetName = `tree-sitter-${platform.name}-${arch.name}.gz`;
 const assetURL = `${releaseURL}/${assetName}`;
 
 // Remove previously-downloaded files.

--- a/cli/npm/package.json
+++ b/cli/npm/package.json
@@ -15,7 +15,8 @@
   "main": "lib/api/index.js",
   "scripts": {
     "install": "node install.js",
-    "prepack": "cp ../../LICENSE ."
+    "prepack": "cp ../../LICENSE ../README.md .",
+    "postpack": "rm LICENSE README.md"
   },
   "bin": {
     "tree-sitter": "cli.js"


### PR DESCRIPTION
This PR introduces a stricter matrix in `cli/npm/install.js` that is used during CLI installation process with a [`tree-sitter-cli`](https://www.npmjs.com/package/tree-sitter-cli) NPM package.

TODO:
- [ ] Introduce additional `machine` / `endianness` properties checks in unclear situations, see notes in #2196