### PR TITLE
fix(lib): don't expose in lib API all alloc pointers

### DIFF
--- a/lib/src/alloc.h
+++ b/lib/src/alloc.h
@@ -11,10 +11,16 @@ extern "C" {
 #include <stdbool.h>
 #include <stdio.h>
 
-extern void *(*ts_current_malloc)(size_t);
-extern void *(*ts_current_calloc)(size_t, size_t);
-extern void *(*ts_current_realloc)(void *, size_t);
-extern void (*ts_current_free)(void *);
+#ifdef _MSC_VER
+#define INTERNAL
+#else
+#define INTERNAL __attribute__ ((visibility ("internal")))
+#endif
+
+extern void *(*ts_current_malloc)(size_t) INTERNAL;
+extern void *(*ts_current_calloc)(size_t, size_t) INTERNAL;
+extern void *(*ts_current_realloc)(void *, size_t) INTERNAL;
+extern void (*ts_current_free)(void *) INTERNAL;
 
 // Allow clients to override allocation functions
 #ifndef ts_malloc
@@ -29,6 +35,8 @@ extern void (*ts_current_free)(void *);
 #ifndef ts_free
 #define ts_free    ts_current_free
 #endif
+
+#undef INTERNAL
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Before:

```sh
# make clean && make
# strip libtree-sitter.so.0.0
# readelf -sW libtree-sitter.so.0.0 | grep -v UND | grep -P OBJECT
    61: 00000000000314a8     8 OBJECT  GLOBAL DEFAULT   23 ts_current_free
   144: 00000000000314b0     8 OBJECT  GLOBAL DEFAULT   23 ts_current_realloc
   195: 00000000000314b8     8 OBJECT  GLOBAL DEFAULT   23 ts_current_calloc
   234: 00000000000314c0     8 OBJECT  GLOBAL DEFAULT   23 ts_current_malloc
```

After:
```sh
# make clean && make
# strip libtree-sitter.so.0.0
# readelf -sW libtree-sitter.so.0.0 | grep -v UND | grep -P OBJECT
```