### PR TITLE
fix: split conditions into isolated iterations

### DIFF
--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -401,15 +401,17 @@ fn offset_for_position(input: &[u8], position: Point) -> usize {
 
 fn position_for_offset(input: &[u8], offset: usize) -> Point {
     let mut result = Point { row: 0, column: 0 };
+    let mut it = input[0..offset].iter().rev();
 
-    for &c in input[0..offset].iter().rev() {
-        if c != b'\n' && result.row == 0 {
-            result.column += 1;
-        }
+    // Count trailing characters of the last line.
+    for &c in &mut it {
         if c == b'\n' {
             result.row += 1;
+            break;
         }
+        result.column += 1;
     }
-
+    // Count the remaining lines if any.
+    result.row += it.filter(|&&c| c == b'\n').count();
     result
 }


### PR DESCRIPTION
This should fix the [regression](https://github.com/tree-sitter/tree-sitter/pull/2600#issuecomment-1736672575) for `position_for_offset` introduced in #2600.

### Changes
- The function first counts the trailing characters for the last line.
- Once it finds a newline, it stops checking for anything but newlines and keeps incrementing the row count.