### PR TITLE
chore: fix CI after fixture grammar updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,11 @@ jobs:
         - { runtime: linux-sparc64     , cc: sparc64-linux-gnu-gcc             , ar: sparc64-linux-gnu-ar           }
         - { runtime: linux-thumbv7neon , cc: arm-linux-gnueabihf-gcc           , ar: arm-linux-gnueabihf-ar         }
 
+        # Rust toolchains
+        - { runtime: linux-mips        , rust-toolchain: 1.71.1 }
+        - { runtime: linux-mips64      , rust-toolchain: 1.71.1 }
+        - { runtime: linux-mipsel      , rust-toolchain: 1.71.1 }
+        - { runtime: linux-mips64el    , rust-toolchain: 1.71.1 }
 
         # See #2041 tree-sitter issue
         - { runtime: windows-x64   , rust-test-threads: 1 }
@@ -145,6 +150,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         targets: ${{ matrix.target }}
+        toolchain: ${{ matrix.rust-toolchain || 'stable' }}
 
     - name: Install cross
       if: ${{ matrix.use-cross }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,12 +27,12 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.runtime }} (${{ matrix.target }}) (${{ matrix.os }})
+    name: ${{ matrix.platform }} (${{ matrix.target }}) (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        runtime:
+        platform:
         - linux-arm64       #
         - linux-arm         #
         - linux-armhf       #
@@ -60,66 +60,66 @@ jobs:
 
         include:
         # When adding a new `target`:
-        # 1. Define a new runtime alias above
+        # 1. Define a new platform alias above
         # 2. Add a new record to a matrix map in `cli/npm/install.js`
-        - { runtime: linux-arm64       , target: aarch64-unknown-linux-gnu           , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-arm         , target: arm-unknown-linux-gnueabi           , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-armhf       , target: arm-unknown-linux-gnueabihf         , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-armv5te     , target: armv5te-unknown-linux-gnueabi       , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-armv7l      , target: armv7-unknown-linux-gnueabihf       , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-x64         , target: x86_64-unknown-linux-gnu            , os: ubuntu-20.04                     } #2272
-        - { runtime: linux-x86         , target: i686-unknown-linux-gnu              , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-i586        , target: i586-unknown-linux-gnu              , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-mips        , target: mips-unknown-linux-gnu              , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-mips64      , target: mips64-unknown-linux-gnuabi64       , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-mipsel      , target: mipsel-unknown-linux-gnu            , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-mips64el    , target: mips64el-unknown-linux-gnuabi64     , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-powerpc     , target: powerpc-unknown-linux-gnu           , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-powerpc64   , target: powerpc64-unknown-linux-gnu         , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-powerpc64el , target: powerpc64le-unknown-linux-gnu       , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-riscv64gc   , target: riscv64gc-unknown-linux-gnu         , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-s390x       , target: s390x-unknown-linux-gnu             , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-sparc64     , target: sparc64-unknown-linux-gnu           , os: ubuntu-latest  , use-cross: true }
-        - { runtime: linux-thumbv7neon , target: thumbv7neon-unknown-linux-gnueabihf , os: ubuntu-latest  , use-cross: true }
-        - { runtime: windows-arm64     , target: aarch64-pc-windows-msvc             , os: windows-latest                   }
-        - { runtime: windows-x64       , target: x86_64-pc-windows-msvc              , os: windows-latest                   }
-        - { runtime: windows-x86       , target: i686-pc-windows-msvc                , os: windows-latest                   }
-        - { runtime: macos-arm64       , target: aarch64-apple-darwin                , os: macos-latest                     }
-        - { runtime: macos-x64         , target: x86_64-apple-darwin                 , os: macos-latest                     }
+        - { platform: linux-arm64       , target: aarch64-unknown-linux-gnu           , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-arm         , target: arm-unknown-linux-gnueabi           , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-armhf       , target: arm-unknown-linux-gnueabihf         , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-armv5te     , target: armv5te-unknown-linux-gnueabi       , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-armv7l      , target: armv7-unknown-linux-gnueabihf       , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-x64         , target: x86_64-unknown-linux-gnu            , os: ubuntu-20.04                     } #2272
+        - { platform: linux-x86         , target: i686-unknown-linux-gnu              , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-i586        , target: i586-unknown-linux-gnu              , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-mips        , target: mips-unknown-linux-gnu              , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-mips64      , target: mips64-unknown-linux-gnuabi64       , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-mipsel      , target: mipsel-unknown-linux-gnu            , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-mips64el    , target: mips64el-unknown-linux-gnuabi64     , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-powerpc     , target: powerpc-unknown-linux-gnu           , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-powerpc64   , target: powerpc64-unknown-linux-gnu         , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-powerpc64el , target: powerpc64le-unknown-linux-gnu       , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-riscv64gc   , target: riscv64gc-unknown-linux-gnu         , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-s390x       , target: s390x-unknown-linux-gnu             , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-sparc64     , target: sparc64-unknown-linux-gnu           , os: ubuntu-latest  , use-cross: true }
+        - { platform: linux-thumbv7neon , target: thumbv7neon-unknown-linux-gnueabihf , os: ubuntu-latest  , use-cross: true }
+        - { platform: windows-arm64     , target: aarch64-pc-windows-msvc             , os: windows-latest                   }
+        - { platform: windows-x64       , target: x86_64-pc-windows-msvc              , os: windows-latest                   }
+        - { platform: windows-x86       , target: i686-pc-windows-msvc                , os: windows-latest                   }
+        - { platform: macos-arm64       , target: aarch64-apple-darwin                , os: macos-latest                     }
+        - { platform: macos-x64         , target: x86_64-apple-darwin                 , os: macos-latest                     }
 
         # Cross compilers for C library
-        - { runtime: linux-arm64       , cc: aarch64-linux-gnu-gcc             , ar: aarch64-linux-gnu-ar           }
-        - { runtime: linux-arm         , cc: arm-linux-gnueabi-gcc             , ar: arm-linux-gnueabi-ar           }
-        - { runtime: linux-armhf       , cc: arm-unknown-linux-gnueabihf-gcc   , ar: arm-unknown-linux-gnueabihf-ar }
-        - { runtime: linux-armv5te     , cc: arm-linux-gnueabi-gcc             , ar: arm-linux-gnueabi-ar           }
-        - { runtime: linux-armv7l      , cc: arm-linux-gnueabihf-gcc           , ar: arm-linux-gnueabihf-ar         }
-        - { runtime: linux-x86         , cc: i686-linux-gnu-gcc                , ar: i686-linux-gnu-ar              }
-        - { runtime: linux-i586        , cc: i686-linux-gnu-gcc                , ar: i686-linux-gnu-ar              }
-        - { runtime: linux-mips        , cc: mips-linux-gnu-gcc                , ar: mips-linux-gnu-ar              }
-        - { runtime: linux-mips64      , cc: mips64-linux-gnuabi64-gcc         , ar: mips64-linux-gnuabi64-ar       }
-        - { runtime: linux-mipsel      , cc: mipsel-linux-gnu-gcc              , ar: mipsel-linux-gnu-ar            }
-        - { runtime: linux-mips64el    , cc: mips64el-linux-gnuabi64-gcc       , ar: mips64el-linux-gnuabi64-ar     }
-        - { runtime: linux-powerpc     , cc: powerpc-linux-gnu-gcc             , ar: powerpc-linux-gnu-ar           }
-        - { runtime: linux-powerpc64   , cc: powerpc64-linux-gnu-gcc           , ar: powerpc64-linux-gnu-ar         }
-        - { runtime: linux-powerpc64el , cc: powerpc64le-linux-gnu-gcc         , ar: powerpc64le-linux-gnu-ar       }
-        - { runtime: linux-riscv64gc   , cc: riscv64-linux-gnu-gcc             , ar: riscv64-linux-gnu-ar           }
-        - { runtime: linux-s390x       , cc: s390x-linux-gnu-gcc               , ar: s390x-linux-gnu-ar             }
-        - { runtime: linux-sparc64     , cc: sparc64-linux-gnu-gcc             , ar: sparc64-linux-gnu-ar           }
-        - { runtime: linux-thumbv7neon , cc: arm-linux-gnueabihf-gcc           , ar: arm-linux-gnueabihf-ar         }
+        - { platform: linux-arm64       , cc: aarch64-linux-gnu-gcc             , ar: aarch64-linux-gnu-ar           }
+        - { platform: linux-arm         , cc: arm-linux-gnueabi-gcc             , ar: arm-linux-gnueabi-ar           }
+        - { platform: linux-armhf       , cc: arm-unknown-linux-gnueabihf-gcc   , ar: arm-unknown-linux-gnueabihf-ar }
+        - { platform: linux-armv5te     , cc: arm-linux-gnueabi-gcc             , ar: arm-linux-gnueabi-ar           }
+        - { platform: linux-armv7l      , cc: arm-linux-gnueabihf-gcc           , ar: arm-linux-gnueabihf-ar         }
+        - { platform: linux-x86         , cc: i686-linux-gnu-gcc                , ar: i686-linux-gnu-ar              }
+        - { platform: linux-i586        , cc: i686-linux-gnu-gcc                , ar: i686-linux-gnu-ar              }
+        - { platform: linux-mips        , cc: mips-linux-gnu-gcc                , ar: mips-linux-gnu-ar              }
+        - { platform: linux-mips64      , cc: mips64-linux-gnuabi64-gcc         , ar: mips64-linux-gnuabi64-ar       }
+        - { platform: linux-mipsel      , cc: mipsel-linux-gnu-gcc              , ar: mipsel-linux-gnu-ar            }
+        - { platform: linux-mips64el    , cc: mips64el-linux-gnuabi64-gcc       , ar: mips64el-linux-gnuabi64-ar     }
+        - { platform: linux-powerpc     , cc: powerpc-linux-gnu-gcc             , ar: powerpc-linux-gnu-ar           }
+        - { platform: linux-powerpc64   , cc: powerpc64-linux-gnu-gcc           , ar: powerpc64-linux-gnu-ar         }
+        - { platform: linux-powerpc64el , cc: powerpc64le-linux-gnu-gcc         , ar: powerpc64le-linux-gnu-ar       }
+        - { platform: linux-riscv64gc   , cc: riscv64-linux-gnu-gcc             , ar: riscv64-linux-gnu-ar           }
+        - { platform: linux-s390x       , cc: s390x-linux-gnu-gcc               , ar: s390x-linux-gnu-ar             }
+        - { platform: linux-sparc64     , cc: sparc64-linux-gnu-gcc             , ar: sparc64-linux-gnu-ar           }
+        - { platform: linux-thumbv7neon , cc: arm-linux-gnueabihf-gcc           , ar: arm-linux-gnueabihf-ar         }
 
         # Rust toolchains
-        - { runtime: linux-mips        , rust-toolchain: 1.71.1 }
-        - { runtime: linux-mips64      , rust-toolchain: 1.71.1 }
-        - { runtime: linux-mipsel      , rust-toolchain: 1.71.1 }
-        - { runtime: linux-mips64el    , rust-toolchain: 1.71.1 }
+        - { platform: linux-mips        , rust-toolchain: 1.71.1 }
+        - { platform: linux-mips64      , rust-toolchain: 1.71.1 }
+        - { platform: linux-mipsel      , rust-toolchain: 1.71.1 }
+        - { platform: linux-mips64el    , rust-toolchain: 1.71.1 }
 
         # See #2041 tree-sitter issue
-        - { runtime: windows-x64   , rust-test-threads: 1 }
-        - { runtime: windows-x86   , rust-test-threads: 1 }
+        - { platform: windows-x64   , rust-test-threads: 1 }
+        - { platform: windows-x86   , rust-test-threads: 1 }
 
         # CLI only build
-        - { runtime: windows-arm64 , cli-only: true }
-        - { runtime: macos-arm64   , cli-only: true }
+        - { platform: windows-arm64 , cli-only: true }
+        - { platform: macos-arm64   , cli-only: true }
 
     env:
       BUILD_CMD: cargo
@@ -218,7 +218,7 @@ jobs:
       run: $BUILD_CMD build --release --target=${{ matrix.target }}
 
     - name: Info about CLI
-      if: ${{ startsWith(matrix.runtime, 'linux') }}
+      if: ${{ startsWith(matrix.platform, 'linux') }}
       run: |
         min_glibc=$(objdump -p target/$TARGET/release/tree-sitter${{ env.EXE }} | sed -nr 's/.*(GLIBC_.+).*/\1/p' | sort -uV | tail -n1)
         echo "🔗 Minimal **glibc** version required for CLI: ${min_glibc}">> $GITHUB_STEP_SUMMARY
@@ -250,13 +250,13 @@ jobs:
     - name: Upload CLI artifact
       uses: actions/upload-artifact@v3
       with:
-        name: tree-sitter.${{ matrix.runtime }}
+        name: tree-sitter.${{ matrix.platform }}
         path: target/${{ matrix.target }}/release/tree-sitter${{ env.EXE }}
         if-no-files-found: error
         retention-days: 7
 
     - name: Upload WASM artifacts
-      if: ${{ matrix.runtime == 'linux-x64' }}
+      if: ${{ matrix.platform == 'linux-x64' }}
       uses: actions/upload-artifact@v3
       with:
         name: tree-sitter.wasm

--- a/lib/binding_web/test/parser-test.js
+++ b/lib/binding_web/test/parser-test.js
@@ -127,19 +127,19 @@ describe("Parser", () => {
 
     it("can use the bash parser", async () => {
       parser.setLanguage(await Parser.Language.load(languageURL('bash')));
-      tree = parser.parse("FOO=bar echo <<EOF 2> err.txt > hello.txt \nhello\nEOF");
+      tree = parser.parse("FOO=bar echo <<EOF 2> err.txt > hello.txt \nhello${FOO}\nEOF");
       assert.equal(
         tree.rootNode.toString(),
-        '(program (redirected_statement ' +
-          'body: (command ' +
-            '(variable_assignment ' +
-              'name: (variable_name) ' +
-              'value: (word)) ' +
-            'name: (command_name (word))) ' +
-          'redirect: (heredoc_redirect (heredoc_start)) ' +
-          'redirect: (file_redirect descriptor: (file_descriptor) destination: (word)) ' +
-          'redirect: (file_redirect destination: (word))) ' +
-          '(heredoc_body))'
+          '(program ' +
+            '(redirected_statement ' +
+              'body: (command ' +
+                '(variable_assignment name: (variable_name) value: (word)) ' +
+                'name: (command_name (word))) ' +
+              'redirect: (heredoc_redirect (heredoc_start) ' +
+                'redirect: (file_redirect descriptor: (file_descriptor) destination: (word)) ' +
+                'redirect: (file_redirect destination: (word)) ' +
+                '(heredoc_body ' +
+                  '(expansion (variable_name))) (heredoc_end))))'
       );
     }).timeout(5000);
 


### PR DESCRIPTION
This PR also pins all `mips*-gnu` targets to Rust's `1.71.1` toolchain version because it's the last version where such targets available.

 _I didn't found any official notes about dropping support for such targets, what looks strange._ :thinking: