### PR TITLE
feat: allow specifying an external scanner's files

### DIFF
--- a/cli/benches/benchmark.rs
+++ b/cli/benches/benchmark.rs
@@ -209,7 +209,7 @@ fn parse(path: &Path, max_path_length: usize, mut action: impl FnMut(&[u8])) -> 
 fn get_language(path: &Path) -> Language {
     let src_dir = GRAMMARS_DIR.join(path).join("src");
     TEST_LOADER
-        .load_language_at_path(&src_dir, &src_dir)
+        .load_language_at_path(&src_dir, &src_dir, &None)
         .with_context(|| format!("Failed to load language at path {:?}", src_dir))
         .unwrap()
 }

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -89,7 +89,6 @@ pub struct LanguageConfiguration<'a> {
     pub locals_filenames: Option<Vec<String>>,
     pub tags_filenames: Option<Vec<String>>,
     pub language_name: String,
-    pub external_files: Option<Vec<String>>,
     language_id: usize,
     highlight_config: OnceCell<Option<HighlightConfiguration>>,
     tags_config: OnceCell<Option<TagsConfiguration>>,
@@ -99,7 +98,7 @@ pub struct LanguageConfiguration<'a> {
 
 pub struct Loader {
     parser_lib_path: PathBuf,
-    languages_by_id: Vec<(PathBuf, OnceCell<Language>, Option<Vec<String>>)>,
+    languages_by_id: Vec<(PathBuf, OnceCell<Language>, Option<Vec<PathBuf>>)>,
     language_configurations: Vec<LanguageConfiguration<'static>>,
     language_configuration_ids_by_file_type: HashMap<String, Vec<usize>>,
     language_configuration_in_current_path: Option<usize>,
@@ -322,7 +321,7 @@ impl Loader {
         &self,
         src_path: &Path,
         header_path: &Path,
-        external_files: &Option<Vec<String>>,
+        external_files: &Option<Vec<PathBuf>>,
     ) -> Result<Language> {
         let grammar_path = src_path.join("grammar.json");
         let parser_path = src_path.join("parser.c");
@@ -348,7 +347,7 @@ impl Loader {
             }
         };
 
-        let external_files = if let Some(external_files) = external_files {
+        let external_scanner_files = if let Some(external_files) = external_files {
             let mut files = Vec::new();
             for path in external_files {
                 files.push(src_path.join(path));
@@ -358,12 +357,19 @@ impl Loader {
             Vec::new()
         };
 
+        let needs_recompile = needs_recompile(
+            &self.parser_lib_path.join(&grammar_json.name),
+            &parser_path,
+            scanner_path.as_deref(),
+            &external_scanner_files,
+        )?;
+
         self.load_language_from_sources(
             &grammar_json.name,
             header_path,
             &parser_path,
             scanner_path.as_deref(),
-            &external_files,
+            needs_recompile,
         )
     }
 
@@ -373,7 +379,7 @@ impl Loader {
         header_path: &Path,
         parser_path: &Path,
         scanner_path: Option<&Path>,
-        external_files: &[PathBuf],
+        needs_recompile: bool,
     ) -> Result<Language> {
         let mut lib_name = name.to_string();
         if self.debug_build {
@@ -382,10 +388,7 @@ impl Loader {
         let mut library_path = self.parser_lib_path.join(lib_name);
         library_path.set_extension(DYLIB_EXTENSION);
 
-        let recompile = needs_recompile(&library_path, parser_path, scanner_path, external_files)
-            .with_context(|| "Failed to compare source and binary timestamps")?;
-
-        if recompile {
+        if needs_recompile {
             fs::create_dir_all(&self.parser_lib_path)?;
             let mut config = cc::Build::new();
             config
@@ -579,7 +582,7 @@ impl Loader {
             locals: PathsJSON,
             #[serde(default)]
             tags: PathsJSON,
-            #[serde(default)]
+            #[serde(rename = "external-files")]
             external_files: PathsJSON,
         }
 
@@ -629,7 +632,20 @@ impl Loader {
                         self.languages_by_id.push((
                             language_path,
                             OnceCell::new(),
-                            config_json.external_files.clone().into_vec(),
+                            config_json.external_files.clone().into_vec().map(|x| {
+                                x.into_iter()
+                                    .map(|p| {
+                                       let path = parser_path.join(p);
+                                        // prevent p being above/outside of parser_pathh
+
+                                        if path.starts_with(parser_path) {
+                                            Ok(path)
+                                        } else {
+                                            Err(anyhow!("External file path {path:?} is outside of parser directory {parser_path:?}"))
+                                        }
+                                    })
+                                    .collect::<Result<Vec<_>>>().unwrap()
+                            }),
                         ));
                         self.languages_by_id.len() - 1
                     });
@@ -646,7 +662,6 @@ impl Loader {
                         injections_filenames: config_json.injections.into_vec(),
                         locals_filenames: config_json.locals.into_vec(),
                         tags_filenames: config_json.tags.into_vec(),
-                        external_files: config_json.external_files.into_vec(),
                         highlights_filenames: config_json.highlights.into_vec(),
                         highlight_config: OnceCell::new(),
                         tags_config: OnceCell::new(),
@@ -696,7 +711,6 @@ impl Loader {
                 locals_filenames: None,
                 highlights_filenames: None,
                 tags_filenames: None,
-                external_files: None,
                 highlight_config: OnceCell::new(),
                 tags_config: OnceCell::new(),
                 highlight_names: &self.highlight_names,

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -995,7 +995,7 @@ impl Generator {
         if action.in_main_token {
             add!(self, "ADVANCE({});", action.state);
         } else {
-            add!(self, "SKIP({})", action.state);
+            add!(self, "SKIP({});", action.state);
         }
     }
 

--- a/cli/src/tests/helpers/fixtures.rs
+++ b/cli/src/tests/helpers/fixtures.rs
@@ -28,7 +28,7 @@ pub fn fixtures_dir<'a>() -> &'static Path {
 
 pub fn get_language(name: &str) -> Language {
     TEST_LOADER
-        .load_language_at_path(&GRAMMARS_DIR.join(name).join("src"), &HEADER_DIR)
+        .load_language_at_path(&GRAMMARS_DIR.join(name).join("src"), &HEADER_DIR, &None)
         .unwrap()
 }
 
@@ -88,7 +88,13 @@ pub fn get_test_language(name: &str, parser_code: &str, path: Option<&Path>) -> 
         }
     });
     TEST_LOADER
-        .load_language_from_sources(name, &HEADER_DIR, &parser_c_path, scanner_path.as_deref())
+        .load_language_from_sources(
+            name,
+            &HEADER_DIR,
+            &parser_c_path,
+            scanner_path.as_deref(),
+            &[],
+        )
         .unwrap()
 }
 

--- a/cli/src/tests/helpers/fixtures.rs
+++ b/cli/src/tests/helpers/fixtures.rs
@@ -20,11 +20,11 @@ lazy_static! {
     };
 }
 
-pub fn test_loader<'a>() -> &'a Loader {
-    &*TEST_LOADER
+pub fn test_loader() -> &'static Loader {
+    &TEST_LOADER
 }
 
-pub fn fixtures_dir<'a>() -> &'static Path {
+pub fn fixtures_dir() -> &'static Path {
     &FIXTURES_DIR
 }
 
@@ -51,7 +51,7 @@ pub fn get_highlight_config(
     } else {
         String::new()
     };
-    let locals_query = fs::read_to_string(queries_path.join("locals.scm")).unwrap_or(String::new());
+    let locals_query = fs::read_to_string(queries_path.join("locals.scm")).unwrap_or_default();
     let mut result = HighlightConfiguration::new(
         language,
         language_name,
@@ -61,7 +61,7 @@ pub fn get_highlight_config(
         false,
     )
     .unwrap();
-    result.configure(&highlight_names);
+    result.configure(highlight_names);
     result
 }
 
@@ -69,12 +69,12 @@ pub fn get_tags_config(language_name: &str) -> TagsConfiguration {
     let language = get_language(language_name);
     let queries_path = get_language_queries_path(language_name);
     let tags_query = fs::read_to_string(queries_path.join("tags.scm")).unwrap();
-    let locals_query = fs::read_to_string(queries_path.join("locals.scm")).unwrap_or(String::new());
+    let locals_query = fs::read_to_string(queries_path.join("locals.scm")).unwrap_or_default();
     TagsConfiguration::new(language, &tags_query, &locals_query).unwrap()
 }
 
 pub fn get_test_language(name: &str, parser_code: &str, path: Option<&Path>) -> Language {
-    let parser_c_path = SCRATCH_DIR.join(&format!("{}-parser.c", name));
+    let parser_c_path = SCRATCH_DIR.join(format!("{}-parser.c", name));
     if !fs::read_to_string(&parser_c_path)
         .map(|content| content == parser_code)
         .unwrap_or(false)
@@ -90,8 +90,13 @@ pub fn get_test_language(name: &str, parser_code: &str, path: Option<&Path>) -> 
         }
     });
 
-    let needs_recompile =
-        needs_recompile(&FIXTURES_DIR.join(name), &parser_c_path, &scanner_path, &[]).unwrap();
+    let paths_to_check = if let Some(scanner_path) = &scanner_path {
+        vec![parser_c_path.clone(), scanner_path.to_path_buf()]
+    } else {
+        vec![parser_c_path.clone()]
+    };
+
+    let needs_recompile = needs_recompile(&FIXTURES_DIR.join(name), &paths_to_check).unwrap();
 
     TEST_LOADER
         .load_language_from_sources(
@@ -106,32 +111,18 @@ pub fn get_test_language(name: &str, parser_code: &str, path: Option<&Path>) -> 
 
 pub fn get_test_grammar(name: &str) -> (String, Option<PathBuf>) {
     let dir = fixtures_dir().join("test_grammars").join(name);
-    let grammar = fs::read_to_string(&dir.join("grammar.json")).expect(&format!(
-        "Can't find grammar.json for test grammar {}",
-        name
-    ));
+    let grammar = fs::read_to_string(dir.join("grammar.json"))
+        .unwrap_or_else(|_| panic!("Can't find grammar.json for test grammar {name}"));
     (grammar, Some(dir))
 }
 
-pub fn needs_recompile(
-    lib_path: &Path,
-    parser_c_path: &Path,
-    scanner_path: &Option<PathBuf>,
-    external_files_paths: &[PathBuf],
-) -> Result<bool> {
+fn needs_recompile(lib_path: &Path, paths_to_check: &[PathBuf]) -> Result<bool> {
     if !lib_path.exists() {
         return Ok(true);
     }
     let lib_mtime = mtime(lib_path)?;
-    if mtime(parser_c_path)? > lib_mtime {
-        return Ok(true);
-    }
-    if let Some(scanner_path) = scanner_path {
-        if mtime(scanner_path)? > lib_mtime {
-            return Ok(true);
-        }
-    }
-    for path in external_files_paths {
+
+    for path in paths_to_check {
         if mtime(path)? > lib_mtime {
             return Ok(true);
         }

--- a/docs/section-4-syntax-highlighting.md
+++ b/docs/section-4-syntax-highlighting.md
@@ -92,6 +92,8 @@ These keys specify basic information about the parser:
 
 * `path` (optional) - A relative path from the directory containing `package.json` to another directory containing the `src/` folder, which contains the actual generated parser. The default value is `"."` (so that `src/` is in the same folder as `package.json`), and this very rarely needs to be overridden.
 
+* `external-files` (optional) - A list of relative paths from the root dir of a parser to files that should be checked for modificiations during recompilation. This is useful during development to have changes to other files besides scanner.c be picked up by the cli.
+
 ### Language Detection
 
 These keys help to decide whether the language applies to a given file:


### PR DESCRIPTION
Supersedes #2533

This time, only an "external_files" array can be specified *only* meant to check the mtime.

The reason the old design was rejected was mainly due to complexity - it overcomplicated a simple problem and added too much that was not needed. Adding features such as controlling the linked-in libraries and compiler flags is not the goal of this PR, that adds unnecessary complexity and will cause platform incompatibilities down the line.

What *is* needed is knowing what files a `scanner.c` might include for compilation, so that the CLI may check its mtime for changes to know *when* it should recompile. This PR does exactly that by allowing one to specify an external-files array in package.json for additional files *beyond* scanner.c.

We want tree-sitter parsers to be as portable and reproducible on any system as possible - allowing one to specify flags and link args to the compiler execution inside the cli can break that if a user uses platform or compiler specific flags and links.