### PR TITLE
fix(injections): only allow setting self/parent via `#set!`

### DIFF
--- a/highlight/src/lib.rs
+++ b/highlight/src/lib.rs
@@ -113,8 +113,6 @@ pub struct HighlightConfiguration {
     non_local_variable_patterns: Vec<bool>,
     injection_content_capture_index: Option<u32>,
     injection_language_capture_index: Option<u32>,
-    injection_parent_capture_index: Option<u32>,
-    injection_self_capture_index: Option<u32>,
     local_scope_capture_index: Option<u32>,
     local_def_capture_index: Option<u32>,
     local_def_value_capture_index: Option<u32>,
@@ -315,8 +313,6 @@ impl HighlightConfiguration {
         // Store the numeric ids for all of the special captures.
         let mut injection_content_capture_index = None;
         let mut injection_language_capture_index = None;
-        let mut injection_parent_capture_index = None;
-        let mut injection_self_capture_index = None;
         let mut local_def_capture_index = None;
         let mut local_def_value_capture_index = None;
         let mut local_ref_capture_index = None;
@@ -326,8 +322,6 @@ impl HighlightConfiguration {
             match name.as_str() {
                 "injection.content" => injection_content_capture_index = i,
                 "injection.language" => injection_language_capture_index = i,
-                "injection.parent" => injection_parent_capture_index = i,
-                "injection.self" => injection_self_capture_index = i,
                 "local.definition" => local_def_capture_index = i,
                 "local.definition-value" => local_def_value_capture_index = i,
                 "local.reference" => local_ref_capture_index = i,
@@ -349,8 +343,6 @@ impl HighlightConfiguration {
             non_local_variable_patterns,
             injection_content_capture_index,
             injection_language_capture_index,
-            injection_parent_capture_index,
-            injection_self_capture_index,
             local_def_capture_index,
             local_def_value_capture_index,
             local_ref_capture_index,
@@ -1145,12 +1137,9 @@ fn injection_for_match<'a>(
 ) -> (Option<&'a str>, Option<Node<'a>>, bool) {
     let content_capture_index = config.injection_content_capture_index;
     let language_capture_index = config.injection_language_capture_index;
-    let parent_capture_index = config.injection_parent_capture_index;
-    let self_capture_index = config.injection_self_capture_index;
 
     let mut language_name = None;
     let mut content_node = None;
-    let parent_name = parent_name.unwrap_or_default();
 
     for capture in query_match.captures {
         let index = Some(capture.index);
@@ -1158,14 +1147,6 @@ fn injection_for_match<'a>(
             language_name = capture.node.utf8_text(source).ok();
         } else if index == content_capture_index {
             content_node = Some(capture.node);
-        } else if index == parent_capture_index && !parent_name.is_empty() {
-            language_name = Some(parent_name);
-            content_node = Some(capture.node);
-        } else if index == self_capture_index {
-            if let Ok(name) = capture.node.utf8_text(source) {
-                language_name = Some(name);
-                content_node = Some(capture.node);
-            }
         }
     }
 
@@ -1187,6 +1168,15 @@ fn injection_for_match<'a>(
             "injection.self" => {
                 if language_name.is_none() {
                     language_name = Some(config.language_name.as_str());
+                }
+            }
+
+            // Setting the `injection.parent` key can be used to specify that
+            // the language name should be the same as the language of the
+            // parent layer
+            "injection.parent" => {
+                if language_name.is_none() {
+                    language_name = parent_name;
                 }
             }
 


### PR DESCRIPTION
Since we already know the languages of self and parent, there's no need to add extra fields to the highlight config since the node's text isn't relevant.