### PR TITLE
Extracted subcommands

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -294,6 +294,18 @@ struct BuildWasm {
     pub path: Option<String>,
 }
 
+impl BuildWasm {
+    fn run(self, current_dir: PathBuf, loader: loader::Loader) -> Result<()> {
+        let grammar_path = current_dir.join(self.path.unwrap_or_default());
+        wasm::compile_language_to_wasm(
+            &loader,
+            &grammar_path,
+            &current_dir,
+            self.docker)?;
+        Ok(())
+    }
+}
+
 #[derive(Args)]
 #[command(
     about = "Start local playground for a parser in the browser",
@@ -765,15 +777,7 @@ fn run() -> Result<()> {
             )?;
         }
 
-        Commands::BuildWasm(wasm_options) => {
-            let grammar_path = current_dir.join(wasm_options.path.unwrap_or_default());
-            wasm::compile_language_to_wasm(
-                &loader,
-                &grammar_path,
-                &current_dir,
-                wasm_options.docker,
-            )?;
-        }
+        Commands::BuildWasm(wasm_options) => return wasm_options.run(current_dir, loader),
 
         Commands::Playground(playground_options) => {
             let open_in_browser = !playground_options.quiet;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -694,11 +694,7 @@ struct BuildWasm {
 impl BuildWasm {
     fn run(self, current_dir: PathBuf, loader: loader::Loader) -> Result<()> {
         let grammar_path = current_dir.join(self.path.unwrap_or_default());
-        wasm::compile_language_to_wasm(
-            &loader,
-            &grammar_path,
-            &current_dir,
-            self.docker)?;
+        wasm::compile_language_to_wasm(&loader, &grammar_path, &current_dir, self.docker)?;
         Ok(())
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -797,7 +797,7 @@ fn run() -> Result<()> {
 
     let current_dir = env::current_dir().unwrap();
     let config = Config::load()?;
-    let mut loader = loader::Loader::new()?;
+    let loader = loader::Loader::new()?;
 
     match command {
         Commands::InitConfig(command) => command.run()?,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -282,6 +282,22 @@ struct Tags {
     pub paths: Option<Vec<String>>,
 }
 
+impl Tags {
+    fn run(&self, config: Config, mut loader: loader::Loader) -> Result<()> {
+        let loader_config = config.get()?;
+        loader.find_all_languages(&loader_config)?;
+        let paths = collect_paths(self.paths_file.as_deref(), self.paths)?;
+        tags::generate_tags(
+            &loader,
+            self.scope.as_deref(),
+            &paths,
+            self.quiet,
+            self.time,
+        )?;
+        Ok(())
+    }
+}
+
 #[derive(Args)]
 #[command(about = "Compile a parser to WASM", alias = "bw")]
 struct BuildWasm {
@@ -764,18 +780,7 @@ fn run() -> Result<()> {
             }
         }
 
-        Commands::Tags(tags_options) => {
-            let loader_config = config.get()?;
-            loader.find_all_languages(&loader_config)?;
-            let paths = collect_paths(tags_options.paths_file.as_deref(), tags_options.paths)?;
-            tags::generate_tags(
-                &loader,
-                tags_options.scope.as_deref(),
-                &paths,
-                tags_options.quiet,
-                tags_options.time,
-            )?;
-        }
+        Commands::Tags(tags_options) => return tags_options.run(config, loader),
 
         Commands::BuildWasm(wasm_options) => return wasm_options.run(current_dir, loader),
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -310,6 +310,32 @@ struct Playground {
 #[command(about = "Print info about all known language parsers", alias = "langs")]
 struct DumpLanguages;
 
+impl DumpLanguages {
+    fn run(&self, config: Config, mut loader: loader::Loader) -> Result<()> {
+        let loader_config = config.get()?;
+        loader.find_all_languages(&loader_config)?;
+        for (configuration, language_path) in loader.get_all_language_configurations() {
+            println!(
+                concat!(
+                    "scope: {}\n",
+                    "parser: {:?}\n",
+                    "highlights: {:?}\n",
+                    "file_types: {:?}\n",
+                    "content_regex: {:?}\n",
+                    "injection_regex: {:?}\n",
+                ),
+                configuration.scope.as_ref().unwrap_or(&String::new()),
+                language_path,
+                configuration.highlights_filenames,
+                configuration.file_types,
+                configuration.content_regex,
+                configuration.injection_regex,
+            );
+        }
+        Ok(())
+    }
+}
+
 fn main() {
     let result = run();
     if let Err(err) = &result {
@@ -754,28 +780,7 @@ fn run() -> Result<()> {
             playground::serve(&current_dir, open_in_browser)?;
         }
 
-        Commands::DumpLanguages(_) => {
-            let loader_config = config.get()?;
-            loader.find_all_languages(&loader_config)?;
-            for (configuration, language_path) in loader.get_all_language_configurations() {
-                println!(
-                    concat!(
-                        "scope: {}\n",
-                        "parser: {:?}\n",
-                        "highlights: {:?}\n",
-                        "file_types: {:?}\n",
-                        "content_regex: {:?}\n",
-                        "injection_regex: {:?}\n",
-                    ),
-                    configuration.scope.as_ref().unwrap_or(&String::new()),
-                    language_path,
-                    configuration.highlights_filenames,
-                    configuration.file_types,
-                    configuration.content_regex,
-                    configuration.injection_regex,
-                );
-            }
-        }
+        Commands::DumpLanguages(command) => return command.run(config, loader),
     }
 
     Ok(())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -715,6 +715,14 @@ struct Playground {
     pub quiet: bool,
 }
 
+impl Playground {
+    fn run(self, current_dir: PathBuf) -> Result<()> {
+        let open_in_browser = !self.quiet;
+        playground::serve(&current_dir, open_in_browser)?;
+        Ok(())
+    }
+}
+
 #[derive(Args)]
 #[command(about = "Print info about all known language parsers", alias = "langs")]
 struct DumpLanguages;
@@ -808,10 +816,6 @@ fn run() -> Result<()> {
 
         Commands::BuildWasm(wasm_options) => return wasm_options.run(current_dir, loader),
 
-        Commands::Playground(playground_options) => {
-            let open_in_browser = !playground_options.quiet;
-            playground::serve(&current_dir, open_in_browser)?;
-        }
 
         Commands::DumpLanguages(command) => return command.run(config, loader),
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -800,24 +800,16 @@ fn run() -> Result<()> {
     let mut loader = loader::Loader::new()?;
 
     match command {
-        Commands::InitConfig(command) => return command.run(),
-
-        Commands::Generate(generate_options) => return generate_options.run(loader, current_dir),
-
-        Commands::Parse(parse_options) => return parse_options.run(config, loader, current_dir),
-
-        Commands::Test(test_options) => return test_options.run(loader, current_dir),
-
-        Commands::Query(query_options) => return query_options.run(config, loader, current_dir),
-
-        Commands::Highlight(highlight_options) => return highlight_options.run(config, loader),
-
-        Commands::Tags(tags_options) => return tags_options.run(config, loader),
-
-        Commands::BuildWasm(wasm_options) => return wasm_options.run(current_dir, loader),
-
-
-        Commands::DumpLanguages(command) => return command.run(config, loader),
+        Commands::InitConfig(command) => command.run()?,
+        Commands::Generate(generate_options) => generate_options.run(loader, current_dir)?,
+        Commands::Parse(parse_options) => parse_options.run(config, loader, current_dir)?,
+        Commands::Test(test_options) => test_options.run(loader, current_dir)?,
+        Commands::Query(query_options) => query_options.run(config, loader, current_dir)?,
+        Commands::Highlight(highlight_options) => highlight_options.run(config, loader)?,
+        Commands::Tags(tags_options) => tags_options.run(config, loader)?,
+        Commands::BuildWasm(wasm_options) => wasm_options.run(current_dir, loader)?,
+        Commands::Playground(playground_options) => playground_options.run(current_dir)?,
+        Commands::DumpLanguages(command) => command.run(config, loader)?,
     }
 
     Ok(())


### PR DESCRIPTION
Broke out the subcommand logic in `run` to individual `.run` functions for each Command enum's relevant struct.

Because the subcommands, don't all make use of the all the common variables (`config`, `loader`, etc.) the arguments of each `.run` are specific to its needs for now. Might could instead bundle these up into some Common struct to make the calling conventions identical and instead create a `SubCommandRun` or some-such trait, and singularly call `command.run(common)` instead of using a match statement. TBD?