### PR TITLE
feat: use lockfiles to dedup recompilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f9df8a11882c4e3335eb2d18a0137c505d9ca927470b0cac9c6f0ae07d28f7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1339,7 @@ dependencies = [
  "anyhow",
  "cc",
  "dirs",
+ "fs4",
  "libloading",
  "once_cell",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,16 +27,17 @@ anstyle = "1.0.6"
 anyhow = "1.0.79"
 cc = "1.0.83"
 clap = { version = "4.4.18", features = [
-	"cargo",
-	"derive",
-	"env",
-	"help",
-	"unstable-styles",
+  "cargo",
+  "derive",
+  "env",
+  "help",
+  "unstable-styles",
 ] }
 ctor = "0.2.6"
 ctrlc = { version = "3.4.2", features = ["termination"] }
 difference = "2.0.0"
 dirs = "5.0.1"
+fs4 = "0.7.0"
 glob = "0.3.1"
 html-escape = "0.2.13"
 indexmap = "2.2.2"

--- a/cli/loader/Cargo.toml
+++ b/cli/loader/Cargo.toml
@@ -18,6 +18,7 @@ wasm = ["tree-sitter/wasm"]
 anyhow.workspace = true
 cc.workspace = true
 dirs.workspace = true
+fs4.workspace = true
 libloading.workspace = true
 once_cell.workspace = true
 regex.workspace = true

--- a/cli/src/tests/async_context_test.rs
+++ b/cli/src/tests/async_context_test.rs
@@ -63,7 +63,7 @@ fn test_node_in_fut() {
 fn test_node_and_cursor_ref_in_fut() {
     let ((), pended) = tokio_like_spawn(async {
         let mut parser = Parser::new();
-        let language = get_language("bash");
+        let language = get_language("c");
         parser.set_language(&language).unwrap();
 
         let tree = parser.parse("#", None).unwrap();
@@ -102,7 +102,7 @@ fn test_node_and_cursor_ref_in_fut() {
 fn test_node_and_cursor_ref_in_fut_with_fut_fabrics() {
     let ((), pended) = tokio_like_spawn(async {
         let mut parser = Parser::new();
-        let language = get_language("bash");
+        let language = get_language("javascript");
         parser.set_language(&language).unwrap();
 
         let tree = parser.parse("#", None).unwrap();
@@ -140,7 +140,7 @@ fn test_node_and_cursor_ref_in_fut_with_fut_fabrics() {
 fn test_node_and_cursor_ref_in_fut_with_inner_spawns() {
     let (ret, pended) = tokio_like_spawn(async {
         let mut parser = Parser::new();
-        let language = get_language("bash");
+        let language = get_language("rust");
         parser.set_language(&language).unwrap();
 
         let tree = parser.parse("#", None).unwrap();


### PR DESCRIPTION
This is a simplified rewrite of #2647, without adding a multithreaded option to the cli and without deriving clone unnecessarily, that was a bad mistake I made there but I did that to spark the conversation as to why that might be, I wasn't 100% sure back then.

I think testing grammars that parse large repos will benefit immensely anyways from having a `-j` flag that tells the cli how many threads to run parsing on, it does help a lot when it's in the order of magnitude of minutes. This is the first step in getting that potentially done, but is also great in that it fixes the spurious racy CI failures which happen when one test compiles a parser and the other attempts to load it when it's partially been written to the fs.

fs4 also seems to be actively maintained, unlike the fs2 crate in the previous PR