### PR TITLE
ci: don't skip tests on failing lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,7 @@ jobs:
     uses: ./.github/workflows/checks.yml
 
   sanitize:
-    needs: checks
     uses: ./.github/workflows/sanitize.yml
 
   build:
-    needs: checks
     uses: ./.github/workflows/build.yml


### PR DESCRIPTION
Problem: A failing lint will block running actual tests, adding friction to contributors who will have to golf the linter before getting to see actually useful test results.

Solution: Don't gate `sanitize` and `build` behind successful `checks` so you can see whether your code works at all _before_ worrying about its quality. (In general, the more feedback you get at the same time, the fewer edit->push->test cycles you need, _saving_ CI time in the long run. Only skip tests you are sure to be useless given previous failures. It makes even less sense if the tests run in parallel, like here.)