### PR TITLE
fix(render): only output SPACE for strings that are just a space

### DIFF
--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -1538,7 +1538,7 @@ impl Generator {
             } else {
                 'special_chars: {
                     let replacement = match c {
-                        ' ' => "SPACE",
+                        ' ' if name.len() == 1 => "SPACE",
                         '~' => "TILDE",
                         '`' => "BQUOTE",
                         '!' => "BANG",
@@ -1613,6 +1613,7 @@ impl Generator {
                             break 'special_chars;
                         }
                         '0'..='9' | 'a'..='z' | 'A'..='Z' | '_' => unreachable!(),
+                        ' ' => break 'special_chars,
                     };
                     if !result.is_empty() && !result.ends_with("_") {
                         result.push('_');


### PR DESCRIPTION
before

![image](https://github.com/tree-sitter/tree-sitter/assets/29718261/238ce884-9625-4206-8a19-fc6e14cec24f)

after

![image](https://github.com/tree-sitter/tree-sitter/assets/29718261/2abad980-6729-458d-bc48-1f2c43a54401)
