### PR TITLE
fix(deps): bump proc-macro2 as an unstable feature became stabilized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]

--- a/cli/src/tests/proc_macro/Cargo.toml
+++ b/cli/src/tests/proc_macro/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1"
+proc-macro2 = "1.0.63"
 quote = "1"
 rand = "0.8.5"
 syn = { version = "1", features = ["full"] }


### PR DESCRIPTION
Relevant discussion - https://github.com/rust-lang/rust/issues/113152

Building tree-sitter on nightly breaks at the moment, and I expect stable would too once the PR that stabilized proc_macro_span_shrink is in Rust stable