### PR TITLE
Fix HTML hex values with leading zeros

### DIFF
--- a/cli/src/highlight.rs
+++ b/cli/src/highlight.rs
@@ -280,7 +280,7 @@ fn style_to_css(style: ansi_term::Style) -> String {
 
 fn write_color(buffer: &mut String, color: Color) {
     if let Color::RGB(r, g, b) = &color {
-        write!(buffer, "color: #{:x?}{:x?}{:x?}", r, g, b).unwrap()
+        write!(buffer, "color: #{r:02x}{g:02x}{b:02x}").unwrap()
     } else {
         write!(
             buffer,
@@ -447,7 +447,7 @@ mod tests {
         env::set_var("COLORTERM", "");
         parse_style(&mut style, Value::String(DARK_CYAN.to_string()));
         assert_eq!(style.ansi.foreground, Some(Color::Fixed(36)));
-        assert_eq!(style.css, Some("style=\'color: #0af87\'".to_string()));
+        assert_eq!(style.css, Some("style=\'color: #00af87\'".to_string()));
 
         // junglegreen is not an ANSI color and is preserved when the terminal supports it
         env::set_var("COLORTERM", "truecolor");


### PR DESCRIPTION
Closes #2472

Hex values with leading zeros in any of the r/g/b components were not being rendered properly in HTML mode. Enforce that each component has length 2, and pad with leading 0s. "?" for debug mode is superfluous since `r` `g` and `b` have type `u8`.