### PR TITLE
fix!: use `abort` instead of `exit(1)` when allocations fail

### DIFF
--- a/lib/src/alloc.c
+++ b/lib/src/alloc.c
@@ -5,7 +5,7 @@ static void *ts_malloc_default(size_t size) {
   void *result = malloc(size);
   if (size > 0 && !result) {
     fprintf(stderr, "tree-sitter failed to allocate %zu bytes", size);
-    exit(1);
+    abort();
   }
   return result;
 }
@@ -14,7 +14,7 @@ static void *ts_calloc_default(size_t count, size_t size) {
   void *result = calloc(count, size);
   if (count > 0 && !result) {
     fprintf(stderr, "tree-sitter failed to allocate %zu bytes", count * size);
-    exit(1);
+    abort();
   }
   return result;
 }
@@ -23,7 +23,7 @@ static void *ts_realloc_default(void *buffer, size_t size) {
   void *result = realloc(buffer, size);
   if (size > 0 && !result) {
     fprintf(stderr, "tree-sitter failed to reallocate %zu bytes", size);
-    exit(1);
+    abort();
   }
   return result;
 }


### PR DESCRIPTION
Closes #805 