### PR TITLE
feat: Use lookup tables in ts_lex

### DIFF
--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -595,6 +595,7 @@ impl Generator {
             self,
             "#pragma GCC diagnostic ignored \"-Wmissing-field-initializers\""
         );
+        add_line!(self, "#pragma GCC diagnostic ignored \"-Wunused-function\"");
         add_line!(self, "#endif");
         add_line!(self, "");
 

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -1051,8 +1051,8 @@ impl Generator {
             add_line!(self, "}}");
 
             dedent!(self);
-            add_line!(self, "}}");
-
+            add_line!(self, "}} else {{ ");
+            indent!(self);
             for (chars, action, is_negated) in optimized_table.states_outside_of_lut {
                 add_whitespace!(self);
                 add!(self, "if (");
@@ -1061,6 +1061,8 @@ impl Generator {
                 self.add_advance_action(&action);
                 add!(self, "\n");
             }
+            add_line!(self, "}}");
+            dedent!(self);
             for (i, action) in optimized_table.helper_function_calls {
                 let transition = &transition_info[i];
                 add_whitespace!(self);

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -265,6 +265,7 @@ fn optimize_lex_state(
                 // Mark all unmarked states within these ranges.
                 for range in &large_set.ranges {
                     let range = range.start..=range.end;
+                    total_comparisons += if range.start() == range.end() { 1 } else { 2 };
                     for character in range {
                         if character as usize >= 128 {
                             break;
@@ -287,6 +288,11 @@ fn optimize_lex_state(
                         allowed_entries[character as usize] = false;
                     }
                 }
+                total_comparisons += transition
+                    .ranges
+                    .iter()
+                    .map(|r| if r.start == r.end { 1 } else { 2 })
+                    .sum::<usize>();
                 for (i, should_skip) in allowed_entries.into_iter().enumerate() {
                     if !should_skip {
                         continue;

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -1,7 +1,6 @@
 use super::{
     char_tree::{CharacterTree, Comparator},
     grammars::{ExternalToken, LexicalGrammar, SyntaxGrammar, VariableType},
-    nfa::CharacterSet,
     rules::{Alias, AliasMap, Symbol, SymbolType},
     tables::{
         AdvanceAction, FieldLocation, GotoAction, LexState, LexTable, ParseAction, ParseTable,
@@ -177,7 +176,6 @@ fn optimize_lex_state(
             helper_function_calls.push((i, action.clone()));
             continue;
         }
-
         // Otherwise, generate code to compare the lookahead character
         // with all of the character ranges.
         if transition.ranges.len() > 0 {
@@ -196,7 +194,6 @@ fn optimize_lex_state(
                     }
                 }
             } else {
-                //assert!(transition.ranges.len() < 2, "{:?}", transition.ranges);
                 for c in (0..TABLE_ENTRY_UPPER_BOUND).into_iter().filter(|f| {
                     !transition
                         .ranges

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -190,7 +190,7 @@ fn optimize_lex_state(
         // Otherwise, generate code to compare the lookahead character
         // with all of the character ranges.
         if transition.ranges.len() > 0 {
-            const TABLE_ENTRY_UPPER_BOUND: u8 = u8::MAX / 2;
+            const TABLE_ENTRY_UPPER_BOUND: u8 = ((u8::MAX as usize + 1) / 2) as u8;
             let res = flatten_character_ranges(&transition.ranges);
             if transition.is_included {
                 let mut non_ascii_items = vec![];

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -923,8 +923,15 @@ impl Generator {
                 add_line!(self, "SKIP((current_state - {}));", sentinel_value);
                 dedent!(self);
             }
-            add_line!(self, "}} else {{ goto label_{}; }}", id);
-            //add_line!(self, "}}");
+            if helpers
+                .iter()
+                .any(|(i, _)| transition_info[*i].call_id.is_some())
+            {
+                add_line!(self, "}} else {{ goto label_{}; }}", id);
+            } else {
+                add_line!(self, "}}");
+            }
+
             dedent!(self);
             add_line!(self, "}}");
         } else {
@@ -970,6 +977,12 @@ impl Generator {
                 break;
             }
         }
+        if helpers
+            .iter()
+            .any(|(i, _)| transition_info[*i].call_id.is_some())
+        {
+            add_line!(self, "label_{}: ", id);
+        }
         for (i, action) in helpers {
             let transition = &transition_info[i];
             add_whitespace!(self);
@@ -994,7 +1007,7 @@ impl Generator {
             }
         }
 
-        add_line!(self, "label_{}: END_STATE();", id);
+        add_line!(self, "END_STATE();");
     }
 
     fn add_character_range_conditions(&mut self, ranges: &[Range<char>]) -> Vec<char> {

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -1075,17 +1075,27 @@ impl Generator {
             }
             add_line!(self, "}}");
 
-            dedent!(self);
-            add_line!(self, "}} else {{ ");
-            indent!(self);
-            for (chars, action, is_negated) in optimized_table.states_outside_of_lut {
-                add_whitespace!(self);
-                add!(self, "if (");
-                self.add_character_range_conditions(&chars, !is_negated, 2);
-                add!(self, ") ");
-                self.add_advance_action(&action);
-                add!(self, "\n");
+            if !optimized_table.states_outside_of_lut.is_empty() {
+                dedent!(self);
+                add_line!(self, "}} else {{ ");
+                indent!(self);
+                for (chars, action, is_negated) in optimized_table.states_outside_of_lut {
+                    add_whitespace!(self);
+                    if !is_negated
+                        || chars
+                            .iter()
+                            .any(|r| r.end as usize >= optimized_table.states.len())
+                    {
+                        add!(self, "if (");
+                        self.add_character_range_conditions(&chars, !is_negated, 2);
+                        add!(self, ") ");
+                    }
+
+                    self.add_advance_action(&action);
+                    add!(self, "\n");
+                }
             }
+
             add_line!(self, "}}");
             dedent!(self);
             for (i, action) in optimized_table.helper_function_calls {

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -1247,9 +1247,9 @@ impl Generator {
                 add!(self, "\n");
             }
         }
-
-        add_line!(self, "}}");
         dedent!(self);
+        add_line!(self, "}}");
+
         for (i, action) in state.helper_function_calls {
             let transition = &transition_info[i];
             add_whitespace!(self);

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -877,8 +877,8 @@ impl Generator {
             }
         }
         if map.len() > 2 {
-            let top = *map.iter().rfind(|p| p.1 != &0).unwrap().0;
-            for i in 0..top {
+            let top = *map.iter().rfind(|p| p.1 != &0).unwrap().0 as usize;
+            for i in 0..(top as u8) {
                 // Fill in the gaps.
                 map.entry(i).or_insert(65535);
             }
@@ -888,7 +888,7 @@ impl Generator {
                 self,
                 "static const uint16_t states_{}[{}] = {{",
                 id,
-                top as usize + 1
+                top + 1
             );
             indent!(self);
             let chunks = map.values();
@@ -911,7 +911,7 @@ impl Generator {
             indent!(self);
             add_line!(self, "ADVANCE(current_state);");
             dedent!(self);
-            if map.values().max().copied().unwrap_or_default() > (top as usize + 1) {
+            if map.values().max().copied().unwrap_or_default() > (top + 1) {
                 add_line!(self, "}} else if (current_state != 65535) {{",);
                 indent!(self);
                 add_line!(self, "SKIP((current_state - 32768));");

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -882,7 +882,7 @@ impl Generator {
                 // Fill in the gaps.
                 map.entry(i).or_insert(65535);
             }
-            add_line!(self, "if (lookahead < {}) {{", top + 1);
+            add_line!(self, "if ((uint32_t)lookahead < {}) {{", top + 1);
             indent!(self);
             add_line!(
                 self,


### PR DESCRIPTION
Summary: This pull request augments `tree-sitter-cli` with ability to generate lookup tables instead of if-else chains. This should reduce compile times of `tree-sitter-rust` and improve binary sizes all around. 

Detailed summary [is available here](https://github.com/osiewicz/ramblings/blob/tree-sitter-lut/posts/tree-sitter/001-lookup-tables/0001-lookup-tables.md) - it's also WIP. 