### PR TITLE
Make Node.js language bindings context aware

### DIFF
--- a/cli/src/generate/templates/binding.cc
+++ b/cli/src/generate/templates/binding.cc
@@ -23,6 +23,6 @@ void Init(Local<Object> exports, Local<Object> module) {
   Nan::Set(module, Nan::New("exports").ToLocalChecked(), instance);
 }
 
-NODE_MODULE(tree_sitter_PARSER_NAME_binding, Init)
+NODE_MODULE_CONTEXT_AWARE(tree_sitter_PARSER_NAME_binding, Init)
 
 }  // namespace


### PR DESCRIPTION
They don't have any dynamic global data, so all it takes is just declaring them as such

Contributed on behalf of [Swimm](https://swimm.io/)