### PR TITLE
Introduce tree-sitter-language crate for grammar crates to depend on

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,6 +1389,7 @@ dependencies = [
  "bindgen",
  "cc",
  "regex",
+ "tree-sitter-language",
  "wasmtime-c-api-impl",
 ]
 
@@ -1457,6 +1458,10 @@ dependencies = [
  "thiserror",
  "tree-sitter",
 ]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.0"
 
 [[package]]
 name = "tree-sitter-loader"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "cli/config",
   "cli/loader",
   "lib",
+  "lib/language",
   "tags",
   "highlight",
   "xtask",

--- a/cli/src/generate/templates/cargo.toml
+++ b/cli/src/generate/templates/cargo.toml
@@ -17,7 +17,10 @@ include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = ">=RUST_BINDING_VERSION"
+tree-sitter-language = "0.1"
+
+[dev-dependencies]
+tree-sitter = { version = "0.22" }
 
 [build-dependencies]
 cc = "1.0.87"

--- a/cli/src/generate/templates/lib.rs
+++ b/cli/src/generate/templates/lib.rs
@@ -7,7 +7,10 @@
 //! let code = r#"
 //! "#;
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(&tree_sitter_PARSER_NAME::language()).expect("Error loading CAMEL_PARSER_NAME grammar");
+//! let language = tree_sitter_PARSER_NAME::LANGUAGE;
+//! parser
+//!     .set_language(&language.into())
+//!     .expect("Error loading CAMEL_PARSER_NAME parser");
 //! let tree = parser.parse(code, None).unwrap();
 //! assert!(!tree.root_node().has_error());
 //! ```
@@ -17,18 +20,14 @@
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
+use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_PARSER_NAME() -> Language;
+    fn tree_sitter_PARSER_NAME() -> *const ();
 }
 
-/// Get the tree-sitter [Language][] for this grammar.
-///
-/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
-    unsafe { tree_sitter_PARSER_NAME() }
-}
+/// The tree-sitter [`LanguageFn`] for this grammar.
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_PARSER_NAME) };
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
@@ -48,7 +47,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(&super::language())
-            .expect("Error loading CAMEL_PARSER_NAME grammar");
+            .set_language(&super::LANGUAGE.into())
+            .expect("Error loading CAMEL_PARSER_NAME parser");
     }
 }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -30,6 +30,7 @@ wasm = ["wasmtime-c-api"]
 
 [dependencies]
 regex.workspace = true
+tree-sitter-language = { version = "0.1", path = "language" }
 
 [dependencies.wasmtime-c-api]
 version = "19"

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -22,6 +22,8 @@ use std::{
     sync::atomic::AtomicUsize,
 };
 
+use tree_sitter_language::LanguageFn;
+
 #[cfg(feature = "wasm")]
 mod wasm_language;
 #[cfg(feature = "wasm")]
@@ -284,6 +286,10 @@ pub struct LossyUtf8<'a> {
 }
 
 impl Language {
+    pub fn new(builder: LanguageFn) -> Self {
+        Self(unsafe { (builder.into_raw())() as _ })
+    }
+
     /// Get the ABI version number that indicates which version of the
     /// Tree-sitter CLI that was used to generate this [`Language`].
     #[doc(alias = "ts_language_version")]
@@ -403,6 +409,12 @@ impl Language {
     pub fn lookahead_iterator(&self, state: u16) -> Option<LookaheadIterator> {
         let ptr = unsafe { ffi::ts_lookahead_iterator_new(self.0, state) };
         (!ptr.is_null()).then(|| unsafe { LookaheadIterator::from_raw(ptr) })
+    }
+}
+
+impl From<LanguageFn> for Language {
+    fn from(value: LanguageFn) -> Self {
+        Self::new(value)
     }
 }
 

--- a/lib/language/Cargo.toml
+++ b/lib/language/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tree-sitter-language"
+description = "The tree-sitter Language type, used by the library and by language implementations"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+
+[lib]
+path = "language.rs"

--- a/lib/language/language.rs
+++ b/lib/language/language.rs
@@ -1,0 +1,20 @@
+/// LanguageFn wraps a C function that returns a pointer to a tree-sitter grammer.
+#[repr(transparent)]
+pub struct LanguageFn(unsafe extern "C" fn() -> *const ());
+
+impl LanguageFn {
+    /// Creates a `LanguageFn`.
+    ///
+    /// # Safety
+    ///
+    /// Only call this with language functions generated from grammars
+    /// by the Tree-sitter CLI.
+    pub const unsafe fn from_raw(f: unsafe extern "C" fn() -> *const ()) -> Self {
+        Self(f)
+    }
+
+    /// Gets the function wrapped by this `LanguageFn`.
+    pub const fn into_raw(self) -> unsafe extern "C" fn() -> *const () {
+        self.0
+    }
+}


### PR DESCRIPTION
This new crate `tree-sitter-language` just provides a `LanguageFn` type that grammar crates like `tree-sitter-json` can create instances of. Formerly, those grammar crates depended on `tree-sitter` itself, which was bad, because they had to depend on a specific version of the library, even though they don't use the library.

This is a breaking change. Grammar repos will need to regenerate their rust bindings.