### PR TITLE
feat: Better time and stat

### DIFF
--- a/cli/benches/benchmark.rs
+++ b/cli/benches/benchmark.rs
@@ -200,9 +200,12 @@ fn parse(path: &Path, max_path_length: usize, mut action: impl FnMut(&[u8])) -> 
         action(&source_code);
     }
     let duration = time.elapsed() / (*REPETITION_COUNT as u32);
-    let duration_ms = duration.as_millis();
-    let speed = source_code.len() as u128 / (duration_ms + 1);
-    eprintln!("time {} ms\tspeed {speed} bytes/ms", duration_ms as usize);
+    let duration_ns = duration.as_nanos();
+    let speed = ((source_code.len() as u128) * 1_000_000) / duration_ns;
+    eprintln!(
+        "time {:>7.2} ms\t\tspeed {speed:>6} bytes/ms",
+        (duration_ns as f64) / 1e6,
+    );
     speed as usize
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -568,20 +568,24 @@ fn run() -> Result<()> {
                     encoding,
                 };
 
-                let this_file_errored = parse::parse_file_at_path(&mut parser, &opts)?;
+                let parse_result = parse::parse_file_at_path(&mut parser, &opts)?;
 
                 if should_track_stats {
                     stats.total_parses += 1;
-                    if !this_file_errored {
+                    if parse_result.successful {
                         stats.successful_parses += 1;
+                    }
+                    if let Some(duration) = parse_result.duration {
+                        stats.total_bytes += parse_result.bytes;
+                        stats.total_duration += duration;
                     }
                 }
 
-                has_error |= this_file_errored;
+                has_error |= !parse_result.successful;
             }
 
             if should_track_stats {
-                println!("{stats}");
+                println!("\n{stats}");
             }
 
             if has_error {


### PR DESCRIPTION
Since test and example files are usually small, parse times often ended up displayed as `0 ms` which was not very useful. Times reported by `--time` option and in benchmarks now also show decimals. Also added speed display to `--time` option, average speed to `--stat` option and improved benchmark speed calculation. Previously it used a resolution of 1 ms which was far too coarse for smaller files and resulted in skewed results.