### PR TITLE
feat(lexer)!: `TSLexer.get_line()`

### DIFF
--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -370,10 +370,22 @@ fn parse_edit_flag(source_code: &Vec<u8>, flag: &str) -> Result<Edit> {
     })
 }
 
-fn offset_for_position(input: &Vec<u8>, position: Point) -> usize {
+fn offset_for_position(input: &[u8], position: Point) -> usize {
     let mut current_position = Point { row: 0, column: 0 };
-    for (i, c) in input.iter().enumerate() {
-        if *c as char == '\n' {
+    let mut it = input.iter().enumerate();
+
+    // Skip to where row equals position.row
+    for (_, &c) in &mut it {
+        if c == b'\n' {
+            current_position.row += 1;
+        }
+        if current_position.row == position.row {
+            break;
+        }
+    }
+
+    for (i, &c) in &mut it {
+        if c == b'\n' {
             current_position.row += 1;
             current_position.column = 0;
         } else {
@@ -383,18 +395,21 @@ fn offset_for_position(input: &Vec<u8>, position: Point) -> usize {
             return i;
         }
     }
-    return input.len();
+
+    input.len()
 }
 
-fn position_for_offset(input: &Vec<u8>, offset: usize) -> Point {
+fn position_for_offset(input: &[u8], offset: usize) -> Point {
     let mut result = Point { row: 0, column: 0 };
-    for c in &input[0..offset] {
-        if *c as char == '\n' {
-            result.row += 1;
-            result.column = 0;
-        } else {
+
+    for &c in input[0..offset].iter().rev() {
+        if c != b'\n' && result.row == 0 {
             result.column += 1;
         }
+        if c == b'\n' {
+            result.row += 1;
+        }
     }
+
     result
 }

--- a/lib/include/tree_sitter/parser.h
+++ b/lib/include/tree_sitter/parser.h
@@ -44,6 +44,7 @@ struct TSLexer {
   TSSymbol result_symbol;
   void (*advance)(TSLexer *, bool);
   void (*mark_end)(TSLexer *);
+  uint32_t (*get_line)(const TSLexer *);
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);

--- a/lib/src/lexer.c
+++ b/lib/src/lexer.c
@@ -245,6 +245,10 @@ static void ts_lexer__mark_end(TSLexer *_self) {
   self->token_end_position = self->current_position;
 }
 
+static uint32_t ts_lexer__get_line(const TSLexer *_self) {
+  return ((Lexer *)_self)->current_position.extent.row;
+}
+
 static uint32_t ts_lexer__get_column(TSLexer *_self) {
   Lexer *self = (Lexer *)_self;
 
@@ -292,6 +296,7 @@ void ts_lexer_init(Lexer *self) {
       // library.
       .advance = ts_lexer__advance,
       .mark_end = ts_lexer__mark_end,
+      .get_line = ts_lexer__get_line,
       .get_column = ts_lexer__get_column,
       .is_at_included_range_start = ts_lexer__is_at_included_range_start,
       .eof = ts_lexer__eof,


### PR DESCRIPTION
Closes: https://github.com/tree-sitter/tree-sitter/issues/1282
Related: https://github.com/nvim-treesitter/nvim-treesitter/issues/4839

Currently, since external scanners are called on-demand at arbitrary
points, they are limited in context/state.

An example of where this leads to redundant computation is when
determining the effective indent of Python comments, which depends not
only on the comment's indentation but also the indentation of the next
non-comment line, which is an expensive lookahead (O(comment_size)). If
there are many consecutive comments (e.g. as generated by an IDE when
commenting out a block of code), then this computation is redundant, and
in total quadratic.

`TSLexer.get_line()` improves the statefulness of external scanners,
allowing to keep track of lookahead state, reducing redundancy.

`TSLexer.get_column()` is insufficient in such cases where state needs
to be reused over lines, not columns.

`serialize/deserialize` is also insufficient in cases where state would
be invalidated by internally scanned text.

see: https://github.com/llllvvuu/tree-sitter-python/commit/cae9dbe58df56627ad4af76f9ba5ab262932c1c5

BREAKING CHANGE: This breaks the `TSLexer` ABI. To minimize disruption,
it can be bundled with other breaking changes.