### PR TITLE
Remove -Werror from default CFLAGS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,6 +177,7 @@ jobs:
         TARGET: ${{ matrix.target }}
         CC: ${{ matrix.cc }}
         AR: ${{ matrix.ar }}
+        IS_WINDOWS: ${{ contains(matrix.os, 'windows') }}
       run: |
         PATH="$PWD/.github/scripts:$PATH"
         echo "$PWD/.github/scripts" >> $GITHUB_PATH
@@ -191,6 +192,8 @@ jobs:
         [ -n "$CC" ] && echo "CC=$CC" >> $GITHUB_ENV
         [ -n "$AR" ] && echo "AR=$AR" >> $GITHUB_ENV
 
+        [ "$IS_WINDOWS" = "false" ] && echo "CFLAGS=-Werror" >> $GITHUB_ENV
+
         if [ "$USE_CROSS" == "true" ]; then
           echo "BUILD_CMD=cross" >> $GITHUB_ENV
           runner=$(BUILD_CMD=cross cross.sh bash -c "env | sed -nr '/^CARGO_TARGET_.*_RUNNER=/s///p'")
@@ -199,7 +202,7 @@ jobs:
 
     - name: Build C library
       if: ${{ !contains(matrix.os, 'windows') }} # Requires an additional adapted Makefile for `cl.exe` compiler
-      run: make.sh CFLAGS="-Werror" -j
+      run: make.sh -j
 
     - name: Build wasm library
       if: ${{ !matrix.cli-only && !matrix.use-cross }} # No sense to build on the same Github runner hosts many times

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 OBJ := $(SRC:.c=.o)
 
 # define default flags, and override to append mandatory flags
-override CFLAGS := -O3 -std=gnu99 -fPIC -fvisibility=hidden -Wall -Wextra -Werror -Wshadow $(CFLAGS)
+override CFLAGS := -O3 -std=gnu99 -fPIC -fvisibility=hidden -Wall -Wextra -Wshadow $(CFLAGS)
 override CFLAGS += -Ilib/src -Ilib/include
 
 # ABI versioning

--- a/lib/binding_rust/build.rs
+++ b/lib/binding_rust/build.rs
@@ -28,7 +28,6 @@ fn main() {
         .flag_if_supported("-std=c99")
         .flag_if_supported("-fvisibility=hidden")
         .flag_if_supported("-Wshadow")
-        .flag_if_supported("-Werror")
         .include(src_path)
         .include("include")
         .file(src_path.join("lib.c"))


### PR DESCRIPTION
Production builds shouldn't include -Werror by default since that could cause spurious build failures when there are toolchain updates.

CI uses -Werror to prevent warnings, so that should be sufficient.

Closes #2531 
