### PR TITLE
feat: allow the grammar to log to stdout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,7 +1239,6 @@ version = "0.20.9"
 dependencies = [
  "ansi_term",
  "anyhow",
- "atty",
  "clap",
  "ctor",
  "ctrlc",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,7 +27,6 @@ wasm = ["tree-sitter/wasm", "tree-sitter-loader/wasm"]
 [dependencies]
 ansi_term = "0.12.1"
 anyhow = "1.0.72"
-atty = "0.2.14"
 clap = "2.32"
 ctrlc = { version = "3.4.0", features = ["termination"] }
 difference = "2.0.0"

--- a/cli/src/generate/dsl.js
+++ b/cli/src/generate/dsl.js
@@ -385,7 +385,7 @@ function grammar(baseGrammar, options) {
     throw new Error("Grammar must have at least one rule.");
   }
 
-  return {name, word, rules, extras, conflicts, precedences, externals, inline, supertypes};
+  return { name, word, rules, extras, conflicts, precedences, externals, inline, supertypes };
 }
 
 function checkArguments(ruleCount, caller, callerName, suffix = '') {
@@ -419,4 +419,4 @@ global.grammar = grammar;
 global.field = field;
 
 const result = require(process.env.TREE_SITTER_GRAMMAR_PATH);
-console.log(JSON.stringify(result, null, 2));
+process.stdout.write(JSON.stringify(result, null, null));


### PR DESCRIPTION
Closes #703

for anyone reading, you can now use console.log or any other stdout logging mechanism without having it break tree-sitter's generate command
