### PR TITLE
chore: provide a CLI flag to open `log.html`

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -145,6 +145,11 @@ struct Parse {
     pub edits: Option<Vec<String>>,
     #[arg(long, help = "The encoding of the input files")]
     pub encoding: Option<String>,
+    #[arg(
+        long,
+        help = "Open `log.html` in the default browser, if `--debug-graph` is supplied"
+    )]
+    pub open_log: bool,
 }
 
 #[derive(Args)]
@@ -191,6 +196,11 @@ struct Test {
     pub wasm: bool,
     #[arg(long, help = "Apply all captures to highlights")]
     pub apply_all_captures: bool,
+    #[arg(
+        long,
+        help = "Open `log.html` in the default browser, if `--debug-graph` is supplied"
+    )]
+    pub open_log: bool,
 }
 
 #[derive(Args)]
@@ -480,6 +490,7 @@ fn run() -> Result<()> {
                     debug_graph: parse_options.debug_graph,
                     cancellation_flag: Some(&cancellation_flag),
                     encoding,
+                    open_log: parse_options.open_log,
                 };
 
                 let parse_result = parse::parse_file_at_path(&mut parser, &opts)?;
@@ -548,6 +559,7 @@ fn run() -> Result<()> {
                     include: test_options.include,
                     exclude: test_options.exclude,
                     update: test_options.update,
+                    open_log: test_options.open_log,
                 };
 
                 test::run_tests_at_path(&mut parser, &mut opts)?;

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -61,6 +61,7 @@ pub struct ParseFileOptions<'a> {
     pub debug_graph: bool,
     pub cancellation_flag: Option<&'a AtomicUsize>,
     pub encoding: Option<u32>,
+    pub open_log: bool,
 }
 
 #[derive(Copy, Clone)]
@@ -85,7 +86,7 @@ pub fn parse_file_at_path(parser: &mut Parser, opts: &ParseFileOptions) -> Resul
 
     // Render an HTML graph if `--debug-graph` was passed
     if opts.debug_graph {
-        _log_session = Some(util::log_graphs(parser, "log.html")?);
+        _log_session = Some(util::log_graphs(parser, "log.html", opts.open_log)?);
     }
     // Log to stderr if `--debug` was passed
     else if opts.debug {
@@ -297,7 +298,7 @@ pub fn parse_file_at_path(parser: &mut Parser, opts: &ParseFileOptions) -> Resul
         }
 
         if opts.output == ParseOutput::Dot {
-            util::print_tree_graph(&tree, "log.html").unwrap();
+            util::print_tree_graph(&tree, "log.html", opts.open_log).unwrap();
         }
 
         let mut first_error = None;

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -64,6 +64,7 @@ pub struct TestOptions<'a> {
     pub include: Option<Regex>,
     pub exclude: Option<Regex>,
     pub update: bool,
+    pub open_log: bool,
 }
 
 pub fn run_tests_at_path(parser: &mut Parser, opts: &mut TestOptions) -> Result<()> {
@@ -71,7 +72,7 @@ pub fn run_tests_at_path(parser: &mut Parser, opts: &mut TestOptions) -> Result<
     let mut _log_session = None;
 
     if opts.debug_graph {
-        _log_session = Some(util::log_graphs(parser, "log.html")?);
+        _log_session = Some(util::log_graphs(parser, "log.html", opts.open_log)?);
     } else if opts.debug {
         parser.set_logger(Some(Box::new(|log_type, message| {
             if log_type == LogType::Lex {

--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -544,7 +544,7 @@ fn get_parser(session: &mut Option<util::LogSession>, log_filename: &str) -> Par
             }
         })));
     } else if *LOG_GRAPH_ENABLED {
-        *session = Some(util::log_graphs(&mut parser, log_filename).unwrap());
+        *session = Some(util::log_graphs(&mut parser, log_filename, false).unwrap());
     }
 
     parser

--- a/cli/src/util.rs
+++ b/cli/src/util.rs
@@ -35,22 +35,23 @@ pub struct LogSession {
     path: PathBuf,
     dot_process: Option<Child>,
     dot_process_stdin: Option<ChildStdin>,
+    open_log: bool,
 }
 
-pub fn print_tree_graph(tree: &Tree, path: &str) -> Result<()> {
-    let session = LogSession::new(path)?;
+pub fn print_tree_graph(tree: &Tree, path: &str, quiet: bool) -> Result<()> {
+    let session = LogSession::new(path, quiet)?;
     tree.print_dot_graph(session.dot_process_stdin.as_ref().unwrap());
     Ok(())
 }
 
-pub fn log_graphs(parser: &mut Parser, path: &str) -> Result<LogSession> {
-    let session = LogSession::new(path)?;
+pub fn log_graphs(parser: &mut Parser, path: &str, open_log: bool) -> Result<LogSession> {
+    let session = LogSession::new(path, open_log)?;
     parser.print_dot_graphs(session.dot_process_stdin.as_ref().unwrap());
     Ok(session)
 }
 
 impl LogSession {
-    fn new(path: &str) -> Result<Self> {
+    fn new(path: &str, open_log: bool) -> Result<Self> {
         use std::io::Write;
 
         let mut dot_file = std::fs::File::create(path)?;
@@ -71,6 +72,7 @@ impl LogSession {
             path: PathBuf::from(path),
             dot_process: Some(dot_process),
             dot_process_stdin: Some(dot_stdin),
+            open_log,
         })
     }
 }
@@ -82,10 +84,8 @@ impl Drop for LogSession {
         drop(self.dot_process_stdin.take().unwrap());
         let output = self.dot_process.take().unwrap().wait_with_output().unwrap();
         if output.status.success() {
-            if cfg!(target_os = "macos")
-                && fs::metadata(&self.path).unwrap().len() > HTML_HEADER.len() as u64
-            {
-                Command::new("open").arg(&self.path).output().unwrap();
+            if self.open_log && fs::metadata(&self.path).unwrap().len() > HTML_HEADER.len() as u64 {
+                webbrowser::open(&self.path.to_string_lossy()).unwrap();
             }
         } else {
             eprintln!(


### PR DESCRIPTION
On macOS, this was done by default regardless of what the user wants. This was also not done on Windows or Linux. Instead, we now provide an `--open-log` flag to open the log file in the default browser, disable it by default on macOS, and it works on all platforms.

Closes #2709