### PR TITLE
chore(build-wasm): use spawn instead of output to give feedback

### DIFF
--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -677,12 +677,12 @@ impl Loader {
         }
 
         command.arg("parser.c");
-        let output = command.output().context("Failed to run emcc command")?;
-        if !output.status.success() {
-            return Err(anyhow!(
-                "emcc command failed - {}",
-                String::from_utf8_lossy(&output.stderr)
-            ));
+        let status = command
+            .spawn()
+            .with_context(|| "Failed to run emcc command")?
+            .wait()?;
+        if !status.success() {
+            return Err(anyhow!("emcc command failed"));
         }
 
         fs::rename(src_path.join(output_name), output_path)


### PR DESCRIPTION
Currently when the user uses `build-wasm` he have no feedback on whats happening, and this command can take a while mainly the first time since its pulls the docker image. 

This PR spawn the command instead so the user can see whats happening live.