### PR TITLE
Rename: `ts_lookahead_iterator_advance` -> `ts_lookahead_iterator_next`

### DIFF
--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -722,7 +722,7 @@ extern "C" {
     ) -> TSStateId;
 }
 extern "C" {
-    #[doc = " Create a new lookahead iterator for the given language and parse state.\n\n This returns `NULL` if state is invalid for the language.\n\n Repeatedly using `ts_lookahead_iterator_advance` and\n `ts_lookahead_iterator_current_symbol` will generate valid symbols in the\n given parse state. Newly created lookahead iterators will contain the `ERROR`\n symbol.\n\n Lookahead iterators can be useful to generate suggestions and improve syntax\n error diagnostics. To get symbols valid in an ERROR node, use the lookahead\n iterator on its first leaf node state. For `MISSING` nodes, a lookahead\n iterator created on the previous non-extra leaf node may be appropriate."]
+    #[doc = " Create a new lookahead iterator for the given language and parse state.\n\n This returns `NULL` if state is invalid for the language.\n\n Repeatedly using `ts_lookahead_iterator_next` and\n `ts_lookahead_iterator_current_symbol` will generate valid symbols in the\n given parse state. Newly created lookahead iterators will contain the `ERROR`\n symbol.\n\n Lookahead iterators can be useful to generate suggestions and improve syntax\n error diagnostics. To get symbols valid in an ERROR node, use the lookahead\n iterator on its first leaf node state. For `MISSING` nodes, a lookahead\n iterator created on the previous non-extra leaf node may be appropriate."]
     pub fn ts_lookahead_iterator_new(
         self_: *const TSLanguage,
         state: TSStateId,
@@ -753,7 +753,7 @@ extern "C" {
 }
 extern "C" {
     #[doc = " Advance the lookahead iterator to the next symbol.\n\n This returns `true` if there is a new symbol and `false` otherwise."]
-    pub fn ts_lookahead_iterator_advance(self_: *mut TSLookaheadIterator) -> bool;
+    pub fn ts_lookahead_iterator_next(self_: *mut TSLookaheadIterator) -> bool;
 }
 extern "C" {
     #[doc = " Get the current symbol of the lookahead iterator;"]

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1509,9 +1509,9 @@ impl LookaheadIterator {
 impl Iterator for LookaheadNamesIterator<'_> {
     type Item = &'static str;
 
-    #[doc(alias = "ts_lookahead_iterator_advance")]
+    #[doc(alias = "ts_lookahead_iterator_next")]
     fn next(&mut self) -> Option<Self::Item> {
-        unsafe { ffi::ts_lookahead_iterator_advance(self.0 .0.as_ptr()) }
+        unsafe { ffi::ts_lookahead_iterator_next(self.0 .0.as_ptr()) }
             .then(|| self.0.current_symbol_name())
     }
 }
@@ -1519,11 +1519,10 @@ impl Iterator for LookaheadNamesIterator<'_> {
 impl Iterator for LookaheadIterator {
     type Item = u16;
 
-    #[doc(alias = "ts_lookahead_iterator_advance")]
+    #[doc(alias = "ts_lookahead_iterator_next")]
     fn next(&mut self) -> Option<Self::Item> {
         // the first symbol is always `0` so we can safely skip it
-        unsafe { ffi::ts_lookahead_iterator_advance(self.0.as_ptr()) }
-            .then(|| self.current_symbol())
+        unsafe { ffi::ts_lookahead_iterator_next(self.0.as_ptr()) }.then(|| self.current_symbol())
     }
 }
 

--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -1025,7 +1025,7 @@ class LookaheadIterable {
     const self = this;
     return {
       next() {
-        if (C._ts_lookahead_iterator_advance(self[0])) {
+        if (C._ts_lookahead_iterator_next(self[0])) {
           return { done: false, value: self.currentType };
         }
 

--- a/lib/binding_web/exports.json
+++ b/lib/binding_web/exports.json
@@ -122,6 +122,6 @@
   "_ts_lookahead_iterator_delete",
   "_ts_lookahead_iterator_reset_state",
   "_ts_lookahead_iterator_reset",
-  "_ts_lookahead_iterator_advance",
+  "_ts_lookahead_iterator_next",
   "_ts_lookahead_iterator_current_symbol"
 ]

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -1076,7 +1076,7 @@ TSStateId ts_language_next_state(const TSLanguage *self, TSStateId state, TSSymb
  *
  * This returns `NULL` if state is invalid for the language.
  *
- * Repeatedly using `ts_lookahead_iterator_advance` and
+ * Repeatedly using `ts_lookahead_iterator_next` and
  * `ts_lookahead_iterator_current_symbol` will generate valid symbols in the
  * given parse state. Newly created lookahead iterators will contain the `ERROR`
  * symbol.
@@ -1119,7 +1119,7 @@ const TSLanguage *ts_lookahead_iterator_language(const TSLookaheadIterator *self
  *
  * This returns `true` if there is a new symbol and `false` otherwise.
 */
-bool ts_lookahead_iterator_advance(TSLookaheadIterator *self);
+bool ts_lookahead_iterator_next(TSLookaheadIterator *self);
 
 /**
  * Get the current symbol of the lookahead iterator;

--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -192,9 +192,9 @@ bool ts_lookahead_iterator_reset(TSLookaheadIterator *self, const TSLanguage *la
   return true;
 }
 
-bool ts_lookahead_iterator_advance(TSLookaheadIterator *self) {
+bool ts_lookahead_iterator_next(TSLookaheadIterator *self) {
   LookaheadIterator *iterator = (LookaheadIterator *)self;
-  return ts_lookahead_iterator_next(iterator);
+  return ts_lookahead_iterator__next(iterator);
 }
 
 TSSymbol ts_lookahead_iterator_current_symbol(const TSLookaheadIterator *self) {

--- a/lib/src/language.h
+++ b/lib/src/language.h
@@ -136,7 +136,7 @@ static inline LookaheadIterator ts_language_lookaheads(
   };
 }
 
-static inline bool ts_lookahead_iterator_next(LookaheadIterator *self) {
+static inline bool ts_lookahead_iterator__next(LookaheadIterator *self) {
   // For small parse states, valid symbols are listed explicitly,
   // grouped by their value. There's no need to look up the actions
   // again until moving to the next group.

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -1265,7 +1265,7 @@ static void ts_query__perform_analysis(
       // Follow every possible path in the parse table, but only visit states that
       // are part of the subgraph for the current symbol.
       LookaheadIterator lookahead_iterator = ts_language_lookaheads(self->language, parse_state);
-      while (ts_lookahead_iterator_next(&lookahead_iterator)) {
+      while (ts_lookahead_iterator__next(&lookahead_iterator)) {
         TSSymbol sym = lookahead_iterator.symbol;
 
         AnalysisSubgraphNode successor = {
@@ -1536,7 +1536,7 @@ static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
   for (TSStateId state = 1; state < (uint16_t)self->language->state_count; state++) {
     unsigned subgraph_index, exists;
     LookaheadIterator lookahead_iterator = ts_language_lookaheads(self->language, state);
-    while (ts_lookahead_iterator_next(&lookahead_iterator)) {
+    while (ts_lookahead_iterator__next(&lookahead_iterator)) {
       if (lookahead_iterator.action_count) {
         for (unsigned i = 0; i < lookahead_iterator.action_count; i++) {
           const TSParseAction *action = &lookahead_iterator.actions[i];


### PR DESCRIPTION
* _Follows up:_ #2324

This PR renames _unreleased yet_ C API method to use more common term applicable for iterators across different programming languages.

I've looked to method names used in JS, Java, C++, Python and Rust and everywhere for iterators names like `next` / `prev` or `next` / `next_back` are commonly used. The  `advance` name works well for parsers where the parser evolves in its state on the every advance step and a reverse operation have no sense in parsing algorithm, but for iterators its not fully reflect an action meaning. Also I'd like to minimize divergence in terms used in C and Rust code parts.