### PR TITLE
fix: apply some `scan-build` suggestions (unused assignment/garbage access)

### DIFF
--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -562,7 +562,6 @@ static Subtree ts_parser__lex(
       current_position.extent.column
     );
     ts_lexer_start(&self->lexer);
-    found_token = false;
     if (ts_language_is_wasm(self->language)) {
       found_token = ts_wasm_store_call_lex_main(self->wasm_store, lex_mode.lex_state);
     } else {

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -2643,7 +2643,6 @@ static TSQueryError ts_query__parse_pattern(
           step->alternative_index < self->steps.size
         ) {
           step_index = step->alternative_index;
-          step = &self->steps.contents[step_index];
         } else {
           break;
         }

--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -221,7 +221,7 @@ TreeCursorStep ts_tree_cursor_goto_last_child_internal(TSTreeCursor *_self) {
   CursorChildIterator iterator = ts_tree_cursor_iterate_children(self);
   if (!iterator.parent.ptr || iterator.parent.ptr->child_count == 0) return TreeCursorStepNone;
 
-  TreeCursorEntry last_entry;
+  TreeCursorEntry last_entry = {0};
   TreeCursorStep last_step = TreeCursorStepNone;
   while (ts_tree_cursor_child_iterator_next(&iterator, &entry, &visible)) {
     if (visible) {
@@ -362,7 +362,6 @@ TreeCursorStep ts_tree_cursor_goto_previous_sibling_internal(TSTreeCursor *_self
   TreeCursor *self = (TreeCursor *)_self;
 
   // for that, save current position before traversing
-  Length position = array_back(&self->stack)->position;
   TreeCursorStep step = ts_tree_cursor_goto_sibling_internal(
       _self, ts_tree_cursor_child_iterator_previous);
   if (step == TreeCursorStepNone)
@@ -374,7 +373,7 @@ TreeCursorStep ts_tree_cursor_goto_previous_sibling_internal(TSTreeCursor *_self
 
   // restore position from the parent node
   const TreeCursorEntry *parent = &self->stack.contents[self->stack.size - 2];
-  position = parent->position;
+  Length position = parent->position;
   uint32_t child_index = array_back(&self->stack)->child_index;
   const Subtree *children = ts_subtree_children((*(parent->subtree)));
 


### PR DESCRIPTION
e.g. found_token is assigned without the prior value being used, last_entry might never be set in the loop if it always evaluates to false, etc

`scan-build make` is pretty neat, but the potential null pointer deref stuff seemed sane to me at a glance for the most part based on conditions/factors clang can't intelligently know