### PR TITLE
fix a bug in the code for new predicates.

### DIFF
--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -865,8 +865,8 @@ class Language {
             throw new Error('Predicates must begin with a literal value');
           }
           const operator = steps[0].value;
-          let isPositive = _predIsPositive(operator);
-          let matchAll = _predMatchall(operator);
+          let isPositive = this._predIsPositive(operator);
+          let matchAll = this._predMatchall(operator);
           switch (operator) {
             case 'any-not-eq?':
             case 'any-eq?':
@@ -971,12 +971,12 @@ class Language {
                   `Arguments to \`#${operator}\` predicate must be a strings.".`
                 );
               }
-              captureName = steps[1].name;
+              const capName = steps[1].name;
               const values = steps.slice(2).map(s => s.value);
               textPredicates[i].push(function(captures) {
                 const nodes = [];
                 for (const c of captures) {
-                  if (c.name === captureName) nodes.push(c.node.text);
+                  if (c.name === capName) nodes.push(c.node.text);
                 }
                 if (nodes.length === 0) return !isPositive;
                 return nodes.every(text => values.includes(text)) === isPositive;

--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -738,6 +738,31 @@ class Language {
     if (address) return new LookaheadIterable(INTERNAL, address, this);
   }
 
+  _predIsPositive(pred) {
+    switch (pred) {
+      case 'any-not-eq?':
+      case 'not-eq?':
+      case 'not-any-match?':
+      case 'not-match?':
+      case 'not-any-of?':
+        return false
+      default:
+        return true;
+    }
+  }
+  
+  _predMatchall(pred) {
+    switch (pred) {
+      case 'any-not-eq?':
+      case 'any-eq?':
+      case 'any-match?':
+      case 'not-any-match?':
+        return false;
+      default:
+        return true;
+    }      
+  }
+
   query(source) {
     const sourceLength = lengthBytesUTF8(source);
     const sourceAddress = C._malloc(sourceLength + 1);
@@ -840,16 +865,12 @@ class Language {
             throw new Error('Predicates must begin with a literal value');
           }
           const operator = steps[0].value;
-          let isPositive = true;
-          let matchAll = true;
+          let isPositive = _predIsPositive(operator);
+          let matchAll = _predMatchall(operator);
           switch (operator) {
             case 'any-not-eq?':
-              isPositive = false;
-              matchAll = false;
             case 'any-eq?':
-              matchAll = false;
             case 'not-eq?':
-              isPositive = false;
             case 'eq?':
               if (steps.length !== 3) throw new Error(
                 `Wrong number of arguments to \`#eq?\` predicate. Expected 2, got ${steps.length - 1}`
@@ -887,12 +908,8 @@ class Language {
               break;
 
             case 'not-any-match?':
-              isPositive = false;
-              matchAll = false;
             case 'any-match?':
-              matchAll = false;
             case 'not-match?':
-              isPositive = false;
             case 'match?':
               if (steps.length !== 3) throw new Error(
                 `Wrong number of arguments to \`#match?\` predicate. Expected 2, got ${steps.length - 1}.`
@@ -942,7 +959,6 @@ class Language {
               break;
 
             case 'not-any-of?':
-              isPositive = false;
             case 'any-of?':
               if (steps.length < 2) throw new Error(
                 `Wrong number of arguments to \`#${operator}\` predicate. Expected at least 1. Got ${steps.length - 1}.`

--- a/lib/binding_web/test/query-test.js
+++ b/lib/binding_web/test/query-test.js
@@ -223,14 +223,14 @@ describe("Query", () => {
         function testFunction() {}
       `);
     
-      const query = new Query(JavaScript, `
+      const query = JavaScript.query(`
         ((function_declaration
           name: (identifier) @function-name)
          (#any-eq? @function-name "testFunction"))
       `);
     
       const captures = query.captures(tree.rootNode);
-      assert.deepEqual(formatCaptures(tree, captures), [
+      assert.deepEqual(formatCaptures(captures), [
         { name: "function-name", text: "testFunction" }
       ]);
     });
@@ -242,14 +242,14 @@ describe("Query", () => {
         function anotherFunc() {}
       `);
     
-      const query = new Query(JavaScript, `
+      const query = JavaScript.query(`
         ((function_declaration
           name: (identifier) @function-name)
          (#any-match? @function-name "^test"))
       `);
     
       const captures = query.captures(tree.rootNode);
-      assert.deepEqual(formatCaptures(tree, captures), [
+      assert.deepEqual(formatCaptures(captures), [
         { name: "function-name", text: "testOne" },
         { name: "function-name", text: "testTwo" }
       ]);
@@ -262,14 +262,14 @@ describe("Query", () => {
         let testVar = 30;
       `);
     
-      const query = new Query(JavaScript, `
+      const query = JavaScript.query(`
         ((variable_declarator
           name: (identifier) @var-name)
          (#any-not-eq? @var-name "testVar"))
       `);
     
       const captures = query.captures(tree.rootNode);
-      assert.deepEqual(formatCaptures(tree, captures), [
+      assert.deepEqual(formatCaptures(captures), [
         { name: "var-name", text: "x" },
         { name: "var-name", text: "y" }
       ]);
@@ -282,14 +282,14 @@ describe("Query", () => {
         function testFunction() {}
       `);
     
-      const query = new Query(JavaScript, `
+      const query = JavaScript.query(`
         ((function_declaration
           name: (identifier) @function-name)
          (#not-any-match? @function-name "^test"))
       `);
     
       const captures = query.captures(tree.rootNode);
-      assert.deepEqual(formatCaptures(tree, captures), [
+      assert.deepEqual(formatCaptures(captures), [
         { name: "function-name", text: "a" },
         { name: "function-name", text: "b" }
       ]);
@@ -302,14 +302,14 @@ describe("Query", () => {
         let cherry;
       `);
     
-      const query = new Query(JavaScript, `
+      const query = JavaScript.query(`
         ((variable_declarator
           name: (identifier) @var-name)
          (#any-of? @var-name "apple" "banana"))
       `);
     
       const captures = query.captures(tree.rootNode);
-      assert.deepEqual(formatCaptures(tree, captures), [
+      assert.deepEqual(formatCaptures(captures), [
         { name: "var-name", text: "apple" },
         { name: "var-name", text: "banana" }
       ]);
@@ -322,14 +322,14 @@ describe("Query", () => {
         let cherry;
       `);
     
-      const query = new Query(JavaScript, `
+      const query = JavaScript.query(`
         ((variable_declarator
           name: (identifier) @var-name)
          (#not-any-of? @var-name "apple" "banana"))
       `);
     
       const captures = query.captures(tree.rootNode);
-      assert.deepEqual(formatCaptures(tree, captures), [
+      assert.deepEqual(formatCaptures(captures), [
         { name: "var-name", text: "cherry" }
       ]);
     });

--- a/lib/binding_web/test/query-test.js
+++ b/lib/binding_web/test/query-test.js
@@ -216,6 +216,124 @@ describe("Query", () => {
       ]);
     });
 
+    it("handles conditions that compare any capture to a literal string using any-eq?", () => {
+      const tree = parser.parse(`
+        function a() {}
+        function b() {}
+        function testFunction() {}
+      `);
+    
+      const query = new Query(JavaScript, `
+        ((function_declaration
+          name: (identifier) @function-name)
+         (#any-eq? @function-name "testFunction"))
+      `);
+    
+      const captures = query.captures(tree.rootNode);
+      assert.deepEqual(formatCaptures(tree, captures), [
+        { name: "function-name", text: "testFunction" }
+      ]);
+    });
+
+    it("handles conditions with any-match? to check if any capture matches a regex", () => {
+      const tree = parser.parse(`
+        function testOne() {}
+        function testTwo() {}
+        function anotherFunc() {}
+      `);
+    
+      const query = new Query(JavaScript, `
+        ((function_declaration
+          name: (identifier) @function-name)
+         (#any-match? @function-name "^test"))
+      `);
+    
+      const captures = query.captures(tree.rootNode);
+      assert.deepEqual(formatCaptures(tree, captures), [
+        { name: "function-name", text: "testOne" },
+        { name: "function-name", text: "testTwo" }
+      ]);
+    });
+
+    it("handles any-not-eq? to ensure no capture equals a specific string", () => {
+      const tree = parser.parse(`
+        let x = 10;
+        let y = 20;
+        let testVar = 30;
+      `);
+    
+      const query = new Query(JavaScript, `
+        ((variable_declarator
+          name: (identifier) @var-name)
+         (#any-not-eq? @var-name "testVar"))
+      `);
+    
+      const captures = query.captures(tree.rootNode);
+      assert.deepEqual(formatCaptures(tree, captures), [
+        { name: "var-name", text: "x" },
+        { name: "var-name", text: "y" }
+      ]);
+    });
+
+    it("handles not-any-match? to ensure no capture matches a regex", () => {
+      const tree = parser.parse(`
+        function a() {}
+        function b() {}
+        function testFunction() {}
+      `);
+    
+      const query = new Query(JavaScript, `
+        ((function_declaration
+          name: (identifier) @function-name)
+         (#not-any-match? @function-name "^test"))
+      `);
+    
+      const captures = query.captures(tree.rootNode);
+      assert.deepEqual(formatCaptures(tree, captures), [
+        { name: "function-name", text: "a" },
+        { name: "function-name", text: "b" }
+      ]);
+    });
+
+    it("handles any-of? to check if any capture is one of specified strings", () => {
+      const tree = parser.parse(`
+        let apple;
+        let banana;
+        let cherry;
+      `);
+    
+      const query = new Query(JavaScript, `
+        ((variable_declarator
+          name: (identifier) @var-name)
+         (#any-of? @var-name "apple" "banana"))
+      `);
+    
+      const captures = query.captures(tree.rootNode);
+      assert.deepEqual(formatCaptures(tree, captures), [
+        { name: "var-name", text: "apple" },
+        { name: "var-name", text: "banana" }
+      ]);
+    });
+
+    it("handles not-any-of? to ensure capture is not one of specified strings", () => {
+      const tree = parser.parse(`
+        let apple;
+        let banana;
+        let cherry;
+      `);
+    
+      const query = new Query(JavaScript, `
+        ((variable_declarator
+          name: (identifier) @var-name)
+         (#not-any-of? @var-name "apple" "banana"))
+      `);
+    
+      const captures = query.captures(tree.rootNode);
+      assert.deepEqual(formatCaptures(tree, captures), [
+        { name: "var-name", text: "cherry" }
+      ]);
+    });
+
     it("handles patterns with properties", () => {
       tree = parser.parse(`a(b.c);`);
       query = JavaScript.query(`


### PR DESCRIPTION
While attempting to add the new query predicates to node-tree-sitter ([see PR](https://github.com/tree-sitter/node-tree-sitter/pull/182)), based on the code in "lib/binding_web/binding.js", I created tests for the predicates. These tests reflect my understanding of the semantics for these predicates.

These tests do not pass until I fix what looks to be a bug in "bindings.js".  I have included the tests as well as the fixes in this PR.

If my understanding of the semantics is correct, the predicates will not work correctly until this PR is merged.

Update: I finally figured out how to build-wasm and run tests.