### PR TITLE
feat(cli): add option to select JS runtime other than node

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -126,6 +126,14 @@ fn run() -> Result<()> {
                         .long("report-states-for-rule")
                         .value_name("rule-name")
                         .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("js-runtime")
+                        .long("js-runtime")
+                        .takes_value(true)
+                        .value_name("executable")
+                        .env("TREE_SITTER_JS_RUNTIME")
+                        .help("Use a JavaScript runtime other than node"),
                 ),
         )
         .subcommand(
@@ -307,6 +315,7 @@ fn run() -> Result<()> {
             let debug_build = matches.is_present("debug-build");
             let build = matches.is_present("build");
             let libdir = matches.value_of("libdir");
+            let js_runtime = matches.value_of("js-runtime");
             let report_symbol_name = matches.value_of("report-states-for-rule").or_else(|| {
                 if matches.is_present("report-states") {
                     Some("")
@@ -336,6 +345,7 @@ fn run() -> Result<()> {
                 abi_version,
                 generate_bindings,
                 report_symbol_name,
+                js_runtime,
             )?;
             if build {
                 if let Some(path) = libdir {

--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -260,7 +260,7 @@ fn test_feature_corpus_files() {
             grammar_path = test_path.join("grammar.json");
         }
         let error_message_path = test_path.join("expected_error.txt");
-        let grammar_json = generate::load_grammar_file(&grammar_path).unwrap();
+        let grammar_json = generate::load_grammar_file(&grammar_path, None).unwrap();
         let generate_result = generate::generate_parser_for_grammar(&grammar_json);
 
         if error_message_path.exists() {


### PR DESCRIPTION
This pull request add s the CLI option `--js-runtime <binary>`, which allows users of the CLI to optionally select a JavaScript runtime other than `node`.

**Use Cases:**
- **CI:** This PR allows specifying a custom runtime path in CI, resolving #1686
- **Lightweight Runtimes:** Some authors that develop tree-sitter grammars may not want their projects to depend on NodeJS. This allows using a lighter runtime such as [bun](https://bun.sh) or [quickjs](https://bellard.org/quickjs/)

---

In case this PR requires any further changes such as updating documentation and/or tests, I would be grateful for a response from a maintainer.

---

related #465
resolves #1686