### PR TITLE
Add more architectures to ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
         runtime:
         - linux-arm64     #
         - linux-arm       #
+        - linux-armv7l    #
         - linux-x64       #
         - linux-x86       #
         - linux-i586      #
@@ -54,6 +55,7 @@ jobs:
         # 2. Add a new record to a matrix map in `cli/npm/install.js`
         - { runtime: linux-arm64     , target: aarch64-unknown-linux-gnu       , os: ubuntu-latest  , use-cross: true }
         - { runtime: linux-arm       , target: arm-unknown-linux-gnueabihf     , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-armv7l    , target: armv7-unknown-linux-gnueabihf   , os: ubuntu-latest  , use-cross: true }
         - { runtime: linux-x64       , target: x86_64-unknown-linux-gnu        , os: ubuntu-20.04                     } #2272
         - { runtime: linux-x86       , target: i686-unknown-linux-gnu          , os: ubuntu-latest  , use-cross: true }
         - { runtime: linux-i586      , target: i586-unknown-linux-gnu          , os: ubuntu-latest  , use-cross: true }
@@ -68,14 +70,15 @@ jobs:
         - { runtime: macos-x64       , target: x86_64-apple-darwin             , os: macos-latest                     }
 
         # Cross compilers for C library
-        - { runtime: linux-arm64     , cc: aarch64-linux-gnu-gcc           , ar: aarch64-linux-gnu-ar               }
-        - { runtime: linux-arm       , cc: arm-unknown-linux-gnueabihf-gcc , ar: arm-unknown-linux-gnueabihf-gcc-ar }
-        - { runtime: linux-x86       , cc: i686-linux-gnu-gcc              , ar: i686-linux-gnu-ar                  }
-        - { runtime: linux-i586      , cc: i686-linux-gnu-gcc              , ar: i686-linux-gnu-ar                  }
-        - { runtime: linux-mipsel    , cc: mipsel-linux-gnu-gcc            , ar: mipsel-linux-gnu-ar                }
-        - { runtime: linux-mips64el  , cc: mips64el-linux-gnuabi64-gcc     , ar: mips64el-linux-gnuabi64-ar         }
-        - { runtime: linux-ppc64el   , cc: powerpc64le-linux-gnu-gcc       , ar: powerpc64le-linux-gnu-ar           }
-        - { runtime: linux-riscv64gc , cc: riscv64-linux-gnu-gcc           , ar: riscv64-linux-gnu-ar               }
+        - { runtime: linux-arm64     , cc: aarch64-linux-gnu-gcc             , ar: aarch64-linux-gnu-ar           }
+        - { runtime: linux-arm       , cc: arm-unknown-linux-gnueabihf-gcc   , ar: arm-unknown-linux-gnueabihf-ar }
+        - { runtime: linux-armv7l    , cc: arm-linux-gnueabihf-gcc           , ar: arm-linux-gnueabihf-ar         }
+        - { runtime: linux-x86       , cc: i686-linux-gnu-gcc                , ar: i686-linux-gnu-ar              }
+        - { runtime: linux-i586      , cc: i686-linux-gnu-gcc                , ar: i686-linux-gnu-ar              }
+        - { runtime: linux-mipsel    , cc: mipsel-linux-gnu-gcc              , ar: mipsel-linux-gnu-ar            }
+        - { runtime: linux-mips64el  , cc: mips64el-linux-gnuabi64-gcc       , ar: mips64el-linux-gnuabi64-ar     }
+        - { runtime: linux-ppc64el   , cc: powerpc64le-linux-gnu-gcc         , ar: powerpc64le-linux-gnu-ar       }
+        - { runtime: linux-riscv64gc , cc: riscv64-linux-gnu-gcc             , ar: riscv64-linux-gnu-ar           }
 
 
         # See #2041 tree-sitter issue

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,7 @@ jobs:
         echo "EMSCRIPTEN_VERSION=$(cat cli/emscripten-version)" >> $GITHUB_ENV
 
     - name: Install Emscripten
+      if: ${{ !matrix.cli-only && !matrix.use-cross }}
       uses: mymindstorm/setup-emsdk@v12
       with:
         version: ${{ env.EMSCRIPTEN_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,34 +33,50 @@ jobs:
       fail-fast: false
       matrix:
         runtime:
-        - linux-arm64   #
-        - linux-arm     #
-        - linux-x64     #
-        - linux-x86     #
-        - windows-arm64 #
-        - windows-x64   # <-- No C library build - requires an additional adapted Makefile for `cl.exe` compiler
-        - windows-x86   #     -- // --
-        - macos-arm64   # <-- MacOS M1/M2 - no tests, only CLI build to be published on release artifacts
-        - macos-x64     #
+        - linux-arm64     #
+        - linux-arm       #
+        - linux-x64       #
+        - linux-x86       #
+        - linux-i586      #
+        - linux-mipsel    #
+        - linux-mips64el  #
+        - linux-ppc64el   #
+        - linux-riscv64gc #
+        - windows-arm64   #
+        - windows-x64     # <-- No C library build - requires an additional adapted Makefile for `cl.exe` compiler
+        - windows-x86     #     -- // --
+        - macos-arm64     # <-- MacOS M1/M2 - no tests, only CLI build to be published on release artifacts
+        - macos-x64       #
 
         include:
         # When adding a new `target`:
         # 1. Define a new runtime alias above
         # 2. Add a new record to a matrix map in `cli/npm/install.js`
-        - { runtime: linux-arm64   , target: aarch64-unknown-linux-gnu   , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-arm     , target: arm-unknown-linux-gnueabihf , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-x64     , target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04                     } #2272
-        - { runtime: linux-x86     , target: i686-unknown-linux-gnu      , os: ubuntu-latest  , use-cross: true }
-        - { runtime: windows-arm64 , target: aarch64-pc-windows-msvc     , os: windows-latest                   }
-        - { runtime: windows-x64   , target: x86_64-pc-windows-msvc      , os: windows-latest                   }
-        - { runtime: windows-x86   , target: i686-pc-windows-msvc        , os: windows-latest                   }
-        - { runtime: macos-arm64   , target: aarch64-apple-darwin        , os: macos-latest                     }
-        - { runtime: macos-x64     , target: x86_64-apple-darwin         , os: macos-latest                     }
+        - { runtime: linux-arm64     , target: aarch64-unknown-linux-gnu       , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-arm       , target: arm-unknown-linux-gnueabihf     , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-x64       , target: x86_64-unknown-linux-gnu        , os: ubuntu-20.04                     } #2272
+        - { runtime: linux-x86       , target: i686-unknown-linux-gnu          , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-i586      , target: i586-unknown-linux-gnu          , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-mipsel    , target: mipsel-unknown-linux-gnu        , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-mips64el  , target: mips64el-unknown-linux-gnuabi64 , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-ppc64el   , target: powerpc64le-unknown-linux-gnu   , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-riscv64gc , target: riscv64gc-unknown-linux-gnu     , os: ubuntu-latest  , use-cross: true }
+        - { runtime: windows-arm64   , target: aarch64-pc-windows-msvc         , os: windows-latest                   }
+        - { runtime: windows-x64     , target: x86_64-pc-windows-msvc          , os: windows-latest                   }
+        - { runtime: windows-x86     , target: i686-pc-windows-msvc            , os: windows-latest                   }
+        - { runtime: macos-arm64     , target: aarch64-apple-darwin            , os: macos-latest                     }
+        - { runtime: macos-x64       , target: x86_64-apple-darwin             , os: macos-latest                     }
 
         # Cross compilers for C library
-        - { runtime: linux-arm64   , cc: aarch64-linux-gnu-gcc           , ar: aarch64-linux-gnu-ar               }
-        - { runtime: linux-arm     , cc: arm-unknown-linux-gnueabihf-gcc , ar: arm-unknown-linux-gnueabihf-gcc-ar }
-        - { runtime: linux-x86     , cc: i686-linux-gnu-gcc              , ar: i686-linux-gnu-ar                  }
+        - { runtime: linux-arm64     , cc: aarch64-linux-gnu-gcc           , ar: aarch64-linux-gnu-ar               }
+        - { runtime: linux-arm       , cc: arm-unknown-linux-gnueabihf-gcc , ar: arm-unknown-linux-gnueabihf-gcc-ar }
+        - { runtime: linux-x86       , cc: i686-linux-gnu-gcc              , ar: i686-linux-gnu-ar                  }
+        - { runtime: linux-i586      , cc: i686-linux-gnu-gcc              , ar: i686-linux-gnu-ar                  }
+        - { runtime: linux-mipsel    , cc: mipsel-linux-gnu-gcc            , ar: mipsel-linux-gnu-ar                }
+        - { runtime: linux-mips64el  , cc: mips64el-linux-gnuabi64-gcc     , ar: mips64el-linux-gnuabi64-ar         }
+        - { runtime: linux-ppc64el   , cc: powerpc64le-linux-gnu-gcc       , ar: powerpc64le-linux-gnu-ar           }
+        - { runtime: linux-riscv64gc , cc: riscv64-linux-gnu-gcc           , ar: riscv64-linux-gnu-ar               }
+
 
         # See #2041 tree-sitter issue
         - { runtime: windows-x64   , rust-test-threads: 1 }

--- a/cli/npm/install.js
+++ b/cli/npm/install.js
@@ -21,6 +21,7 @@ const matrix = {
       arch: {
         'arm64': { name: 'arm64' },
         'arm': { name: 'arm' },
+        'armv7l': { name: 'armv7l' },
         'x64': { name: 'x64' },
         'x86': { name: 'x86' },
         'i586': { name: 'i586' },

--- a/cli/npm/install.js
+++ b/cli/npm/install.js
@@ -23,11 +23,11 @@ const matrix = {
         'arm': { name: 'arm' },
         'x64': { name: 'x64' },
         'x86': { name: 'x86' },
-        'mipsel': { name: 'x64' },
-        'mips64el': { name: 'x64' },
-        'ppc64el': { name: 'x64' },
-        'i586': { name: 'x64' },
-        'riscv64gc': { name: 'x86_64' },
+        'i586': { name: 'i586' },
+        'mipsel': { name: 'mipsel' },
+        'mips64el': { name: 'mips64el' },
+        'ppc64el': { name: 'ppc64el' },
+        'riscv64gc': { name: 'riscv64gc' },
       }
     },
     'win32': {

--- a/cli/npm/install.js
+++ b/cli/npm/install.js
@@ -23,6 +23,11 @@ const matrix = {
         'arm': { name: 'arm' },
         'x64': { name: 'x64' },
         'x86': { name: 'x86' },
+        'mipsel': { name: 'x64' },
+        'mips64el': { name: 'x64' },
+        'ppc64el': { name: 'x64' },
+        'i586': { name: 'x64' },
+        'riscv64gc': { name: 'x86_64' },
       }
     },
     'win32': {

--- a/cli/src/tests/helpers/allocations.rs
+++ b/cli/src/tests/helpers/allocations.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     os::raw::c_void,
     sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering::SeqCst},
+        atomic::{AtomicBool, AtomicUsize, Ordering::SeqCst},
         Mutex,
     },
 };
@@ -25,8 +25,8 @@ unsafe impl Sync for Allocation {}
 #[derive(Default)]
 struct AllocationRecorder {
     enabled: AtomicBool,
-    allocation_count: AtomicU64,
-    outstanding_allocations: Mutex<HashMap<Allocation, u64>>,
+    allocation_count: AtomicUsize,
+    outstanding_allocations: Mutex<HashMap<Allocation, usize>>,
 }
 
 thread_local! {


### PR DESCRIPTION
This PR also fixes portability issue in tests for the `mipsel` target:
```
error[E0432]: unresolved import `std::sync::atomic::AtomicU64`
 --> cli/src/tests/helpers/allocations.rs:5:30
  |
5 |         atomic::{AtomicBool, AtomicU64, Ordering::SeqCst},
  |                              ^^^^^^^^^
  |                              |
  |                              no `AtomicU64` in `sync::atomic`
  |                              help: a similar name exists in the module: `AtomicU32`

For more information about this error, try `rustc --explain E0432`.
```

Closes: #1366 