### PR TITLE
refactor: remove extern/const where possible

### DIFF
--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -263,7 +263,6 @@ impl Generator {
 
     fn add_pragmas(&mut self) {
         add_line!(self, "#if defined(__GNUC__) || defined(__clang__)");
-        add_line!(self, "#pragma GCC diagnostic push");
         add_line!(
             self,
             "#pragma GCC diagnostic ignored \"-Wmissing-field-initializers\""
@@ -1342,14 +1341,23 @@ impl Generator {
             add_line!(self, "");
         }
 
+        add_line!(self, "#ifdef TS_PUBLIC");
+        add_line!(self, "#undef TS_PUBLIC");
+        add_line!(self, "#endif");
+        add_line!(self, "");
         add_line!(self, "#ifdef _WIN32");
-        add_line!(self, "#define extern __declspec(dllexport)");
+        add_line!(self, "#define TS_PUBLIC __declspec(dllexport)");
+        add_line!(self, "#else");
+        add_line!(
+            self,
+            "#define TS_PUBLIC __attribute__((visibility(\"default\")))"
+        );
         add_line!(self, "#endif");
         add_line!(self, "");
 
         add_line!(
             self,
-            "extern const TSLanguage *{language_function_name}(void) {{",
+            "TS_PUBLIC const TSLanguage *{language_function_name}() {{",
         );
         indent!(self);
         add_line!(self, "static const TSLanguage language = {{");

--- a/cli/src/generate/templates/PARSER_NAME.h
+++ b/cli/src/generate/templates/PARSER_NAME.h
@@ -7,7 +7,7 @@ typedef struct TSLanguage TSLanguage;
 extern "C" {
 #endif
 
-extern const TSLanguage *tree_sitter_PARSER_NAME(void);
+const TSLanguage *tree_sitter_PARSER_NAME(void);
 
 #ifdef __cplusplus
 }

--- a/cli/src/generate/templates/Package.swift
+++ b/cli/src/generate/templates/Package.swift
@@ -43,5 +43,6 @@ let package = Package(
                 ],
                 publicHeadersPath: "bindings/swift",
                 cSettings: [.headerSearchPath("src")])
-    ]
+    ],
+    cLanguageStandard: .c11
 )

--- a/cli/src/generate/templates/binding.gyp
+++ b/cli/src/generate/templates/binding.gyp
@@ -2,7 +2,9 @@
   "targets": [
     {
       "target_name": "tree_sitter_PARSER_NAME_binding",
-      "dependencies": ["<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except"],
+      "dependencies": [
+        "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except",
+      ],
       "include_dirs": [
         "src",
       ],
@@ -13,17 +15,6 @@
       ],
       "cflags_c": [
         "-std=c11",
-      ],
-      "cflags_cc": [
-        "-Wno-cast-function-type",
-      ],
-      "conditions": [
-        ["OS=='mac'", {
-            "cflags+": ["-fvisibility=hidden"],
-            "xcode_settings": {
-              "GCC_SYMBOLS_PRIVATE_EXTERN": "YES", # -fvisibility=hidden
-            }
-        }]
       ],
     }
   ]

--- a/cli/src/generate/templates/build.rs
+++ b/cli/src/generate/templates/build.rs
@@ -2,12 +2,13 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.include(src_dir);
+    c_config.std("c11").include(src_dir);
+
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
     // NOTE: if your language uses an external scanner, uncomment this block:
-
     /*
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
@@ -15,5 +16,4 @@ fn main() {
     */
 
     c_config.compile("tree-sitter-PARSER_NAME");
-    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 }

--- a/cli/src/generate/templates/py-binding.c
+++ b/cli/src/generate/templates/py-binding.c
@@ -2,10 +2,10 @@
 
 typedef struct TSLanguage TSLanguage;
 
-extern const TSLanguage *tree_sitter_LOWER_PARSER_NAME(void);
+TSLanguage *tree_sitter_LOWER_PARSER_NAME(void);
 
 static PyObject* _binding_language(PyObject *self, PyObject *args) {
-    return PyLong_FromVoidPtr((void *)tree_sitter_LOWER_PARSER_NAME());
+    return PyLong_FromVoidPtr(tree_sitter_LOWER_PARSER_NAME());
 }
 
 static PyMethodDef methods[] = {

--- a/cli/src/tests/detect_language.rs
+++ b/cli/src/tests/detect_language.rs
@@ -97,10 +97,15 @@ fn tree_sitter_dir(package_json: &str, name: &str) -> tempfile::TempDir {
         format!(
             r##"
                 #include "tree_sitter/parser.h"
-                #ifdef _WIN32
-                #define extern __declspec(dllexport)
+                #ifdef TS_PUBLIC
+                #undef TS_PUBLIC
                 #endif
-                extern const TSLanguage *tree_sitter_{name}(void) {{}}
+                #ifdef _WIN32
+                #define TS_PUBLIC __declspec(dllexport)
+                #else
+                #define TS_PUBLIC __attribute__((visibility("default")))
+                #endif
+                TS_PUBLIC const TSLanguage *tree_sitter_{name}() {{}}
             "##
         ),
     )

--- a/docs/section-2-using-parsers.md
+++ b/docs/section-2-using-parsers.md
@@ -51,7 +51,7 @@ Here's an example of a simple C program that uses the Tree-sitter [JSON parser](
 
 // Declare the `tree_sitter_json` function, which is
 // implemented by the `tree-sitter-json` library.
-extern const TSLanguage *tree_sitter_json();
+const TSLanguage *tree_sitter_json(void);
 
 int main() {
   // Create a parser.
@@ -326,9 +326,9 @@ Conceptually, it can be represented by three syntax trees with overlapping range
 #include <tree_sitter/api.h>
 
 // These functions are each implemented in their own repo.
-extern const TSLanguage *tree_sitter_embedded_template();
-extern const TSLanguage *tree_sitter_html();
-extern const TSLanguage *tree_sitter_ruby();
+const TSLanguage *tree_sitter_embedded_template(void);
+const TSLanguage *tree_sitter_html(void);
+const TSLanguage *tree_sitter_ruby(void);
 
 int main(int argc, const char **argv) {
   const char *text = argv[1];

--- a/lib/src/array.h
+++ b/lib/src/array.h
@@ -15,10 +15,7 @@ extern "C" {
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4101)
-#elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-variable"
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #endif
@@ -109,8 +106,12 @@ extern "C" {
 #define array_assign(self, other) \
   _array__assign((Array *)(self), (const Array *)(other), array_elem_size(self))
 
+/// Swap one array with another
 #define array_swap(self, other) \
   _array__swap((Array *)(self), (Array *)(other))
+
+/// Get the size of the array contents
+#define array_elem_size(self) (sizeof *(self)->contents)
 
 /// Search a sorted array for a given `needle` value, using the given `compare`
 /// callback to determine the order.
@@ -128,7 +129,7 @@ extern "C" {
 ///
 /// See also `array_search_sorted_with`.
 #define array_search_sorted_by(self, field, needle, _index, _exists) \
-  _array__search_sorted(self, 0, compare_int, field, needle, _index, _exists)
+  _array__search_sorted(self, 0, _compare_int, field, needle, _index, _exists)
 
 /// Insert a given `value` into a sorted array, using the given `compare`
 /// callback to determine the order.
@@ -153,8 +154,6 @@ extern "C" {
 // Private
 
 typedef Array(void) Array;
-
-#define array_elem_size(self) sizeof(*(self)->contents)
 
 /// This is not what you're looking for, see `array_delete`.
 static inline void _array__delete(Array *self) {
@@ -273,13 +272,11 @@ static inline void _array__splice(Array *self, size_t element_size,
 
 /// Helper macro for the `_sorted_by` routines below. This takes the left (existing)
 /// parameter by reference in order to work with the generic sorting function above.
-#define compare_int(a, b) ((int)*(a) - (int)(b))
+#define _compare_int(a, b) ((int)*(a) - (int)(b))
 
 #ifdef _MSC_VER
 #pragma warning(default : 4101)
-#elif defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
`extern` is redundant in function prototypes.
`const` is discarded in most if not all binding functions.