### PR TITLE
CLI: Re-use highlight cancellation flag for HTML highlights

### DIFF
--- a/cli/src/highlight.rs
+++ b/cli/src/highlight.rs
@@ -1,4 +1,3 @@
-use super::util;
 use ansi_term::Color;
 use anyhow::Result;
 use lazy_static::lazy_static;
@@ -385,16 +384,16 @@ pub fn html(
     config: &HighlightConfiguration,
     quiet: bool,
     print_time: bool,
+    cancellation_flag: Option<&AtomicUsize>,
 ) -> Result<()> {
     use std::io::Write;
 
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
     let time = Instant::now();
-    let cancellation_flag = util::cancel_on_signal();
     let mut highlighter = Highlighter::new();
 
-    let events = highlighter.highlight(config, source, Some(&cancellation_flag), |string| {
+    let events = highlighter.highlight(config, source, cancellation_flag, |string| {
         loader.highlight_config_for_injection_string(string)
     })?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -609,6 +609,7 @@ fn run() -> Result<()> {
                             highlight_config,
                             quiet,
                             time,
+                            Some(&cancellation_flag),
                         )?;
                     } else {
                         highlight::ansi(


### PR DESCRIPTION
The `html` highlight function created its own cancellation flag which conflicts with the Ctrl-c handler set up in the CLI's `main` block for `tree-sitter highlight`. We can re-use the cancellation flag from that block to avoid a panic that happens when using `tree-sitter highlight -H <file>`

    thread 'main' panicked at 'Error setting Ctrl-C handler: MultipleHandlers', cli/src/util.rs:31:6

This change also aligns the parameters that `highlight::ansi` and `highlight::html` take.