### PR TITLE
ts_node__prev_child: Reset earlier node when backtracking

### DIFF
--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -237,6 +237,8 @@ static inline TSNode ts_node__prev_sibling(TSNode self, bool include_anonymous) 
       return earlier_node;
     } else {
       node = earlier_node;
+      earlier_node = ts_node__null();
+      earlier_node_is_relevant = false;
     }
   }
 


### PR DESCRIPTION
`earlier_node` must be reset when backtracking up the tree or else `ts_node__prev_child` may loop infinitely on a subtree which contains zero-width tokens.

Fixes #2421