### PR TITLE
build: bump minimum version to 1.70.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["cli", "lib"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [profile.optimize]
 inherits = "release"


### PR DESCRIPTION
Package which v6.0.0 requires rustc 1.70 or newer.
