### PR TITLE
feat: implement first-line-regex 

### DIFF
--- a/cli/src/tests/detect_language.rs
+++ b/cli/src/tests/detect_language.rs
@@ -1,0 +1,122 @@
+use crate::tests::helpers::fixtures::scratch_dir;
+
+use std::path::Path;
+use tree_sitter_loader::Loader;
+
+#[test]
+fn detect_language_by_first_line_regex() {
+    let strace_dir = tree_sitter_dir(
+        r#"{
+  "name": "tree-sitter-strace",
+  "version": "0.0.1",
+  "tree-sitter": [
+    {
+      "scope": "source.strace",
+      "file-types": [
+        "strace"
+      ],
+      "first-line-regex":  "[0-9:.]* *execve"
+    }
+  ]
+}
+"#,
+        "strace",
+    );
+
+    let mut loader = Loader::with_parser_lib_path(scratch_dir().to_path_buf());
+    let config = loader
+        .find_language_configurations_at_path(strace_dir.path(), false)
+        .unwrap();
+
+    // this is just to validate that we can read the package.json correctly
+    assert_eq!(config[0].scope.as_ref().unwrap(), "source.strace");
+
+    let file_name = strace_dir.path().join("strace.log");
+    std::fs::write(&file_name, "execve\nworld").unwrap();
+    assert_eq!(
+        get_lang_scope(&mut loader, &file_name),
+        Some("source.strace".into())
+    );
+
+    let file_name = strace_dir.path().join("strace.log");
+    std::fs::write(&file_name, "447845 execve\nworld").unwrap();
+    assert_eq!(
+        get_lang_scope(&mut loader, &file_name),
+        Some("source.strace".into())
+    );
+
+    let file_name = strace_dir.path().join("strace.log");
+    std::fs::write(&file_name, "hello\nexecve").unwrap();
+    assert!(get_lang_scope(&mut loader, &file_name).is_none());
+
+    let file_name = strace_dir.path().join("strace.log");
+    std::fs::write(&file_name, "").unwrap();
+    assert!(get_lang_scope(&mut loader, &file_name).is_none());
+
+    let dummy_dir = tree_sitter_dir(
+        r#"{
+  "name": "tree-sitter-dummy",
+  "version": "0.0.1",
+  "tree-sitter": [
+    {
+      "scope": "source.dummy",
+      "file-types": [
+        "dummy"
+      ]
+    }
+  ]
+}
+"#,
+        "dummy",
+    );
+
+    // file-type takes precedence over first-line-regex
+    loader
+        .find_language_configurations_at_path(dummy_dir.path(), false)
+        .unwrap();
+    let file_name = dummy_dir.path().join("strace.dummy");
+    std::fs::write(&file_name, "execve").unwrap();
+    assert_eq!(
+        get_lang_scope(&mut loader, &file_name),
+        Some("source.dummy".into())
+    );
+}
+
+fn tree_sitter_dir(package_json: &str, name: &str) -> tempfile::TempDir {
+    let temp_dir = tempfile::tempdir().unwrap();
+    std::fs::write(temp_dir.path().join("package.json"), package_json).unwrap();
+    std::fs::create_dir(temp_dir.path().join("src")).unwrap();
+    std::fs::create_dir(temp_dir.path().join("src/tree_sitter")).unwrap();
+    std::fs::write(
+        temp_dir.path().join("src/grammar.json"),
+        format!(r#"{{"name":"{name}"}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        temp_dir.path().join("src/parser.c"),
+        format!(
+            r##"
+                #include "tree_sitter/parser.h"
+                #ifdef _WIN32
+                #define extern __declspec(dllexport)
+                #endif
+                extern const TSLanguage *tree_sitter_{name}(void) {{}}
+            "##
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        temp_dir.path().join("src/tree_sitter/parser.h"),
+        include_str!("../../../lib/src/parser.h"),
+    )
+    .unwrap();
+    temp_dir
+}
+
+// if we manage to get the language scope, it means we correctly detected the file-type
+fn get_lang_scope(loader: &mut Loader, file_name: &Path) -> Option<String> {
+    loader
+        .language_configuration_for_file_name(file_name)
+        .unwrap()
+        .and_then(|r| r.1.scope.clone())
+}

--- a/cli/src/tests/helpers/fixtures.rs
+++ b/cli/src/tests/helpers/fixtures.rs
@@ -27,6 +27,10 @@ pub fn fixtures_dir() -> &'static Path {
     &FIXTURES_DIR
 }
 
+pub fn scratch_dir() -> &'static Path {
+    &SCRATCH_DIR
+}
+
 pub fn get_language(name: &str) -> Language {
     TEST_LOADER
         .load_language_at_path(

--- a/cli/src/tests/mod.rs
+++ b/cli/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod async_context_test;
 mod corpus_test;
+mod detect_language;
 mod github_issue_test;
 mod helpers;
 mod highlight_test;


### PR DESCRIPTION
fix https://github.com/tree-sitter/tree-sitter/issues/2478

I added a PR for helix for the same thing https://github.com/helix-editor/helix/pull/7853

But there I went with a Vec<String> instead of a String, the example is strace output it can start with `["execve", ,"^[0-9:.]* *execve", "^__libc_start_main"]`

Obviously this is not a structured language by any mean (though I wrote a wip grammar for it) so it might be an invalid argument