### PR TITLE
test: don't use TS_REUSE_ALLOCATOR on Darwin systems

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -30,9 +30,6 @@ fn main() {
         target_os = "dragonfly",
     ))]
     println!("cargo:rustc-link-arg=-Wl,--dynamic-list=cli/dynamic-symbols.txt");
-
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
-    println!("cargo:rustc-link-arg=-Wl,-exported_symbols_list,cli/dynamic-symbols-darwin.txt");
 }
 
 fn web_playground_files_present() -> bool {

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -602,6 +602,7 @@ impl Loader {
 
         // Always use the same allocator in the CLI as any scanner, useful for debugging and
         // tracking memory leaks in tests.
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
         command.arg("-DTS_REUSE_ALLOCATOR");
 
         let output = command.output().with_context(|| {


### PR DESCRIPTION
For some reason, the linker seems to behave a bit differently with `-exported_symbols_list` on macOS **only** for tests vs other operating systems, so we'll disable this for now