### PR TITLE
docs: explicitly mention behavior of walking outside the given root node for a `TSTreeCursor`

### DIFF
--- a/docs/section-2-using-parsers.md
+++ b/docs/section-2-using-parsers.md
@@ -410,6 +410,12 @@ Internally, copying a syntax tree just entails incrementing an atomic reference 
 
 You can access every node in a syntax tree using the `TSNode` APIs [described above](#retrieving-nodes), but if you need to access a large number of nodes, the fastest way to do so is with a _tree cursor_. A cursor is a stateful object that allows you to walk a syntax tree with maximum efficiency.
 
+Note that the given input node is considered the root of the cursor, and the
+cursor cannot walk outside this node, so going to the parent or any sibling
+of the root node will return `false`. This has no unexpected effects if the given
+input node is the actual `root` node of the tree, but is something to keep in mind
+when using nodes that are not the `root` node.
+
 You can initialize a cursor from any node:
 
 ```c


### PR DESCRIPTION
Closes #1992 