### PR TITLE
build: improve changelog settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,94 +1,107 @@
 # Changelog
 
-## [0.21.0] — 2024-02-21
+## [0.21.0] - 2024-02-21
 
 ### Breaking
-
-- Remove the apply-all-captures flag, make last-wins precedence the default _by_ @amaanq
+- Remove the apply-all-captures flag, make last-wins precedence the default
 
   **NOTE**: This change might cause breakage in your grammar's highlight tests.
   Just flip the order around of the relevant queries, and keep in mind that the
   last query that matches will win.
 
+### Features
+- Use lockfiles to dedup recompilation
+- Improve error message for files with an unknown grammar path (https://github.com/tree-sitter/tree-sitter/pull/2475)
+- Implement first-line-regex (https://github.com/tree-sitter/tree-sitter/pull/2479)
+- Error out if an empty string is in the `extras` array
+- Allow specifying an external scanner's files (https://github.com/tree-sitter/tree-sitter/pull/3031)
+- Better error info when a scanner is missing required symbols
+- **cli**: Add an optional `grammar-path` argument for the playground (https://github.com/tree-sitter/tree-sitter/pull/3014)
+- **cli**: Add optional `config-path` argument (https://github.com/tree-sitter/tree-sitter/pull/3050)
+- **loader**: Add more commonly used default parser directories
+
+
 ### Bug Fixes
+- Prettify xml output and add node position info (https://github.com/tree-sitter/tree-sitter/pull/2970)
+- Inherited grammar generation
+- Properly error out when the word property is an invalid rule
+- Update schema for regex flags (https://github.com/tree-sitter/tree-sitter/pull/3006)
+- Properly handle Query.matches when filtering out results (https://github.com/tree-sitter/tree-sitter/pull/3013)
+- Sexp format edge case with quoted closed parenthesis (https://github.com/tree-sitter/tree-sitter/pull/3016)
+- Always push the default files if there's no `externals`
+- Don't log NUL characters (https://github.com/tree-sitter/tree-sitter/pull/3037)
+- Don't throw an error if the user uses `map` in the grammar (https://github.com/tree-sitter/tree-sitter/pull/3041)
+- Remove redundant imports (https://github.com/tree-sitter/tree-sitter/pull/3047)
+- **cli**: Installation via a HTTP tunnel proxy (https://github.com/tree-sitter/tree-sitter/pull/2824)
+- **cli**: Don't update tests automatically if parse errors are detected (https://github.com/tree-sitter/tree-sitter/pull/3033)
+- **cli**: Don't use `long` for `grammar_path`
+- **test**: Allow writing updates to tests without erroneous nodes instead of denying all of them if a single error is found
+- **test**: Edge case when parsing `UNEXPECTED`/`MISSING` nodes with an indentation level greater than 0
+- **wasm**: Remove C++ mangled symbols (https://github.com/tree-sitter/tree-sitter/pull/2971)
 
-- Prettify xml output and add node position info _by_ @amaanq _in_ #2970
-- Inherited grammar generation _by_ @amaanq
-- Properly error out when the word property is an invalid rule _by_ @amaanq
-- Update schema for regex flags _by_ @amaanq _in_ #3006
-- Properly handle `Query.matches` when filtering out results _by_ @amaanq _in_ #3013
-- Sexp format edge case with quoted closed parenthesis _by_ @amaanq _in_ #3016
-- Always push the default files if there's no `externals` _by_ @amaanq
-- Don't log NUL characters _by_ @amaanq _in_ #3037
-- Don't throw an error if the user uses `map` in the grammar _by_ @amaanq _in_ #3041
-- Remove redundant imports _by_ @amaanq _in_ #3047
-- **cli**: Installation via a HTTP tunnel proxy _by_ @stormyyd _in_ #2824
-- **cli**: Don't update tests automatically if parse errors are detected _by_ @amaanq _in_ #3033
-- **cli**: Don't use `long` for `grammar_path` _by_ @amaanq
-- **test**: Allow writing updates to tests without erroneous nodes instead of denying all of them if a single error is found _by_ @amaanq
-- **test**: Edge case when parsing `UNEXPECTED`/`MISSING` nodes with an indentation level greater than 0 _by_ @amaanq
-- **wasm**: Remove C++ mangled symbols _by_ @amaanq _in_ #2971
-
-### Build System
-
-- Add useful development targets to makefile _by_ @dundargoc _in_ #2979
-- Add editorconfig _by_ @dundargoc _in_ #2998
-- Remove symbolic links from repository _by_ @dundargoc _in_ #2997
-- Move common Cargo.toml keys into the workspace and inherit them _by_ @amaanq _in_ #3019
-- Enable creating changelogs with git-cliff _by_ @dundargoc _in_ #3040
-- **deps**: Bump clap from 4.4.18 to 4.5.0 _by_ @dependabot[bot] _in_ #3007
-- **deps**: Bump wasmtime from v16.0.0 to v17.0.1 _by_ @dependabot[bot] _in_ #3008
-- **deps**: Bump wasmtime to v18.0.1 _by_ @amaanq _in_ #3057
 
 ### Documentation
+- Create issue template (https://github.com/tree-sitter/tree-sitter/pull/2978)
+- Document regex limitations
+- Mention that `token($.foo)` is illegal
+- Explicitly mention behavior of walking outside the given "root" node for a `TSTreeCursor` (https://github.com/tree-sitter/tree-sitter/pull/3021)
+- Small fixes (https://github.com/tree-sitter/tree-sitter/pull/2987)
+- Add `Tact` language parser (https://github.com/tree-sitter/tree-sitter/pull/3030)
+- **web**: Provide deno usage information (https://github.com/tree-sitter/tree-sitter/pull/2498)
 
-- Create issue template _by_ @dundargoc _in_ #2978
-- Document regex limitations _by_ @amaanq
-- Mention that `token($.foo)` is illegal _by_ @amaanq
-- Explicitly mention behavior of walking outside the given "root" node for a `TSTreeCursor` _by_ @amaanq _in_ #3021
-- Small fixes _by_ @dundargoc _in_ #2987
-- Add `Tact` language parser _by_ @novusnota _in_ #3030
-- **web**: Provide deno usage information _by_ @sigmaSd _in_ #2498
-
-### Features
-
-- Use lockfiles to dedup recompilation _by_ @amaanq
-- Improve error message for files with an unknown grammar path _by_ @amaanq _in_ #2475
-- Implement first-line-regex _by_ @sigmaSd _in_ #2479
-- Error out if an empty string is in the `extras` array _by_ @aminya
-- Allow specifying an external scanner's files _by_ @amaanq _in_ #3031
-- Better error info when a scanner is missing required symbols _by_ @amaanq
-- **cli**: Add an optional `grammar-path` argument for the playground _by_ @amaanq _in_ #3014
-- **cli**: Add optional `config-path` argument _by_ @WillLillis _in_ #3050
-- **loader**: Add more commonly used default parser directories _by_ @amaanq
-
-### Miscellaneous Tasks
-
-- Document preferred language for scanner _by_ @calebdw _in_ #2972
-- Add java and tsx to corpus tests _by_ @amaanq _in_ #2992
-- Provide a CLI flag to open `log.html` _by_ @amaanq _in_ #2996
-- Some more clippy lints _by_ @amaanq _in_ #3010
-- Remove deprecated query parsing mechanism _by_ @amaanq _in_ #3011
-- Print out full compiler arguments ran when it fails _by_ @amaanq _in_ #3018
-- Deprecate C++ scanners _by_ @amaanq _in_ #3020
-- Update relevant rust tests _by_ @amaanq _in_ #2947
-- Clippy lints _by_ @amaanq _in_ #3032
-- Error out when multiple arguments are passed to `token`/`token.immediate` _by_ @amaanq _in_ #3036
-- Update `Cargo.lock` _by_ @amaanq
-- Get rid of `github_issue_test` file _by_ @amaanq _in_ #3055
-- **cli**: Use spawn to display `emcc`'s stdout and stderr _by_ @amaanq _in_ #2494
-- **cli**: Warn users when a query path needed for a subcommand isn't specified in a grammar's package.json _by_ @amaanq
-- **generate**: Dedup and warn about duplicate or invalid rules _by_ @amaanq _in_ #2994
-- **test**: Use different languages for async tests _by_ @amaanq _in_ #2953
-- **wasm**: Use `SIDE_MODULE=2` to silence warning _by_ @amaanq _in_ #3003
 
 ### Refactor
+- Extract regex check into a function and lower its precedence
+- `&PathBuf` -> `&Path` (https://github.com/tree-sitter/tree-sitter/pull/3035)
+- Name anonymous types in api.h (https://github.com/tree-sitter/tree-sitter/pull/1659)
 
-- Extract regex check into a function and lower its precedence _by_ @amaanq
-- `&PathBuf` -> `&Path` _by_ @amaanq _in_ #3035
-- Name anonymous types in api.h _by_ @MatthewGentoo _in_ #1659
 
 ### Testing
+- Add quotes around bash variables (https://github.com/tree-sitter/tree-sitter/pull/3023)
+- Update html tests
 
-- Add quotes around bash variables _by_ @dundargoc _in_ #3023
-- Update html tests _by_ @amaanq
+
+### Build System and CI
+- Only create release for normal semver tags (https://github.com/tree-sitter/tree-sitter/pull/2973)
+- Add useful development targets to makefile (https://github.com/tree-sitter/tree-sitter/pull/2979)
+- Remove minimum glibc information in summary page (https://github.com/tree-sitter/tree-sitter/pull/2988)
+- Use the native m1 mac runner (https://github.com/tree-sitter/tree-sitter/pull/2995)
+- Add editorconfig (https://github.com/tree-sitter/tree-sitter/pull/2998)
+- Remove symbolic links from repository (https://github.com/tree-sitter/tree-sitter/pull/2997)
+- Move common Cargo.toml keys into the workspace and inherit them (https://github.com/tree-sitter/tree-sitter/pull/3019)
+- Remove reviewers when drafting or closing a PR (https://github.com/tree-sitter/tree-sitter/pull/2963)
+- Enable creating changelogs with git-cliff (https://github.com/tree-sitter/tree-sitter/pull/3040)
+- Cache fixtures (https://github.com/tree-sitter/tree-sitter/pull/3038)
+- Don't cancel jobs on master (https://github.com/tree-sitter/tree-sitter/pull/3052)
+- Relax caching requirements (https://github.com/tree-sitter/tree-sitter/pull/3051)
+- **deps**: Bump clap from 4.4.18 to 4.5.0 (https://github.com/tree-sitter/tree-sitter/pull/3007)
+- **deps**: Bump wasmtime from v16.0.0 to v17.0.1 (https://github.com/tree-sitter/tree-sitter/pull/3008)
+- **deps**: Bump wasmtime to v18.0.1 (https://github.com/tree-sitter/tree-sitter/pull/3057)
+- **sanitize**: Add a timeout of 60 minutes (https://github.com/tree-sitter/tree-sitter/pull/3017)
+- **sanitize**: Reduce timeout to 20 minutes (https://github.com/tree-sitter/tree-sitter/pull/3054)
+
+
+### Other
+- Document preferred language for scanner (https://github.com/tree-sitter/tree-sitter/pull/2972)
+- Add java and tsx to corpus tests (https://github.com/tree-sitter/tree-sitter/pull/2992)
+- Provide a CLI flag to open `log.html` (https://github.com/tree-sitter/tree-sitter/pull/2996)
+- Some more clippy lints (https://github.com/tree-sitter/tree-sitter/pull/3010)
+- Remove deprecated query parsing mechanism (https://github.com/tree-sitter/tree-sitter/pull/3011)
+- Print out full compiler arguments ran when it fails (https://github.com/tree-sitter/tree-sitter/pull/3018)
+- Deprecate C++ scanners (https://github.com/tree-sitter/tree-sitter/pull/3020)
+- Add some documentation to the playground page (https://github.com/tree-sitter/tree-sitter/pull/1495)
+- Update relevant rust tests (https://github.com/tree-sitter/tree-sitter/pull/2947)
+- Clippy lints (https://github.com/tree-sitter/tree-sitter/pull/3032)
+- Error out when multiple arguments are passed to `token`/`token.immediate` (https://github.com/tree-sitter/tree-sitter/pull/3036)
+- Tidying
+- Prefer turbofish syntax where possible (https://github.com/tree-sitter/tree-sitter/pull/3048)
+- Use published wasmtime crates
+- Cleaner cast
+- Update Cargo.lock
+- Get rid of `github_issue_test` file (https://github.com/tree-sitter/tree-sitter/pull/3055)
+- **cli**: Use spawn to display `emcc`'s stdout and stderr (https://github.com/tree-sitter/tree-sitter/pull/2494)
+- **cli**: Warn users when a query path needed for a subcommand isn't specified in a grammar's package.json
+- **generate**: Dedup and warn about duplicate or invalid rules (https://github.com/tree-sitter/tree-sitter/pull/2994)
+- **test**: Use different languages for async tests (https://github.com/tree-sitter/tree-sitter/pull/2953)
+- **wasm**: Use `SIDE_MODULE=2` to silence warning (https://github.com/tree-sitter/tree-sitter/pull/3003)
+

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,6 @@ format:
 	cargo fmt --all
 
 changelog:
-	git-cliff --config script/cliff.toml --output CHANGELOG.md --latest
+	@git-cliff --config script/cliff.toml --output CHANGELOG.md --latest --github-token $(shell gh auth token)
 
 .PHONY: test test_wasm lint format changelog

--- a/script/cliff.toml
+++ b/script/cliff.toml
@@ -1,5 +1,3 @@
-# configuration file for git-cliff (0.1.0)
-
 [changelog]
 # changelog header
 header = """
@@ -14,22 +12,20 @@ body = """
     ## [unreleased]
 {% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
-    ### {{ group | upper_first }}
+    ### {{ group | striptags | upper_first }}
     {% for commit in commits%}\
         {% if not commit.scope %}\
             - {{ commit.message | upper_first }}\
-              {% if commit.github.username %} *by* @{{ commit.github.username }}{%- endif %}\
-              {% if commit.github.pr_number %} *in* #{{ commit.github.pr_number }}{%- endif %}
+              {% if commit.github.pr_number %} (https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/pull/{{ commit.github.pr_number }}){%- endif %}
         {% endif %}\
     {% endfor %}\
     {% for group, commits in commits | group_by(attribute="scope") %}\
         {% for commit in commits %}\
             - **{{commit.scope}}**: {{ commit.message | upper_first }}\
-                {% if commit.github.username %} *by* @{{ commit.github.username }}{%- endif %}\
-                {% if commit.github.pr_number %} *in* #{{ commit.github.pr_number }}{%- endif %}
+                {% if commit.github.pr_number %} (https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/pull/{{ commit.github.pr_number }}){%- endif %}
         {% endfor %}\
     {% endfor %}
-{% endfor %}\n
+{% endfor %}
 """
 # remove the leading and trailing whitespace from the template
 trim = true
@@ -38,7 +34,7 @@ trim = true
 # parse the commits based on https://www.conventionalcommits.org
 conventional_commits = true
 # filter out the commits that are not conventional
-filter_unconventional = true
+filter_unconventional = false
 # process each line of a commit as an individual commit
 split_commits = false
 # regex for preprocessing the commit messages
@@ -47,19 +43,19 @@ commit_preprocessors = [
 ]
 # regex for parsing and grouping commits
 commit_parsers = [
-    { message = "!:", group = "Breaking"},
-    { message = "^feat", group = "Features"},
-    { message = "^fix", group = "Bug Fixes"},
-    { message = "^doc", group = "Documentation"},
-    { message = "^perf", group = "Performance"},
-    { message = "^refactor", group = "Refactor"},
-    { message = "^test", group = "Testing"},
-    { message = "^chore", group = "Miscellaneous Tasks"},
-    { message = "^build", group = "Build System"},
-    { message = "^Revert", group = "Reverted Changes"},
+    { message = "!:", group = "<!-- 0 -->Breaking"},
+    { message = "^feat", group = "<!-- 1 -->Features"},
+    { message = "^fix", group = "<!-- 2 -->Bug Fixes"},
+    { message = "^perf", group = "<!-- 3 -->Performance"},
+    { message = "^doc", group = "<!-- 4 -->Documentation"},
+    { message = "^refactor", group = "<!-- 5 -->Refactor"},
+    { message = "^test", group = "<!-- 6 -->Testing"},
+    { message = "^build", group = "<!-- 7 -->Build System and CI"},
+    { message = "^ci", group = "<!-- 7 -->Build System and CI"},
+    { message = ".*", group = "<!-- 8 -->Other"},
 ]
 # filter out the commits that are not matched by commit parsers
-filter_commits = true
+filter_commits = false
 # glob pattern for matching git tags
 tag_pattern = "v[0-9]*"
 # regex for skipping tags


### PR DESCRIPTION
Quality of life improvements:

- automatically use `gh auth token` when running `make changelog`
- Add full links to related pull requests
- Include non-conventional commits
- Force group order by adding html comments
