### PR TITLE
feat: allow setting the output directory for the generated C code

### DIFF
--- a/cli/generate/src/lib.rs
+++ b/cli/generate/src/lib.rs
@@ -44,6 +44,7 @@ pub const ARRAY_HEADER: &str = include_str!("templates/array.h");
 
 pub fn generate_parser_in_directory(
     repo_path: &Path,
+    out_path: Option<&str>,
     grammar_path: Option<&str>,
     abi_version: usize,
     report_symbol_name: Option<&str>,
@@ -72,7 +73,9 @@ pub fn generate_parser_in_directory(
     // Read the grammar file.
     let grammar_json = load_grammar_file(&grammar_path, js_runtime)?;
 
-    let src_path = repo_path.join("src");
+    let src_path = out_path
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repo_path.join("src"));
     let header_path = src_path.join("tree_sitter");
 
     // Ensure that the output directories exist.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -103,6 +103,13 @@ struct Generate {
     pub libdir: Option<String>,
     #[arg(
         long,
+        short,
+        value_name = "DIRECTORY",
+        help = "The path to output the generated source files"
+    )]
+    pub output: Option<String>,
+    #[arg(
+        long,
         help = "Produce a report of the states for the given rule, use `-` to report every rule"
     )]
     pub report_states_for_rule: Option<String>,
@@ -693,6 +700,7 @@ impl Generate {
                 });
         tree_sitter_generate::generate_parser_in_directory(
             current_dir,
+            self.output.as_deref(),
             self.grammar_path.as_deref(),
             abi_version,
             self.report_states_for_rule.as_deref(),


### PR DESCRIPTION
Automatically disables bindings as they are a bit more difficult to relocate into a single directory. Furthermore this makes integration into meson easier/possible(?) I'm not sure this is the right approach, but it works at least for my usecase.