### PR TITLE
doc: fix multi-language program typo

### DIFF
--- a/docs/section-2-using-parsers.md
+++ b/docs/section-2-using-parsers.md
@@ -332,7 +332,7 @@ const TSLanguage *tree_sitter_ruby();
 
 int main(int argc, const char **argv) {
   const char *text = argv[1];
-  unsigned len = strlen(src);
+  unsigned len = strlen(text);
 
   // Parse the entire text as ERB.
   TSParser *parser = ts_parser_new();


### PR DESCRIPTION
The `src` variable is not declared, and I think you meant `text`.