### PR TITLE
build: move common Cargo.toml keys into the workspace and inherit them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,14 @@ members = ["cli", "cli/config", "cli/loader", "lib", "tags", "highlight"]
 resolver = "2"
 
 [workspace.package]
+authors = ["Max Brunsfeld <maxbrunsfeld@gmail.com>"]
+edition = "2021"
 rust-version = "1.70"
+homepage = "https://tree-sitter.github.io/tree-sitter"
+repository = "https://github.com/tree-sitter/tree-sitter"
+license = "MIT"
+keywords = ["incremental", "parsing"]
+categories = ["command-line-utilities", "parsing"]
 
 [profile.optimize]
 inherits = "release"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,14 +2,15 @@
 name = "tree-sitter-cli"
 description = "CLI tool for developing, testing, and using Tree-sitter parsers"
 version = "0.20.9"
-authors = ["Max Brunsfeld <maxbrunsfeld@gmail.com>"]
-edition = "2021"
-license = "MIT"
-readme = "README.md"
-keywords = ["incremental", "parsing"]
-categories = ["command-line-utilities", "parsing"]
-repository = "https://github.com/tree-sitter/tree-sitter"
+authors.workspace = true
+edition.workspace = true
 rust-version.workspace = true
+readme = "README.md"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [[bin]]
 name = "tree-sitter"

--- a/cli/config/Cargo.toml
+++ b/cli/config/Cargo.toml
@@ -2,14 +2,15 @@
 name = "tree-sitter-config"
 description = "User configuration of tree-sitter's command line programs"
 version = "0.19.0"
-authors = ["Max Brunsfeld <maxbrunsfeld@gmail.com>"]
-edition = "2021"
-license = "MIT"
-readme = "README.md"
-keywords = ["incremental", "parsing"]
-categories = ["command-line-utilities", "parsing"]
-repository = "https://github.com/tree-sitter/tree-sitter"
+authors.workspace = true
+edition.workspace = true
 rust-version.workspace = true
+readme = "README.md"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/cli/loader/Cargo.toml
+++ b/cli/loader/Cargo.toml
@@ -2,14 +2,15 @@
 name = "tree-sitter-loader"
 description = "Locates, builds, and loads tree-sitter grammars at runtime"
 version = "0.20.0"
-authors = ["Max Brunsfeld <maxbrunsfeld@gmail.com>"]
-edition = "2021"
-license = "MIT"
-readme = "README.md"
-keywords = ["incremental", "parsing"]
-categories = ["command-line-utilities", "parsing"]
-repository = "https://github.com/tree-sitter/tree-sitter"
+authors.workspace = true
+edition.workspace = true
 rust-version.workspace = true
+readme = "README.md"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [features]
 wasm = ["tree-sitter/wasm"]

--- a/cli/src/tests/proc_macro/Cargo.toml
+++ b/cli/src/tests/proc_macro/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "tree-sitter-tests-proc-macro"
 version = "0.0.0"
-edition = "2021"
-publish = false
+edition.workspace = true
 rust-version.workspace = true
+publish = false
 
 [lib]
 proc-macro = true

--- a/highlight/Cargo.toml
+++ b/highlight/Cargo.toml
@@ -3,16 +3,17 @@ name = "tree-sitter-highlight"
 description = "Library for performing syntax highlighting with Tree-sitter"
 version = "0.20.2"
 authors = [
-	"Max Brunsfeld <maxbrunsfeld@gmail.com>",
-	"Tim Clem <timothy.clem@gmail.com>",
+  "Max Brunsfeld <maxbrunsfeld@gmail.com>",
+  "Tim Clem <timothy.clem@gmail.com>",
 ]
-license = "MIT"
+edition.workspace = true
+rust-version.workspace = true
 readme = "README.md"
-edition = "2021"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["incremental", "parsing", "syntax", "highlighting"]
 categories = ["parsing", "text-editors"]
-repository = "https://github.com/tree-sitter/tree-sitter"
-rust-version.workspace = true
 
 [lib]
 crate-type = ["lib", "staticlib"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -2,25 +2,26 @@
 name = "tree-sitter"
 description = "Rust bindings to the Tree-sitter parsing library"
 version = "0.20.10"
-authors = ["Max Brunsfeld <maxbrunsfeld@gmail.com>"]
-edition = "2021"
-license = "MIT"
-readme = "binding_rust/README.md"
-keywords = ["incremental", "parsing"]
-categories = ["api-bindings", "parsing", "text-editors"]
-repository = "https://github.com/tree-sitter/tree-sitter"
+authors.workspace = true
+edition.workspace = true
 rust-version.workspace = true
+readme = "binding_rust/README.md"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories = ["api-bindings", "parsing", "text-editors"]
 
 build = "binding_rust/build.rs"
 links = "tree-sitter"
 
 include = [
-	"/binding_rust/*",
-	"/Cargo.toml",
-	"/src/*.h",
-	"/src/*.c",
-	"/src/unicode/*",
-	"/include/tree_sitter/api.h",
+  "/binding_rust/*",
+  "/Cargo.toml",
+  "/src/*.h",
+  "/src/*.c",
+  "/src/unicode/*",
+  "/include/tree_sitter/api.h",
 ]
 
 [features]

--- a/tags/Cargo.toml
+++ b/tags/Cargo.toml
@@ -3,16 +3,17 @@ name = "tree-sitter-tags"
 description = "Library for extracting tag information"
 version = "0.20.2"
 authors = [
-	"Max Brunsfeld <maxbrunsfeld@gmail.com>",
-	"Patrick Thomson <patrickt@github.com>",
+  "Max Brunsfeld <maxbrunsfeld@gmail.com>",
+  "Patrick Thomson <patrickt@github.com>",
 ]
-license = "MIT"
+edition.workspace = true
+rust-version.workspace = true
 readme = "README.md"
-edition = "2021"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["incremental", "parsing", "syntax", "tagging"]
 categories = ["parsing", "text-editors"]
-repository = "https://github.com/tree-sitter/tree-sitter"
-rust-version.workspace = true
 
 [lib]
 crate-type = ["lib", "staticlib"]


### PR DESCRIPTION
1 source of truth for each of the crates = easier management