### PR TITLE
fix: disallow inlining the first rule

### DIFF
--- a/cli/src/generate/prepare_grammar/process_inlines.rs
+++ b/cli/src/generate/prepare_grammar/process_inlines.rs
@@ -203,6 +203,12 @@ pub(super) fn process_inlines(
                     lexical_grammar.variables[symbol.index].name,
                 ))
             }
+            SymbolType::NonTerminal if symbol.index == 0 => {
+                return Err(anyhow!(
+                    "Rule `{}` cannot be inlined because it is the first rule",
+                    grammar.variables[symbol.index].name,
+                ))
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
This prevents a panic when indexing symbol_ids during the generation process


This solves one case in #768, namely
```js
module.exports = grammar({
  name: 'mylang',

  inline: $ => [
    $.block,
  ],

  rules: {
    block: $ => $.macr,
    macr: $ => choice("M", "m"),
    source_file: $ => "hello"
  }
});
```

The others are more difficult, and seem to have to do w/ the extractor replacing/modifying symbols