### PR TITLE
Negative assertions

### DIFF
--- a/cli/src/test_highlight.rs
+++ b/cli/src/test_highlight.rs
@@ -94,6 +94,7 @@ pub fn iterate_assertions(
     let mut actual_highlights = Vec::<&String>::new();
     for Assertion {
         position,
+        negative,
         expected_capture_name: expected_highlight,
     } in assertions
     {
@@ -117,12 +118,13 @@ pub fn iterate_assertions(
                         break 'highlight_loop;
                     }
 
-                    // If the highlight matches the assertion, this test passes. Otherwise,
+                    // If the highlight matches the assertion, or if the highlight doesn't
+                    // match the assertion but it's negative, this test passes. Otherwise,
                     // add this highlight to the list of actual highlights that span the
                     // assertion's position, in order to generate an error message in the event
                     // of a failure.
                     let highlight_name = &highlight_names[(highlight.2).0];
-                    if *highlight_name == *expected_highlight {
+                    if (*highlight_name == *expected_highlight) == !negative {
                         passed = true;
                         break 'highlight_loop;
                     } else {
@@ -162,68 +164,7 @@ pub fn test_highlight(
     let assertions =
         parse_position_comments(highlighter.parser(), highlight_config.language, source)?;
 
-    iterate_assertions(&assertions, &highlights, &highlight_names)?;
-
-    // Iterate through all of the highlighting assertions, checking each one against the
-    // actual highlights.
-    let mut i = 0;
-    let mut actual_highlights = Vec::<&String>::new();
-    for Assertion {
-        position,
-        expected_capture_name: expected_highlight,
-    } in &assertions
-    {
-        let mut passed = false;
-        actual_highlights.clear();
-
-        'highlight_loop: loop {
-            // The assertions are ordered by position, so skip past all of the highlights that
-            // end at or before this assertion's position.
-            if let Some(highlight) = highlights.get(i) {
-                if highlight.1 <= *position {
-                    i += 1;
-                    continue;
-                }
-
-                // Iterate through all of the highlights that start at or before this assertion's,
-                // position, looking for one that matches the assertion.
-                let mut j = i;
-                while let (false, Some(highlight)) = (passed, highlights.get(j)) {
-                    if highlight.0 > *position {
-                        break 'highlight_loop;
-                    }
-
-                    // If the highlight matches the assertion, this test passes. Otherwise,
-                    // add this highlight to the list of actual highlights that span the
-                    // assertion's position, in order to generate an error message in the event
-                    // of a failure.
-                    let highlight_name = &highlight_names[(highlight.2).0];
-                    if *highlight_name == *expected_highlight {
-                        passed = true;
-                        break 'highlight_loop;
-                    } else {
-                        actual_highlights.push(highlight_name);
-                    }
-
-                    j += 1;
-                }
-            } else {
-                break;
-            }
-        }
-
-        if !passed {
-            return Err(Failure {
-                row: position.row,
-                column: position.column,
-                expected_highlight: expected_highlight.clone(),
-                actual_highlights: actual_highlights.into_iter().cloned().collect(),
-            }
-            .into());
-        }
-    }
-
-    Ok(assertions.len())
+    iterate_assertions(&assertions, &highlights, &highlight_names)
 }
 
 pub fn get_highlight_positions(

--- a/cli/src/test_tags.rs
+++ b/cli/src/test_tags.rs
@@ -125,6 +125,9 @@ pub fn test_tag(
                     }
 
                     j += 1;
+                    if tag == tags.last().unwrap() {
+                        break 'tag_loop;
+                    }
                 }
             } else {
                 break;

--- a/cli/src/test_tags.rs
+++ b/cli/src/test_tags.rs
@@ -96,6 +96,7 @@ pub fn test_tag(
     let mut actual_tags = Vec::<&String>::new();
     for Assertion {
         position,
+        negative,
         expected_capture_name: expected_tag,
     } in &assertions
     {
@@ -117,7 +118,7 @@ pub fn test_tag(
                     }
 
                     let tag_name = &tag.2;
-                    if *tag_name == *expected_tag {
+                    if (*tag_name == *expected_tag) == !negative {
                         passed = true;
                         break 'tag_loop;
                     } else {

--- a/cli/src/tests/test_highlight_test.rs
+++ b/cli/src/tests/test_highlight_test.rs
@@ -23,6 +23,7 @@ fn test_highlight_test_with_basic_test() {
         "  //       ^ keyword",
         "  return d + e;",
         "  //     ^ variable.parameter",
+        "  //       ^ !variable",
         "};",
     ]
     .join("\n");
@@ -32,18 +33,10 @@ fn test_highlight_test_with_basic_test() {
     assert_eq!(
         assertions,
         &[
-            Assertion {
-                position: Point::new(1, 5),
-                expected_capture_name: "function".to_string()
-            },
-            Assertion {
-                position: Point::new(1, 11),
-                expected_capture_name: "keyword".to_string()
-            },
-            Assertion {
-                position: Point::new(4, 9),
-                expected_capture_name: "variable.parameter".to_string()
-            },
+            Assertion::new(1, 5, false, String::from("function")),
+            Assertion::new(1, 11, false, String::from("keyword")),
+            Assertion::new(4, 9, false, String::from("variable.parameter")),
+            Assertion::new(4, 11, true, String::from("variable")),
         ]
     );
 

--- a/cli/src/tests/test_tags_test.rs
+++ b/cli/src/tests/test_tags_test.rs
@@ -16,6 +16,7 @@ fn test_tags_test_with_basic_test() {
         "    #    ^ reference.call",
         "    return d(e)",
         "    #      ^ reference.call",
+        "    #        ^ !variable.parameter",
         "",
     ]
     .join("\n");
@@ -26,18 +27,10 @@ fn test_tags_test_with_basic_test() {
     assert_eq!(
         assertions,
         &[
-            Assertion {
-                position: Point::new(1, 4),
-                expected_capture_name: "definition.function".to_string(),
-            },
-            Assertion {
-                position: Point::new(3, 9),
-                expected_capture_name: "reference.call".to_string(),
-            },
-            Assertion {
-                position: Point::new(5, 11),
-                expected_capture_name: "reference.call".to_string(),
-            },
+            Assertion::new(1, 4, false, String::from("definition.function")),
+            Assertion::new(3, 9, false, String::from("reference.call")),
+            Assertion::new(5, 11, false, String::from("reference.call")),
+            Assertion::new(5, 13, true, String::from("variable.parameter")),
         ]
     );
 

--- a/docs/section-4-syntax-highlighting.md
+++ b/docs/section-4-syntax-highlighting.md
@@ -428,6 +428,9 @@ var abc = function(d) {
     //    ^ string
     //          ^ variable
   }
+
+  baz();
+  ^ !variable
 };
 ```
 
@@ -438,3 +441,5 @@ From the Sublime text docs:
 > **Caret**: ^ this will test the following selector against the scope on the most recent non-test line. It will test it at the same column the ^ is in. Consecutive ^s will test each column against the selector.
 >
 > **Arrow**: <- this will test the following selector against the scope on the most recent non-test line. It will test it at the same column as the comment character is in.
+
+Note that an exclamation mark (`!`) can be used to negate a selector. For example, `!keyword` will match any scope that is not the `keyword` class.


### PR DESCRIPTION
This PR adds the ability to negate an assertion with `!` before a capture name. I think this could be useful to have in certain cases where tag logic can get messy or specific to some predicate matches, with a minimal cost to runtime added. Closes #2304