### PR TITLE
feat: add `injection.self` to inject a node with itself

### DIFF
--- a/cli/src/tests/helpers/fixtures.rs
+++ b/cli/src/tests/helpers/fixtures.rs
@@ -52,6 +52,7 @@ pub fn get_highlight_config(
     let locals_query = fs::read_to_string(queries_path.join("locals.scm")).unwrap_or(String::new());
     let mut result = HighlightConfiguration::new(
         language,
+        language_name,
         &highlights_query,
         &injections_query,
         &locals_query,

--- a/cli/src/tests/highlight_test.rs
+++ b/cli/src/tests/highlight_test.rs
@@ -507,12 +507,14 @@ fn test_highlighting_via_c_api() {
     let js_scope = c_string("source.js");
     let js_injection_regex = c_string("^javascript");
     let language = get_language("javascript");
+    let lang_name = c_string("javascript");
     let queries = get_language_queries_path("javascript");
     let highlights_query = fs::read_to_string(queries.join("highlights.scm")).unwrap();
     let injections_query = fs::read_to_string(queries.join("injections.scm")).unwrap();
     let locals_query = fs::read_to_string(queries.join("locals.scm")).unwrap();
     c::ts_highlighter_add_language(
         highlighter,
+        lang_name.as_ptr(),
         js_scope.as_ptr(),
         js_injection_regex.as_ptr(),
         language,
@@ -528,11 +530,13 @@ fn test_highlighting_via_c_api() {
     let html_scope = c_string("text.html.basic");
     let html_injection_regex = c_string("^html");
     let language = get_language("html");
+    let lang_name = c_string("html");
     let queries = get_language_queries_path("html");
     let highlights_query = fs::read_to_string(queries.join("highlights.scm")).unwrap();
     let injections_query = fs::read_to_string(queries.join("injections.scm")).unwrap();
     c::ts_highlighter_add_language(
         highlighter,
+        lang_name.as_ptr(),
         html_scope.as_ptr(),
         html_injection_regex.as_ptr(),
         language,
@@ -607,7 +611,7 @@ fn test_highlighting_with_all_captures_applied() {
         [ \"{\" \"}\" \"(\" \")\" ] @punctuation.bracket
     "};
     let mut rust_highlight_reverse =
-        HighlightConfiguration::new(language, &highlights_query, "", "", true).unwrap();
+        HighlightConfiguration::new(language, "rust", &highlights_query, "", "", true).unwrap();
     rust_highlight_reverse.configure(&HIGHLIGHT_NAMES);
 
     assert_eq!(

--- a/docs/section-4-syntax-highlighting.md
+++ b/docs/section-4-syntax-highlighting.md
@@ -364,6 +364,7 @@ The language injection behavior can also be configured by some properties associ
 * `injection.language` - can be used to hard-code the name of a specific language.
 * `injection.combined` - indicates that *all* of the matching nodes in the tree should have their content parsed as *one* nested document.
 * `injection.include-children` - indicates that the `@injection.content` node's *entire* text should be re-parsed, including the text of its child nodes. By default, child nodes' text will be *excluded* from the injected document.
+* `injection.self` - indicates that the `@injection.content` node should be parsed using the same language as the parent node. This is useful for cases where the parent node's language is not known until runtime (e.g. via inheriting another language)
 
 #### Examples
 

--- a/highlight/src/c_lib.rs
+++ b/highlight/src/c_lib.rs
@@ -29,6 +29,7 @@ pub enum ErrorCode {
     InvalidUtf8,
     InvalidRegex,
     InvalidQuery,
+    InvalidLanguageName,
 }
 
 #[no_mangle]
@@ -61,6 +62,7 @@ pub extern "C" fn ts_highlighter_new(
 #[no_mangle]
 pub extern "C" fn ts_highlighter_add_language(
     this: *mut TSHighlighter,
+    language_name: *const c_char,
     scope_name: *const c_char,
     injection_regex: *const c_char,
     language: Language,
@@ -110,8 +112,13 @@ pub extern "C" fn ts_highlighter_add_language(
             ""
         };
 
+        let lang = unsafe { CStr::from_ptr(language_name) }
+            .to_str()
+            .or(Err(ErrorCode::InvalidLanguageName))?;
+
         let mut config = HighlightConfiguration::new(
             language,
+            lang,
             highlight_query,
             injection_query,
             locals_query,

--- a/highlight/src/lib.rs
+++ b/highlight/src/lib.rs
@@ -102,6 +102,7 @@ pub enum HighlightEvent {
 /// This struct is immutable and can be shared between threads.
 pub struct HighlightConfiguration {
     pub language: Language,
+    pub language_name: String,
     pub query: Query,
     pub apply_all_captures: bool,
     combined_injections_query: Option<Query>,
@@ -244,6 +245,7 @@ impl HighlightConfiguration {
     /// Returns a `HighlightConfiguration` that can then be used with the `highlight` method.
     pub fn new(
         language: Language,
+        name: impl Into<String>,
         highlights_query: &str,
         injection_query: &str,
         locals_query: &str,
@@ -327,6 +329,7 @@ impl HighlightConfiguration {
         let highlight_indices = vec![None; query.capture_names().len()];
         Ok(HighlightConfiguration {
             language,
+            language_name: name.into(),
             query,
             apply_all_captures,
             combined_injections_query,
@@ -1110,7 +1113,7 @@ impl HtmlRenderer {
 }
 
 fn injection_for_match<'a>(
-    config: &HighlightConfiguration,
+    config: &'a HighlightConfiguration,
     query: &'a Query,
     query_match: &QueryMatch<'a, 'a>,
     source: &'a [u8],
@@ -1138,6 +1141,12 @@ fn injection_for_match<'a>(
             "injection.language" => {
                 if language_name.is_none() {
                     language_name = prop.value.as_ref().map(|s| s.as_ref())
+                }
+            }
+
+            "injection.self" => {
+                if language_name.is_none() {
+                    language_name = Some(config.language_name.as_str());
                 }
             }
 


### PR DESCRIPTION
# Motivation

In certain cases, a language can extend upon another, and in many cases, the language is backwards compatible (C/C++ *practically* are, bar a few features like `auto`, `register` and different number suffixes)

It makes sense for downstream to treat C queries as compatible with C++, and to only add C++ features to its queries (this is what Neovim does w/ its inherit directive at the start of a query file)

An issue arises though, when injections inject itself. Currently, preproc_arg in C is injected with C, but if that's inherited in C++, C parsing is applied instead of C++, thus removing the capability to inherit

# Solution

An `injection.self` property in the set directive of injections fixes this, where inheriting always ensures the injected language is that of the language itself.

This could be moved to just be a capture `@injection.self` similar to how `@injection.language` is used for heredoc delimiters