### PR TITLE
fix: pass a value_id the same size of predicate_capture_ids's elements to avoid big-endian integer narrowing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,52 +33,79 @@ jobs:
       fail-fast: false
       matrix:
         runtime:
-        - linux-arm64     #
-        - linux-arm       #
-        - linux-armv7l    #
-        - linux-x64       #
-        - linux-x86       #
-        - linux-i586      #
-        - linux-mipsel    #
-        - linux-mips64el  #
-        - linux-ppc64el   #
-        - linux-riscv64gc #
-        - windows-arm64   #
-        - windows-x64     # <-- No C library build - requires an additional adapted Makefile for `cl.exe` compiler
-        - windows-x86     #     -- // --
-        - macos-arm64     # <-- MacOS M1/M2 - no tests, only CLI build to be published on release artifacts
-        - macos-x64       #
+        - linux-arm64       #
+        - linux-arm         #
+        - linux-armhf       #
+        - linux-armv5te     #
+        - linux-armv7l      #
+        - linux-x64         #
+        - linux-x86         #
+        - linux-i586        #
+        - linux-mips        #
+        - linux-mips64      #
+        - linux-mipsel      #
+        - linux-mips64el    #
+        - linux-powerpc     #
+        - linux-powerpc64   #
+        - linux-powerpc64el #
+        - linux-riscv64gc   #
+        - linux-s390x       #
+        - linux-sparc64     #
+        - linux-thumbv7neon #
+        - windows-arm64     #
+        - windows-x64       # <-- No C library build - requires an additional adapted Makefile for `cl.exe` compiler
+        - windows-x86       #     -- // --
+        - macos-arm64       # <-- MacOS M1/M2 - no tests, only CLI build to be published on release artifacts
+        - macos-x64         #
 
         include:
         # When adding a new `target`:
         # 1. Define a new runtime alias above
         # 2. Add a new record to a matrix map in `cli/npm/install.js`
-        - { runtime: linux-arm64     , target: aarch64-unknown-linux-gnu       , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-arm       , target: arm-unknown-linux-gnueabihf     , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-armv7l    , target: armv7-unknown-linux-gnueabihf   , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-x64       , target: x86_64-unknown-linux-gnu        , os: ubuntu-20.04                     } #2272
-        - { runtime: linux-x86       , target: i686-unknown-linux-gnu          , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-i586      , target: i586-unknown-linux-gnu          , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-mipsel    , target: mipsel-unknown-linux-gnu        , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-mips64el  , target: mips64el-unknown-linux-gnuabi64 , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-ppc64el   , target: powerpc64le-unknown-linux-gnu   , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-riscv64gc , target: riscv64gc-unknown-linux-gnu     , os: ubuntu-latest  , use-cross: true }
-        - { runtime: windows-arm64   , target: aarch64-pc-windows-msvc         , os: windows-latest                   }
-        - { runtime: windows-x64     , target: x86_64-pc-windows-msvc          , os: windows-latest                   }
-        - { runtime: windows-x86     , target: i686-pc-windows-msvc            , os: windows-latest                   }
-        - { runtime: macos-arm64     , target: aarch64-apple-darwin            , os: macos-latest                     }
-        - { runtime: macos-x64       , target: x86_64-apple-darwin             , os: macos-latest                     }
+        - { runtime: linux-arm64       , target: aarch64-unknown-linux-gnu           , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-arm         , target: arm-unknown-linux-gnueabi           , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-armhf       , target: arm-unknown-linux-gnueabihf         , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-armv5te     , target: armv5te-unknown-linux-gnueabi       , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-armv7l      , target: armv7-unknown-linux-gnueabihf       , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-x64         , target: x86_64-unknown-linux-gnu            , os: ubuntu-20.04                     } #2272
+        - { runtime: linux-x86         , target: i686-unknown-linux-gnu              , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-i586        , target: i586-unknown-linux-gnu              , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-mips        , target: mips-unknown-linux-gnu              , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-mips64      , target: mips64-unknown-linux-gnuabi64       , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-mipsel      , target: mipsel-unknown-linux-gnu            , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-mips64el    , target: mips64el-unknown-linux-gnuabi64     , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-powerpc     , target: powerpc-unknown-linux-gnu           , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-powerpc64   , target: powerpc64-unknown-linux-gnu         , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-powerpc64el , target: powerpc64le-unknown-linux-gnu       , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-riscv64gc   , target: riscv64gc-unknown-linux-gnu         , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-s390x       , target: s390x-unknown-linux-gnu             , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-sparc64     , target: sparc64-unknown-linux-gnu           , os: ubuntu-latest  , use-cross: true }
+        - { runtime: linux-thumbv7neon , target: thumbv7neon-unknown-linux-gnueabihf , os: ubuntu-latest  , use-cross: true }
+        - { runtime: windows-arm64     , target: aarch64-pc-windows-msvc             , os: windows-latest                   }
+        - { runtime: windows-x64       , target: x86_64-pc-windows-msvc              , os: windows-latest                   }
+        - { runtime: windows-x86       , target: i686-pc-windows-msvc                , os: windows-latest                   }
+        - { runtime: macos-arm64       , target: aarch64-apple-darwin                , os: macos-latest                     }
+        - { runtime: macos-x64         , target: x86_64-apple-darwin                 , os: macos-latest                     }
 
         # Cross compilers for C library
-        - { runtime: linux-arm64     , cc: aarch64-linux-gnu-gcc             , ar: aarch64-linux-gnu-ar           }
-        - { runtime: linux-arm       , cc: arm-unknown-linux-gnueabihf-gcc   , ar: arm-unknown-linux-gnueabihf-ar }
-        - { runtime: linux-armv7l    , cc: arm-linux-gnueabihf-gcc           , ar: arm-linux-gnueabihf-ar         }
-        - { runtime: linux-x86       , cc: i686-linux-gnu-gcc                , ar: i686-linux-gnu-ar              }
-        - { runtime: linux-i586      , cc: i686-linux-gnu-gcc                , ar: i686-linux-gnu-ar              }
-        - { runtime: linux-mipsel    , cc: mipsel-linux-gnu-gcc              , ar: mipsel-linux-gnu-ar            }
-        - { runtime: linux-mips64el  , cc: mips64el-linux-gnuabi64-gcc       , ar: mips64el-linux-gnuabi64-ar     }
-        - { runtime: linux-ppc64el   , cc: powerpc64le-linux-gnu-gcc         , ar: powerpc64le-linux-gnu-ar       }
-        - { runtime: linux-riscv64gc , cc: riscv64-linux-gnu-gcc             , ar: riscv64-linux-gnu-ar           }
+        - { runtime: linux-arm64       , cc: aarch64-linux-gnu-gcc             , ar: aarch64-linux-gnu-ar           }
+        - { runtime: linux-arm         , cc: arm-linux-gnueabi-gcc             , ar: arm-linux-gnueabi-ar           }
+        - { runtime: linux-armhf       , cc: arm-unknown-linux-gnueabihf-gcc   , ar: arm-unknown-linux-gnueabihf-ar }
+        - { runtime: linux-armv5te     , cc: arm-linux-gnueabi-gcc             , ar: arm-linux-gnueabi-ar           }
+        - { runtime: linux-armv7l      , cc: arm-linux-gnueabihf-gcc           , ar: arm-linux-gnueabihf-ar         }
+        - { runtime: linux-x86         , cc: i686-linux-gnu-gcc                , ar: i686-linux-gnu-ar              }
+        - { runtime: linux-i586        , cc: i686-linux-gnu-gcc                , ar: i686-linux-gnu-ar              }
+        - { runtime: linux-mips        , cc: mips-linux-gnu-gcc                , ar: mips-linux-gnu-ar              }
+        - { runtime: linux-mips64      , cc: mips64-linux-gnuabi64-gcc         , ar: mips64-linux-gnuabi64-ar       }
+        - { runtime: linux-mipsel      , cc: mipsel-linux-gnu-gcc              , ar: mipsel-linux-gnu-ar            }
+        - { runtime: linux-mips64el    , cc: mips64el-linux-gnuabi64-gcc       , ar: mips64el-linux-gnuabi64-ar     }
+        - { runtime: linux-powerpc     , cc: powerpc-linux-gnu-gcc             , ar: powerpc-linux-gnu-ar           }
+        - { runtime: linux-powerpc64   , cc: powerpc64-linux-gnu-gcc           , ar: powerpc64-linux-gnu-ar         }
+        - { runtime: linux-powerpc64el , cc: powerpc64le-linux-gnu-gcc         , ar: powerpc64le-linux-gnu-ar       }
+        - { runtime: linux-riscv64gc   , cc: riscv64-linux-gnu-gcc             , ar: riscv64-linux-gnu-ar           }
+        - { runtime: linux-s390x       , cc: s390x-linux-gnu-gcc               , ar: s390x-linux-gnu-ar             }
+        - { runtime: linux-sparc64     , cc: sparc64-linux-gnu-gcc             , ar: sparc64-linux-gnu-ar           }
+        - { runtime: linux-thumbv7neon , cc: arm-linux-gnueabihf-gcc           , ar: arm-linux-gnueabihf-ar         }
 
 
         # See #2041 tree-sitter issue

--- a/cli/npm/install.js
+++ b/cli/npm/install.js
@@ -25,10 +25,16 @@ const matrix = {
         'x64': { name: 'x64' },
         'x86': { name: 'x86' },
         'i586': { name: 'i586' },
+        'mips': { name: 'mips' },
+        'mips64': { name: 'mips64' },
         'mipsel': { name: 'mipsel' },
         'mips64el': { name: 'mips64el' },
-        'ppc64el': { name: 'ppc64el' },
+        'ppc': { name: 'powerpc' },
+        'ppc64': { name: 'powerpc64' },
+        'ppc64el': { name: 'powerpc64el' },
         'riscv64gc': { name: 'riscv64gc' },
+        's390x': { name: 's390x' },
+        'sparc64': { name: 'sparc64' },
       }
     },
     'win32': {

--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -429,7 +429,12 @@ fn set_included_ranges(parser: &mut Parser, input: &[u8], delimiters: Option<(&s
         let mut ranges = Vec::new();
         let mut ix = 0;
         while ix < input.len() {
-            let Some(mut start_ix) = input[ix..].windows(2).position(|win| win == start.as_bytes()) else { break };
+            let Some(mut start_ix) = input[ix..]
+                .windows(2)
+                .position(|win| win == start.as_bytes())
+            else {
+                break;
+            };
             start_ix += ix + start.len();
             let end_ix = input[start_ix..]
                 .windows(2)

--- a/cli/src/tests/helpers/dirs.rs
+++ b/cli/src/tests/helpers/dirs.rs
@@ -4,7 +4,37 @@ lazy_static! {
     static ref HEADER_DIR: PathBuf = ROOT_DIR.join("lib").join("include");
     static ref GRAMMARS_DIR: PathBuf = ROOT_DIR.join("test").join("fixtures").join("grammars");
     static ref SCRATCH_DIR: PathBuf = {
-        let result = ROOT_DIR.join("target").join("scratch");
+        // https://doc.rust-lang.org/reference/conditional-compilation.html
+        let vendor = if cfg!(target_vendor = "apple") {
+            "apple"
+        } else if cfg!(target_vendor = "fortanix") {
+            "fortanix"
+        } else if cfg!(target_vendor = "pc") {
+            "pc"
+        } else {
+            "unknown"
+        };
+        let env = if cfg!(target_env = "gnu") {
+            "gnu"
+        } else if cfg!(target_env = "msvc") {
+            "msvc"
+        } else if cfg!(target_env = "musl") {
+            "musl"
+        } else if cfg!(target_env = "sgx") {
+            "sgx"
+        } else {
+            "unknown"
+        };
+        let endian = if cfg!(target_endian = "little") {
+            "little"
+        } else if cfg!(target_endian = "big") {
+            "big"
+        } else {
+            "unknown"
+        };
+
+        let machine = format!("{}-{}-{}-{}-{}", std::env::consts::ARCH, std::env::consts::OS, vendor, env, endian);
+        let result = ROOT_DIR.join("target").join("scratch").join(machine);
         fs::create_dir_all(&result).unwrap();
         result
     };

--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -252,9 +252,13 @@ fn test_node_parent_of_child_by_field_name() {
 fn test_node_field_name_for_child() {
     let mut parser = Parser::new();
     parser.set_language(get_language("c")).unwrap();
-    let tree = parser.parse("x + y;", None).unwrap();
+    let tree = parser.parse("void main() { x + y; }", None).unwrap();
     let translation_unit_node = tree.root_node();
     let binary_expression_node = translation_unit_node
+        .named_child(0)
+        .unwrap()
+        .named_child(2)
+        .unwrap()
         .named_child(0)
         .unwrap()
         .named_child(0)

--- a/cli/src/tests/parser_test.rs
+++ b/cli/src/tests/parser_test.rs
@@ -661,7 +661,11 @@ fn test_parsing_with_a_timeout() {
         None,
     );
     assert!(tree.is_none());
+    #[cfg(not(target_arch = "sparc64"))]
     assert!(start_time.elapsed().as_micros() < 2000);
+
+    #[cfg(target_arch = "sparc64")]
+    assert!(start_time.elapsed().as_micros() < 4000);
 
     // Continue parsing, but pause after 1 ms of processing.
     parser.set_timeout_micros(5000);

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -1788,7 +1788,8 @@ static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
     ) {
       TSQueryPredicateStep *step = &self->predicate_steps.contents[j];
       if (step->type == TSQueryPredicateStepTypeCapture) {
-        array_insert_sorted_by(&predicate_capture_ids, , step->value_id);
+        uint16_t value_id = step->value_id;
+        array_insert_sorted_by(&predicate_capture_ids, , value_id);
       }
     }
 


### PR DESCRIPTION
Closes #2395 

This solves a bug on big-endian architectures where the value would be later passed by reference as an elements "view" before being inserted. The bug is in `ts_query__analyze_patterns`, specifically when the macro `array_inserted_sorted_by` is called on line 1791. The issue is that the step's value_id is a uint32_t, and is casted as a void pointer eventually when the value (if it doesn't exist) is inserted in the array in `array__splice`. Then when writing elements that are the size of the input array's elements which is 2 for `predicate_capture_ids` (uint16_t), only two of the bytes of the original `uint32_t step->value_id` are written. This is okay for little-endian systems, which is largely why it was undetected for so long, but not big-endian. The reason this fails is because the number will be in one "data byte" - think of the data byte being 01 in 00 00 00 01. Since we're only writing two bytes, the `00 01` part isn't written and we lose out on data. I'm not sure of other spots that can contain this kind of bug - but I do think better care could be taken (maybe an assert for the elem size vs input size?)

For the scope of this PR, the change I made should be sufficient though.

TLDR; casting is messy, C is hard