### PR TITLE
fix(gen): `parser.c` should include `parser.h` relatively

### DIFF
--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -256,7 +256,7 @@ impl Generator {
     }
 
     fn add_includes(&mut self) {
-        add_line!(self, "#include <tree_sitter/parser.h>");
+        add_line!(self, "#include \"tree_sitter/parser.h\"");
         add_line!(self, "");
     }
 


### PR DESCRIPTION
Related to https://github.com/tree-sitter/tree-sitter-bash/issues/199#issuecomment-1694416505