### PR TITLE
ci(sanitize): add a timeout of 60 minutes

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -11,6 +11,7 @@ jobs:
   check_undefined_behaviour:
     name: Sanitizer checks
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       TREE_SITTER: ${{ github.workspace }}/target/release/tree-sitter
     steps:


### PR DESCRIPTION
There's a possibility of the test freezing so we add this as precaution.
