### PR TITLE
fix: dsl.d.ts - define previous param in rule callbacks

### DIFF
--- a/cli/npm/dsl.d.ts
+++ b/cli/npm/dsl.d.ts
@@ -42,6 +42,7 @@ type GrammarSymbols<RuleName extends string> = {
 
 type RuleBuilder<RuleName extends string> = (
   $: GrammarSymbols<RuleName>,
+  previous: Rule,
 ) => RuleOrLiteral;
 
 type RuleBuilders<


### PR DESCRIPTION
This PR describes the second `previous` param in rule declaration callbacks like:
```js
  hello: ($, previous) => seq(previous, "again"),
```

The `previous` should be mapped to `Rule` because the previous is actually a processed output of dsl functions used in a rule. It's possible to verify this by adding to the `tree-sitter-typescript` grammar the following rule def:
```js
identifier: ($, previous) => { console.warn(previous); return previous; },
```
And run `tree-sitter generate`, the output will be:
```js
{
  type: 'TOKEN',
  content: { type: 'SEQ', members: [ [Object], [Object] ] }
}
```