### PR TITLE
Revert "fix: musl compilation"

### DIFF
--- a/lib/src/atomic.h
+++ b/lib/src/atomic.h
@@ -1,7 +1,6 @@
 #ifndef TREE_SITTER_ATOMIC_H_
 #define TREE_SITTER_ATOMIC_H_
 
-#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __TINYC__
@@ -47,19 +46,11 @@ static inline size_t atomic_load(const volatile size_t *p) {
 }
 
 static inline uint32_t atomic_inc(volatile uint32_t *p) {
-  #ifdef __ATOMIC_RELAXED
-    return __atomic_add_fetch(p, 1U, __ATOMIC_RELAXED);
-  #else
-    return __sync_add_and_fetch(p, 1U);
-  #endif
+  return __sync_add_and_fetch(p, 1U);
 }
 
 static inline uint32_t atomic_dec(volatile uint32_t *p) {
-  #ifdef __ATOMIC_RELAXED
-    return __atomic_sub_fetch(p, 1U, __ATOMIC_RELAXED);
-  #else
-    return __sync_sub_and_fetch(p, 1U);
-  #endif
+  return __sync_sub_and_fetch(p, 1U);
 }
 
 #endif


### PR DESCRIPTION
Reverts tree-sitter/tree-sitter#2492

Atomic relaxed level doesn't provide any synchronization guaranties between multiple threads and I'm not sure that it's correct to change `SEQ_CST` used by `__sync_add_and_fetch` and `__sync_sub_and_fetch` to the `RELAXED` level.