### PR TITLE
fix(wasm): properly handle Query.matches when filtering out results

### DIFF
--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -3020,6 +3020,26 @@ fn test_query_captures_with_predicates() {
                 (QueryProperty::new("name", Some("something"), None), false),
             ]
         );
+
+        let source = "const a = window.b";
+        let mut parser = Parser::new();
+        parser.set_language(&language).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+
+        let query = Query::new(
+            &language,
+            r#"((identifier) @variable.builtin
+                (#match? @variable.builtin "^(arguments|module|console|window|document)$")
+                (#is-not? local))
+            "#,
+        )
+        .unwrap();
+
+        let mut cursor = QueryCursor::new();
+        let matches = cursor.matches(&query, tree.root_node(), source.as_bytes());
+        let matches = collect_matches(matches, &query, source);
+
+        assert_eq!(matches, &[(0, vec![("variable.builtin", "window")])]);
     });
 }
 

--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -1182,13 +1182,14 @@ class Query {
       const captures = new Array(captureCount);
       address = unmarshalCaptures(this, node.tree, address, captures);
       if (this.textPredicates[pattern].every((p) => p(captures))) {
-        result[filteredCount++] = {pattern, captures};
+        result[filteredCount] = {pattern, captures};
         const setProperties = this.setProperties[pattern];
-        if (setProperties) result[i].setProperties = setProperties;
+        if (setProperties) result[filteredCount].setProperties = setProperties;
         const assertedProperties = this.assertedProperties[pattern];
-        if (assertedProperties) result[i].assertedProperties = assertedProperties;
+        if (assertedProperties) result[filteredCount].assertedProperties = assertedProperties;
         const refutedProperties = this.refutedProperties[pattern];
-        if (refutedProperties) result[i].refutedProperties = refutedProperties;
+        if (refutedProperties) result[filteredCount].refutedProperties = refutedProperties;
+        filteredCount++;
       }
     }
     result.length = filteredCount;

--- a/lib/binding_web/test/query-test.js
+++ b/lib/binding_web/test/query-test.js
@@ -107,6 +107,23 @@ describe('Query', () => {
         {pattern: 0, captures: [{name: 'name', text: 'gross'}]},
       ]);
     });
+
+    it('handles multiple matches where the first one is filtered', () => {
+      tree = parser.parse(`
+        const a = window.b;
+      `);
+
+      query = JavaScript.query(`
+        ((identifier) @variable.builtin
+          (#match? @variable.builtin "^(arguments|module|console|window|document)$")
+          (#is-not? local))
+      `);
+
+      const matches = query.matches(tree.rootNode);
+      assert.deepEqual(formatMatches(matches), [
+        {pattern: 0, captures: [{name: 'variable.builtin', text: 'window'}]},
+      ]);
+    });
   });
 
   describe('.captures', () => {


### PR DESCRIPTION
Closes #2045
Supersedes #2091