### PR TITLE
cli: reworded test diff color key

### DIFF
--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -152,9 +152,10 @@ pub fn check_queries_at_path(language: &Language, path: &Path) -> Result<()> {
 
 pub fn print_diff_key() {
     println!(
-        "\n{} / {}",
+        "\n{} / {} / {}",
+        Colour::White.paint("correct"),
         Colour::Green.paint("expected"),
-        Colour::Red.paint("actual")
+        Colour::Red.paint("unexpected")
     );
 }
 


### PR DESCRIPTION
- Reworded the color key for diffed tests
- Added a `#[ignore]`ed test to make previewing any future changes trivial

<img width="336" alt="image" src="https://github.com/tree-sitter/tree-sitter/assets/77247638/9bb8ced3-62de-4848-9606-a2b09a7a9a72">