### PR TITLE
rust: remove `Copy, Clone` derives from raw struct where it's not applicable

### DIFF
--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -3,27 +3,27 @@
 pub type TSSymbol = u16;
 pub type TSFieldId = u16;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct TSLanguage {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct TSParser {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct TSTree {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct TSQuery {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct TSQueryCursor {
     _unused: [u8; 0],
 }
@@ -49,7 +49,7 @@ pub struct TSRange {
     pub end_byte: u32,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct TSInput {
     pub payload: *mut ::std::os::raw::c_void,
     pub read: ::std::option::Option<
@@ -66,7 +66,7 @@ pub const TSLogType_TSLogTypeParse: TSLogType = 0;
 pub const TSLogType_TSLogTypeLex: TSLogType = 1;
 pub type TSLogType = ::std::os::raw::c_uint;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct TSLogger {
     pub payload: *mut ::std::os::raw::c_void,
     pub log: ::std::option::Option<
@@ -102,7 +102,7 @@ pub struct TSTreeCursor {
     pub context: [u32; 2usize],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct TSQueryCapture {
     pub node: TSNode,
     pub index: u32,
@@ -114,7 +114,7 @@ pub const TSQuantifier_TSQuantifierOne: TSQuantifier = 3;
 pub const TSQuantifier_TSQuantifierOneOrMore: TSQuantifier = 4;
 pub type TSQuantifier = ::std::os::raw::c_uint;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct TSQueryMatch {
     pub id: u32,
     pub pattern_index: u16,
@@ -126,7 +126,7 @@ pub const TSQueryPredicateStepType_TSQueryPredicateStepTypeCapture: TSQueryPredi
 pub const TSQueryPredicateStepType_TSQueryPredicateStepTypeString: TSQueryPredicateStepType = 2;
 pub type TSQueryPredicateStepType = ::std::os::raw::c_uint;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct TSQueryPredicateStep {
     pub type_: TSQueryPredicateStepType,
     pub value_id: u32,

--- a/script/generate-bindings
+++ b/script/generate-bindings
@@ -2,12 +2,26 @@
 
 output_path=lib/binding_rust/bindings.rs
 header_path='lib/include/tree_sitter/api.h'
+no_derive_copy=(
+  TSInput
+  TSLanguage
+  TSLogger
+  TSParser
+  TSTree
+  TSQuery
+  TSQueryCursor
+  TSQueryCapture
+  TSQueryMatch
+  TSQueryPredicateStep
+)
+no_copy=$(IFS='|'; echo "${no_derive_copy[*]}")
 
 bindgen                                        \
   --no-layout-tests                            \
   --allowlist-type '^TS.*'                     \
   --allowlist-function '^ts_.*'                \
   --blocklist-type '^__.*'                     \
+  --no-copy "$no_copy"                         \
   $header_path > $output_path
 
 echo "" >> $output_path

--- a/script/generate-bindings
+++ b/script/generate-bindings
@@ -16,6 +16,18 @@ no_derive_copy=(
 )
 no_copy=$(IFS='|'; echo "${no_derive_copy[*]}")
 
+file_version=$(head -n1 "$output_path" | cut -d' ' -f6)
+tool_version=$(bindgen --version | cut -d' ' -f2)
+higher_version=$(echo -e "${file_version}\n${tool_version}" | sort -V | tail -n1)
+
+if [ "$higher_version" != "$tool_version" ]; then
+  echo "Latest used bindgen version was $file_version" >&2
+  echo "Currently installed bindgen CLI version is $tool_version" >&2
+  echo >&2
+  echo "It's needed to upgrade bindgen CLI first with \`cargo install bindgen-cli\`" >&2
+  exit 1
+fi
+
 bindgen                                        \
   --no-layout-tests                            \
   --allowlist-type '^TS.*'                     \
@@ -31,7 +43,7 @@ defines=(
   TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION
 )
 
-for define in ${defines[@]}; do
-  define_value=$(egrep "#define $define (.*)" $header_path | cut -d' ' -f3)
+for define in "${defines[@]}"; do
+  define_value=$(grep -E "#define $define (.*)" $header_path | cut -d' ' -f3)
   echo "pub const $define: usize = $define_value;" >> $output_path
 done


### PR DESCRIPTION
This PR:
* Removes `Copy, Clone` from raw binding structs that contains a `_unused: [u8; 0]` placeholder and don't expose their real layout. In the autogenerated bindings such structs are just _opaque_ handles that are used to differentiate C types accessible only by pointers.
* Removes `Copy, Clone` from other raw structs that don't require them for the current bindings implementation. It's better to have such derives thoughtful and not by default.
* Adds protection from using older bindgen versions in the `script/generate-bindings` script.