### PR TITLE
Return early if syntax errors are encountered

### DIFF
--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -215,6 +215,17 @@ extern "C" {
     pub fn ts_parser_cancellation_flag(self_: *const TSParser) -> *const usize;
 }
 extern "C" {
+    #[doc = " Set if the parser should immediately return after encountering a syntax error while parsing, it will halt early, returning NULL.\n See `ts_parser_parse` for more information."]
+    pub fn ts_parser_set_early_out_on_syntax_error(
+        self_: *mut TSParser,
+        early_out_on_syntax_error: bool,
+    );
+}
+extern "C" {
+    #[doc = " Get the parser's current early out on a syntax error setting."]
+    pub fn ts_parser_early_out_on_syntax_error(self_: *const TSParser) -> bool;
+}
+extern "C" {
     #[doc = " Set the logger that a parser should use during parsing.\n\n The parser does not take ownership over the logger payload. If a logger was\n previously assigned, the caller is responsible for releasing any memory\n owned by the previous logger."]
     pub fn ts_parser_set_logger(self_: *mut TSParser, logger: TSLogger);
 }

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -458,6 +458,7 @@ impl Parser {
     ///  * The parser has not yet had a language assigned with [Parser::set_language]
     ///  * The timeout set with [Parser::set_timeout_micros] expired
     ///  * The cancellation flag set with [Parser::set_cancellation_flag] was flipped
+    ///  * A syntax error was encountered and [Parser::set_early_out_on_syntax_error] was set true
     #[doc(alias = "ts_parser_parse")]
     pub fn parse(&mut self, text: impl AsRef<[u8]>, old_tree: Option<&Tree>) -> Option<Tree> {
         let bytes = text.as_ref();
@@ -597,7 +598,7 @@ impl Parser {
 
     /// Instruct the parser to start the next parse from the beginning.
     ///
-    /// If the parser previously failed because of a timeout or a cancellation, then
+    /// If the parser previously failed because of a timeout, cancellation, or a syntax error, then
     /// by default, it will resume where it left off on the next call to `parse` or
     /// other parsing functions. If you don't want to resume, and instead intend to
     /// use this parser to parse some other document, you must call `reset` first.
@@ -689,6 +690,25 @@ impl Parser {
             );
         } else {
             ffi::ts_parser_set_cancellation_flag(self.0.as_ptr(), ptr::null());
+        }
+    }
+
+    /// Get if the parser will early out due to a syntax error.
+    ///
+    /// This is set via [set_early_out_on_syntax_error](Parser::set_early_out_on_syntax_error).
+    #[doc(alias = "ts_parser_early_out_on_syntax_error")]
+    pub fn early_out_on_syntax_error(&self) -> bool {
+        unsafe { ffi::ts_parser_early_out_on_syntax_error(self.0.as_ptr()) }
+    }
+
+    /// Set if the parser should early out of parsing due to a syntax error.
+    ///
+    /// If a syntax error is encountered, it will halt early, returning `None`.
+    /// See `parse` for more information.
+    #[doc(alias = "ts_parser_set_early_out_on_syntax_error")]
+    pub fn set_early_out_on_syntax_error(&mut self, early_out_on_syntax_error: bool) {
+        unsafe {
+            ffi::ts_parser_set_early_out_on_syntax_error(self.0.as_ptr(), early_out_on_syntax_error)
         }
     }
 }

--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -125,6 +125,14 @@ class ParserImpl {
     return C._ts_parser_timeout_micros(this[0]);
   }
 
+  setEarlyOutOnSyntaxError(early_out) {
+    C._ts_parser_set_early_out_on_syntax_error(this[0], early_out);
+  }
+
+  getEarlyOutOnSyntaxError() {
+    return C._ts_parser_early_out_on_syntax_error(this[0]);
+  }
+
   setLogger(callback) {
     if (!callback) {
       callback = null;

--- a/lib/binding_web/exports.json
+++ b/lib/binding_web/exports.json
@@ -75,6 +75,8 @@
   "_ts_parser_set_language",
   "_ts_parser_set_timeout_micros",
   "_ts_parser_timeout_micros",
+  "_ts_parser_set_early_out_on_syntax_error",
+  "_ts_parser_early_out_on_syntax_error",
   "_ts_query_capture_count",
   "_ts_query_capture_name_for_id",
   "_ts_query_captures_wasm",

--- a/lib/binding_web/tree-sitter-web.d.ts
+++ b/lib/binding_web/tree-sitter-web.d.ts
@@ -14,6 +14,8 @@ declare module 'web-tree-sitter' {
     setLogger(logFunc?: Parser.Logger | undefined | null): void;
     setTimeoutMicros(value: number): void;
     getTimeoutMicros(): number;
+    setEarlyOutOnSyntaxError(value: boolean): void;
+    getEarlyOutOnSyntaxError(): boolean;
   }
 
   namespace Parser {

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -249,6 +249,9 @@ const TSRange *ts_parser_included_ranges(
  *    earlier call to `ts_parser_set_cancellation_flag`. You can resume parsing
  *    from where the parser left out by calling `ts_parser_parse` again with
  *    the same arguments.
+ * 4. A syntax error was encountered and `ts_parser_set_early_out_on_syntax_error` 
+ *    was set true. You can resume parsing from where the parser left out by
+ *    calling `ts_parser_parse` again with the same arguments.
  */
 TSTree *ts_parser_parse(
   TSParser *self,
@@ -286,11 +289,11 @@ TSTree *ts_parser_parse_string_encoding(
 /**
  * Instruct the parser to start the next parse from the beginning.
  *
- * If the parser previously failed because of a timeout or a cancellation, then
- * by default, it will resume where it left off on the next call to
- * `ts_parser_parse` or other parsing functions. If you don't want to resume,
- * and instead intend to use this parser to parse some other document, you must
- * call `ts_parser_reset` first.
+ * If the parser previously failed because of a timeout, cancellation,
+ * or a syntax error, then by default, it will resume where it left off
+ * on the next call to `ts_parser_parse` or other parsing functions. If
+ * you don't want to resume, and instead intend to use this parser to
+ * parse some other document, you must call `ts_parser_reset` first.
  */
 void ts_parser_reset(TSParser *self);
 
@@ -307,6 +310,19 @@ void ts_parser_set_timeout_micros(TSParser *self, uint64_t timeout);
  * Get the duration in microseconds that parsing is allowed to take.
  */
 uint64_t ts_parser_timeout_micros(const TSParser *self);
+
+/**
+ * Set if the parser should early out of parsing due to a syntax error.
+ *
+ * If a syntax error is encountered, it will halt early, returning `None`.
+ * See `ts_parser_parse` for more information.
+ */
+void ts_parser_set_early_out_on_syntax_error(TSParser *self, bool early_out);
+
+/**
+ * Get if the parser will early out due to a syntax error.
+ */
+bool ts_parser_early_out_on_syntax_error(const TSParser *self);
 
 /**
  * Set the parser's current cancellation flag pointer.


### PR DESCRIPTION
Hi Tree-Sitter team!

In my use case of Tree-Sitter I've been parsing source code samples but was wanting to early exit if the file had an error during the parsing. I followed in the footsteps of the other parser settings (exit flag and timeout) for the rust binding.

Full disclosure I'm not completely sure if I got all the web asm binding side of things, I'm primarily coming in through the Rust binding side. But I tried to mimic everywhere I saw the timeout exit being exposed.

Happy to make changes!