### PR TITLE
Add Noir tree-sitter-grammar to Docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,7 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 * [Meson](https://github.com/staysail/tree-sitter-meson)
 * [Motorola 68000 Assembly](https://github.com/grahambates/tree-sitter-m68k)
 * [Nix](https://github.com/cstrahan/tree-sitter-nix)
+* [Noir](https://github.com/hhamud/tree-sitter-noir)
 * [Objective-C](https://github.com/jiyee/tree-sitter-objc)
 * [OCaml](https://github.com/tree-sitter/tree-sitter-ocaml)
 * [Org](https://github.com/milisims/tree-sitter-org)


### PR DESCRIPTION
* Added a link to the newly created [grammar](https://github.com/hhamud/tree-sitter-noir) of the [noir language](https://noir-lang.org/) to the doc site