### PR TITLE
chore(rust): make `Query` predicates state fully immutable

### DIFF
--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -828,8 +828,8 @@ impl<'a> LanguageConfiguration<'a> {
                     let mut all_highlight_names = self.highlight_names.lock().unwrap();
                     if self.use_all_highlight_names {
                         for capture_name in result.query.capture_names() {
-                            if !all_highlight_names.contains(capture_name) {
-                                all_highlight_names.push(capture_name.clone());
+                            if !all_highlight_names.iter().any(|x| x == capture_name) {
+                                all_highlight_names.push(capture_name.to_string());
                             }
                         }
                     }

--- a/cli/src/tests/helpers/query_helpers.rs
+++ b/cli/src/tests/helpers/query_helpers.rs
@@ -353,7 +353,7 @@ fn format_captures<'a>(
     captures
         .map(|capture| {
             (
-                query.capture_names()[capture.index as usize].as_str(),
+                query.capture_names()[capture.index as usize],
                 capture.node.utf8_text(source.as_bytes()).unwrap(),
             )
         })

--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -2269,7 +2269,7 @@ fn test_query_captures_within_byte_range_assigned_after_iterating() {
         for (mat, capture_ix) in captures.by_ref().take(5) {
             let capture = mat.captures[capture_ix as usize];
             results.push((
-                query.capture_names()[capture.index as usize].as_str(),
+                query.capture_names()[capture.index as usize],
                 &source[capture.node.byte_range()],
             ));
         }
@@ -2292,7 +2292,7 @@ fn test_query_captures_within_byte_range_assigned_after_iterating() {
         for (mat, capture_ix) in captures {
             let capture = mat.captures[capture_ix as usize];
             results.push((
-                query.capture_names()[capture.index as usize].as_str(),
+                query.capture_names()[capture.index as usize],
                 &source[capture.node.byte_range()],
             ));
         }
@@ -2533,7 +2533,7 @@ fn test_query_matches_with_captured_wildcard_at_root() {
                     .iter()
                     .map(|c| {
                         (
-                            query.capture_names()[c.index as usize].as_str(),
+                            query.capture_names()[c.index as usize],
                             c.node.kind(),
                             c.node.start_position().row,
                         )
@@ -2934,7 +2934,8 @@ fn test_query_captures_with_predicates() {
                 args: vec![
                     QueryPredicateArg::Capture(0),
                     QueryPredicateArg::String("omg".to_string().into_boxed_str()),
-                ],
+                ]
+                .into_boxed_slice(),
             },]
         );
         assert_eq!(query.property_settings(1), &[]);
@@ -3826,7 +3827,7 @@ fn test_query_random() {
                     captures: mat
                         .captures
                         .iter()
-                        .map(|c| (query.capture_names()[c.index as usize].as_str(), c.node))
+                        .map(|c| (query.capture_names()[c.index as usize], c.node))
                         .collect::<Vec<_>>(),
                 })
                 .collect::<Vec<_>>();

--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -3605,12 +3605,7 @@ fn test_query_capture_names() {
 
         assert_eq!(
             query.capture_names(),
-            &[
-                "left-operand".to_string(),
-                "right-operand".to_string(),
-                "body".to_string(),
-                "loop-condition".to_string(),
-            ]
+            ["left-operand", "right-operand", "body", "loop-condition"]
         );
     });
 }

--- a/highlight/src/lib.rs
+++ b/highlight/src/lib.rs
@@ -321,7 +321,7 @@ impl HighlightConfiguration {
         let mut local_scope_capture_index = None;
         for (i, name) in query.capture_names().iter().enumerate() {
             let i = Some(i as u32);
-            match name.as_str() {
+            match *name {
                 "injection.content" => injection_content_capture_index = i,
                 "injection.language" => injection_language_capture_index = i,
                 "local.definition" => local_def_capture_index = i,
@@ -353,7 +353,7 @@ impl HighlightConfiguration {
     }
 
     /// Get a slice containing all of the highlight names used in the configuration.
-    pub fn names(&self) -> &[String] {
+    pub fn names(&self) -> &[&str] {
         self.query.capture_names()
     }
 
@@ -399,7 +399,7 @@ impl HighlightConfiguration {
     // Return the list of this configuration's capture names that are neither present in the
     // list of predefined 'canonical' names nor start with an underscore (denoting 'private' captures
     // used as part of capture internals).
-    pub fn nonconformant_capture_names(&self, capture_names: &HashSet<&str>) -> Vec<&String> {
+    pub fn nonconformant_capture_names(&self, capture_names: &HashSet<&str>) -> Vec<&str> {
         let capture_names = if capture_names.is_empty() {
             &*STANDARD_CAPTURE_NAMES
         } else {
@@ -407,7 +407,8 @@ impl HighlightConfiguration {
         };
         self.names()
             .iter()
-            .filter(|&n| !(n.starts_with('_') || capture_names.contains(n.as_str())))
+            .filter(|&n| !(n.starts_with('_') || capture_names.contains(n)))
+            .map(|n| *n)
             .collect()
     }
 }

--- a/tags/src/lib.rs
+++ b/tags/src/lib.rs
@@ -136,7 +136,7 @@ impl TagsConfiguration {
         let mut local_scope_capture_index = None;
         let mut local_definition_capture_index = None;
         for (i, name) in query.capture_names().iter().enumerate() {
-            match name.as_str() {
+            match *name {
                 "" => continue,
                 "name" => name_capture_index = Some(i as u32),
                 "ignore" => ignore_capture_index = Some(i as u32),


### PR DESCRIPTION
This PR applies the use of only immutable structs for predicates state and removes redundant data copies. 