### PR TITLE
ci: don't cancel jobs on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   checks:


### PR DESCRIPTION
It can be useful to see the full results of all master commits when
trying to bisect a regression.
