### PR TITLE
Allow `--filter` to take regex

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Context, Error, Result};
 use clap::{App, AppSettings, Arg, SubCommand};
 use glob::glob;
+use regex::Regex;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::{env, fs, u64};
@@ -237,7 +238,7 @@ fn run() -> Result<()> {
                         .long("filter")
                         .short("f")
                         .takes_value(true)
-                        .help("Only run corpus test cases whose name includes the given string"),
+                        .help("Only run corpus test cases whose name matches the given regex"),
                 )
                 .arg(
                     Arg::with_name("update")
@@ -389,7 +390,7 @@ fn run() -> Result<()> {
             let debug_graph = matches.is_present("debug-graph");
             let debug_build = matches.is_present("debug-build");
             let update = matches.is_present("update");
-            let filter = matches.value_of("filter");
+            let filter = Regex::new(matches.value_of("filter"))?;
             let apply_all_captures = matches.is_present("apply-all-captures");
 
             if debug {

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -61,7 +61,7 @@ pub fn run_tests_at_path(
     path: &Path,
     debug: bool,
     debug_graph: bool,
-    filter: Option<&str>,
+    filter: Option<&Regex>,
     update: bool,
 ) -> Result<()> {
     let test_entry = parse_tests(path)?;
@@ -177,7 +177,7 @@ pub fn print_diff(actual: &String, expected: &String) {
 fn run_tests(
     parser: &mut Parser,
     test_entry: TestEntry,
-    filter: Option<&str>,
+    filter: Option<&Regex>,
     mut indent_level: i32,
     failures: &mut Vec<(String, String, String)>,
     update: bool,
@@ -192,8 +192,8 @@ fn run_tests(
             divider_delim_len,
             has_fields,
         } => {
-            if let Some(filter) = filter {
-                if !name.contains(filter) {
+            if let Some(re) = filter {
+                if !re.is_match(name) {
                     if update {
                         let input = String::from_utf8(input).unwrap();
                         let output = format_sexp(&output);


### PR DESCRIPTION
Replace `str::contains` with `Regex::is_match` to allow more flexible matching.