### PR TITLE
Separate text-provider lifetime

### DIFF
--- a/highlight/src/lib.rs
+++ b/highlight/src/lib.rs
@@ -165,7 +165,7 @@ where
 struct HighlightIterLayer<'a> {
     _tree: Tree,
     cursor: QueryCursor,
-    captures: iter::Peekable<QueryCaptures<'a, 'a, &'a [u8]>>,
+    captures: iter::Peekable<QueryCaptures<'a, 'a, 'a, &'a [u8]>>,
     config: &'a HighlightConfiguration,
     highlight_end_stack: Vec<usize>,
     scope_stack: Vec<LocalScope<'a>>,


### PR DESCRIPTION
Hi, I ran into a lifetime issue with the signatures for `QueryCursor::matches()`/`QueryCursor::captures()`

Specifically the current signature is equating the lifetime of the text provider parameter with the lifetime of other parameters eg the query

But that caused a problem for me, I can try and make a small repro case if you want but basically I was doing something like:
```
fn outer<'a>(text_provider: impl TextProvider<'a>) {
    let mut query_cursor = QueryCursor::new();
    let query = &something;
    ...
    query_cursor.captures(query, ..., text_provider)....
}
```
and the compiler expected eg the `query` reference to live as long as `'a` which it doesn't

But so the changes in this PR did get rid of the lifetime issue for me