### PR TITLE
Redundant redundant escapes

### DIFF
--- a/cli/src/generate/prepare_grammar/expand_tokens.rs
+++ b/cli/src/generate/prepare_grammar/expand_tokens.rs
@@ -4,7 +4,6 @@ use crate::generate::nfa::{CharacterSet, Nfa, NfaState};
 use crate::generate::rules::{Precedence, Rule};
 use anyhow::{anyhow, Context, Result};
 use lazy_static::lazy_static;
-use regex::Regex;
 use regex_syntax::ast::{
     parse, Ast, ClassPerlKind, ClassSet, ClassSetBinaryOpKind, ClassSetItem, ClassUnicodeKind,
     RepetitionKind, RepetitionRange,
@@ -13,8 +12,6 @@ use std::collections::HashMap;
 use std::i32;
 
 lazy_static! {
-    static ref CURLY_BRACE_REGEX: Regex =
-        Regex::new(r"(^|[^\\pP])\{([^}]*[^0-9A-Fa-f,}][^}]*)\}").unwrap();
     static ref UNICODE_CATEGORIES: HashMap<&'static str, Vec<u32>> =
         serde_json::from_str(UNICODE_CATEGORIES_JSON).unwrap();
     static ref UNICODE_PROPERTIES: HashMap<&'static str, Vec<u32>> =
@@ -29,7 +26,6 @@ const UNICODE_CATEGORIES_JSON: &str = include_str!("./unicode-categories.json");
 const UNICODE_PROPERTIES_JSON: &str = include_str!("./unicode-properties.json");
 const UNICODE_CATEGORY_ALIASES_JSON: &str = include_str!("./unicode-category-aliases.json");
 const UNICODE_PROPERTY_ALIASES_JSON: &str = include_str!("./unicode-property-aliases.json");
-const ALLOWED_REDUNDANT_ESCAPED_CHARS: [char; 4] = ['!', '\'', '"', '/'];
 
 struct NfaBuilder {
     nfa: Nfa,
@@ -58,29 +54,6 @@ const fn get_completion_precedence(rule: &Rule) -> i32 {
         }
     }
     0
-}
-
-fn preprocess_regex(content: &str) -> String {
-    let content = CURLY_BRACE_REGEX.replace(content, "$1\\{$2\\}");
-    let mut result = String::with_capacity(content.len());
-    let mut is_escaped = false;
-    for c in content.chars() {
-        if is_escaped {
-            if !ALLOWED_REDUNDANT_ESCAPED_CHARS.contains(&c) {
-                result.push('\\');
-            }
-            result.push(c);
-            is_escaped = false;
-        } else if c == '\\' {
-            is_escaped = true;
-        } else {
-            result.push(c);
-        }
-    }
-    if is_escaped {
-        result.push('\\');
-    }
-    result
 }
 
 pub fn expand_tokens(mut grammar: ExtractedLexicalGrammar) -> Result<LexicalGrammar> {
@@ -138,8 +111,7 @@ impl NfaBuilder {
     fn expand_rule(&mut self, rule: &Rule, mut next_state_id: u32) -> Result<bool> {
         match rule {
             Rule::Pattern(s, f) => {
-                let s = preprocess_regex(s);
-                let ast = parse::Parser::new().parse(&s)?;
+                let ast = parse::Parser::new().parse(s)?;
                 self.expand_regex(&ast, next_state_id, f.contains('i'))
             }
             Rule::String(s) => {
@@ -847,11 +819,9 @@ mod tests {
                     ("\u{00df}", Some((3, "\u{00df}"))),
                 ],
             },
-            // allowing un-escaped curly braces
             Row {
                 rules: vec![
-                    // Un-escaped curly braces
-                    Rule::pattern(r"u{[0-9a-fA-F]+}", ""),
+                    Rule::pattern(r"u\{[0-9a-fA-F]+\}", ""),
                     // Already-escaped curly braces
                     Rule::pattern(r"\{[ab]{3}\}", ""),
                     // Unicode codepoints


### PR DESCRIPTION
Fixes #2837; see that issue for further discussion.

The regex-syntax crate natively supports `\!`, `\'`, `\"`, and `\/` identity escapes now, so we don't need to preprocess the regex in order to support those.

Unescaped `{}` are only permitted in Unicode-unaware JS regexp, and that syntax is deprecated, only kept for web compatibility, and should not be relied upon. In Unicode-aware JS regexp (via the `u` or `v` flag), unescaped `{}` are syntax errors. Unicode-aware mode is required for support for `\u{hhhh}` or `\p{UnicodeProperty}` syntaxes, which Tree-sitter always supports.

The current behavior is sort of a "worst of both worlds" where Tree-sitter's regex flavor is neither Rust nor ECMAScript compatible. Removing the special curly brace preprocessing means Tree-sitter's regex now matches Rust flavor again and moves it closer to that of ECMAScript in `u` or `v` mode. (And the divergences, unlike unescaped `{}`, are much less likely to be hit unintentionally.) And even though this means any previously-preprocessed regex will change meaning, it will always[^almost] be changed to emit a clear error pointing out the `{` which now needs to be manually escaped.

[^almost]: Well, *almost* always. In the specific case of `\b{start}`, `\b{end}`, `\b{start-half}`, or `\b{end-half}`, the pre-preprocessing version is valid with a different meaning.

## Changelog

- Regexes are now always interpreted by Tree-sitter using Rust flavored regex syntax. The main impact is that `{` now need to be escaped outside of `[]`. If this occurs in your grammar, Tree-sitter will error, indicating the regex which needs to be edited.