### PR TITLE
fix(tests): sort categories alphabetically

### DIFF
--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -353,9 +353,18 @@ pub fn parse_tests(path: &Path) -> io::Result<TestEntry> {
             let entry = entry?;
             let hidden = entry.file_name().to_str().unwrap_or("").starts_with(".");
             if !hidden {
-                children.push(parse_tests(&entry.path())?);
+                children.push(entry.path());
             }
         }
+        children.sort_by(|a, b| {
+            a.file_name()
+                .unwrap_or_default()
+                .cmp(&b.file_name().unwrap_or_default())
+        });
+        let children = children
+            .iter()
+            .map(|path| parse_tests(path))
+            .collect::<io::Result<Vec<TestEntry>>>()?;
         Ok(TestEntry::Group {
             name,
             children,


### PR DESCRIPTION
Closes #373

@razzeee I know this is old but can you try this out? Seems to work on my Linux machine for Elm's tests

![image](https://github.com/tree-sitter/tree-sitter/assets/29718261/4a27e3ab-f599-47de-9e8b-d9f2e0919641)
