### PR TITLE
ci: add timeout to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: ${{ matrix.platform }} (${{ matrix.target }}) (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This will abort the run early if it gets caught in an infinite loop
during testing.
