### PR TITLE
ci: add workflow_dispatch event to publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: Publish to registries
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   crates_io:


### PR DESCRIPTION
This allows manual publishing in case the automatic publishing fails for
some reason.
