### PR TITLE
Fix OOB in `Query::new`

### DIFF
--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -4575,3 +4575,19 @@ fn test_query_max_start_depth() {
         }
     });
 }
+
+#[test]
+fn test_query_error_does_not_oob() {
+    let language = get_language("javascript");
+
+    assert_eq!(
+        Query::new(language, "(clas").unwrap_err(),
+        QueryError {
+            row: 0,
+            offset: 1,
+            column: 1,
+            kind: QueryErrorKind::NodeType,
+            message: "clas".to_string()
+        }
+    );
+}

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1401,7 +1401,7 @@ impl Query {
                     let suffix = source.split_at(offset).1;
                     let end_offset = suffix
                         .find(|c| !char::is_alphanumeric(c) && c != '_' && c != '-')
-                        .unwrap_or(source.len());
+                        .unwrap_or(suffix.len());
                     message = suffix.split_at(end_offset).0.to_string();
                     kind = match error_type {
                         ffi::TSQueryError_TSQueryErrorNodeType => QueryErrorKind::NodeType,


### PR DESCRIPTION
Pretty self-explanatory.

With out the fix, `test_query_error_does_not_oob` produces this:
```
thread 'tests::query_test::test_query_error_does_not_oob' panicked at 'byte index 5 is out of bounds of `clas`'
```

(Please forgive the barrage of PRs.)