### PR TITLE
fix(loader): flag check doesn't work without `OUT_DIR` env

### DIFF
--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -422,10 +422,11 @@ impl Loader {
         config
             .cpp(true)
             .opt_level(2)
-            .cargo_metadata(false)
-            .target(BUILD_TARGET)
             .host(BUILD_TARGET)
-            .flag_if_supported("-Werror=implicit-function-declaration");
+            .target(BUILD_TARGET)
+            .flag_if_supported("-Werror=implicit-function-declaration")
+            .out_dir(env::temp_dir())
+            .cargo_metadata(false);
         let compiler = config.get_compiler();
         let mut command = Command::new(compiler.path());
         for (key, value) in compiler.env() {


### PR DESCRIPTION
There was a compiler flag check addition to the loader crate in:
* https://github.com/tree-sitter/tree-sitter/pull/2414

But it silently doesn't work at all if there is no defined `OUT_DIR` environment variable because `cc` crate by default designed to work in `build.rs` files and it needs to know a place where it can place temporary files and call a compiler to check that the compiler understands such flags. The `OUT_DIR` by default exists if to run Tree-sitter CLI by `cargo run -- parse ...` but if to use Tree-sitter CLI directly the flag check just [doesn't happen at all](https://github.com/rust-lang/cc-rs/blob/bfd68f2d0b19b0872d8bc085290d94d40ca85d60/src/lib.rs#L1665C62-L1665C63).

But there was a bug in `cc` crate and under `cargo run` Tree-sitter CLI produces a lot of noise on stdout like:
```
cargo:rerun-if-env-changed=CXX_x86_64-unknown-linux-gnu
CXX_x86_64-unknown-linux-gnu = None
cargo:rerun-if-env-changed=CXX_x86_64_unknown_linux_gnu
CXX_x86_64_unknown_linux_gnu = None
cargo:rerun-if-env-changed=HOST_CXX
HOST_CXX = None
cargo:rerun-if-env-changed=CXX
CXX = None
cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
CRATE_CC_NO_DEFAULTS = None
CARGO_CFG_TARGET_FEATURE = None
cargo:rerun-if-env-changed=CXXFLAGS_x86_64-unknown-linux-gnu
CXXFLAGS_x86_64-unknown-linux-gnu = None
cargo:rerun-if-env-changed=CXXFLAGS_x86_64_unknown_linux_gnu
CXXFLAGS_x86_64_unknown_linux_gnu = None
cargo:rerun-if-env-changed=HOST_CXXFLAGS
HOST_CXXFLAGS = None
cargo:rerun-if-env-changed=CXXFLAGS
CXXFLAGS = None
```

The mentioned `cc` crate bug is already fixed:
* https://github.com/rust-lang/cc-rs/pull/908

_But it isn't released yet so this PR should be updated with the next `cc` version after its release and to be merged only after that._