### PR TITLE
fix: makefile should install only `api.h` header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ install: all
 	ln -sf libtree-sitter.$(SOEXTVER) '$(DESTDIR)$(LIBDIR)'/libtree-sitter.$(SOEXT)
 
 	install -d '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter
-	install -m644 lib/include/tree_sitter/*.h '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/
+	install -m644 lib/include/tree_sitter/api.h '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/
 
 	install -d '$(DESTDIR)$(PCLIBDIR)'
 	install -m644 tree-sitter.pc '$(DESTDIR)$(PCLIBDIR)'/


### PR DESCRIPTION
This PR addresses an issue raised in https://github.com/tree-sitter/tree-sitter-bash/issues/199#issuecomment-1694416505
Because Gentoo distributive solely relies on Tree-sitter's Makefile and got an issue due to an issue in the Makefile.