### PR TITLE
fix(bindings): editorconfig and setup.py fixes

### DIFF
--- a/cli/src/generate/grammar_files.rs
+++ b/cli/src/generate/grammar_files.rs
@@ -25,7 +25,7 @@ const GRAMMAR_JS_TEMPLATE: &str = include_str!("./templates/grammar.js");
 const PACKAGE_JSON_TEMPLATE: &str = include_str!("./templates/package.json");
 const GITIGNORE_TEMPLATE: &str = include_str!("./templates/gitignore");
 const GITATTRIBUTES_TEMPLATE: &str = include_str!("./templates/gitattributes");
-const EDITORCONFIG_TEMPLATE: &str = include_str!("./templates/gitattributes");
+const EDITORCONFIG_TEMPLATE: &str = include_str!("./templates/.editorconfig");
 
 const RUST_BINDING_VERSION: &str = env!("CARGO_PKG_VERSION");
 const RUST_BINDING_VERSION_PLACEHOLDER: &str = "RUST_BINDING_VERSION";

--- a/cli/src/generate/templates/.editorconfig
+++ b/cli/src/generate/templates/.editorconfig
@@ -6,12 +6,11 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{json,toml,yml}]
+[*.{json,toml,yml,gyp}]
 indent_style = space
 indent_size = 2
 
 [*.js]
-quote_type = double
 indent_style = space
 indent_size = 2
 
@@ -24,7 +23,6 @@ indent_style = space
 indent_size = 4
 
 [*.{py,pyi}]
-quote_type = double
 indent_style = space
 indent_size = 4
 

--- a/cli/src/generate/templates/setup.py
+++ b/cli/src/generate/templates/setup.py
@@ -1,4 +1,6 @@
-from os.path import join
+from os.path import isdir, join
+from platform import system
+
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build import build
 from wheel.bdist_wheel import bdist_wheel
@@ -6,11 +8,9 @@ from wheel.bdist_wheel import bdist_wheel
 
 class Build(build):
     def run(self):
-        dest = join(self.build_lib, "tree_sitter_PARSER_NAME", "queries")
-        try:
+        if isdir("queries"):
+            dest = join(self.build_lib, "tree_sitter_PARSER_NAME", "queries")
             self.copy_tree("queries", dest)
-        except:
-            pass
         super().run()
 
 
@@ -38,12 +38,20 @@ setup(
                 "src/parser.c",
                 # NOTE: if your language uses an external scanner, add it here.
             ],
-            extra_compile_args=["-std=c11"],
-            define_macros=[("Py_LIMITED_API", "0x03080000"), ("PY_SSIZE_T_CLEAN", None)],
+            extra_compile_args=(
+                ["-std=c11"] if system() != 'Windows' else []
+            ),
+            define_macros=[
+                ("Py_LIMITED_API", "0x03080000"),
+                ("PY_SSIZE_T_CLEAN", None)
+            ],
             include_dirs=["src"],
             py_limited_api=True,
         )
     ],
-    cmdclass={"build": Build, "bdist_wheel": BdistWheel},
+    cmdclass={
+        "build": Build,
+        "bdist_wheel": BdistWheel
+    },
     zip_safe=False,
 )


### PR DESCRIPTION
#### editorconfig

- `EDITORCONFIG_TEMPLATE` was using `gitattributes` instead of `editorconfig` (whoops).
- Renamed it to `.editorconfig` so it also applies to the templates in this codebase.
- Removed non-standard `quote_type` rule and added `gyp` file.

#### setup.py

- Unfolded one-liners for clarity.
- Changed try-catch block to `isdir()`.
- Unset `extra_compile_args` on Windows.