### PR TITLE
Package.swift: move 'cLanguageStandard' behind 'targets'

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,6 @@ let package = Package(
             name: "TreeSitter",
             targets: ["TreeSitter"]),
     ],
-    cLanguageStandard: .c11,
     targets: [
         .target(name: "TreeSitter",
                 path: "lib",
@@ -36,5 +35,6 @@ let package = Package(
                     "src/query.c"
                 ],
                 sources: ["src/lib.c"]),
-    ]
+    ],
+    cLanguageStandard: .c11
 )


### PR DESCRIPTION
Before this PR:

```shell
> swift build
Updating https://github.com/tree-sitter/tree-sitter.git
Updated https://github.com/tree-sitter/tree-sitter.git (1.29s)
error: Invalid manifest (compiled with: ["/Library/Developer/CommandLineTools/usr/bin/swiftc", "-vfsoverlay", "/var/folders/x_/z7jrp4m90z948c1n3qnzfmt80000gn/T/TemporaryDirectory.1y3Gmk/vfs.yaml", "-L", "/Library/Developer/CommandLineTools/usr/lib/swift/pm/ManifestAPI", "-lPackageDescription", "-Xlinker", "-rpath", "-Xlinker", "/Library/Developer/CommandLineTools/usr/lib/swift/pm/ManifestAPI", "-target", "arm64-apple-macosx13.0", "-sdk", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk", "-swift-version", "5", "-I", "/Library/Developer/CommandLineTools/usr/lib/swift/pm/ManifestAPI", "-sdk", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk", "-package-description-version", "5.8.0", "/Package.swift", "-Xfrontend", "-disable-implicit-concurrency-module-import", "-Xfrontend", "-disable-implicit-string-processing-module-import", "-o", "/var/folders/x_/z7jrp4m90z948c1n3qnzfmt80000gn/T/TemporaryDirectory.Jppl9X/tree-sitter-manifest"])
/Package.swift:15:5: error: argument 'targets' must precede argument 'cLanguageStandard'
    targets: [
~~~~^~~~~~~~~~ in https://github.com/tree-sitter/tree-sitter.git
```

After this PR:

```shell
> swift build
Fetching https://github.com/JmPotato/tree-sitter.git from cache
Fetched https://github.com/JmPotato/tree-sitter.git (0.99s)
Creating working copy for https://github.com/JmPotato/tree-sitter.git
Working copy of https://github.com/JmPotato/tree-sitter.git resolved at fix_swift_package
```