### PR TITLE
Add serialization support for queries, highlight configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,6 +757,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +931,8 @@ dependencies = [
  "bindgen",
  "cc",
  "regex",
+ "serde",
+ "serde_regex",
 ]
 
 [[package]]
@@ -982,6 +994,7 @@ version = "0.20.2"
 dependencies = [
  "lazy_static",
  "regex",
+ "serde",
  "thiserror",
  "tree-sitter",
 ]

--- a/cli/src/tests/helpers/query_helpers.rs
+++ b/cli/src/tests/helpers/query_helpers.rs
@@ -353,7 +353,7 @@ fn format_captures<'a>(
     captures
         .map(|capture| {
             (
-                query.capture_names()[capture.index as usize],
+                query.capture_names()[capture.index as usize].as_str(),
                 capture.node.utf8_text(source.as_bytes()).unwrap(),
             )
         })

--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -2269,7 +2269,7 @@ fn test_query_captures_within_byte_range_assigned_after_iterating() {
         for (mat, capture_ix) in captures.by_ref().take(5) {
             let capture = mat.captures[capture_ix as usize];
             results.push((
-                query.capture_names()[capture.index as usize],
+                query.capture_names()[capture.index as usize].as_str(),
                 &source[capture.node.byte_range()],
             ));
         }
@@ -2292,7 +2292,7 @@ fn test_query_captures_within_byte_range_assigned_after_iterating() {
         for (mat, capture_ix) in captures {
             let capture = mat.captures[capture_ix as usize];
             results.push((
-                query.capture_names()[capture.index as usize],
+                query.capture_names()[capture.index as usize].as_str(),
                 &source[capture.node.byte_range()],
             ));
         }
@@ -2533,7 +2533,7 @@ fn test_query_matches_with_captured_wildcard_at_root() {
                     .iter()
                     .map(|c| {
                         (
-                            query.capture_names()[c.index as usize],
+                            query.capture_names()[c.index as usize].as_str(),
                             c.node.kind(),
                             c.node.start_position().row,
                         )
@@ -3822,7 +3822,7 @@ fn test_query_random() {
                     captures: mat
                         .captures
                         .iter()
-                        .map(|c| (query.capture_names()[c.index as usize], c.node))
+                        .map(|c| (query.capture_names()[c.index as usize].as_str(), c.node))
                         .collect::<Vec<_>>(),
                 })
                 .collect::<Vec<_>>();

--- a/highlight/Cargo.toml
+++ b/highlight/Cargo.toml
@@ -17,10 +17,14 @@ rust-version.workspace = true
 [lib]
 crate-type = ["lib", "staticlib"]
 
+[features]
+serde = ["dep:serde", "tree-sitter/serde"]
+
 [dependencies]
 lazy_static = "1.4.0"
 regex = "1.9.1"
 thiserror = "1.0.43"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dependencies.tree-sitter]
 version = "0.20"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -22,8 +22,13 @@ include = [
   "/src/unicode/*",
 ]
 
+[features]
+serde = ["dep:serde", "serde_regex"]
+
 [dependencies]
 regex = "1.9.1"
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_regex = { version = "1.1", optional = true }
 
 [build-dependencies]
 bindgen = { version = "^0.66.1", optional = true }

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -665,18 +665,17 @@ extern "C" {
     pub fn ts_query_cursor_set_max_start_depth(self_: *mut TSQueryCursor, max_start_depth: u32);
 }
 extern "C" {
-    #[doc = " Serializes a Query to a bytestring."]
+    #[doc = " Serialize a query."]
     pub fn ts_query_serialize(
-        arg1: *const TSQuery,
-        arg2: *mut usize,
+        self_: *const TSQuery,
+        size: *mut usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Deserializes a bytestring to a TSQuery."]
+    #[doc = " Deserialize a query."]
     pub fn ts_query_deserialize(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const usize,
-        arg3: *const TSLanguage,
+        src: *const ::std::os::raw::c_char,
+        language: *const TSLanguage,
     ) -> *mut TSQuery;
 }
 extern "C" {

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -665,6 +665,21 @@ extern "C" {
     pub fn ts_query_cursor_set_max_start_depth(self_: *mut TSQueryCursor, max_start_depth: u32);
 }
 extern "C" {
+    #[doc = " Serializes a Query to a bytestring."]
+    pub fn ts_query_serialize(
+        arg1: *const TSQuery,
+        arg2: *mut usize,
+    ) -> *const ::std::os::raw::c_char;
+}
+extern "C" {
+    #[doc = " Deserializes a bytestring to a TSQuery."]
+    pub fn ts_query_deserialize(
+        arg1: *const ::std::os::raw::c_char,
+        arg2: *const usize,
+        arg3: *const TSLanguage,
+    ) -> *mut TSQuery;
+}
+extern "C" {
     #[doc = " Get the number of distinct node types in the language."]
     pub fn ts_language_symbol_count(self_: *const TSLanguage) -> u32;
 }

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -116,7 +116,17 @@ pub struct TreeCursor<'cursor>(ffi::TSTreeCursor, PhantomData<&'cursor ()>);
 #[derive(Debug)]
 pub struct Query {
     ptr: NonNull<ffi::TSQuery>,
-    capture_names: Box<[&'static str]>,
+    metadata: QueryMetadata,
+}
+
+#[derive(Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SerializableQuery(Vec<u8>, QueryMetadata);
+
+#[derive(Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct QueryMetadata {
+    capture_names: Box<[String]>,
     capture_quantifiers: Box<[Box<[CaptureQuantifier]>]>,
     text_predicates: Box<[Box<[TextPredicateCapture]>]>,
     property_settings: Box<[Box<[QueryProperty]>]>,
@@ -126,6 +136,7 @@ pub struct Query {
 
 /// A quantifier for captures
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CaptureQuantifier {
     Zero,
     ZeroOrOne,
@@ -155,6 +166,7 @@ pub struct QueryCursor {
 
 /// A key-value pair associated with a particular pattern in a [`Query`].
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryProperty {
     pub key: Box<str>,
     pub value: Option<Box<str>>,
@@ -162,6 +174,7 @@ pub struct QueryProperty {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum QueryPredicateArg {
     Capture(u32),
     String(Box<str>),
@@ -169,6 +182,7 @@ pub enum QueryPredicateArg {
 
 /// A key-value pair associated with a particular pattern in a [`Query`].
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPredicate {
     pub operator: Box<str>,
     pub args: Box<[QueryPredicateArg]>,
@@ -263,10 +277,16 @@ pub enum QueryErrorKind {
 /// The first bool is if the capture is positive
 /// The last item is a bool signifying whether or not it's meant to match
 /// any or all captures
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 enum TextPredicateCapture {
     EqString(u32, Box<str>, bool, bool),
     EqCapture(u32, u32, bool, bool),
-    MatchString(u32, regex::bytes::Regex, bool, bool),
+    MatchString(
+        u32,
+        #[cfg_attr(feature = "serde", serde(with = "serde_regex"))]
+        regex::bytes::Regex,
+        bool, bool
+    ),
     AnyString(u32, Box<[Box<str>]>, bool),
 }
 
@@ -1677,7 +1697,7 @@ impl Query {
                     as *const u8;
                 let name = slice::from_raw_parts(name, length as usize);
                 let name = str::from_utf8_unchecked(name);
-                capture_names.push(name);
+                capture_names.push(name.to_string());
             }
         }
 
@@ -1910,12 +1930,14 @@ impl Query {
 
         let result = Query {
             ptr: unsafe { NonNull::new_unchecked(ptr.0) },
-            capture_names: capture_names.into(),
-            capture_quantifiers: capture_quantifiers_vec.into(),
-            text_predicates: text_predicates_vec.into(),
-            property_predicates: property_predicates_vec.into(),
-            property_settings: property_settings_vec.into(),
-            general_predicates: general_predicates_vec.into(),
+            metadata: QueryMetadata {
+                capture_names: capture_names.into(),
+                capture_quantifiers: capture_quantifiers_vec.into(),
+                text_predicates: text_predicates_vec.into(),
+                property_predicates: property_predicates_vec.into(),
+                property_settings: property_settings_vec.into(),
+                general_predicates: general_predicates_vec.into(),
+            },
         };
 
         std::mem::forget(ptr);
@@ -1945,7 +1967,7 @@ impl Query {
     }
 
     /// Get the names of the captures used in the query.
-    pub fn capture_names(&self) -> &[&str] {
+    pub fn capture_names(&self) -> &[String] {
         &self.capture_names
     }
 
@@ -2037,7 +2059,7 @@ impl Query {
     fn parse_property(
         row: usize,
         function_name: &str,
-        capture_names: &[&str],
+        capture_names: &[String],
         string_values: &[&str],
         args: &[ffi::TSQueryPredicateStep],
     ) -> Result<QueryProperty, QueryError> {
@@ -2096,8 +2118,9 @@ impl Query {
         }
     }
 
+    /// Convert `self` into a serializable version of itself.
     #[doc(alias = "ts_query_serialize")]
-    pub fn serialize(&self) -> Result<Vec<u8>, SerializationError> {
+    pub fn serializable(mut self) -> Result<SerializableQuery, SerializationError> {
         let mut size: usize = 0;
         let ptr = unsafe { ffi::ts_query_serialize(self.ptr.as_ptr(), &mut size) };
         if ptr.is_null() {
@@ -2106,33 +2129,32 @@ impl Query {
             let slice = unsafe { slice::from_raw_parts(ptr as *const u8, size) };
             let vec = slice.to_vec();
             unsafe { (FREE_FN)(ptr as *mut c_void) };
-            Ok(vec)
+            let metadata = std::mem::replace(&mut self.metadata, QueryMetadata::default());
+            Ok(SerializableQuery(vec, metadata))
         }
     }
 
+    /// Deserialize the serializable version of a query.
     #[doc(alias = "ts_query_deserialize")]
     pub fn deserialize(
-        bytes: &Vec<u8>,
-        language: &Language,
-        source: &str,
+        data: SerializableQuery,
+        language: Language,
     ) -> Result<Self, SerializationError> {
         let version = language.version();
         if version < MIN_COMPATIBLE_LANGUAGE_VERSION || version > LANGUAGE_VERSION {
             Err(SerializationError::LanguageError(LanguageError { version }))
         } else {
-            let size: usize = bytes.len();
             let ptr = unsafe {
-                ffi::ts_query_deserialize(
-                    bytes.as_slice().as_ptr() as *const i8,
-                    size as *const usize,
-                    language.0,
-                )
+                let data_ptr = data.0.as_slice().as_ptr() as *const c_char;
+                ffi::ts_query_deserialize(data_ptr, language.0)
             };
             if ptr.is_null() {
                 Err(SerializationError::AllocationError)
             } else {
-                unsafe { Query::from_raw_parts(ptr, source) }
-                    .map_err(SerializationError::DeserializationError)
+                Ok(Query {
+                    ptr: unsafe { NonNull::new_unchecked(ptr) },
+                    metadata: data.1,
+                })
             }
         }
     }
@@ -2404,6 +2426,20 @@ impl<'tree> QueryMatch<'_, 'tree> {
                     true
                 }
             })
+    }
+}
+
+impl std::ops::Deref for Query {
+    type Target = QueryMetadata;
+
+    fn deref(&self) -> &Self::Target {
+        &self.metadata
+    }
+}
+
+impl std::ops::DerefMut for Query {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.metadata
     }
 }
 

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -1009,6 +1009,19 @@ bool ts_query_cursor_next_capture(
  */
 void ts_query_cursor_set_max_start_depth(TSQueryCursor *self, uint32_t max_start_depth);
 
+/**
+ * Serialize a query.
+ */
+const char *ts_query_serialize(const TSQuery *self, size_t *size);
+
+/**
+ * Deserialize a query.
+ */
+TSQuery *ts_query_deserialize(
+  const char *src,
+  const TSLanguage *language
+);
+
 /**********************/
 /* Section - Language */
 /**********************/

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -4144,12 +4144,12 @@ void ts_query_cursor_set_max_start_depth(
 // Any additional capacity is discarded
 #define array_cpy(dest, self) \
   do { \
-    uint32_t size = (self)->size; \
-    uint32_t content_size = array__elem_size(self) * size; \
-    memcpy((dest), (void *)(&size), sizeof(size)); \
-    (dest) += sizeof(size); \
-    memcpy((dest), (self)->contents, content_size); \
-    (dest) += content_size; \
+    uint32_t _size = (self)->size; \
+    uint32_t _content_size = array__elem_size(self) * _size; \
+    memcpy((dest), (void *)(&_size), sizeof(_size)); \
+    (dest) += sizeof(_size); \
+    memcpy((dest), (self)->contents, _content_size); \
+    (dest) += _content_size; \
   } while (0)
 
 // Calculates the size in bytes a serialized ts_query would take up.
@@ -4193,8 +4193,7 @@ size_t query_serialize__size(const TSQuery *self) {
 // Serializes the provided query. The size of the resulting buffer is returned
 // via the size_t* argument.
 const char *ts_query_serialize(const TSQuery *self, size_t *size) {
-
-  // Calculates the required buffer sie exactly.
+  // Calculates the required buffer size exactly.
   size_t nr_bytes = query_serialize__size(self);
 
   // Report buffer size back to caller
@@ -4253,8 +4252,11 @@ const char *ts_query_serialize(const TSQuery *self, size_t *size) {
     (self)->capacity = (self)->size; \
   } while (0)
 
-TSQuery *ts_query_deserialize(const char *src, const size_t size,
-                              const TSLanguage *language) {
+// FIXME: Verify valid length of `src`.
+TSQuery *ts_query_deserialize(
+  const char *src,
+  const TSLanguage *language
+) {
   TSQuery *self = ts_malloc(sizeof(TSQuery));
 
   // Return NULL to indicate failure

--- a/tags/src/lib.rs
+++ b/tags/src/lib.rs
@@ -136,7 +136,7 @@ impl TagsConfiguration {
         let mut local_scope_capture_index = None;
         let mut local_definition_capture_index = None;
         for (i, name) in query.capture_names().iter().enumerate() {
-            match *name {
+            match name.as_str() {
                 "" => continue,
                 "name" => name_capture_index = Some(i as u32),
                 "ignore" => ignore_capture_index = Some(i as u32),


### PR DESCRIPTION
This is a continuation of #2374 which fully resolves #1942.

The approach here is to expose serializable versions of queries and highlight configurations instead of attempting to provide serialized versions directly. This enables the consumer to serialize the structures as they wish, and importantly, to do so in a way that respects things like byte order properly.

The above is exposed via new `serializable()` and `deserialize()` methods on `Query` and `HighlightConfiguration` and `Serializable{Query,HighlightConfiguration}` structures which implement `serde::{Serialize, Deserialize}` when the newly supported `serde` feature is enabled. I have successfully used this API to deserialize over 100 of highlight configurations in ~3 ms. This compares to ~3000ms to generate the configurations directly, or a 1000x improvement. The resulting structures can be used immediately without any additional preprocessing.

I should mention that there are a few concerns with the exact approach from #2374, which is replicated here:
  * There is no checking that the `const char *src` array's size is sufficient. Previously, a `size` argument was passed in but was unused. We should use the argument to check against the expected size.
  * Some sort of versioning needs to be added to (de)serialization. Otherwise, serialized bytes from a previous version can be deserialized by a new, incompatible version. While the bytes may physically fit, they may not semantically fit.  