### PR TITLE
Add a link to the tree-sitter-cel repo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 * [C](https://github.com/tree-sitter/tree-sitter-c)
 * [C++](https://github.com/tree-sitter/tree-sitter-cpp)
 * [C#](https://github.com/tree-sitter/tree-sitter-c-sharp)
+* [CEL](https://github.com/bufbuild/tree-sitter-cel)
 * [Clojure](https://github.com/sogaiu/tree-sitter-clojure)
 * [CMake](https://github.com/uyha/tree-sitter-cmake)
 * [Comment](https://github.com/stsewd/tree-sitter-comment)


### PR DESCRIPTION
Supporting the [Common Expression Language (CEL)](https://github.com/google/cel-spec/blob/master/doc/langdef.md#syntax)

See https://github.com/tree-sitter/tree-sitter/issues/2362