### PR TITLE
docs: remove controversial statement

### DIFF
--- a/docs/section-3-creating-parsers.md
+++ b/docs/section-3-creating-parsers.md
@@ -530,7 +530,7 @@ Grammars often contain multiple tokens that can match the same characters. For e
 
 1. **Context-Aware Lexing** - Tree-sitter performs lexing on-demand, during the parsing process. At any given position in a source document, the lexer only tries to recognize tokens that are *valid* at that position in the document.
 
-1. **Explicit Lexical Precedence** - When the precedence functions described [above](#the-grammar-dsl) are used within the `token` function, the given precedence values serve as instructions to the lexer. If there are two valid tokens that match the characters at a given position in the document, Tree-sitter will select the one with the higher precedence.
+1. **Explicit Lexical Precedence** - When the precedence functions described [above](#the-grammar-dsl) are used within the `token` function like `token(prec(N, ...))`, the given precedence values serve as instructions to the lexer. If there are two valid tokens that match the characters at a given position in the document, Tree-sitter will select the one with the higher precedence.
 
 1. **Match Length** - If multiple valid tokens with the same precedence match the characters at a given position in a document, Tree-sitter will select the token that matches the [longest sequence of characters][longest-match].
 

--- a/docs/section-3-creating-parsers.md
+++ b/docs/section-3-creating-parsers.md
@@ -530,8 +530,6 @@ Grammars often contain multiple tokens that can match the same characters. For e
 
 1. **Context-Aware Lexing** - Tree-sitter performs lexing on-demand, during the parsing process. At any given position in a source document, the lexer only tries to recognize tokens that are *valid* at that position in the document.
 
-1. **Earliest Starting Position** - Tree-sitter will prefer tokens with an earlier starting position. This is most often seen with very permissive regular expressions similar to `/.*/`, which are greedy and will consume as much text as possible. In this example the regex would consume all text until hitting a newline - even if text on that line could be interpreted as a different token.
-
 1. **Explicit Lexical Precedence** - When the precedence functions described [above](#the-grammar-dsl) are used within the `token` function, the given precedence values serve as instructions to the lexer. If there are two valid tokens that match the characters at a given position in the document, Tree-sitter will select the one with the higher precedence.
 
 1. **Match Length** - If multiple valid tokens with the same precedence match the characters at a given position in a document, Tree-sitter will select the token that matches the [longest sequence of characters][longest-match].


### PR DESCRIPTION
This PR removes wrong and controversial the **Earliest Starting Position** statement added by the https://github.com/tree-sitter/tree-sitter/commit/87a0517f3ce1d0eef47333dd50e8b25d932564c1 commit originated from #1612 because the statement isn't true and by the logic conflicts with other **Match Length** and **Match Specificity** statements. Also string defined tokens can win over variadic length regex defined tokens in cases if both can consume only the same amount of input chars on the same position according with the **Match Specificity** statement.

**Notes:**
- If there are two tokens like `/\{/` and `'{'` that can be matched on a same position and may belong to different grammar rules that intersect over a some parent rule. The `'{'` string defined token will win over the `/\{/` regex defined token due to **Match Specificity** precedence rule.
- If there are two tokens like `'{{{'` and `'{'` that can be matched on a same position for them works the **Rule Order** precedence rule.