### PR TITLE
ci: only create release for normal semver tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - v*
+      - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   build:


### PR DESCRIPTION
We don't need releases for pre-releases.
