### PR TITLE
feat: add option to display context around parse errors

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -140,6 +140,7 @@ fn run() -> Result<()> {
                 .arg(&debug_graph_arg)
                 .arg(Arg::with_name("output-dot").long("dot"))
                 .arg(Arg::with_name("output-xml").long("xml").short("x"))
+                .arg(Arg::with_name("output-context").long("context"))
                 .arg(
                     Arg::with_name("stat")
                         .help("Show parsing statistic")
@@ -406,6 +407,8 @@ fn run() -> Result<()> {
                 ParseOutput::Xml
             } else if matches.is_present("quiet") {
                 ParseOutput::Quiet
+            } else if matches.is_present("output-context") {
+                ParseOutput::Context
             } else {
                 ParseOutput::Normal
             };


### PR DESCRIPTION
Strawperson proposal for an option to `tree-sitter parse` that displays some context around errors. Example output:

```
==========
Parsing error:

   !> Possible characters encountered in a lexeme
   type :: enum_char
      character(1, tfc) :: space = tfc_" "
                                   ^~~~
                                   ERROR
      character(1, tfc) :: hash = tfc_"#"
      character(1, tfc) :: squote = tfc_"'"
```

Obviously there's a few things that could be done to polish this, for example including line numbers, optional size of the context, and so on.