### PR TITLE
fix(lib): expose only symbols defined in `api.h`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ libtree-sitter.$(SOEXTVER): $(OBJ)
 	$(CC) $(LDFLAGS) $(LINKSHARED) $^ $(LDLIBS) -o $@
 	ln -sf $@ libtree-sitter.$(SOEXT)
 	ln -sf $@ libtree-sitter.$(SOEXTVER_MAJOR)
+ifneq ($(STRIP),)
+	$(STRIP) $@
+endif
 
 install: all
 	install -d '$(DESTDIR)$(LIBDIR)'

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 OBJ := $(SRC:.c=.o)
 
 # define default flags, and override to append mandatory flags
-override CFLAGS := -O3 -std=gnu99 -fPIC -Wall -Wextra -Werror -Wshadow $(CFLAGS)
+override CFLAGS := -O3 -std=gnu99 -fPIC -fvisibility=hidden -Wall -Wextra -Werror -Wshadow $(CFLAGS)
 override CFLAGS += -Ilib/src -Ilib/include
 
 # ABI versioning

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ endif
 OBJ := $(SRC:.c=.o)
 
 # define default flags, and override to append mandatory flags
-CFLAGS ?= -O3 -Wall -Wextra -Werror -Wshadow
-override CFLAGS += -std=gnu99 -fPIC -Ilib/src -Ilib/include
+override CFLAGS := -O3 -std=gnu99 -fPIC -Wall -Wextra -Werror -Wshadow $(CFLAGS)
+override CFLAGS += -Ilib/src -Ilib/include
 
 # ABI versioning
 SONAME_MAJOR := 0

--- a/lib/binding_rust/build.rs
+++ b/lib/binding_rust/build.rs
@@ -26,7 +26,9 @@ fn main() {
 
     cc::Build::new()
         .flag_if_supported("-std=c99")
-        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-fvisibility=hidden")
+        .flag_if_supported("-Wshadow")
+        .flag_if_supported("-Werror")
         .include(src_path)
         .include("include")
         .file(src_path.join("lib.c"))

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -1,6 +1,8 @@
 #ifndef TREE_SITTER_API_H_
 #define TREE_SITTER_API_H_
 
+#pragma GCC visibility push(default)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -1162,5 +1164,7 @@ void ts_set_allocator(
 #ifdef __cplusplus
 }
 #endif
+
+#pragma GCC visibility pop
 
 #endif  // TREE_SITTER_API_H_

--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -647,10 +647,10 @@ Subtree ts_subtree_edit(Subtree self, const TSInputEdit *input_edit, SubtreePool
   typedef struct {
     Subtree *tree;
     Edit edit;
-  } StackEntry;
+  } EditEntry;
 
-  Array(StackEntry) stack = array_new();
-  array_push(&stack, ((StackEntry) {
+  Array(EditEntry) stack = array_new();
+  array_push(&stack, ((EditEntry) {
     .tree = &self,
     .edit = (Edit) {
       .start = {input_edit->start_byte, input_edit->start_point},
@@ -660,7 +660,7 @@ Subtree ts_subtree_edit(Subtree self, const TSInputEdit *input_edit, SubtreePool
   }));
 
   while (stack.size) {
-    StackEntry entry = array_pop(&stack);
+    EditEntry entry = array_pop(&stack);
     Edit edit = entry.edit;
     bool is_noop = edit.old_end.bytes == edit.start.bytes && edit.new_end.bytes == edit.start.bytes;
     bool is_pure_insertion = edit.old_end.bytes == edit.start.bytes;
@@ -788,7 +788,7 @@ Subtree ts_subtree_edit(Subtree self, const TSInputEdit *input_edit, SubtreePool
       }
 
       // Queue processing of this child's subtree.
-      array_push(&stack, ((StackEntry) {
+      array_push(&stack, ((EditEntry) {
         .tree = child,
         .edit = child_edit,
       }));


### PR DESCRIPTION
* Resolves: #1276
* Closes: #2512 
---
Now the output of the `readelf` is pretty clear.
<details>

```sh
# readelf -sW libtree-sitter.so.0.0 | sed 1,3d | sort -k 8,8
     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND
     2: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND abort@GLIBC_2.2.5 (2)
     9: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND __assert_fail@GLIBC_2.2.5 (2)
    18: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND bcmp@GLIBC_2.2.5 (2)
    12: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND calloc@GLIBC_2.2.5 (2)
     5: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND clock_gettime@GLIBC_2.17 (3)
    26: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND __ctype_b_loc@GLIBC_2.3 (5)
    25: 0000000000000000     0 FUNC    WEAK   DEFAULT  UND __cxa_finalize@GLIBC_2.2.5 (2)
     8: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND dup@GLIBC_2.2.5 (2)
     6: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND fclose@GLIBC_2.2.5 (2)
    20: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND fdopen@GLIBC_2.2.5 (2)
    13: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND fprintf@GLIBC_2.2.5 (2)
    11: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND fputc@GLIBC_2.2.5 (2)
     1: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND free@GLIBC_2.2.5 (2)
    23: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND fwrite@GLIBC_2.2.5 (2)
    14: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND __gmon_start__
    16: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND iswalnum@GLIBC_2.2.5 (2)
    21: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND iswspace@GLIBC_2.2.5 (2)
     4: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _ITM_deregisterTMCloneTable
    24: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _ITM_registerTMCloneTable
    17: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND malloc@GLIBC_2.2.5 (2)
    15: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND memcpy@GLIBC_2.14 (4)
    22: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND memmove@GLIBC_2.2.5 (2)
    10: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND memset@GLIBC_2.2.5 (2)
    19: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND realloc@GLIBC_2.2.5 (2)
     7: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND snprintf@GLIBC_2.2.5 (2)
    27: 0000000000000000     0 OBJECT  GLOBAL DEFAULT  UND stderr@GLIBC_2.2.5 (2)
     3: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND strncmp@GLIBC_2.2.5 (2)
   131: 00000000000057c0     4 FUNC    GLOBAL DEFAULT   11 ts_language_field_count
   115: 0000000000005c20   112 FUNC    GLOBAL DEFAULT   11 ts_language_field_id_for_name
   116: 0000000000005c00    25 FUNC    GLOBAL DEFAULT   11 ts_language_field_name_for_id
    87: 0000000000005920   307 FUNC    GLOBAL DEFAULT   11 ts_language_next_state
    63: 00000000000057a0     4 FUNC    GLOBAL DEFAULT   11 ts_language_state_count
   138: 0000000000005790     7 FUNC    GLOBAL DEFAULT   11 ts_language_symbol_count
   122: 0000000000005aa0   282 FUNC    GLOBAL DEFAULT   11 ts_language_symbol_for_name
    75: 0000000000005a60    55 FUNC    GLOBAL DEFAULT   11 ts_language_symbol_name
   123: 0000000000005bc0    58 FUNC    GLOBAL DEFAULT   11 ts_language_symbol_type
   108: 00000000000057b0     3 FUNC    GLOBAL DEFAULT   11 ts_language_version
   107: 0000000000005f60     5 FUNC    GLOBAL DEFAULT   11 ts_lookahead_iterator_current_symbol
    47: 0000000000005f70    61 FUNC    GLOBAL DEFAULT   11 ts_lookahead_iterator_current_symbol_name
    60: 0000000000005d30     9 FUNC    GLOBAL DEFAULT   11 ts_lookahead_iterator_delete
   136: 0000000000005dd0     4 FUNC    GLOBAL DEFAULT   11 ts_lookahead_iterator_language
   132: 0000000000005c90   160 FUNC    GLOBAL DEFAULT   11 ts_lookahead_iterator_new
   103: 0000000000005e70   230 FUNC    GLOBAL DEFAULT   11 ts_lookahead_iterator_next
    82: 0000000000005de0   139 FUNC    GLOBAL DEFAULT   11 ts_lookahead_iterator_reset
   118: 0000000000005d40   136 FUNC    GLOBAL DEFAULT   11 ts_lookahead_iterator_reset_state
   141: 00000000000075b0    46 FUNC    GLOBAL DEFAULT   11 ts_node_child
    59: 0000000000007a90   797 FUNC    GLOBAL DEFAULT   11 ts_node_child_by_field_id
    86: 0000000000008210    61 FUNC    GLOBAL DEFAULT   11 ts_node_child_by_field_name
   112: 0000000000007db0    25 FUNC    GLOBAL DEFAULT   11 ts_node_child_count
    90: 0000000000007150    30 FUNC    GLOBAL DEFAULT   11 ts_node_descendant_count
    42: 0000000000009880    46 FUNC    GLOBAL DEFAULT   11 ts_node_descendant_for_byte_range
    52: 0000000000009c70    46 FUNC    GLOBAL DEFAULT   11 ts_node_descendant_for_point_range
   157: 000000000000a0a0   147 FUNC    GLOBAL DEFAULT   11 ts_node_edit
    98: 0000000000006e20    31 FUNC    GLOBAL DEFAULT   11 ts_node_end_byte
    81: 0000000000006e40    93 FUNC    GLOBAL DEFAULT   11 ts_node_end_point
    55: 0000000000006ff0    27 FUNC    GLOBAL DEFAULT   11 ts_node_eq
    77: 0000000000007dd0  1078 FUNC    GLOBAL DEFAULT   11 ts_node_field_name_for_child
   145: 0000000000009400    46 FUNC    GLOBAL DEFAULT   11 ts_node_first_child_for_byte
   109: 0000000000009850    43 FUNC    GLOBAL DEFAULT   11 ts_node_first_named_child_for_byte
    36: 0000000000006f70    21 FUNC    GLOBAL DEFAULT   11 ts_node_grammar_symbol
   121: 0000000000006f90    57 FUNC    GLOBAL DEFAULT   11 ts_node_grammar_type
    73: 00000000000070b0    29 FUNC    GLOBAL DEFAULT   11 ts_node_has_changes
   117: 00000000000070d0    50 FUNC    GLOBAL DEFAULT   11 ts_node_has_error
   154: 0000000000007110    63 FUNC    GLOBAL DEFAULT   11 ts_node_is_error
    51: 0000000000007020    29 FUNC    GLOBAL DEFAULT   11 ts_node_is_extra
    79: 0000000000007090    29 FUNC    GLOBAL DEFAULT   11 ts_node_is_missing
   152: 0000000000007040    67 FUNC    GLOBAL DEFAULT   11 ts_node_is_named
   105: 0000000000007010    10 FUNC    GLOBAL DEFAULT   11 ts_node_is_null
    94: 0000000000006f60    10 FUNC    GLOBAL DEFAULT   11 ts_node_language
   156: 0000000000007a60    43 FUNC    GLOBAL DEFAULT   11 ts_node_named_child
    54: 0000000000008250    25 FUNC    GLOBAL DEFAULT   11 ts_node_named_child_count
    49: 0000000000009c40    43 FUNC    GLOBAL DEFAULT   11 ts_node_named_descendant_for_byte_range
    44: 000000000000a070    43 FUNC    GLOBAL DEFAULT   11 ts_node_named_descendant_for_point_range
    83: 0000000000008a40    43 FUNC    GLOBAL DEFAULT   11 ts_node_next_named_sibling
   119: 0000000000007190    62 FUNC    GLOBAL DEFAULT   11 ts_node_next_parse_state
   114: 0000000000008270    46 FUNC    GLOBAL DEFAULT   11 ts_node_next_sibling
    29: 00000000000071d0   451 FUNC    GLOBAL DEFAULT   11 ts_node_parent
    41: 0000000000007170    22 FUNC    GLOBAL DEFAULT   11 ts_node_parse_state
    95: 00000000000093d0    43 FUNC    GLOBAL DEFAULT   11 ts_node_prev_named_sibling
    62: 0000000000008a70    46 FUNC    GLOBAL DEFAULT   11 ts_node_prev_sibling
   153: 0000000000006e00     5 FUNC    GLOBAL DEFAULT   11 ts_node_start_byte
   150: 0000000000006e10     6 FUNC    GLOBAL DEFAULT   11 ts_node_start_point
    96: 0000000000006fd0    24 FUNC    GLOBAL DEFAULT   11 ts_node_string
   143: 0000000000006ea0    82 FUNC    GLOBAL DEFAULT   11 ts_node_symbol
    65: 0000000000006f00    82 FUNC    GLOBAL DEFAULT   11 ts_node_type
   140: 000000000000a6f0     8 FUNC    GLOBAL DEFAULT   11 ts_parser_cancellation_flag
    74: 000000000000a370   396 FUNC    GLOBAL DEFAULT   11 ts_parser_delete
    85: 000000000000a740     5 FUNC    GLOBAL DEFAULT   11 ts_parser_included_ranges
   133: 000000000000a580     8 FUNC    GLOBAL DEFAULT   11 ts_parser_language
   100: 000000000000a690    15 FUNC    GLOBAL DEFAULT   11 ts_parser_logger
    45: 000000000000a250   285 FUNC    GLOBAL DEFAULT   11 ts_parser_new
    32: 000000000000a750 14946 FUNC    GLOBAL DEFAULT   11 ts_parser_parse
    80: 000000000000e280    72 FUNC    GLOBAL DEFAULT   11 ts_parser_parse_string
   148: 000000000000e2d0    69 FUNC    GLOBAL DEFAULT   11 ts_parser_parse_string_encoding
    91: 000000000000a6b0    61 FUNC    GLOBAL DEFAULT   11 ts_parser_print_dot_graphs
    93: 000000000000a590   247 FUNC    GLOBAL DEFAULT   11 ts_parser_reset
    68: 000000000000a700     8 FUNC    GLOBAL DEFAULT   11 ts_parser_set_cancellation_flag
    53: 000000000000a730     5 FUNC    GLOBAL DEFAULT   11 ts_parser_set_included_ranges
   120: 000000000000a500   123 FUNC    GLOBAL DEFAULT   11 ts_parser_set_language
   134: 000000000000a6a0    15 FUNC    GLOBAL DEFAULT   11 ts_parser_set_logger
   113: 000000000000a720     8 FUNC    GLOBAL DEFAULT   11 ts_parser_set_timeout_micros
    38: 000000000000a710     8 FUNC    GLOBAL DEFAULT   11 ts_parser_timeout_micros
    97: 0000000000014e20     4 FUNC    GLOBAL DEFAULT   11 ts_query_capture_count
    67: 0000000000014e40    20 FUNC    GLOBAL DEFAULT   11 ts_query_capture_name_for_id
   142: 0000000000014e60    68 FUNC    GLOBAL DEFAULT   11 ts_query_capture_quantifier_for_id
    58: 00000000000152d0   160 FUNC    GLOBAL DEFAULT   11 ts_query_cursor_delete
   146: 0000000000015370     8 FUNC    GLOBAL DEFAULT   11 ts_query_cursor_did_exceed_match_limit
    56: 00000000000153a0   151 FUNC    GLOBAL DEFAULT   11 ts_query_cursor_exec
    69: 0000000000015380     4 FUNC    GLOBAL DEFAULT   11 ts_query_cursor_match_limit
    33: 0000000000015220   174 FUNC    GLOBAL DEFAULT   11 ts_query_cursor_new
   102: 0000000000016f00   861 FUNC    GLOBAL DEFAULT   11 ts_query_cursor_next_capture
    78: 0000000000015730   192 FUNC    GLOBAL DEFAULT   11 ts_query_cursor_next_match
   151: 0000000000016df0   262 FUNC    GLOBAL DEFAULT   11 ts_query_cursor_remove_match
    28: 0000000000015440    16 FUNC    GLOBAL DEFAULT   11 ts_query_cursor_set_byte_range
    31: 0000000000015390     4 FUNC    GLOBAL DEFAULT   11 ts_query_cursor_set_match_limit
   126: 0000000000017440     4 FUNC    GLOBAL DEFAULT   11 ts_query_cursor_set_max_start_depth
    46: 0000000000015450    39 FUNC    GLOBAL DEFAULT   11 ts_query_cursor_set_point_range
    35: 0000000000014cb0   344 FUNC    GLOBAL DEFAULT   11 ts_query_delete
    39: 0000000000015080   269 FUNC    GLOBAL DEFAULT   11 ts_query_disable_capture
    43: 0000000000015190   143 FUNC    GLOBAL DEFAULT   11 ts_query_disable_pattern
   106: 0000000000014fb0   110 FUNC    GLOBAL DEFAULT   11 ts_query_is_pattern_guaranteed_at_step
   111: 0000000000014f80    33 FUNC    GLOBAL DEFAULT   11 ts_query_is_pattern_non_local
   130: 0000000000014f20    83 FUNC    GLOBAL DEFAULT   11 ts_query_is_pattern_rooted
    64: 0000000000010aa0 11095 FUNC    GLOBAL DEFAULT   11 ts_query_new
    30: 0000000000014e10     7 FUNC    GLOBAL DEFAULT   11 ts_query_pattern_count
    48: 0000000000014ed0    39 FUNC    GLOBAL DEFAULT   11 ts_query_predicates_for_pattern
    71: 0000000000014f00    18 FUNC    GLOBAL DEFAULT   11 ts_query_start_byte_for_pattern
    99: 0000000000014e30     4 FUNC    GLOBAL DEFAULT   11 ts_query_string_count
    76: 0000000000014eb0    21 FUNC    GLOBAL DEFAULT   11 ts_query_string_value_for_id
    66: 0000000000003480    83 FUNC    GLOBAL DEFAULT   11 ts_set_allocator
    84: 00000000000208f0   119 FUNC    GLOBAL DEFAULT   11 ts_tree_copy
   125: 0000000000023120   110 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_copy
   127: 0000000000022de0   164 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_current_depth
   101: 0000000000022890    55 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_current_descendant_index
   129: 0000000000022f80   356 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_current_field_id
    61: 00000000000230f0    38 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_current_field_name
   144: 00000000000228d0   194 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_current_node
   155: 00000000000211d0    26 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_delete
    50: 0000000000022570   785 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_goto_descendant
    89: 0000000000021650    42 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_goto_first_child
    34: 0000000000021900     4 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_goto_first_child_for_byte
    57: 0000000000021d30    10 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_goto_first_child_for_point
    72: 00000000000218d0    42 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_goto_last_child
   149: 0000000000021f70    58 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_goto_next_sibling
    92: 00000000000224a0   199 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_goto_parent
   128: 0000000000022460    58 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_goto_previous_sibling
    37: 0000000000020f50   176 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_new
   147: 00000000000210e0   236 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_reset
   124: 0000000000023190   178 FUNC    GLOBAL DEFAULT   11 ts_tree_cursor_reset_to
   135: 0000000000020970    77 FUNC    GLOBAL DEFAULT   11 ts_tree_delete
    88: 0000000000020b00   534 FUNC    GLOBAL DEFAULT   11 ts_tree_edit
   104: 0000000000020d60   431 FUNC    GLOBAL DEFAULT   11 ts_tree_get_changed_ranges
   139: 0000000000020d20    50 FUNC    GLOBAL DEFAULT   11 ts_tree_included_ranges
   110: 0000000000020af0     5 FUNC    GLOBAL DEFAULT   11 ts_tree_language
    40: 0000000000020f10    61 FUNC    GLOBAL DEFAULT   11 ts_tree_print_dot_graph
    70: 00000000000209c0    85 FUNC    GLOBAL DEFAULT   11 ts_tree_root_node
   137: 0000000000020a20   205 FUNC    GLOBAL DEFAULT   11 ts_tree_root_node_with_offset
```
</details>

Checked with the bellow oneliners:
```sh
api_list(){ tree-sitter q -c <(echo "(function_declarator (identifier) @fn.name)") lib/include/tree_sitter/api.h | sed -nr 's/.*text: `([^`]+)`/\1/p' | sort;}
lib_list(){ readelf -sW libtree-sitter.so.0.0 | sed 1,3d | sort -k 8,8 | sed -nr 's/.*(ts_[^ ]+).*/\1/p';}
comm -3 <(api_list) <(lib_list)
```
The list of visible symbols fully corresponds to all defined in the `api.h`.