### PR TITLE
Use workspace dependencies for internal crates like Tree-sitter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,3 +84,9 @@ walkdir = "2.4.0"
 wasmparser = "0.200.0"
 webbrowser = "0.8.12"
 which = "6.0.0"
+
+tree-sitter = { version = "=0.21.0", path = "./lib" }
+tree-sitter-loader = { version = "=0.21.0", path = "./cli/loader" }
+tree-sitter-config = { version = "=0.21.0", path = "./cli/config" }
+tree-sitter-highlight = { version = "=0.21.0", path = "./highlight" }
+tree-sitter-tags = { version = "=0.21.0", path = "./tags" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -54,25 +54,11 @@ wasmparser.workspace = true
 webbrowser.workspace = true
 which.workspace = true
 
-[dependencies.tree-sitter]
-version = "0.21.0"
-path = "../lib"
-
-[dependencies.tree-sitter-config]
-version = "0.21.0"
-path = "config"
-
-[dependencies.tree-sitter-highlight]
-version = "0.21.0"
-path = "../highlight"
-
-[dependencies.tree-sitter-loader]
-version = "0.21.0"
-path = "loader"
-
-[dependencies.tree-sitter-tags]
-version = "0.21.0"
-path = "../tags"
+tree-sitter.workspace = true
+tree-sitter-config.workspace = true
+tree-sitter-highlight.workspace = true
+tree-sitter-loader.workspace = true
+tree-sitter-tags.workspace = true
 
 [dev-dependencies]
 tree_sitter_proc_macro = { path = "src/tests/proc_macro", package = "tree-sitter-tests-proc-macro" }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -10,9 +10,6 @@ fn main() {
     if web_playground_files_present() {
         println!("cargo:rustc-cfg=TREE_SITTER_EMBED_WASM_BINDING");
     }
-
-    let rust_binding_version = read_rust_binding_version();
-    println!("cargo:rustc-env=RUST_BINDING_VERSION={rust_binding_version}");
 }
 
 fn web_playground_files_present() -> bool {
@@ -102,15 +99,4 @@ fn read_git_sha() -> Option<String> {
     }
 
     None
-}
-
-fn read_rust_binding_version() -> String {
-    let path = "Cargo.toml";
-    let text = fs::read_to_string(path).unwrap();
-    let cargo_toml = toml::from_str::<toml::Value>(text.as_ref()).unwrap();
-    cargo_toml["dependencies"]["tree-sitter"]["version"]
-        .as_str()
-        .unwrap()
-        .trim_matches('"')
-        .to_string()
 }

--- a/cli/loader/Cargo.toml
+++ b/cli/loader/Cargo.toml
@@ -28,14 +28,6 @@ serde.workspace = true
 serde_json.workspace = true
 which.workspace = true
 
-[dependencies.tree-sitter]
-version = "0.21.0"
-path = "../../lib"
-
-[dependencies.tree-sitter-highlight]
-version = "0.21.0"
-path = "../../highlight"
-
-[dependencies.tree-sitter-tags]
-version = "0.21.0"
-path = "../../tags"
+tree-sitter.workspace = true
+tree-sitter-highlight.workspace = true
+tree-sitter-tags.workspace = true

--- a/cli/src/generate/binding_files.rs
+++ b/cli/src/generate/binding_files.rs
@@ -12,8 +12,7 @@ const CARGO_TOML_TEMPLATE: &str = include_str!("./templates/cargo.toml");
 const PACKAGE_JSON_TEMPLATE: &str = include_str!("./templates/package.json");
 const PARSER_NAME_PLACEHOLDER: &str = "PARSER_NAME";
 const CLI_VERSION_PLACEHOLDER: &str = "CLI_VERSION";
-const CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
-const RUST_BINDING_VERSION: &str = env!("RUST_BINDING_VERSION");
+const TREE_SITTER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const RUST_BINDING_VERSION_PLACEHOLDER: &str = "RUST_BINDING_VERSION";
 
 pub fn generate_binding_files(repo_path: &Path, language_name: &str) -> Result<()> {
@@ -118,8 +117,8 @@ fn generate_file(path: &Path, template: &str, language_name: &str) -> Result<()>
         path,
         template
             .replace(PARSER_NAME_PLACEHOLDER, language_name)
-            .replace(CLI_VERSION_PLACEHOLDER, CLI_VERSION)
-            .replace(RUST_BINDING_VERSION_PLACEHOLDER, RUST_BINDING_VERSION),
+            .replace(CLI_VERSION_PLACEHOLDER, TREE_SITTER_VERSION)
+            .replace(RUST_BINDING_VERSION_PLACEHOLDER, TREE_SITTER_VERSION),
     )
 }
 

--- a/highlight/Cargo.toml
+++ b/highlight/Cargo.toml
@@ -23,6 +23,4 @@ lazy_static.workspace = true
 regex.workspace = true
 thiserror.workspace = true
 
-[dependencies.tree-sitter]
-version = "0.21.0"
-path = "../lib"
+tree-sitter.workspace = true

--- a/tags/Cargo.toml
+++ b/tags/Cargo.toml
@@ -19,10 +19,8 @@ categories = ["parsing", "text-editors"]
 crate-type = ["lib", "staticlib"]
 
 [dependencies]
-regex.workspace = true
 memchr.workspace = true
+regex.workspace = true
 thiserror.workspace = true
 
-[dependencies.tree-sitter]
-version = "0.21.0"
-path = "../lib"
+tree-sitter.workspace = true


### PR DESCRIPTION
This way, the Rust version is just located in the top-level Cargo.toml.