### PR TITLE
fix: retain header and divider delimiter lengths when updating tests

### DIFF
--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -95,7 +95,7 @@ pub fn parse_file_at_path(opts: ParseFileOptions) -> Result<bool> {
                 .collect::<Vec<_>>();
             parser.parse_utf16(&source_code_utf16, None)
         }
-        None if is_utf16_bom(&source_code[0..2]) => {
+        None if source_code.len() >= 2 && is_utf16_bom(&source_code[0..2]) => {
             let source_code_utf16 = source_code
                 .chunks_exact(2)
                 .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))

--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -502,6 +502,7 @@ fn flatten_tests(test: TestEntry) -> Vec<FlattenedTest> {
                 input,
                 output,
                 has_fields,
+                ..
             } => {
                 if !prefix.is_empty() {
                     name.insert_str(0, " - ");


### PR DESCRIPTION
This helps to prevent visual bloat in diffs when updating tests where the delimiter is not 80 chars long (with `ts t -u`)

Also throwing in a small bug fix when parsing empty files (or those with 1 byte)