### PR TITLE
Revert "Alt #2454"

### DIFF
--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -766,6 +766,7 @@ impl Generator {
         indent!(self);
 
         add_line!(self, "START_LEXER();");
+        add_line!(self, "eof = lexer->eof(lexer);");
         add_line!(self, "switch (state) {{");
 
         indent!(self);

--- a/lib/include/tree_sitter/parser.h
+++ b/lib/include/tree_sitter/parser.h
@@ -129,9 +129,16 @@ struct TSLanguage {
  *  Lexer Macros
  */
 
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
+  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -139,8 +146,7 @@ struct TSLanguage {
   lexer->advance(lexer, skip);  \
   start:                        \
   skip = false;                 \
-  lookahead = lexer->lookahead; \
-  eof = lexer->eof(lexer);
+  lookahead = lexer->lookahead;
 
 #define ADVANCE(state_value) \
   {                          \


### PR DESCRIPTION
Reverts tree-sitter/tree-sitter#2482

On an attempt to add a parameter to CLI to show compiler warnings on a external scanner files compilation I've figured out that Tree-sitter in some cases generates additional functions that don't use the `eof` variable what leads to an another sort of compiler complains, so it's better to step back to previous version of warnigns suppression even than #2482 version looked more clear and compact.