### PR TITLE
Add a `#replace!` predicate that can update a node

### DIFF
--- a/docs/section-2-using-parsers.md
+++ b/docs/section-2-using-parsers.md
@@ -714,6 +714,18 @@ Here's another example finding Cgo comments to potentially inject with C
   (#match? @injection.content "^//"))
 ```
 
+##### replace!
+
+This predicate will replace the value received by a capture using regex. It does
+not affect other patterns that happen to capture the same node.
+
+```scheme
+(fenced_block
+  (shebang) @injection.language
+  (body) @injection.content
+  (#replace? @injection.language "#!\S*[/ ](?P<lang>\S+).*" "$lang"))
+```
+
 ##### any-of?, not-any-of?
 
 The "any-of?" predicate allows you to match a capture against multiple strings,


### PR DESCRIPTION
This PR is an attempt to add a `#replace! @capture "regexp(.*)" "rep$1" predicate that can be used to filter content. This is useful for things like extracting injection languages from shebangs or heredocs, and will provide an official equivalent of the `#gsub!` function supported by NeoVim.

However, I am not sure what the best way to do this is. It seems like this more or less requires instrumenting a `Node` in some way that `utf8_text` / `utf_16` text know to return data from a buffer rather than the input. I am going to try adding something to `Node` to allow this, but would like to know if there are other suggestions.