### PR TITLE
Web Bindings: Expose fieldNameForChild C function

### DIFF
--- a/lib/binding_web/binding.c
+++ b/lib/binding_web/binding.c
@@ -361,6 +361,11 @@ uint16_t ts_node_symbol_wasm(const TSTree *tree) {
   return ts_node_symbol(node);
 }
 
+const char *ts_node_field_name_for_child_wasm(const TSTree *tree, uint32_t index) {
+  TSNode node = unmarshal_node(tree);
+  return ts_node_field_name_for_child(node, index);
+}
+
 uint16_t ts_node_grammar_symbol_wasm(const TSTree *tree) {
   TSNode node = unmarshal_node(tree);
   return ts_node_grammar_symbol(node);

--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -282,6 +282,17 @@ class Node {
     return unmarshalNode(this.tree);
   }
 
+  fieldNameForChild(index) {
+    marshalNode(this);
+    const address = C._ts_node_field_name_for_child_wasm(this.tree[0], index);
+    if (!address) {
+      return null;
+    }
+    const result = AsciiToString(address);
+    // must not free, the string memory is owned by the language
+    return result;
+  }
+
   namedChild(index) {
     marshalNode(this);
     C._ts_node_named_child_wasm(this.tree[0], index);

--- a/lib/binding_web/exports.json
+++ b/lib/binding_web/exports.json
@@ -44,6 +44,7 @@
   "_ts_language_symbol_type",
   "_ts_language_version",
   "_ts_language_next_state",
+  "_ts_node_field_name_for_child_wasm",
   "_ts_node_child_by_field_id_wasm",
   "_ts_node_child_count_wasm",
   "_ts_node_child_wasm",

--- a/lib/binding_web/test/node-test.js
+++ b/lib/binding_web/test/node-test.js
@@ -454,4 +454,20 @@ describe("Node", () => {
       assert(!node1.equals(node2));
     });
   });
+
+  describe('.fieldNameForChild(index)', () => {
+    it('returns the field of a child or null', () => {
+      tree = parser.parse('let a = 5');
+
+      const noField = tree.rootNode.fieldNameForChild(0);
+      const name = tree.rootNode.firstChild.children[1].fieldNameForChild(0);
+      const value = tree.rootNode.firstChild.children[1].fieldNameForChild(2);
+      const overflow = tree.rootNode.firstChild.children[1].fieldNameForChild(3);
+
+      assert.equal(noField, null);
+      assert.equal(name, 'name');
+      assert.equal(value, 'value');
+      assert.equal(overflow, null);
+    });
+  });
 });


### PR DESCRIPTION
The function is currently not exposed. I believe the only way to get fields via the web bindings right now is to use the TreeCursor API instead.