### PR TITLE
fix(lib): include `api.h` so `ts_set_allocator` is visible

### DIFF
--- a/lib/src/alloc.c
+++ b/lib/src/alloc.c
@@ -1,4 +1,5 @@
 #include "alloc.h"
+#include "tree_sitter/api.h"
 #include <stdlib.h>
 
 static void *ts_malloc_default(size_t size) {


### PR DESCRIPTION
Closes #3091