### PR TITLE
docs: Add `Tact` language parser

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -151,6 +151,7 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 * [Svelte](https://github.com/Himujjal/tree-sitter-svelte)
 * [Swift](https://github.com/alex-pinkus/tree-sitter-swift)
 * [SystemRDL](https://github.com/SystemRDL/tree-sitter-systemrdl)
+* [Tact](https://github.com/tact-lang/tree-sitter-tact)
 * [Thrift](https://github.com/duskmoon314/tree-sitter-thrift)
 * ["TODO:" comments](https://github.com/stsewd/tree-sitter-comment)
 * [TOML](https://github.com/ikatyang/tree-sitter-toml)


### PR DESCRIPTION
Adding the complete parser of the [Tact ](https://tact-lang.org) contract programming language.\
It has highlights, locals and tags generic queries, as well as editor-specific ones.\
Besides, the parser itself, tag and highlighting queries are test-covered.