### PR TITLE
fix: take the last range element by default if the query error isn't found

### DIFF
--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -782,7 +782,7 @@ impl<'a> LanguageConfiguration<'a> {
         let (path, range) = ranges
             .iter()
             .find(|(_, range)| range.contains(&offset_within_section))
-            .unwrap();
+            .unwrap_or(ranges.last().unwrap());
         error.offset = offset_within_section - range.start;
         error.row = source[range.start..offset_within_section]
             .chars()


### PR DESCRIPTION
Closes #1753 

In the screenshot we can see the new range end is 1901 (from the example in the linked issue), `contains` will not include the last index, so an error at 1900 previously where the range was from `0..1900` would panic

![image](https://github.com/tree-sitter/tree-sitter/assets/29718261/e69ed142-a940-4566-92cb-4587c76623e2)

Typical off-by-one bug