### PR TITLE
build: remove symbolic links from repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-docs/section-6-contributing.md
+See [section-6-contributing.md](./docs/section-6-contributing.md)

--- a/script/reproduce
+++ b/script/reproduce
@@ -1,1 +1,30 @@
-run-fuzzer
+#!/bin/bash
+
+set -eux
+
+root=$(dirname "$0")/..
+export ASAN_OPTIONS="quarantine_size_mb=10:detect_leaks=1:symbolize=1"
+export UBSAN="print_stacktrace=1:halt_on_error=1:symbolize=1"
+
+# check if CI env var exists
+
+if [ -z "${CI:-}" ]; then
+  declare -A mode_config=( ["halt"]="-timeout=1 -rss_limit_mb=2048" ["recover"]="-timeout=10 -rss_limit_mb=2048" )
+else
+  declare -A mode_config=( ["halt"]="-max_total_time=120 -timeout=1 -rss_limit_mb=2048" ["recover"]="-time=120 -timeout=10 -rss_limit_mb=2048" )
+fi
+
+if [ "$#" -lt 3 ]; then
+  echo "usage: $0 <language> (halt|recover) <testcase> <libFuzzer args...>"
+  exit 1
+fi
+
+lang="$1"
+shift
+mode="$1"
+shift
+testcase="$1"
+shift
+# Treat remainder of arguments as libFuzzer arguments
+
+"${root}/test/fuzz/out/${lang}_fuzzer" "${mode_config[$mode]}" -runs=1 "${testcase}" "$@"

--- a/script/run-fuzzer
+++ b/script/run-fuzzer
@@ -14,51 +14,25 @@ else
   declare -A mode_config=( ["halt"]="-max_total_time=120 -timeout=1 -rss_limit_mb=2048" ["recover"]="-time=120 -timeout=10 -rss_limit_mb=2048" )
 fi
 
-run_fuzzer() {
-  if [ "$#" -lt 2 ]; then
-    echo "usage: $0 <language> <halt|recover> <libFuzzer args...>"
-    exit 1
-  fi
-
-  lang="$1"
-  shift
-  mode="$1"
-  shift
-  # Treat remainder of arguments as libFuzzer arguments
-
-  # Fuzzing logs and testcases are always written to `pwd`, so `cd` there first
-  results="${root}/test/fuzz/out/fuzz-results/${lang}"
-  mkdir -p "${results}"
-  cd "${results}"
-
-  # Create a corpus directory, so new discoveries are stored on disk. These will
-  # then be loaded on subsequent fuzzing runs
-  mkdir -p corpus
-
-  pwd
-  "../../${lang}_fuzzer" "-dict=../../${lang}.dict" "-artifact_prefix=${lang}_" -max_len=2048 "${mode_config[$mode]}" "./corpus" "$@"
-}
-
-reproduce() {
-  if [ "$#" -lt 3 ]; then
-    echo "usage: $0 <language> (halt|recover) <testcase> <libFuzzer args...>"
-    exit 1
-  fi
-
-  lang="$1"
-  shift
-  mode="$1"
-  shift
-  testcase="$1"
-  shift
-  # Treat remainder of arguments as libFuzzer arguments
-
-  "${root}/test/fuzz/out/${lang}_fuzzer" "${mode_config[$mode]}" -runs=1 "${testcase}" "$@"
-}
-
-script=$(basename "$0")
-if [ "$script" == "run-fuzzer" ]; then
-  run_fuzzer "$@"
-elif [ "$script" == "reproduce" ]; then
-  reproduce "$@"
+if [ "$#" -lt 2 ]; then
+  echo "usage: $0 <language> <halt|recover> <libFuzzer args...>"
+  exit 1
 fi
+
+lang="$1"
+shift
+mode="$1"
+shift
+# Treat remainder of arguments as libFuzzer arguments
+
+# Fuzzing logs and testcases are always written to `pwd`, so `cd` there first
+results="${root}/test/fuzz/out/fuzz-results/${lang}"
+mkdir -p "${results}"
+cd "${results}"
+
+# Create a corpus directory, so new discoveries are stored on disk. These will
+# then be loaded on subsequent fuzzing runs
+mkdir -p corpus
+
+pwd
+"../../${lang}_fuzzer" "-dict=../../${lang}.dict" "-artifact_prefix=${lang}_" -max_len=2048 "${mode_config[$mode]}" "./corpus" "$@"


### PR DESCRIPTION
This will reduce cross-platform differences between windows and linux.

Closes https://github.com/tree-sitter/tree-sitter/issues/627.