### PR TITLE
fix: update javascript tests and use cpp/javascript master for fixtures

### DIFF
--- a/cli/src/tests/highlight_test.rs
+++ b/cli/src/tests/highlight_test.rs
@@ -62,7 +62,7 @@ lazy_static! {
 fn test_highlighting_javascript() {
     let source = "const a = function(b) { return b + c; }";
     assert_eq!(
-        &to_token_vector(&source, &JS_HIGHLIGHT).unwrap(),
+        &to_token_vector(source, &JS_HIGHLIGHT).unwrap(),
         &[vec![
             ("const", vec!["keyword"]),
             (" ", vec![]),
@@ -72,14 +72,14 @@ fn test_highlighting_javascript() {
             (" ", vec![]),
             ("function", vec!["keyword"]),
             ("(", vec!["punctuation.bracket"]),
-            ("b", vec!["variable.parameter"]),
+            ("b", vec!["variable"]),
             (")", vec!["punctuation.bracket"]),
             (" ", vec![]),
             ("{", vec!["punctuation.bracket"]),
             (" ", vec![]),
             ("return", vec!["keyword"]),
             (" ", vec![]),
-            ("b", vec!["variable.parameter"]),
+            ("b", vec!["variable"]),
             (" ", vec![]),
             ("+", vec!["operator"]),
             (" ", vec![]),
@@ -93,7 +93,7 @@ fn test_highlighting_javascript() {
 
 #[test]
 fn test_highlighting_injected_html_in_javascript() {
-    let source = vec!["const s = html `<div>${a < b}</div>`;"].join("\n");
+    let source = ["const s = html `<div>${a < b}</div>`;"].join("\n");
 
     assert_eq!(
         &to_token_vector(&source, &JS_HIGHLIGHT).unwrap(),
@@ -157,7 +157,7 @@ fn test_highlighting_injected_javascript_in_html_mini() {
 
 #[test]
 fn test_highlighting_injected_javascript_in_html() {
-    let source = vec![
+    let source = [
         "<body>",
         "  <script>",
         "    const x = new Thing();",
@@ -212,7 +212,7 @@ fn test_highlighting_injected_javascript_in_html() {
 
 #[test]
 fn test_highlighting_multiline_nodes_to_html() {
-    let source = vec![
+    let source = [
         "const SOMETHING = `",
         "  one ${",
         "    two()",
@@ -236,7 +236,7 @@ fn test_highlighting_multiline_nodes_to_html() {
 
 #[test]
 fn test_highlighting_with_local_variable_tracking() {
-    let source = vec![
+    let source = [
         "module.exports = function a(b) {",
         "  const module = c;",
         "  console.log(module, b);",
@@ -258,7 +258,7 @@ fn test_highlighting_with_local_variable_tracking() {
                 (" ", vec![]),
                 ("a", vec!["function"]),
                 ("(", vec!["punctuation.bracket"]),
-                ("b", vec!["variable.parameter"]),
+                ("b", vec!["variable"]),
                 (")", vec!["punctuation.bracket"]),
                 (" ", vec![]),
                 ("{", vec!["punctuation.bracket"])
@@ -285,7 +285,7 @@ fn test_highlighting_with_local_variable_tracking() {
                 (",", vec!["punctuation.delimiter"]),
                 (" ", vec![]),
                 // A parameter, because `b` was defined as a parameter above.
-                ("b", vec!["variable.parameter"]),
+                ("b", vec!["variable"]),
                 (")", vec!["punctuation.bracket"]),
                 (";", vec!["punctuation.delimiter"]),
             ],
@@ -296,7 +296,7 @@ fn test_highlighting_with_local_variable_tracking() {
 
 #[test]
 fn test_highlighting_empty_lines() {
-    let source = vec![
+    let source = [
         "class A {",
         "",
         "  b(c) {",
@@ -314,7 +314,7 @@ fn test_highlighting_empty_lines() {
         &[
             "<span class=keyword>class</span> <span class=constructor>A</span> <span class=punctuation.bracket>{</span>\n".to_string(),
             "\n".to_string(),
-            "  <span class=function>b</span><span class=punctuation.bracket>(</span><span class=variable.parameter>c</span><span class=punctuation.bracket>)</span> <span class=punctuation.bracket>{</span>\n".to_string(),
+            "  <span class=function>b</span><span class=punctuation.bracket>(</span><span class=variable>c</span><span class=punctuation.bracket>)</span> <span class=punctuation.bracket>{</span>\n".to_string(),
             "\n".to_string(),
             "    <span class=function>d</span><span class=punctuation.bracket>(</span><span class=variable>e</span><span class=punctuation.bracket>)</span>\n".to_string(),
             "\n".to_string(),
@@ -330,7 +330,7 @@ fn test_highlighting_carriage_returns() {
     let source = "a = \"a\rb\"\r\nb\r";
 
     assert_eq!(
-        &to_html(&source, &JS_HIGHLIGHT).unwrap(),
+        &to_html(source, &JS_HIGHLIGHT).unwrap(),
         &[
             "<span class=variable>a</span> <span class=operator>=</span> <span class=string>&quot;a<span class=carriage-return></span>b&quot;</span>\n",
             "<span class=variable>b</span>\n",
@@ -340,7 +340,7 @@ fn test_highlighting_carriage_returns() {
 
 #[test]
 fn test_highlighting_ejs_with_html_and_javascript() {
-    let source = vec!["<div><% foo() %></div><script> bar() </script>"].join("\n");
+    let source = ["<div><% foo() %></div><script> bar() </script>"].join("\n");
 
     assert_eq!(
         &to_token_vector(&source, &EJS_HIGHLIGHT).unwrap(),
@@ -377,7 +377,7 @@ fn test_highlighting_ejs_with_html_and_javascript() {
 fn test_highlighting_javascript_with_jsdoc() {
     // Regression test: the middle comment has no highlights. This should not prevent
     // later injections from highlighting properly.
-    let source = vec!["a /* @see a */ b; /* nothing */ c; /* @see b */"].join("\n");
+    let source = ["a /* @see a */ b; /* nothing */ c; /* @see b */"].join("\n");
 
     assert_eq!(
         &to_token_vector(&source, &JS_HIGHLIGHT).unwrap(),
@@ -405,7 +405,7 @@ fn test_highlighting_javascript_with_jsdoc() {
 
 #[test]
 fn test_highlighting_with_content_children_included() {
-    let source = vec!["assert!(", "    a.b.c() < D::e::<F>()", ");"].join("\n");
+    let source = ["assert!(", "    a.b.c() < D::e::<F>()", ");"].join("\n");
 
     assert_eq!(
         &to_token_vector(&source, &RUST_HIGHLIGHT).unwrap(),
@@ -483,7 +483,7 @@ fn test_highlighting_cancellation() {
 
 #[test]
 fn test_highlighting_via_c_api() {
-    let highlights = vec![
+    let highlights = [
         "class=tag\0",
         "class=function\0",
         "class=string\0",
@@ -622,11 +622,11 @@ fn test_highlighting_with_all_captures_applied() {
         [ \"{\" \"}\" \"(\" \")\" ] @punctuation.bracket
     "};
     let mut rust_highlight_reverse =
-        HighlightConfiguration::new(language, "rust", &highlights_query, "", "", true).unwrap();
+        HighlightConfiguration::new(language, "rust", highlights_query, "", "", true).unwrap();
     rust_highlight_reverse.configure(&HIGHLIGHT_NAMES);
 
     assert_eq!(
-        &to_token_vector(&source, &rust_highlight_reverse).unwrap(),
+        &to_token_vector(source, &rust_highlight_reverse).unwrap(),
         &[[
             ("fn", vec!["keyword"]),
             (" ", vec![]),
@@ -743,20 +743,20 @@ fn to_token_vector<'a>(
             }
             HighlightEvent::Source { start, end } => {
                 let s = str::from_utf8(&src[start..end]).unwrap();
-                for (i, l) in s.split("\n").enumerate() {
+                for (i, l) in s.split('\n').enumerate() {
                     let l = l.trim_end_matches('\r');
                     if i > 0 {
                         lines.push(line);
                         line = Vec::new();
                     }
-                    if l.len() > 0 {
+                    if !l.is_empty() {
                         line.push((l, highlights.clone()));
                     }
                 }
             }
         }
     }
-    if line.len() > 0 {
+    if !line.is_empty() {
         lines.push(line);
     }
     Ok(lines)

--- a/cli/src/tests/parser_test.rs
+++ b/cli/src/tests/parser_test.rs
@@ -148,7 +148,7 @@ fn test_parsing_with_custom_utf8_input() {
         )
     );
     assert_eq!(root.kind(), "source_file");
-    assert_eq!(root.has_error(), false);
+    assert!(!root.has_error());
     assert_eq!(root.child(0).unwrap().kind(), "function_item");
 }
 
@@ -187,7 +187,7 @@ fn test_parsing_with_custom_utf16_input() {
         "(source_file (function_item (visibility_modifier) name: (identifier) parameters: (parameters) body: (block (integer_literal))))"
     );
     assert_eq!(root.kind(), "source_file");
-    assert_eq!(root.has_error(), false);
+    assert!(!root.has_error());
     assert_eq!(root.child(0).unwrap().kind(), "function_item");
 }
 
@@ -834,7 +834,7 @@ fn test_parsing_with_one_included_range() {
         concat!(
             "(program (expression_statement (call_expression ",
             "function: (member_expression object: (identifier) property: (property_identifier)) ",
-            "arguments: (arguments (string)))))",
+            "arguments: (arguments (string (string_fragment))))))",
         )
     );
     assert_eq!(
@@ -1183,7 +1183,7 @@ fn test_parsing_with_a_newly_included_range() {
         .set_included_ranges(&[simple_range(range1_start, range1_end)])
         .unwrap();
     let tree = parser
-        .parse_with(&mut chunked_input(&source_code, 3), None)
+        .parse_with(&mut chunked_input(source_code, 3), None)
         .unwrap();
     assert_eq!(
         tree.root_node().to_sexp(),
@@ -1202,7 +1202,7 @@ fn test_parsing_with_a_newly_included_range() {
         ])
         .unwrap();
     let tree2 = parser
-        .parse_with(&mut chunked_input(&source_code, 3), Some(&tree))
+        .parse_with(&mut chunked_input(source_code, 3), Some(&tree))
         .unwrap();
     assert_eq!(
         tree2.root_node().to_sexp(),
@@ -1226,7 +1226,7 @@ fn test_parsing_with_a_newly_included_range() {
             simple_range(range3_start, range3_end),
         ])
         .unwrap();
-    let tree3 = parser.parse(&source_code, Some(&tree)).unwrap();
+    let tree3 = parser.parse(source_code, Some(&tree)).unwrap();
     assert_eq!(
         tree3.root_node().to_sexp(),
         concat!(

--- a/cli/src/tests/test_highlight_test.rs
+++ b/cli/src/tests/test_highlight_test.rs
@@ -12,7 +12,7 @@ fn test_highlight_test_with_basic_test() {
         Some("injections.scm"),
         &[
             "function".to_string(),
-            "variable.parameter".to_string(),
+            "variable".to_string(),
             "keyword".to_string(),
         ],
     );
@@ -22,7 +22,7 @@ fn test_highlight_test_with_basic_test() {
         "  // ^ function",
         "  //       ^ keyword",
         "  return d + e;",
-        "  //     ^ variable.parameter",
+        "  //     ^ variable",
         "  //       ^ !variable",
         "};",
     ]
@@ -35,7 +35,7 @@ fn test_highlight_test_with_basic_test() {
         &[
             Assertion::new(1, 5, false, String::from("function")),
             Assertion::new(1, 11, false, String::from("keyword")),
-            Assertion::new(4, 9, false, String::from("variable.parameter")),
+            Assertion::new(4, 9, false, String::from("variable")),
             Assertion::new(4, 11, true, String::from("variable")),
         ]
     );
@@ -53,6 +53,7 @@ fn test_highlight_test_with_basic_test() {
             (Point::new(1, 19), Point::new(1, 20), Highlight(1)), // "d"
             (Point::new(4, 2), Point::new(4, 8), Highlight(2)), // "return"
             (Point::new(4, 9), Point::new(4, 10), Highlight(1)), // "d"
+            (Point::new(4, 13), Point::new(4, 14), Highlight(1)), // "e"
         ]
     );
 }

--- a/script/fetch-fixtures
+++ b/script/fetch-fixtures
@@ -23,12 +23,12 @@ fetch_grammar() {
 
 fetch_grammar bash              master
 fetch_grammar c                 master
-fetch_grammar cpp               670404d7c689be1c868a46f919ba2a3912f2b7ef
+fetch_grammar cpp               master
 fetch_grammar embedded-template master
 fetch_grammar go                master
 fetch_grammar html              master
 fetch_grammar java              master
-fetch_grammar javascript        partial-order-precedences
+fetch_grammar javascript        master
 fetch_grammar jsdoc             master
 fetch_grammar json              master
 fetch_grammar php               master

--- a/test/fixtures/error_corpus/javascript_errors.txt
+++ b/test/fixtures/error_corpus/javascript_errors.txt
@@ -74,8 +74,8 @@ if ({a: 'b'} {c: 'd'}) {
 (program
   (if_statement
     (parenthesized_expression
-      (ERROR (object (pair (property_identifier) (string))))
-      (object (pair (property_identifier) (string))))
+      (ERROR (object (pair (property_identifier) (string (string_fragment)))))
+      (object (pair (property_identifier) (string (string_fragment)))))
     (statement_block
       (expression_statement
         (assignment_expression
@@ -178,12 +178,12 @@ function main(x) {
       (expression_statement
         (call_expression
           (member_expression (identifier) (property_identifier))
-          (arguments (string))))
+          (arguments (string (string_fragment)))))
       (expression_statement
         (binary_expression
           (identifier)
           (ERROR)
           (call_expression
             (member_expression (identifier) (property_identifier))
-            (arguments (string)))))
+            (arguments (string (string_fragment))))))
       (return_statement (object)))))


### PR DESCRIPTION
JS changes from the old pinned branch to master

- _expression -> expression
-  parameter query got thrown in its own file to not interfere with Typescript
- string contains a string_fragment node