### PR TITLE
Keep default release profile with default settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,16 +6,17 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.65"
 
-[profile.release]
+[profile.optimize]
+inherits = "release"
 strip = true      # Automatically strip symbols from the binary.
 lto = true        # Link-time optimization.
 opt-level = 3     # Optimization level 3.
 codegen-units = 1 # Maximum size reduction optimizations.
 
 [profile.size]
-inherits = "release"
-opt-level = "s"      # Optimize for size.
+inherits = "optimize"
+opt-level = "s"   # Optimize for size.
 
 [profile.profile]
-inherits = "release"
+inherits = "optimize"
 strip = false


### PR DESCRIPTION
* _Related_ #2502 

This PR sets the default cargo release profile to be with default settings because it's uncomfortable to build the release profile on development environment for testing optimization improvements or to use a fresh optimized CLI locally and test it updates. The `opt-level` equal to 3, `lto` set to `true` and other params _significantly_ increases compile a time for the last linker step that isn't parallel. We can peek the `optimize` profile in the CI directly for the released CLI package.