### PR TITLE
Partially revert d4d5e29

### DIFF
--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -4648,7 +4648,7 @@ fn test_query_max_start_depth() {
             eprintln!("  query example: {:?}", row.description);
 
             let query = Query::new(language, row.pattern).unwrap();
-            cursor.set_max_start_depth(row.depth);
+            cursor.set_max_start_depth(Some(row.depth));
 
             let matches = cursor.matches(&query, tree.root_node(), source.as_bytes());
             let expected = row
@@ -4782,7 +4782,7 @@ fn test_query_max_start_depth_more() {
         for row in rows.iter() {
             eprintln!("  depth: {}", row.depth);
 
-            cursor.set_max_start_depth(row.depth);
+            cursor.set_max_start_depth(Some(row.depth));
 
             let matches = cursor.matches(&query, node, source.as_bytes());
             let expected = row

--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -4577,19 +4577,22 @@ fn test_query_max_start_depth() {
     #[rustfmt::skip]
     let rows = &[
         Row {
-            description: "depth 0: match all",
+            description: "depth 0: match translation unit",
+            depth: 0,
+            pattern: r#"
+                (translation_unit) @capture
+            "#,
+            matches: &[
+                (0, &[("capture", "if (a1 && a2) {\n    if (b1 && b2) { }\n    if (c) { }\n}\nif (d) {\n    if (e1 && e2) { }\n    if (f) { }\n}\n")]),
+            ]
+        },
+        Row {
+            description: "depth 0: match none",
             depth: 0,
             pattern: r#"
                 (if_statement) @capture
             "#,
-            matches: &[
-                (0, &[("capture", "if (a1 && a2) {\n    if (b1 && b2) { }\n    if (c) { }\n}")]),
-                (0, &[("capture", "if (b1 && b2) { }")]),
-                (0, &[("capture", "if (c) { }")]),
-                (0, &[("capture", "if (d) {\n    if (e1 && e2) { }\n    if (f) { }\n}")]),
-                (0, &[("capture", "if (e1 && e2) { }")]),
-                (0, &[("capture", "if (f) { }")]),
-            ]
+            matches: &[]
         },
         Row {
             description: "depth 1: match 2 if statements at the top level",

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -639,7 +639,7 @@ extern "C" {
     ) -> bool;
 }
 extern "C" {
-    #[doc = " Set the maximum start depth for a cursor.\n\n This prevents cursors from exploring children nodes at a certain depth.\n Note if a pattern includes many children, then they will still be checked.\n\n Set to `0` to remove the maximum start depth."]
+    #[doc = " Set the maximum start depth for a query cursor.\n\n This prevents cursors from exploring children nodes at a certain depth.\n Note if a pattern includes many children, then they will still be checked.\n\n The zero max start depth value can be used as a special behavior and\n it helps to destructure a subtree by staying on a node and using captures\n for interested parts. Note that the zero max start depth only limit a search\n depth for a pattern's root node but other nodes that are parts of the pattern\n may be searched at any depth what defined by the pattern structure.\n\n Set to `UINT32_MAX` to remove the maximum start depth."]
     pub fn ts_query_cursor_set_max_start_depth(arg1: *mut TSQueryCursor, arg2: u32);
 }
 extern "C" {

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -2174,10 +2174,25 @@ impl QueryCursor {
         self
     }
 
+    /// Set the maximum start depth for a query cursor.
+    ///
+    /// This prevents cursors from exploring children nodes at a certain depth.
+    /// Note if a pattern includes many children, then they will still be checked.
+    ///
+    /// The zero max start depth value can be used as a special behavior and
+    /// it helps to destructure a subtree by staying on a node and using captures
+    /// for interested parts. Note that the zero max start depth only limit a search
+    /// depth for a pattern's root node but other nodes that are parts of the pattern
+    /// may be searched at any depth what defined by the pattern structure.
+    ///
+    /// Set to `None` to remove the maximum start depth.
     #[doc(alias = "ts_query_cursor_set_max_start_depth")]
-    pub fn set_max_start_depth(&mut self, max_start_depth: u32) -> &mut Self {
+    pub fn set_max_start_depth(&mut self, max_start_depth: Option<u32>) -> &mut Self {
         unsafe {
-            ffi::ts_query_cursor_set_max_start_depth(self.ptr.as_ptr(), max_start_depth);
+            ffi::ts_query_cursor_set_max_start_depth(
+                self.ptr.as_ptr(),
+                max_start_depth.unwrap_or(u32::MAX),
+            );
         }
         self
     }

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -984,12 +984,18 @@ bool ts_query_cursor_next_capture(
 );
 
 /**
- * Set the maximum start depth for a cursor.
+ * Set the maximum start depth for a query cursor.
  *
  * This prevents cursors from exploring children nodes at a certain depth.
  * Note if a pattern includes many children, then they will still be checked.
  *
- * Set to `0` to remove the maximum start depth.
+ * The zero max start depth value can be used as a special behavior and
+ * it helps to destructure a subtree by staying on a node and using captures
+ * for interested parts. Note that the zero max start depth only limit a search
+ * depth for a pattern's root node but other nodes that are parts of the pattern
+ * may be searched at any depth what defined by the pattern structure.
+ *
+ * Set to `UINT32_MAX` to remove the maximum start depth.
  */
 void ts_query_cursor_set_max_start_depth(TSQueryCursor *, uint32_t);
 

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -4124,11 +4124,7 @@ void ts_query_cursor_set_max_start_depth(
   TSQueryCursor *self,
   uint32_t max_start_depth
 ) {
-  if (max_start_depth == 0) {
-    self->max_start_depth = UINT32_MAX;
-  } else {
-    self->max_start_depth = max_start_depth;
-  }
+  self->max_start_depth = max_start_depth;
 }
 
 #undef LOG


### PR DESCRIPTION
I'd like to propose that d4d5e29 be partially reverted.

Those changes made it so that the max start depth cannot be set to 0.

Please recall that one of the [original motivations](https://github.com/tree-sitter/tree-sitter/issues/1673) for this feature was to test a query against a node without traversing its descendants.