### PR TITLE
cicd: improvements + less strict glibc version requirement for CLI

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -3,6 +3,11 @@ name: CICD
 on:
   workflow_dispatch:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   push:
     branches-ignore:
       - release/v*

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -72,7 +72,7 @@ jobs:
     name: Release
     needs: [init, fast_checks, full_checks, min_version, build, sanitize]
     if: >
-      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event_name == 'pull_request' &&
       startsWith(github.head_ref, 'release/v') &&
       !github.event.pull_request.draft
     uses: ./.github/workflows/release.yml

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -68,7 +68,8 @@ jobs:
     needs: [init, fast_checks, full_checks, min_version, build, sanitize]
     if: >
       github.event.pull_request.head.repo.full_name == github.repository &&
-      startsWith(github.head_ref, 'release/v')
+      startsWith(github.head_ref, 'release/v') &&
+      !github.event.pull_request.draft
     uses: ./.github/workflows/release.yml
     with:
       ref: ${{ needs.init.outputs.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         # 2. Add a new record to a matrix map in `cli/npm/install.js`
         - { runtime: linux-arm64   , target: aarch64-unknown-linux-gnu   , os: ubuntu-latest  , use-cross: true }
         - { runtime: linux-arm     , target: arm-unknown-linux-gnueabihf , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-x64     , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest                    }
+        - { runtime: linux-x64     , target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04                     } #2272
         - { runtime: linux-x86     , target: i686-unknown-linux-gnu      , os: ubuntu-latest  , use-cross: true }
         - { runtime: windows-arm64 , target: aarch64-pc-windows-msvc     , os: windows-latest                   }
         - { runtime: windows-x64   , target: x86_64-pc-windows-msvc      , os: windows-latest                   }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,8 @@ jobs:
 
     env:
       BUILD_CMD: cargo
+      EMSCRIPTEN_VERSION: ""
+      EXE: ${{ contains(matrix.target, 'windows') && '.exe' || '' }}
 
     defaults:
       run:
@@ -159,6 +161,12 @@ jobs:
     - name: Build CLI
       run: $BUILD_CMD build --release --target=${{ matrix.target }}
 
+    - name: Info about CLI
+      if: ${{ startsWith(matrix.runtime, 'linux') }}
+      run: |
+        min_glibc=$(objdump -p target/$TARGET/release/tree-sitter${{ env.EXE }} | sed -nr 's/.*(GLIBC_.+).*/\1/p' | sort -uV | tail -n1)
+        echo "🔗 Minimal **glibc** version required for CLI: ${min_glibc}">> $GITHUB_STEP_SUMMARY
+
     - name: Fetch fixtures
       if: ${{ inputs.run-tests && !matrix.cli-only }} # Don't fetch fixtures for only CLI building targets
       run: script/fetch-fixtures
@@ -187,7 +195,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: tree-sitter.${{ matrix.runtime }}
-        path: target/${{ matrix.target }}/release/tree-sitter${{ contains(matrix.target, 'windows') && '.exe' || '' }}
+        path: target/${{ matrix.target }}/release/tree-sitter${{ env.EXE }}
         if-no-files-found: error
         retention-days: 7
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,20 @@ env:
   CROSS_DEBUG: 1
 
 on:
-  workflow_dispatch:
   workflow_call:
     inputs:
       ref:
         default: ${{ github.ref }}
         type: string
+      run-tests:
+        default: true
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      run-tests:
+        description: Run tests
+        default: true
+        type: boolean
 
 jobs:
   build:
@@ -141,34 +149,34 @@ jobs:
       run: make.sh CFLAGS="-Werror" -j
 
     - name: Build wasm library
-      if: ${{ !matrix.use-cross && !matrix.cli-only }} # No sense to build on the same Github runner hosts many times
+      if: ${{ !matrix.cli-only && !matrix.use-cross }} # No sense to build on the same Github runner hosts many times
       run: script/build-wasm
 
     - name: Build CLI
       run: $BUILD_CMD build --release --target=${{ matrix.target }}
 
     - name: Fetch fixtures
-      if: ${{ !matrix.cli-only }} # Don't fetch fixtures for only CLI building targets
+      if: ${{ inputs.run-tests && !matrix.cli-only }} # Don't fetch fixtures for only CLI building targets
       run: script/fetch-fixtures
 
     - name: Generate fixtures
-      if: ${{ !matrix.cli-only }} # Can't natively run CLI on Github runner's host
+      if: ${{ inputs.run-tests && !matrix.cli-only }} # Can't natively run CLI on Github runner's host
       run: script/generate-fixtures
 
     - name: Generate WASM fixtures
-      if: ${{ !matrix.use-cross && !matrix.cli-only }} # See comment for the "Build wasm library" step
+      if: ${{ inputs.run-tests && !matrix.cli-only && !matrix.use-cross }} # See comment for the "Build wasm library" step
       run: script/generate-fixtures-wasm
 
     - name: Run main tests
-      if: ${{ !matrix.cli-only }} # Can't natively run CLI on Github runner's host
+      if: ${{ inputs.run-tests && !matrix.cli-only }} # Can't natively run CLI on Github runner's host
       run: $BUILD_CMD test --target=${{ matrix.target }}
 
     - name: Run wasm tests
-      if: ${{ !matrix.use-cross && !matrix.cli-only }} # See comment for the "Build wasm library" step
+      if: ${{ inputs.run-tests && !matrix.cli-only && !matrix.use-cross }} # See comment for the "Build wasm library" step
       run: script/test-wasm
 
     - name: Run benchmarks
-      if: ${{ !matrix.use-cross && !matrix.cli-only }} # Cross-compiled benchmarks make no sense
+      if: ${{ inputs.run-tests && !matrix.cli-only && !matrix.use-cross }} # Cross-compiled benchmarks make no sense
       run: $BUILD_CMD bench benchmark -p tree-sitter-cli --target=${{ matrix.target }}
 
     - name: Upload CLI artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ on:
         description: Run tests
         default: true
         type: boolean
+      rust-test-threads:
+        description: Number of Rust test threads
+        default: ""
+        type: string
 
 jobs:
   build:
@@ -119,7 +123,7 @@ jobs:
 
     - name: Setup env extras
       env:
-        RUST_TEST_THREADS: ${{ matrix.rust-test-threads }}
+        RUST_TEST_THREADS: ${{ matrix.rust-test-threads || inputs.rust-test-threads || '' }}
         USE_CROSS: ${{ matrix.use-cross }}
         TARGET: ${{ matrix.target }}
         CC: ${{ matrix.cc }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,14 @@ jobs:
     name: Check permissions
     runs-on: ubuntu-latest
     outputs:
-      release_allowed: ${{ steps.maintainer.outputs.is_maintainer == 'true' }}
+      release_allowed: >
+        ${{
+          steps.maintainer.outputs.is_maintainer == 'true' &&
+          steps.local_branch.outputs.is_local == 'true'
+        }}
     steps:
 
-    - name: Is maintainer
+    - name: Initated by a maintainer
       id: maintainer
       env:
         GH_TOKEN: ${{ github.token }}
@@ -30,6 +34,13 @@ jobs:
           echo "@${actor} has maintainer level permissions :rocket:" >> $GITHUB_STEP_SUMMARY;
           echo "is_maintainer=true" >> $GITHUB_OUTPUT
         fi
+
+    - name: The ref branch is local
+      id: local_branch
+      env:
+        is_local: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+      run: |
+        echo "is_local=${is_local}" >> $GITHUB_OUTPUT
 
   release:
     name: Release


### PR DESCRIPTION
- Closes #2272 - rollback runner version to link against older GLIBC
- Adds ability to run build task manually without tests to just check the compilation process.
- Adds check that a _release_ PR is draft and then don't make an actual release until PR would be normal.