### PR TITLE
feat!: compare max dynamic precedence level first

### DIFF
--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -917,7 +917,8 @@ static StackVersion ts_parser__reduce(
     } else {
       parent.ptr->parse_state = state;
     }
-    if (dynamic_precedence > parent.ptr->dynamic_precedence) {
+    if ((dynamic_precedence > parent.ptr->dynamic_precedence && dynamic_precedence != 0)
+    || (dynamic_precedence < 0 && parent.ptr->dynamic_precedence == 0)) {
       parent.ptr->dynamic_precedence = dynamic_precedence;
     }
     parent.ptr->dynamic_precedence_sum += dynamic_precedence;

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -745,6 +745,20 @@ static bool ts_parser__select_tree(TSParser *self, Subtree left, Subtree right) 
     return false;
   }
 
+  if (ts_subtree_dynamic_precedence_sum(right) > ts_subtree_dynamic_precedence_sum(left)) {
+    LOG("select_higher_precedence_sum symbol:%s, prec:%d, over_symbol:%s, other_prec:%d",
+        TREE_NAME(right), ts_subtree_dynamic_precedence_sum(right), TREE_NAME(left),
+        ts_subtree_dynamic_precedence_sum(left));
+    return true;
+  }
+
+  if (ts_subtree_dynamic_precedence_sum(left) > ts_subtree_dynamic_precedence_sum(right)) {
+    LOG("select_higher_precedence_sum symbol:%s, prec:%d, over_symbol:%s, other_prec:%d",
+        TREE_NAME(left), ts_subtree_dynamic_precedence_sum(left), TREE_NAME(right),
+        ts_subtree_dynamic_precedence_sum(right));
+    return false;
+  }
+
   if (ts_subtree_error_cost(left) > 0) return true;
 
   int comparison = ts_subtree_compare(left, right);
@@ -903,7 +917,10 @@ static StackVersion ts_parser__reduce(
     } else {
       parent.ptr->parse_state = state;
     }
-    parent.ptr->dynamic_precedence += dynamic_precedence;
+    if (dynamic_precedence > parent.ptr->dynamic_precedence) {
+      parent.ptr->dynamic_precedence = dynamic_precedence;
+    }
+    parent.ptr->dynamic_precedence_sum += dynamic_precedence;
 
     // Push the parent node onto the stack, along with any extra tokens that
     // were previously on top of the stack.

--- a/lib/src/stack.c
+++ b/lib/src/stack.c
@@ -168,6 +168,7 @@ static StackNode *stack_node_new(
       node->position = length_add(node->position, ts_subtree_total_size(subtree));
       node->node_count += stack__subtree_node_count(subtree);
       int32_t subtree_precedence = ts_subtree_dynamic_precedence(subtree);
+      // TODO: change stack's behavior all and test again
       if (subtree_precedence > node->dynamic_precedence) {
         node->dynamic_precedence = subtree_precedence;
       }

--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -437,7 +437,8 @@ void ts_subtree_summarize_children(
 
     // update dynamic precedence to max value of child's precedence
     int32_t subtree_prec = ts_subtree_dynamic_precedence(child);
-    if (subtree_prec > self.ptr->dynamic_precedence) {
+    if ((subtree_prec > self.ptr->dynamic_precedence && subtree_prec != 0)
+    || (subtree_prec < 0 && self.ptr->dynamic_precedence == 0)) {
       self.ptr->dynamic_precedence = subtree_prec;
     }
     self.ptr->dynamic_precedence_sum += ts_subtree_dynamic_precedence_sum(child);

--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -381,6 +381,7 @@ void ts_subtree_summarize_children(
   self.ptr->depends_on_column = false;
   self.ptr->has_external_scanner_state_change = false;
   self.ptr->dynamic_precedence = 0;
+  self.ptr->dynamic_precedence_sum = 0;
 
   uint32_t structural_index = 0;
   const TSSymbol *alias_sequence = ts_language_alias_sequence(language, self.ptr->production_id);
@@ -434,7 +435,12 @@ void ts_subtree_summarize_children(
       }
     }
 
-    self.ptr->dynamic_precedence += ts_subtree_dynamic_precedence(child);
+    // update dynamic precedence to max value of child's precedence
+    int32_t subtree_prec = ts_subtree_dynamic_precedence(child);
+    if (subtree_prec > self.ptr->dynamic_precedence) {
+      self.ptr->dynamic_precedence = subtree_prec;
+    }
+    self.ptr->dynamic_precedence_sum += ts_subtree_dynamic_precedence_sum(child);
     self.ptr->visible_descendant_count += ts_subtree_visible_descendant_count(child);
 
     if (alias_sequence && alias_sequence[structural_index] != 0 && !ts_subtree_extra(child)) {

--- a/lib/src/subtree.h
+++ b/lib/src/subtree.h
@@ -137,6 +137,7 @@ typedef struct {
       uint32_t named_child_count;
       uint32_t visible_descendant_count;
       int32_t dynamic_precedence;
+      int32_t dynamic_precedence_sum;
       uint16_t repeat_depth;
       uint16_t production_id;
       struct {
@@ -321,6 +322,10 @@ static inline uint32_t ts_subtree_error_cost(Subtree self) {
 
 static inline int32_t ts_subtree_dynamic_precedence(Subtree self) {
   return (self.data.is_inline || self.ptr->child_count == 0) ? 0 : self.ptr->dynamic_precedence;
+}
+
+static inline int32_t ts_subtree_dynamic_precedence_sum(Subtree self) {
+  return (self.data.is_inline || self.ptr->child_count == 0) ? 0 : self.ptr->dynamic_precedence_sum;
 }
 
 static inline uint16_t ts_subtree_production_id(Subtree self) {


### PR DESCRIPTION
Fixes #2733

When calculating dynamic precedence levels, tree-sitter sums up all child nodes' dynamic precedence level for parent node's. This leads issues described from #2733.

Dynamic precedences should not be summed to avoid this issue.

This PR changes parser behavior to give parent node a highest precedence level of child nodes, not sum of those.
And add extra logic to compare that _max dynamic precedence level_ first, and then compare the summed levels.

I tried my best to fix without changing previous behavior too much, but it eventually became breaking change.

```
failures:
    tests::corpus_test::test_corpus_for_c
    tests::corpus_test::test_corpus_for_cpp
    tests::corpus_test::test_corpus_for_go
    tests::corpus_test::test_corpus_for_javascript
    tests::corpus_test::test_corpus_for_python

test result: FAILED. 258 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out; finished in 19.58s
```

- tree-sitter-c
- tree-sitter-cpp
- tree-sitter-go
- tree-sitter-javascript
- tree-sitter-python

These 5 parsers are failing right now.