### PR TITLE
Docs: Added a link to tree-sitter-usd

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -137,6 +137,7 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 * [Turtle](https://github.com/BonaBeavis/tree-sitter-turtle)
 * [Twig](https://github.com/gbprod/tree-sitter-twig)
 * [TypeScript](https://github.com/tree-sitter/tree-sitter-typescript)
+* [USD](https://github.com/ColinKennedy/tree-sitter-usd)
 * [Verilog](https://github.com/tree-sitter/tree-sitter-verilog)
 * [VHDL](https://github.com/alemuller/tree-sitter-vhdl)
 * [Vue](https://github.com/ikatyang/tree-sitter-vue)


### PR DESCRIPTION
This PR adds [tree-sitter-usd](https://github.com/ColinKennedy/tree-sitter-usd) to the list of parser.

USD is the format used by .usd and .usda files: https://github.com/PixarAnimationStudios/OpenUSD

I've verified that this parser is robust but running it on several hundreds of FOSS production files.