### PR TITLE
feat: rework lifetimes, relax dependencies and tie only on implementations

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -81,7 +81,7 @@ pub struct InputEdit {
 #[doc(alias = "TSNode")]
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-pub struct Node<'a>(ffi::TSNode, PhantomData<&'a ()>);
+pub struct Node<'tree>(ffi::TSNode, PhantomData<&'tree ()>);
 
 /// A stateful object that this is used to produce a `Tree` based on some source code.
 #[doc(alias = "TSParser")]
@@ -106,7 +106,7 @@ type Logger<'a> = Box<dyn FnMut(LogType, &str) + 'a>;
 
 /// A stateful object for walking a syntax `Tree` efficiently.
 #[doc(alias = "TSTreeCursor")]
-pub struct TreeCursor<'a>(ffi::TSTreeCursor, PhantomData<&'a ()>);
+pub struct TreeCursor<'cursor>(ffi::TSTreeCursor, PhantomData<&'cursor ()>);
 
 /// A set of patterns that match nodes in a syntax tree.
 #[doc(alias = "TSQuery")]
@@ -180,23 +180,23 @@ pub struct QueryMatch<'cursor, 'tree> {
 }
 
 /// A sequence of `QueryMatch`es associated with a given `QueryCursor`.
-pub struct QueryMatches<'a, 'tree: 'a, T: TextProvider<I>, I: AsRef<[u8]>> {
+pub struct QueryMatches<'query, 'cursor, T: TextProvider<I>, I: AsRef<[u8]>> {
     ptr: *mut ffi::TSQueryCursor,
-    query: &'a Query,
+    query: &'query Query,
     text_provider: T,
     buffer1: Vec<u8>,
     buffer2: Vec<u8>,
-    _phantom: PhantomData<(&'tree (), I)>,
+    _phantom: PhantomData<(&'cursor (), I)>,
 }
 
 /// A sequence of `QueryCapture`s associated with a given `QueryCursor`.
-pub struct QueryCaptures<'a, 'tree: 'a, T: TextProvider<I>, I: AsRef<[u8]>> {
+pub struct QueryCaptures<'query, 'cursor, T: TextProvider<I>, I: AsRef<[u8]>> {
     ptr: *mut ffi::TSQueryCursor,
-    query: &'a Query,
+    query: &'query Query,
     text_provider: T,
     buffer1: Vec<u8>,
     buffer2: Vec<u8>,
-    _phantom: PhantomData<(&'tree (), I)>,
+    _phantom: PhantomData<(&'cursor (), I)>,
 }
 
 pub trait TextProvider<I>
@@ -210,8 +210,8 @@ where
 /// A particular `Node` that has been captured with a particular name within a `Query`.
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
-pub struct QueryCapture<'a> {
-    pub node: Node<'a>,
+pub struct QueryCapture<'tree> {
+    pub node: Node<'tree>,
     pub index: u32,
 }
 
@@ -548,7 +548,7 @@ impl Parser {
     ///   If the text of the document has changed since `old_tree` was
     ///   created, then you must edit `old_tree` to match the new text using
     ///   [Tree::edit].
-    pub fn parse_with<'a, T: AsRef<[u8]>, F: FnMut(usize, Point) -> T>(
+    pub fn parse_with<T: AsRef<[u8]>, F: FnMut(usize, Point) -> T>(
         &mut self,
         callback: &mut F,
         old_tree: Option<&Tree>,
@@ -561,7 +561,7 @@ impl Parser {
         let mut payload: (&mut F, Option<T>) = (callback, None);
 
         // This C function is passed to Tree-sitter as the input callback.
-        unsafe extern "C" fn read<'a, T: AsRef<[u8]>, F: FnMut(usize, Point) -> T>(
+        unsafe extern "C" fn read<T: AsRef<[u8]>, F: FnMut(usize, Point) -> T>(
             payload: *mut c_void,
             byte_offset: u32,
             position: ffi::TSPoint,
@@ -598,7 +598,7 @@ impl Parser {
     ///   If the text of the document has changed since `old_tree` was
     ///   created, then you must edit `old_tree` to match the new text using
     ///   [Tree::edit].
-    pub fn parse_utf16_with<'a, T: AsRef<[u16]>, F: FnMut(usize, Point) -> T>(
+    pub fn parse_utf16_with<T: AsRef<[u16]>, F: FnMut(usize, Point) -> T>(
         &mut self,
         callback: &mut F,
         old_tree: Option<&Tree>,
@@ -611,7 +611,7 @@ impl Parser {
         let mut payload: (&mut F, Option<T>) = (callback, None);
 
         // This C function is passed to Tree-sitter as the input callback.
-        unsafe extern "C" fn read<'a, T: AsRef<[u16]>, F: FnMut(usize, Point) -> T>(
+        unsafe extern "C" fn read<T: AsRef<[u16]>, F: FnMut(usize, Point) -> T>(
             payload: *mut c_void,
             byte_offset: u32,
             position: ffi::TSPoint,
@@ -689,10 +689,7 @@ impl Parser {
     /// If this requirement is not satisfied, method will return IncludedRangesError
     /// error with an offset in the passed ranges slice pointing to a first incorrect range.
     #[doc(alias = "ts_parser_set_included_ranges")]
-    pub fn set_included_ranges<'a>(
-        &mut self,
-        ranges: &'a [Range],
-    ) -> Result<(), IncludedRangesError> {
+    pub fn set_included_ranges(&mut self, ranges: &[Range]) -> Result<(), IncludedRangesError> {
         let ts_ranges: Vec<ffi::TSRange> =
             ranges.iter().cloned().map(|range| range.into()).collect();
         let result = unsafe {
@@ -1035,7 +1032,7 @@ impl<'tree> Node<'tree> {
     /// if you might be iterating over a long list of children, you should use
     /// [Node::named_children] instead.
     #[doc(alias = "ts_node_named_child")]
-    pub fn named_child<'a>(&'a self, i: usize) -> Option<Self> {
+    pub fn named_child(&self, i: usize) -> Option<Self> {
         Self::new(unsafe { ffi::ts_node_named_child(self.0, i as u32) })
     }
 
@@ -1094,10 +1091,10 @@ impl<'tree> Node<'tree> {
     ///
     /// If you're walking the tree recursively, you may want to use the `TreeCursor`
     /// APIs directly instead.
-    pub fn children<'a>(
+    pub fn children<'cursor>(
         &self,
-        cursor: &'a mut TreeCursor<'tree>,
-    ) -> impl ExactSizeIterator<Item = Node<'tree>> + 'a {
+        cursor: &'cursor mut TreeCursor<'tree>,
+    ) -> impl ExactSizeIterator<Item = Node<'tree>> + 'cursor {
         cursor.reset(*self);
         cursor.goto_first_child();
         (0..self.child_count()).into_iter().map(move |_| {
@@ -1110,10 +1107,10 @@ impl<'tree> Node<'tree> {
     /// Iterate over this node's named children.
     ///
     /// See also [Node::children].
-    pub fn named_children<'a>(
+    pub fn named_children<'cursor>(
         &self,
-        cursor: &'a mut TreeCursor<'tree>,
-    ) -> impl ExactSizeIterator<Item = Node<'tree>> + 'a {
+        cursor: &'cursor mut TreeCursor<'tree>,
+    ) -> impl ExactSizeIterator<Item = Node<'tree>> + 'cursor {
         cursor.reset(*self);
         cursor.goto_first_child();
         (0..self.named_child_count()).into_iter().map(move |_| {
@@ -1131,11 +1128,11 @@ impl<'tree> Node<'tree> {
     /// Iterate over this node's children with a given field name.
     ///
     /// See also [Node::children].
-    pub fn children_by_field_name<'a>(
+    pub fn children_by_field_name<'cursor>(
         &self,
         field_name: &str,
-        cursor: &'a mut TreeCursor<'tree>,
-    ) -> impl Iterator<Item = Node<'tree>> + 'a {
+        cursor: &'cursor mut TreeCursor<'tree>,
+    ) -> impl Iterator<Item = Node<'tree>> + 'cursor {
         let field_id = self.language().field_id_for_name(field_name);
         let mut done = field_id.is_none();
         if !done {
@@ -1162,11 +1159,11 @@ impl<'tree> Node<'tree> {
     /// Iterate over this node's children with a given field id.
     ///
     /// See also [Node::children_by_field_name].
-    pub fn children_by_field_id<'a>(
+    pub fn children_by_field_id<'cursor>(
         &self,
         field_id: FieldId,
-        cursor: &'a mut TreeCursor<'tree>,
-    ) -> impl Iterator<Item = Node<'tree>> + 'a {
+        cursor: &'cursor mut TreeCursor<'tree>,
+    ) -> impl Iterator<Item = Node<'tree>> + 'cursor {
         cursor.reset(*self);
         cursor.goto_first_child();
         let mut done = false;
@@ -1294,15 +1291,15 @@ impl<'tree> Node<'tree> {
     }
 }
 
-impl<'a> PartialEq for Node<'a> {
+impl PartialEq for Node<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.0.id == other.0.id
     }
 }
 
-impl<'a> Eq for Node<'a> {}
+impl Eq for Node<'_> {}
 
-impl<'a> hash::Hash for Node<'a> {
+impl hash::Hash for Node<'_> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.0.id.hash(state);
         self.0.context[0].hash(state);
@@ -1312,7 +1309,7 @@ impl<'a> hash::Hash for Node<'a> {
     }
 }
 
-impl<'a> fmt::Debug for Node<'a> {
+impl fmt::Debug for Node<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(
             f,
@@ -1324,10 +1321,10 @@ impl<'a> fmt::Debug for Node<'a> {
     }
 }
 
-impl<'a> TreeCursor<'a> {
+impl<'cursor> TreeCursor<'cursor> {
     /// Get the tree cursor's current [Node].
     #[doc(alias = "ts_tree_cursor_current_node")]
-    pub fn node(&self) -> Node<'a> {
+    pub fn node(&self) -> Node<'cursor> {
         Node(
             unsafe { ffi::ts_tree_cursor_current_node(&self.0) },
             PhantomData,
@@ -1470,7 +1467,7 @@ impl<'a> TreeCursor<'a> {
 
     /// Re-initialize this tree cursor to start at a different node.
     #[doc(alias = "ts_tree_cursor_reset")]
-    pub fn reset(&mut self, node: Node<'a>) {
+    pub fn reset(&mut self, node: Node<'cursor>) {
         unsafe { ffi::ts_tree_cursor_reset(&mut self.0, node.0) };
     }
 
@@ -1479,18 +1476,18 @@ impl<'a> TreeCursor<'a> {
     /// Unlike `reset`, this will not lose parent information and
     /// allows reusing already created cursors.
     #[doc(alias = "ts_tree_cursor_reset_to")]
-    pub fn reset_to(&mut self, cursor: TreeCursor<'a>) {
+    pub fn reset_to(&mut self, cursor: TreeCursor<'cursor>) {
         unsafe { ffi::ts_tree_cursor_reset_to(&mut self.0, &cursor.0) };
     }
 }
 
-impl<'a> Clone for TreeCursor<'a> {
+impl Clone for TreeCursor<'_> {
     fn clone(&self) -> Self {
         TreeCursor(unsafe { ffi::ts_tree_cursor_copy(&self.0) }, PhantomData)
     }
 }
 
-impl<'a> Drop for TreeCursor<'a> {
+impl Drop for TreeCursor<'_> {
     fn drop(&mut self) {
         unsafe { ffi::ts_tree_cursor_delete(&mut self.0) }
     }
@@ -2107,12 +2104,12 @@ impl QueryCursor {
     /// Because multiple patterns can match the same set of nodes, one match may contain
     /// captures that appear *before* some of the captures from a previous match.
     #[doc(alias = "ts_query_cursor_exec")]
-    pub fn matches<'a, 'tree: 'a, T: TextProvider<I>, I: AsRef<[u8]>>(
-        &'a mut self,
-        query: &'a Query,
+    pub fn matches<'query, 'tree, T: TextProvider<I>, I: AsRef<[u8]>>(
+        &mut self,
+        query: &'query Query,
         node: Node<'tree>,
         text_provider: T,
-    ) -> QueryMatches<'a, 'tree, T, I> {
+    ) -> QueryMatches<'query, 'tree, T, I> {
         let ptr = self.ptr.as_ptr();
         unsafe { ffi::ts_query_cursor_exec(ptr, query.ptr.as_ptr(), node.0) };
         QueryMatches {
@@ -2130,12 +2127,12 @@ impl QueryCursor {
     /// This is useful if you don't care about which pattern matched, and just want a single,
     /// ordered sequence of captures.
     #[doc(alias = "ts_query_cursor_exec")]
-    pub fn captures<'a, 'tree: 'a, T: TextProvider<I>, I: AsRef<[u8]>>(
-        &'a mut self,
-        query: &'a Query,
+    pub fn captures<'query, 'tree, T: TextProvider<I>, I: AsRef<[u8]>>(
+        &mut self,
+        query: &'query Query,
         node: Node<'tree>,
         text_provider: T,
-    ) -> QueryCaptures<'a, 'tree, T, I> {
+    ) -> QueryCaptures<'query, 'tree, T, I> {
         let ptr = self.ptr.as_ptr();
         unsafe { ffi::ts_query_cursor_exec(self.ptr.as_ptr(), query.ptr.as_ptr(), node.0) };
         QueryCaptures {
@@ -2183,7 +2180,7 @@ impl QueryCursor {
     }
 }
 
-impl<'a, 'tree> QueryMatch<'a, 'tree> {
+impl<'tree> QueryMatch<'_, 'tree> {
     pub fn id(&self) -> u32 {
         self.id
     }
@@ -2227,8 +2224,8 @@ impl<'a, 'tree> QueryMatch<'a, 'tree> {
     fn satisfies_text_predicates<I: AsRef<[u8]>>(
         &self,
         query: &Query,
-        buffer1: &'a mut Vec<u8>,
-        buffer2: &'a mut Vec<u8>,
+        buffer1: &mut Vec<u8>,
+        buffer2: &mut Vec<u8>,
         text_provider: &mut impl TextProvider<I>,
     ) -> bool {
         struct NodeText<'a, T> {
@@ -2318,8 +2315,10 @@ impl QueryProperty {
     }
 }
 
-impl<'a, 'tree, T: TextProvider<I>, I: AsRef<[u8]>> Iterator for QueryMatches<'a, 'tree, T, I> {
-    type Item = QueryMatch<'a, 'tree>;
+impl<'query, 'tree: 'query, T: TextProvider<I>, I: AsRef<[u8]>> Iterator
+    for QueryMatches<'query, 'tree, T, I>
+{
+    type Item = QueryMatch<'query, 'tree>;
 
     fn next(&mut self) -> Option<Self::Item> {
         unsafe {
@@ -2343,8 +2342,10 @@ impl<'a, 'tree, T: TextProvider<I>, I: AsRef<[u8]>> Iterator for QueryMatches<'a
     }
 }
 
-impl<'a, 'tree, T: TextProvider<I>, I: AsRef<[u8]>> Iterator for QueryCaptures<'a, 'tree, T, I> {
-    type Item = (QueryMatch<'a, 'tree>, usize);
+impl<'query, 'tree: 'query, T: TextProvider<I>, I: AsRef<[u8]>> Iterator
+    for QueryCaptures<'query, 'tree, T, I>
+{
+    type Item = (QueryMatch<'query, 'tree>, usize);
 
     fn next(&mut self) -> Option<Self::Item> {
         unsafe {
@@ -2375,7 +2376,7 @@ impl<'a, 'tree, T: TextProvider<I>, I: AsRef<[u8]>> Iterator for QueryCaptures<'
     }
 }
 
-impl<'a, 'tree, T: TextProvider<I>, I: AsRef<[u8]>> QueryMatches<'a, 'tree, T, I> {
+impl<T: TextProvider<I>, I: AsRef<[u8]>> QueryMatches<'_, '_, T, I> {
     #[doc(alias = "ts_query_cursor_set_byte_range")]
     pub fn set_byte_range(&mut self, range: ops::Range<usize>) {
         unsafe {
@@ -2391,7 +2392,7 @@ impl<'a, 'tree, T: TextProvider<I>, I: AsRef<[u8]>> QueryMatches<'a, 'tree, T, I
     }
 }
 
-impl<'a, 'tree, T: TextProvider<I>, I: AsRef<[u8]>> QueryCaptures<'a, 'tree, T, I> {
+impl<T: TextProvider<I>, I: AsRef<[u8]>> QueryCaptures<'_, '_, T, I> {
     #[doc(alias = "ts_query_cursor_set_byte_range")]
     pub fn set_byte_range(&mut self, range: ops::Range<usize>) {
         unsafe {
@@ -2407,7 +2408,7 @@ impl<'a, 'tree, T: TextProvider<I>, I: AsRef<[u8]>> QueryCaptures<'a, 'tree, T, 
     }
 }
 
-impl<'cursor, 'tree> fmt::Debug for QueryMatch<'cursor, 'tree> {
+impl fmt::Debug for QueryMatch<'_, '_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -2508,7 +2509,7 @@ impl From<ffi::TSRange> for Range {
     }
 }
 
-impl<'a> Into<ffi::TSInputEdit> for &'a InputEdit {
+impl Into<ffi::TSInputEdit> for &'_ InputEdit {
     fn into(self) -> ffi::TSInputEdit {
         ffi::TSInputEdit {
             start_byte: self.start_byte as u32,


### PR DESCRIPTION
This PR:
* Adds meaningful names for lifetimes where it makes sense.
* Removes lifetime dependencies on structs and moves all dependencies on `impl`s.
* Removes redundant lifetime specifications and replaces with `'_` lifetime placeholder to let compiler deduce correct lifetime by itself in obvious situations.