### PR TITLE
docs: add css for inline code

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -33,7 +33,7 @@ a[href^="http"]:after {
   padding: $padding 0;
 }
 
-#main-content code:not(pre code) {
+#main-content code:not(pre code, a code) {
   color: #c7254e;
   font-size: 0.9em;
   background-color: #f8f8f8;

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -33,6 +33,16 @@ a[href^="http"]:after {
   padding: $padding 0;
 }
 
+#main-content code:not(pre code) {
+  color: #c7254e;
+  font-size: 0.9em;
+  background-color: #f8f8f8;
+  border: 1px solid #eaeaea;
+  border-radius: 3px;
+  margin: 0 2px;
+  padding: 0 5px;
+}
+
 #sidebar {
   position: fixed;
   background: white;


### PR DESCRIPTION
Recently I am building a parser with tree-sitter and while reading the docs, I thought it would be better if the inline code was more readable, so I changed the style.

What do you think? I'd love to hear your thoughts.

Here are some examples of the styling


| as-is | to-be |
| --- | --- |
| ![image](https://github.com/tree-sitter/tree-sitter/assets/11611397/a61d4be6-1fb8-47f3-83c2-e2e0360cbe93) | ![image](https://github.com/tree-sitter/tree-sitter/assets/11611397/6900b022-52bd-4bbe-8e41-55f0b489ae31) |

ex) https://tree-sitter.github.io/tree-sitter/creating-parsers#keywords

| as-is | to-be |
| --- | --- |
| ![image](https://github.com/tree-sitter/tree-sitter/assets/11611397/5a6d306e-3793-4e7d-b232-6f57d535b86b) | ![image](https://github.com/tree-sitter/tree-sitter/assets/11611397/128dc572-5483-4996-8f8e-bf935ba4998b) |

ex) https://tree-sitter.github.io/tree-sitter/creating-parsers#external-scanners

You can check other pages here: https://sh-cho.github.io/tree-sitter/

I only highlighted `<code>` inside `#main-content` except `<code>` inside `<a>` or `<pre>` tag.