### PR TITLE
chore: switch `fetch-fixtures.cmd` to all master branches

### DIFF
--- a/script/fetch-fixtures.cmd
+++ b/script/fetch-fixtures.cmd
@@ -2,12 +2,12 @@
 
 call:fetch_grammar bash              master
 call:fetch_grammar c                 master
-call:fetch_grammar cpp               670404d7c689be1c868a46f919ba2a3912f2b7ef
+call:fetch_grammar cpp               master
 call:fetch_grammar embedded-template master
 call:fetch_grammar go                master
 call:fetch_grammar html              master
 call:fetch_grammar java              master
-call:fetch_grammar javascript        partial-order-precedences
+call:fetch_grammar javascript        master
 call:fetch_grammar jsdoc             master
 call:fetch_grammar json              master
 call:fetch_grammar php               master


### PR DESCRIPTION
All issues that were reasons to stick on specific fixture versions are resolved.
The javascript grammar uses [partial order precedences](https://github.com/tree-sitter/tree-sitter-javascript/compare/master...partial-order-precedences#diff-919ac210accac9ecc55a76d10a7590e3d85ca3f0e165b52d30f08faee486d0cbR39-R66) on the [master](https://github.com/tree-sitter/tree-sitter-javascript/blob/master/grammar.js#L41-L69) branch. 