### PR TITLE
perf: cache the current language configuration to lookup for later use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ codegen-units = 1 # Maximum size reduction optimizations.
 [profile.size]
 inherits = "release"
 opt-level = "s"      # Optimize for size.
+
+[profile.profile]
+inherits = "release"
+strip = false


### PR DESCRIPTION
# Background

In tree-sitter-bash, I recently added the Gentoo repo as a corpus to test on. It's massive, with around 30k files and was very helpful in finding regressions quickly. The only issue was that it increased the script parsing time from a few seconds to several minutes, which I thought was not ideal, but okay for the sake of detecting regressions. It's not horrible, but something must be amiss I thought...

# Profiling

I decided to use `perf` to see what was going on, this is only available on Linux systems, MacOS has Instruments as an alternative, and Windows I have no clue.

Let's take tree-sitter on master and build it with a special profile to ensure we get similar performance as a release build, yet can inspect symbols, you may apply this patch to Cargo.toml to follow along (which is also in this PR):

```diff
diff --git a/Cargo.toml b/Cargo.toml
index 03e24caf..bc2aedaa 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ codegen-units = 1 # Maximum size reduction optimizations.
 [profile.size]
 inherits = "release"
 opt-level = "s"      # Optimize for size.
+
+[profile.profile]
+inherits = "release"
+strip = false
```

And install it locally using `cargo install --path cli --profile profile`

Now you can begin inspecting, clone tree-sitter-bash and run the following:
`sudo perf record --call-graph dwarf -g ./script/parse-examples`

The call graph argument is needed to see call stacks and find out where some slowness might stem from.

Now after some time you should have a profile.data file, run `sudo perf report --hierarchy --children` to inspect it, here's what it looks like for me initially - it took 8m40s to record and is a whopping 19GB file, to make it faster you could comment out parsing the ebuild files and only parse the eclass ones instead:

![image](https://github.com/tree-sitter/tree-sitter/assets/29718261/cd487b5f-d79e-4d30-a7ed-2c45f86925f7)

Let's inspect tree-sitter...hit '+' on it to expand it:

![image](https://github.com/tree-sitter/tree-sitter/assets/29718261/b4605cde-b9b8-498e-b850-3a4f9e38bc88)

Interesting - seems like serde_json::next is being called a lot somewhere...let's find out where - again hit '+' on it, but you'll see there's several addresses to expand, I don't know entirely what all of them mean but the first one that's just 0xffffffffffffffff in my case contains the correct call chain:

![image](https://github.com/tree-sitter/tree-sitter/assets/29718261/6776aa06-14f2-4976-a74c-bd66e46ef5f6)

## Analysis

Now it's pretty clear, the Loader crate is calling find_language_configurations_at_path all the time - but why? we do in fact check to see if the extension has a configuration that exists already in the global configuration list, so why isn't it finding the config there..?

The answer is that the bash repo provides "sh" and "bash" as valid file types for the bash parser, but not Gentoo's ebuild or eclass files, hence we *always* look up the current LanguageConfiguration in our path, which is stupidly expensive and should absolutely not be done.

# Solution

We can simply cache the current language configuration in our path, which should not be done when loading all languages - so we simply set a bool argument `set_current_path_config` to do so. If that's true, we will set the `language_configuration_in_current_path` field of the Loader if it's not already set. Lastly, in `select_language` we should check if this is not none before trying to get the first language at the path. Let's now try it out with these changes in mind (which are basically the changes in this PR). Rebuild tree-sitter again and run the same profiling commands.

It took 8 seconds instead of 8 minutes, the profiling data is only 189MB instead of 19GB, and the report no longer shows serde_json iteration being the culprit of slowness, amazing! Here's what the new perf report looks like, which seems much more in-line with what we'd expect:

![image](https://github.com/tree-sitter/tree-sitter/assets/29718261/b5e90c8e-9891-4c8b-89e5-157a9dfc6c03)

In fact, just running the parse script in tree-sitter-bash takes less than 5 seconds to parse 35k files with these changes