### PR TITLE
Fix miscompilation of queries that start with repetitions followed by alternatives

### DIFF
--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -252,16 +252,14 @@ fn test_node_parent_of_child_by_field_name() {
 fn test_node_field_name_for_child() {
     let mut parser = Parser::new();
     parser.set_language(get_language("c")).unwrap();
-    let tree = parser.parse("void main() { x + y; }", None).unwrap();
+    let tree = parser.parse("int w = x + y;", None).unwrap();
     let translation_unit_node = tree.root_node();
-    let binary_expression_node = translation_unit_node
-        .named_child(0)
+    let declaration_node = translation_unit_node.named_child(0).unwrap();
+
+    let binary_expression_node = declaration_node
+        .child_by_field_name("declarator")
         .unwrap()
-        .named_child(2)
-        .unwrap()
-        .named_child(0)
-        .unwrap()
-        .named_child(0)
+        .child_by_field_name("value")
         .unwrap();
 
     assert_eq!(binary_expression_node.field_name_for_child(0), Some("left"));

--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -1827,6 +1827,53 @@ fn test_query_matches_with_alternatives_and_too_many_permutations_to_track() {
 }
 
 #[test]
+fn test_repetitions_before_with_alternatives() {
+    allocations::record(|| {
+        let language = get_language("rust");
+        let query = Query::new(
+            language,
+            r#"
+            (
+                (line_comment)* @comment
+                .
+                [
+                    (struct_item name: (_) @name)
+                    (function_item name: (_) @name)
+                    (enum_item name: (_) @name)
+                    (impl_item type: (_) @name)
+                ]
+            )
+            "#,
+        )
+        .unwrap();
+
+        assert_query_matches(
+            language,
+            &query,
+            r#"
+            // a
+            // b
+            fn c() {}
+
+            // d
+            // e
+            impl F {}
+            "#,
+            &[
+                (
+                    0,
+                    vec![("comment", "// a"), ("comment", "// b"), ("name", "c")],
+                ),
+                (
+                    0,
+                    vec![("comment", "// d"), ("comment", "// e"), ("name", "F")],
+                ),
+            ],
+        );
+    });
+}
+
+#[test]
 fn test_query_matches_with_anonymous_tokens() {
     allocations::record(|| {
         let language = get_language("javascript");


### PR DESCRIPTION
This fixes a bug in the compilation of queries like the following:

```clj
(
  (line_comment)* @comment
  .
  [
    (function_item) @func
    (struct_item) @struct
  ]
)
```

Previously, the query would fail to match the repeated nodes preceding any of the alternatives except for the first alternative.

The fix was a one line deletion, but it took me a while to find. Along the way, I improved the query debugging code.