### PR TITLE
add the parser for apex language

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 * [Ada](https://github.com/briot/tree-sitter-ada)
 * [Agda](https://github.com/tree-sitter/tree-sitter-agda)
 * [Apex](https://github.com/aheber/tree-sitter-sfapex)
+* [ApexCode](https://github.com/jsuarez-chipiron/tree-sitter-apex)
 * [Bash](https://github.com/tree-sitter/tree-sitter-bash)
 * [Beancount](https://github.com/zwpaper/tree-sitter-beancount)
 * [Cap'n Proto](https://github.com/amaanq/tree-sitter-capnp)


### PR DESCRIPTION
Hi, long time ago I created a grammar for Salesforce Apex language based on the java existing grammar. I've been using it mostly from neovim but also with the rust and python bindings and used to perform static analysis in very large code base of Apex.

Here is the repo where my grammar is: https://github.com/jsuarez-chipiron/tree-sitter-apex

