### PR TITLE
Intern/absorption edge case fix

### DIFF
--- a/cli/src/generate/mod.rs
+++ b/cli/src/generate/mod.rs
@@ -226,8 +226,8 @@ fn load_js_grammar_file(grammar_path: &Path, js_runtime: Option<&str>) -> Result
     write!(
         js_stdin,
         "globalThis.TREE_SITTER_CLI_VERSION_MAJOR = {};
-        globalThis.TREE_SITTER_CLI_VERSION_MINOR = {};
-        globalThis.TREE_SITTER_CLI_VERSION_PATCH = {};",
+         globalThis.TREE_SITTER_CLI_VERSION_MINOR = {};
+         globalThis.TREE_SITTER_CLI_VERSION_PATCH = {};",
         cli_version.major, cli_version.minor, cli_version.patch,
     )
     .with_context(|| format!("Failed to write tree-sitter version to {js_runtime}'s stdin"))?;

--- a/cli/src/generate/prepare_grammar/intern_symbols.rs
+++ b/cli/src/generate/prepare_grammar/intern_symbols.rs
@@ -18,13 +18,13 @@ pub(super) fn intern_symbols(grammar: &InputGrammar) -> Result<InternedGrammar> 
         variables.push(Variable {
             name: variable.name.clone(),
             kind: variable_type_for_name(&variable.name),
-            rule: interner.intern_rule(&variable.rule)?,
+            rule: interner.intern_rule(&variable.rule, Some(&variable.name))?,
         });
     }
 
     let mut external_tokens = Vec::with_capacity(grammar.external_tokens.len());
     for external_token in &grammar.external_tokens {
-        let rule = interner.intern_rule(external_token)?;
+        let rule = interner.intern_rule(external_token, None)?;
         let (name, kind) = if let Rule::NamedSymbol(name) = external_token {
             (name.clone(), variable_type_for_name(name))
         } else {
@@ -35,7 +35,7 @@ pub(super) fn intern_symbols(grammar: &InputGrammar) -> Result<InternedGrammar> 
 
     let mut extra_symbols = Vec::with_capacity(grammar.extra_symbols.len());
     for extra_token in &grammar.extra_symbols {
-        extra_symbols.push(interner.intern_rule(extra_token)?);
+        extra_symbols.push(interner.intern_rule(extra_token, None)?);
     }
 
     let mut supertype_symbols = Vec::with_capacity(grammar.supertype_symbols.len());
@@ -99,33 +99,37 @@ struct Interner<'a> {
 }
 
 impl<'a> Interner<'a> {
-    fn intern_rule(&self, rule: &Rule) -> Result<Rule> {
+    fn intern_rule(&self, rule: &Rule, name: Option<&str>) -> Result<Rule> {
         match rule {
             Rule::Choice(elements) => {
+                if let Some(result) = self.intern_single(elements, name) {
+                    return result;
+                }
                 let mut result = Vec::with_capacity(elements.len());
                 for element in elements {
-                    result.push(self.intern_rule(element)?);
+                    result.push(self.intern_rule(element, name)?);
                 }
                 Ok(Rule::Choice(result))
             }
             Rule::Seq(elements) => {
+                if let Some(result) = self.intern_single(elements, name) {
+                    return result;
+                }
                 let mut result = Vec::with_capacity(elements.len());
                 for element in elements {
-                    result.push(self.intern_rule(element)?);
+                    result.push(self.intern_rule(element, name)?);
                 }
                 Ok(Rule::Seq(result))
             }
-            Rule::Repeat(content) => Ok(Rule::Repeat(Box::new(self.intern_rule(content)?))),
+            Rule::Repeat(content) => Ok(Rule::Repeat(Box::new(self.intern_rule(content, name)?))),
             Rule::Metadata { rule, params } => Ok(Rule::Metadata {
-                rule: Box::new(self.intern_rule(rule)?),
+                rule: Box::new(self.intern_rule(rule, name)?),
                 params: params.clone(),
             }),
-
             Rule::NamedSymbol(name) => self.intern_name(name).map_or_else(
                 || Err(anyhow!("Undefined symbol `{name}`")),
                 |symbol| Ok(Rule::Symbol(symbol)),
             ),
-
             _ => Ok(rule.clone()),
         }
     }
@@ -146,6 +150,21 @@ impl<'a> Interner<'a> {
         }
 
         None
+    }
+
+    // In the case of a seq or choice rule of 1 element in a hidden rule, weird
+    // inconsistent behavior w/ queries can occur. So we should treat it as that single rule itself
+    // in this case.
+    fn intern_single(&self, elements: &[Rule], name: Option<&str>) -> Option<Result<Rule>> {
+        if elements.len() == 1 && matches!(elements[0], Rule::String(_) | Rule::Pattern(_, _)) {
+            eprintln!(
+                "Warning: rule {} is just a `seq` or `choice` rule with a single element. This is unnecessary.",
+                name.unwrap_or_default()
+            );
+            Some(self.intern_rule(&elements[0], name))
+        } else {
+            None
+        }
     }
 }
 
@@ -237,6 +256,42 @@ mod tests {
             Err(e) => assert_eq!(e.to_string(), "Undefined symbol `y`"),
             _ => panic!("Expected an error but got none"),
         }
+    }
+
+    #[test]
+    fn test_interning_a_seq_or_choice_of_one_rule() {
+        let grammar = intern_symbols(&build_grammar(vec![
+            Variable::named("w", Rule::choice(vec![Rule::string("a")])),
+            Variable::named("x", Rule::seq(vec![Rule::pattern("b", "")])),
+            Variable::named("y", Rule::string("a")),
+            Variable::named("z", Rule::pattern("b", "")),
+            // Hidden rules should not affect this.
+            Variable::hidden("_a", Rule::choice(vec![Rule::string("a")])),
+            Variable::hidden("_b", Rule::seq(vec![Rule::pattern("b", "")])),
+            Variable::hidden("_c", Rule::string("a")),
+            Variable::hidden("_d", Rule::pattern("b", "")),
+        ]))
+        .unwrap();
+
+        assert_eq!(
+            grammar.variables,
+            vec![
+                Variable::named("w", Rule::string("a")),
+                Variable::named("x", Rule::pattern("b", "")),
+                Variable::named("y", Rule::string("a")),
+                Variable::named("z", Rule::pattern("b", "")),
+                // Hidden rules show no change.
+                Variable::hidden("_a", Rule::string("a")),
+                Variable::hidden("_b", Rule::pattern("b", "")),
+                Variable::hidden("_c", Rule::string("a")),
+                Variable::hidden("_d", Rule::pattern("b", "")),
+            ]
+        );
+
+        assert_eq!(grammar.variables[0].rule, grammar.variables[2].rule);
+        assert_eq!(grammar.variables[1].rule, grammar.variables[3].rule);
+        assert_eq!(grammar.variables[4].rule, grammar.variables[6].rule);
+        assert_eq!(grammar.variables[5].rule, grammar.variables[7].rule);
     }
 
     fn build_grammar(variables: Vec<Variable>) -> InputGrammar {

--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -5011,7 +5011,7 @@ fn test_grammar_with_aliased_literal_query() {
     let (parser_name, parser_code) = generate_parser_for_grammar(
         r#"
         {
-            "name": "test",
+            "name": "test_grammar_with_aliased_literal_query",
             "rules": {
                 "source": {
                     "type": "REPEAT",
@@ -5071,7 +5071,69 @@ fn test_grammar_with_aliased_literal_query() {
         &language,
         r#"
         (compound_statement "}" @bracket1)
+        (expansion) @bracket2
+        "#,
+    );
+
+    assert!(query.is_ok());
+
+    let query = Query::new(
+        &language,
+        r#"
         (expansion "}" @bracket2)
+        "#,
+    );
+
+    assert!(query.is_err());
+}
+
+#[test]
+fn test_query_with_seq_or_choice_of_one_rule() {
+    // module.exports = grammar({
+    //   name: 'test',
+    //
+    //   rules: {
+    //     source: $ => choice($._seq, $._choice),
+    //
+    //     _seq: $ => seq("hi"),
+    //     _choice: $ => choice("bye"),
+    //   },
+    // });
+
+    let (parser_name, parser_code) = generate_parser_for_grammar(
+        r#"
+        {
+          "name": "test_query_with_seq_or_choice_of_one_rule",
+          "rules": {
+            "source": {
+              "type": "CHOICE",
+              "members": [
+                { "type": "SYMBOL", "name": "_seq" },
+                { "type": "SYMBOL", "name": "_choice" }
+              ]
+            },
+            "_seq": {
+              "type": "SEQ",
+              "members": [{ "type": "STRING", "value": "hi" }]
+            },
+            "_choice": {
+              "type": "CHOICE",
+              "members": [ { "type": "STRING", "value": "bye" } ]
+            }
+          },
+          "extras": [{ "type": "PATTERN", "value": "\\s" }]
+        }
+        "#,
+    )
+    .unwrap();
+
+    let language = get_test_language(&parser_name, &parser_code, None);
+
+    let query = Query::new(
+        &language,
+        r#"
+        "hi" @seq
+        "bye" @choice
         "#,
     );
 


### PR DESCRIPTION
# Problem/Background

Currently, the CLI and parser show weird and inconsistent behavior given a few edge cases that might come up when users are writing grammar. I initially thought it stemmed from the same problem, but there are actually two problems.

One, consider the following:

```js
module.exports = grammar({
    name: 'test',

    rules: {
        source: $ => choice($.a, $.b, $.c),
        
        a: $ => 'a',
        b: $ => seq('a'),
        c: $ => choice('c'),
});
```

At a glance, you'd assume `a`, `b`, and `c` to be similarly constructed in the parser, and the "under the hood" stuff to be roughly the same. This is *not* the case though when it comes to parsing and querying a grammar constructed like this. The problem lies in the usage of `seq` and `choice` on a single terminal, and the CLI not processing this the same way that it would given just one single terminal, in that it does not perform the same "absorbing" or "replacing" effect as it would given just the terminal itself.

When trying to query for a, we would need to use `(a)` since we know any named `a` nodes will *always* consist of the letter a, and so we cannot query for the anonymous literal node `"a"` because of this absorption effect. We know the same holds true for a sequence or choice of a singular terminal as well, given that it can only be that one item, so we *should* process these the same way as we do with just a single terminal.

However, for `b` and `c`, we can query for both the named nodes *and* their anonymous literal node *as well*, which is at best, unnoticed, and at worst, bizarrely inconsistent when one is writing queries with these edge cases in their grammar. 

Two, this is an even bigger problem when we consider hidden nodes: 

```js
module.exports = grammar({
    name: 'test',

    rules: {
        source: $ => choice($._a, $._b, $._c),
        
        _a: $ => 'a',
        _b: $ => seq('a'),
        _c: $ => choice('c'),
});
```

Hidden nodes that consist of a single terminal will get that terminal absorbed (in the above example, that would be `_a`), and then those that are a seq or choice of that single terminal can *query* for that literal, since as we know, a hidden node cannot be queried, but as we explained above, a single terminal wrapped in a seq or choice can be queried for. In this case, the hiding of a node provides extremely inconsistent behavior for a user, and can be a source of frustration for those that do not understand what's going on - this is the second problem, and while it does go hand-in-hand with the first one, it stems from another issue entirely.

Ideally, a user would not write rules that have these bizarre edge cases, but we should not have these inconsistencies to begin with as well.

# Solution

Fixing the first problem is not too hard - we should simply intern a sequence or choice of 1 rule the exact same way we intern a literal or pattern, and we should also print a warning to the user that this is a weird construct and is unnecessary.

The second problem is also not so hard, but it is a different problem entirely. When extracting terminal rules that have a single usage, we should not replace them if the rule encompassing them is a hidden rule, so that we can ensure these literals are query-able. In the case of visible nodes, the node itself should directly be used.

Tests were added for both cases that fail before the given changes, and illustrate the expected behavior of my changes :grin: 

