### PR TITLE
Restore `children_by_field_id` API to receive non option field id

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -334,11 +334,7 @@ impl Language {
                 field_name.len() as u32,
             )
         };
-        if id == 0 {
-            None
-        } else {
-            Some(FieldId::new(id).unwrap())
-        }
+        FieldId::new(id)
     }
 }
 
@@ -1249,14 +1245,8 @@ impl<'a> TreeCursor<'a> {
     /// See also [field_name](TreeCursor::field_name).
     #[doc(alias = "ts_tree_cursor_current_field_id")]
     pub fn field_id(&self) -> Option<FieldId> {
-        unsafe {
-            let id = ffi::ts_tree_cursor_current_field_id(&self.0);
-            if id == 0 {
-                None
-            } else {
-                Some(FieldId::new(id).unwrap())
-            }
-        }
+        let id = unsafe { ffi::ts_tree_cursor_current_field_id(&self.0) };
+        FieldId::new(id)
     }
 
     /// Get the field name of this tree cursor's current node.


### PR DESCRIPTION
* Fixes #2423 a change for `children_by_field_id` API

The `field_id: Option<FieldId>` parameter for `children_by_field_id` method looks weird and it's obvious that if someone going to call the `children_by_field_id` method then it has a correct field id and it's nonsense to call  `children_by_field_id()` with `field_id: None` to get nothing in response.