### PR TITLE
`@injection.parent`

### DIFF
--- a/cli/src/tests/highlight_test.rs
+++ b/cli/src/tests/highlight_test.rs
@@ -24,6 +24,7 @@ lazy_static! {
         get_highlight_config("rust", Some("injections.scm"), &HIGHLIGHT_NAMES);
     static ref HIGHLIGHT_NAMES: Vec<String> = [
         "attribute",
+        "boolean",
         "carriage-return",
         "comment",
         "constant",


### PR DESCRIPTION
# Background

Re2c is a parser generator tool for use with C, Go, and Rust. It is used inside block comments for each language. Now the issue is you can embed the parent language's code inside the comment. Here's an example:

```c
bool lex() {
    /*!re2c
        * { return false; }
    */
}
```

The content inside the brackets is a `host_code` node. We want to dynamically inject the parent language inside *that* re2c node, which could be C, Go, or Rust. 

# Solution

An `@injection.parent` capture is added, which is used to capture a node meant to be injected w/ the parent language.

I tested this in `highlight_test.rs` with a local copy of re2c in the fixtures dir and found it to work well:

```rs
#[test]
fn test_highlighting_injected_c_in_re2c_in_c() {
    let source = "bool lex() { /*!re2c * { return false; } */ }";

    let vec = to_token_vector(source, &C_HIGHLIGHT).unwrap();

    let res = &[vec![
        ("bool", vec!["type"]),
        (" ", vec![]),
        ("lex", vec!["function"]),
        ("() { ", vec![]),
        ("/*!re2c ", vec!["comment"]),
        ("*", vec!["comment", "constant"]),
        (" ", vec!["comment"]),
        ("{", vec!["comment", "punctuation.bracket"]),
        (" ", vec!["comment"]),
        ("return", vec!["comment", "keyword"]),
        (" ", vec!["comment"]),
        ("false", vec!["comment", "boolean"]),
        (";", vec!["comment", "punctuation.delimiter"]),
        (" ", vec!["comment"]),
        ("}", vec!["comment", "punctuation.bracket"]),
        (" */", vec!["comment"]),
        (" }", vec![]),
    ]];

    assert_eq!(vec, res);
}                                     
```

Though since re2c is not an upstream parser I won't add the test here, and I can't think of another case where this could be tested.



Note - I also added `@injection.self` since we can set injection.self already, we might as well allow that as well