### PR TITLE
ci: introduce "response bot"

### DIFF
--- a/.github/scripts/close_unresponsive.js
+++ b/.github/scripts/close_unresponsive.js
@@ -1,0 +1,58 @@
+function labeledEvent(data) {
+  return (
+    data.event === "labeled" && data.label.name === "more-information-needed"
+  );
+}
+
+const numberOfDaysLimit = 30;
+const close_message = `This has been closed since a request for information has \
+not been answered for ${numberOfDaysLimit} days. It can be reopened when the \
+requested information is provided.`;
+
+module.exports = async ({ github, context }) => {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+
+  const issues = await github.rest.issues.listForRepo({
+    owner: owner,
+    repo: repo,
+    labels: "more-information-needed",
+  });
+  const numbers = issues.data.map((e) => e.number);
+
+  for (const number of numbers) {
+    const events = await github.paginate(
+      github.rest.issues.listEventsForTimeline,
+      {
+        owner: owner,
+        repo: repo,
+        issue_number: number,
+      },
+      (response) => response.data.filter(labeledEvent),
+    );
+
+    const latest_response_label = events[events.length - 1];
+
+    const created_at = new Date(latest_response_label.created_at);
+    const now = new Date();
+    const diff = now - created_at;
+    const diffDays = diff / (1000 * 60 * 60 * 24);
+
+    if (diffDays > numberOfDaysLimit) {
+      github.rest.issues.update({
+        owner: owner,
+        repo: repo,
+        issue_number: number,
+        state_reason: "not_planned",
+        state: "closed",
+      });
+
+      github.rest.issues.createComment({
+        owner: owner,
+        repo: repo,
+        issue_number: number,
+        body: close_message,
+      });
+    }
+  }
+};

--- a/.github/scripts/remove_response_label.js
+++ b/.github/scripts/remove_response_label.js
@@ -1,0 +1,19 @@
+module.exports = async ({ github, context }) => {
+  const commenter = context.actor;
+  const issue = await github.rest.issues.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: context.issue.number,
+  });
+  const author = issue.data.user.login;
+  const labels = issue.data.labels.map((e) => e.name);
+
+  if (author === commenter && labels.includes("more-information-needed")) {
+    github.rest.issues.removeLabel({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: context.issue.number,
+      name: "more-information-needed",
+    });
+  }
+};

--- a/.github/workflows/response.yml
+++ b/.github/workflows/response.yml
@@ -1,0 +1,35 @@
+name: no_response
+on:
+  schedule:
+    - cron: '30 1 * * *' # Run every day at 01:30
+  workflow_dispatch:
+  issue_comment:
+
+jobs:
+  close:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./.github/scripts/close_unresponsive.js')
+            await script({github, context})
+
+  remove_label:
+    if: github.event_name == 'issue_comment'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./.github/scripts/remove_response_label.js')
+            await script({github, context})


### PR DESCRIPTION
It's basically a bot that closes issues or PRs if the author hasn't
responded after 30 days. This is only done on issues/PRs that has the
`more-information-needed` label and is meant to be used for issues that
has hit a dead-end and cannot progress without further information from
the author. If the author responds after an issue is closed and gives
more context the issue can simply be reopened.
