### PR TITLE
fix: ignore regex u flag

### DIFF
--- a/cli/src/generate/parse_grammar.rs
+++ b/cli/src/generate/parse_grammar.rs
@@ -150,10 +150,10 @@ fn parse_rule(json: RuleJSON) -> Rule {
                 f.chars()
                     .filter(|c| {
                         if *c != 'i' {
-                            eprintln!("Warning: unsupported flag {}", c);
+                            eprintln!("Warning: unsupported flag {c}");
                             false
                         } else {
-                            true
+                            *c != 'u' // silently ignore unicode flag
                         }
                     })
                     .collect()


### PR DESCRIPTION
It's needed for certain regex patterns in JS, and we can just silently ignore it.