### PR TITLE
Work around tree-sitter-typescript#244

### DIFF
--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -908,7 +908,7 @@ class Language {
       : loadWebAssemblyModule;
 
     return bytes
-      .then(bytes => loadModule(bytes, {loadAsync: true}))
+      .then(bytes => loadModule(bytes, {allowUndefined: true, loadAsync: true}))
       .then(mod => {
         const symbolNames = Object.keys(mod)
         const functionName = symbolNames.find(key =>

--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "web-tree-sitter",
-  "version": "0.20.8",
+  "name": "@xeger/web-tree-sitter",
+  "version": "0.20.9",
+  "private": false,
   "description": "Tree-sitter bindings for the web",
   "main": "tree-sitter.js",
   "types": "tree-sitter-web.d.ts",
@@ -14,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tree-sitter/tree-sitter.git"
+    "url": "git+https://github.com/xeger/tree-sitter.git"
   },
   "keywords": [
     "incremental",


### PR DESCRIPTION
This allows `tree-sitter-typescript` and numerous other NPM modules to work correctly under Electron 22.

I'm not sure if it's the right fix. I'm not sure if it has unintended consequences. But it lets my [VS Code extension](https://github.com/cucumber/vscode) load and run again!

(Note: I've published a forked build of `web-tree-sitter` to prove the concept of this workaround, and the alterations to `package.json` are present on this branch. Don't merge as-is -- not that I'd expect anyone to be so bold without a thorough understanding of the issue!)