### PR TITLE
fix(generate): add Vertical Tab and Form Feed to the whitespace class

### DIFF
--- a/cli/src/generate/prepare_grammar/expand_tokens.rs
+++ b/cli/src/generate/prepare_grammar/expand_tokens.rs
@@ -475,7 +475,9 @@ impl NfaBuilder {
                 .add_char(' ')
                 .add_char('\t')
                 .add_char('\r')
-                .add_char('\n'),
+                .add_char('\n')
+                .add_char('\x0B')
+                .add_char('\x0C'),
             ClassPerlKind::Word => CharacterSet::empty()
                 .add_char('_')
                 .add_range('A', 'Z')


### PR DESCRIPTION
Motivation: https://github.com/tree-sitter/tree-sitter-c/issues/117