### PR TITLE
test: add `TREE_SITTER_DUMP_EDITS` env var to dump corpus edits

### DIFF
--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -111,8 +111,10 @@ fn test_language_corpus(start_seed: usize, language_name: &str) {
     }
 
     println!();
-    for test in tests {
-        println!("  {} example - {}", language_name, test.name);
+    for (test_index, test) in tests.iter().enumerate() {
+        let test_name = format!("{language_name} example - {}", test.name);
+
+        println!("  {test_index}. {test_name}");
 
         let passed = allocations::record(|| {
             let mut log_session = None;
@@ -173,11 +175,16 @@ fn test_language_corpus(start_seed: usize, language_name: &str) {
                 }
 
                 if log_seed {
-                    println!("    seed: {}", seed);
+                    println!("   {test_index}.{trial:<2} seed: {}", seed);
                 }
 
                 if dump_edits {
-                    fs::write(SCRATCH_BASE_DIR.join(format!("{seed}.edit")), &input).unwrap();
+                    fs::write(
+                        SCRATCH_BASE_DIR
+                            .join(format!("edit.{seed}.{test_index}.{trial} {test_name}")),
+                        &input,
+                    )
+                    .unwrap();
                 }
 
                 if *LOG_GRAPH_ENABLED {

--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -1,7 +1,7 @@
 use super::helpers::{
     allocations,
     edits::{get_random_edit, invert_edit},
-    fixtures::{fixtures_dir, get_language, get_test_language},
+    fixtures::{fixtures_dir, get_language, get_test_language, SCRATCH_BASE_DIR},
     new_seed,
     random::Rand,
     scope_sequence::ScopeSequence,
@@ -104,6 +104,7 @@ fn test_language_corpus(start_seed: usize, language_name: &str) {
     let mut failure_count = 0;
 
     let log_seed = env::var("TREE_SITTER_LOG_SEED").is_ok();
+    let dump_edits = env::var("TREE_SITTER_DUMP_EDITS").is_ok();
 
     if log_seed {
         println!("  start seed: {}", start_seed);
@@ -173,6 +174,10 @@ fn test_language_corpus(start_seed: usize, language_name: &str) {
 
                 if log_seed {
                     println!("    seed: {}", seed);
+                }
+
+                if dump_edits {
+                    fs::write(SCRATCH_BASE_DIR.join(format!("{seed}.edit")), &input).unwrap();
                 }
 
                 if *LOG_GRAPH_ENABLED {

--- a/cli/src/tests/helpers/dirs.rs
+++ b/cli/src/tests/helpers/dirs.rs
@@ -1,9 +1,14 @@
 lazy_static! {
-    static ref ROOT_DIR: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR")).parent().unwrap().to_owned();
-    static ref FIXTURES_DIR: PathBuf = ROOT_DIR.join("test").join("fixtures");
-    static ref HEADER_DIR: PathBuf = ROOT_DIR.join("lib").join("include");
-    static ref GRAMMARS_DIR: PathBuf = ROOT_DIR.join("test").join("fixtures").join("grammars");
-    static ref SCRATCH_DIR: PathBuf = {
+    pub static ref ROOT_DIR: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR")).parent().unwrap().to_owned();
+    pub static ref FIXTURES_DIR: PathBuf = ROOT_DIR.join("test").join("fixtures");
+    pub static ref HEADER_DIR: PathBuf = ROOT_DIR.join("lib").join("include");
+    pub static ref GRAMMARS_DIR: PathBuf = ROOT_DIR.join("test").join("fixtures").join("grammars");
+    pub static ref SCRATCH_BASE_DIR: PathBuf = {
+        let result = ROOT_DIR.join("target").join("scratch");
+        fs::create_dir_all(&result).unwrap();
+        result
+    };
+    pub static ref SCRATCH_DIR: PathBuf = {
         // https://doc.rust-lang.org/reference/conditional-compilation.html
         let vendor = if cfg!(target_vendor = "apple") {
             "apple"
@@ -34,7 +39,7 @@ lazy_static! {
         };
 
         let machine = format!("{}-{}-{}-{}-{}", std::env::consts::ARCH, std::env::consts::OS, vendor, env, endian);
-        let result = ROOT_DIR.join("target").join("scratch").join(machine);
+        let result = SCRATCH_BASE_DIR.join(machine);
         fs::create_dir_all(&result).unwrap();
         result
     };


### PR DESCRIPTION
It dumps edits to the `target/scratch` folder ~~in a format like `<SEED>.edit`~~

![Screenshot from 2023-08-17 21-01-50](https://github.com/tree-sitter/tree-sitter/assets/14666676/28fa909e-7f20-436f-b974-0c3c1afc8f92)

---
### Edit
Edits are dumped in a format `edit.<SEED>.<TEST_INDEX>.<SEED_INDEX>.<TEST_NAME>`.

To cleanup edits use the following shell command instead of the standard `rm target/scratch/edit.*`:
```sh
find target/scratch/ -name 'edit.*' -delete
```

---
* _Follows up:_ #2517