### PR TITLE
Rework lifetimes

### DIFF
--- a/highlight/src/lib.rs
+++ b/highlight/src/lib.rs
@@ -105,7 +105,7 @@ where
 struct HighlightIterLayer<'a> {
     _tree: Tree,
     cursor: QueryCursor,
-    captures: iter::Peekable<QueryCaptures<'a, 'a, &'a [u8]>>,
+    captures: iter::Peekable<QueryCaptures<'a, 'a, 'a, 'a, &'a [u8]>>,
     config: &'a HighlightConfiguration,
     highlight_end_stack: Vec<usize>,
     scope_stack: Vec<LocalScope<'a>>,


### PR DESCRIPTION
This PR proposes to rework how `QueryMatches`, `QueryMatch`, and `QueryCaptures` use lifetimes.

With the current lifetimes, this function does not compile: https://github.com/smoelius/tree-sitter/blob/19c0a5591e2ca7cebb5a75323a56d6a3127522fc/cli/src/tests/query_test.rs#L4590-L4610

With the changes proposed in this PR, the function compiles.

The current lifetimes have other adverse consequences. For example, both [`QueryMatches`](https://github.com/smoelius/tree-sitter/blob/2a9d951cd6faf8367a402210c406f0f64818aa24/lib/binding_rust/lib.rs#L175) and [`QueryCaptures`](https://github.com/smoelius/tree-sitter/blob/2a9d951cd6faf8367a402210c406f0f64818aa24/lib/binding_rust/lib.rs#L185) require that the tree outlive the query. But there is no obvious reason for such a requirement. Moreover, it prevents applications from building a set of queries then operating on multiple trees, for example.

Additional reasons/discussion are given in #1922.

To state the obvious, merging this PR would be a breaking change.