### PR TITLE
Fix another bug in subtree_compare

### DIFF
--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -623,15 +623,19 @@ int ts_subtree_compare(Subtree left, Subtree right, SubtreePool *pool) {
   array_push(&pool->tree_stack, ts_subtree_to_mut_unsafe(left));
   array_push(&pool->tree_stack, ts_subtree_to_mut_unsafe(right));
 
-  int result = 0;
-  while (result == 0 && pool->tree_stack.size > 0) {
+  while (pool->tree_stack.size > 0) {
     right = ts_subtree_from_mut(array_pop(&pool->tree_stack));
     left = ts_subtree_from_mut(array_pop(&pool->tree_stack));
 
+    int result = 0;
     if (ts_subtree_symbol(left) < ts_subtree_symbol(right)) result = -1;
     if (ts_subtree_symbol(right) < ts_subtree_symbol(left)) result = 1;
     if (ts_subtree_child_count(left) < ts_subtree_child_count(right)) result = -1;
     if (ts_subtree_child_count(right) < ts_subtree_child_count(left)) result = 1;
+    if (result != 0) {
+      array_clear(&pool->tree_stack);
+      return result;
+    }
 
     for (uint32_t i = ts_subtree_child_count(left); i > 0; i--) {
       Subtree left_child = ts_subtree_children(left)[i - 1];
@@ -641,8 +645,7 @@ int ts_subtree_compare(Subtree left, Subtree right, SubtreePool *pool) {
     }
   }
 
-  array_clear(&pool->tree_stack);
-  return result;
+  return 0;
 }
 
 static inline void ts_subtree_set_has_changes(MutableSubtree *self) {


### PR DESCRIPTION
When subtrees differ, exit loop before pushing children to the stack. This fixes a regression introduced in https://github.com/tree-sitter/tree-sitter/pull/2788, which could cause a crash.