### PR TITLE
ci(sanitize): reduce timeout to 20 minutes

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -11,7 +11,7 @@ jobs:
   check_undefined_behaviour:
     name: Sanitizer checks
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 20
     env:
       TREE_SITTER: ${{ github.workspace }}/target/release/tree-sitter
     steps:


### PR DESCRIPTION
60 minutes is too long, even without any caching. It should at most take
10 minutes, but we add another 10 to account for any variance.