### PR TITLE
Add tree-sitter-quakec to the parser list

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -107,6 +107,7 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 * [Protocol Buffers](https://github.com/mitchellh/tree-sitter-proto)
 * [Python](https://github.com/tree-sitter/tree-sitter-python)
 * [QML](https://github.com/yuja/tree-sitter-qmljs)
+* [QuakeC](https://github.com/vkazanov/tree-sitter-quakec)
 * [Racket](https://github.com/6cdh/tree-sitter-racket)
 * [Rasi](https://github.com/Fymyte/tree-sitter-rasi)
 * [re2c](https://github.com/alemuller/tree-sitter-re2c)


### PR DESCRIPTION
Add tree-sitter-quakec (a language of Quake 1 mods) to the parser list