### PR TITLE
feat(lexer)!: `TSLexer.get_byte()`

### DIFF
--- a/lib/include/tree_sitter/parser.h
+++ b/lib/include/tree_sitter/parser.h
@@ -44,6 +44,7 @@ struct TSLexer {
   TSSymbol result_symbol;
   void (*advance)(TSLexer *, bool);
   void (*mark_end)(TSLexer *);
+  uint32_t (*get_byte)(TSLexer *);
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);

--- a/lib/src/lexer.c
+++ b/lib/src/lexer.c
@@ -245,6 +245,10 @@ static void ts_lexer__mark_end(TSLexer *_self) {
   self->token_end_position = self->current_position;
 }
 
+static uint32_t ts_lexer__get_byte(TSLexer *self) {
+  return ((Lexer *)self)->current_position.bytes;
+}
+
 static uint32_t ts_lexer__get_column(TSLexer *_self) {
   Lexer *self = (Lexer *)_self;
 
@@ -292,6 +296,7 @@ void ts_lexer_init(Lexer *self) {
       // library.
       .advance = ts_lexer__advance,
       .mark_end = ts_lexer__mark_end,
+      .get_byte = ts_lexer__get_byte,
       .get_column = ts_lexer__get_column,
       .is_at_included_range_start = ts_lexer__is_at_included_range_start,
       .eof = ts_lexer__eof,


### PR DESCRIPTION
Currently, since external scanners are called on-demand at arbitrary
points, they are limited in context/state.

An example of where this leads to redundant computation is when
determining the effective indent of Python comments, which depends not
only on the comment's indentation but also the indentation of the next
non-comment line, which is an expensive lookahead (O(comment_size)). If
there are many consecutive comments (e.g. as generated by an IDE when
commenting out a block of code), then this computation is redundant, and
in total quadratic.

`TSLexer.get_byte()` improves the statefulness of external scanners,
allowing to keep track of lookahead state, reducing redundancy.

see: https://github.com/tree-sitter/tree-sitter-python/pull/245

BREAKING CHANGE: This breaks the `TSLexer` ABI. To minimize disruption,
it can be bundled with other breaking changes.