### PR TITLE
fix: use opt-level 3 by default, and add a size profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,9 @@ rust-version = "1.65"
 [profile.release]
 strip = true      # Automatically strip symbols from the binary.
 lto = true        # Link-time optimization.
-opt-level = "s"   # Optimize for speed.
+opt-level = 3     # Optimization level 3.
 codegen-units = 1 # Maximum size reduction optimizations.
+
+[profile.size]
+inherits = "release"
+opt-level = "s"      # Optimize for size.


### PR DESCRIPTION
3 is ~10% faster than size
size is ~10% smaller than 3