### PR TITLE
refactor(wasm)!: make `current*`, `is*`, and `has*` methods properties

### DIFF
--- a/docs/assets/js/playground.js
+++ b/docs/assets/js/playground.js
@@ -175,7 +175,7 @@ let tree;
           const start = cursor.startPosition;
           const end = cursor.endPosition;
           const id = cursor.nodeId;
-          let fieldName = cursor.currentFieldName();
+          let fieldName = cursor.currentFieldName;
           if (fieldName) {
             fieldName += ': ';
           } else {

--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -249,27 +249,27 @@ class Node {
     return C._ts_node_next_parse_state_wasm(this.tree[0]);
   }
 
-  isNamed() {
+  get isNamed() {
     marshalNode(this);
     return C._ts_node_is_named_wasm(this.tree[0]) === 1;
   }
 
-  hasError() {
+  get hasError() {
     marshalNode(this);
     return C._ts_node_has_error_wasm(this.tree[0]) === 1;
   }
 
-  hasChanges() {
+  get hasChanges() {
     marshalNode(this);
     return C._ts_node_has_changes_wasm(this.tree[0]) === 1;
   }
 
-  isError() {
+  get isError() {
     marshalNode(this);
     return C._ts_node_is_error_wasm(this.tree[0]) === 1;
   }
 
-  isMissing() {
+  get isMissing() {
     marshalNode(this);
     return C._ts_node_is_missing_wasm(this.tree[0]) === 1;
   }
@@ -608,19 +608,19 @@ class TreeCursor {
     return C._ts_tree_cursor_end_index_wasm(this.tree[0]);
   }
 
-  currentNode() {
+  get currentNode() {
     marshalTreeCursor(this);
     C._ts_tree_cursor_current_node_wasm(this.tree[0]);
     return unmarshalNode(this.tree);
   }
 
-  currentFieldId() {
+  get currentFieldId() {
     marshalTreeCursor(this);
     return C._ts_tree_cursor_current_field_id_wasm(this.tree[0]);
   }
 
-  currentFieldName() {
-    return this.tree.language.fields[this.currentFieldId()];
+  get currentFieldName() {
+    return this.tree.language.fields[this.currentFieldId];
   }
 
   gotoFirstChild() {

--- a/lib/binding_web/test/language-test.js
+++ b/lib/binding_web/test/language-test.js
@@ -55,7 +55,7 @@ describe('Lookahead iterator', () => {
     const cursor = tree.walk();
     assert(cursor.gotoFirstChild());
     assert(cursor.gotoFirstChild());
-    state = cursor.currentNode().nextParseState;
+    state = cursor.currentNode.nextParseState;
     lookahead = JavaScript.lookaheadIterator(state);
     assert.exists(lookahead);
   });

--- a/lib/binding_web/test/node-test.js
+++ b/lib/binding_web/test/node-test.js
@@ -251,7 +251,7 @@ describe('Node', () => {
     });
   });
 
-  describe('.hasError()', () => {
+  describe('.hasError', () => {
     it('returns true if the node contains an error', () => {
       tree = parser.parse('1 + 2 * * 3');
       const node = tree.rootNode;
@@ -261,14 +261,14 @@ describe('Node', () => {
       );
 
       const sum = node.firstChild.firstChild;
-      assert(sum.hasError());
-      assert(!sum.children[0].hasError());
-      assert(!sum.children[1].hasError());
-      assert(sum.children[2].hasError());
+      assert(sum.hasError);
+      assert(!sum.children[0].hasError);
+      assert(!sum.children[1].hasError);
+      assert(sum.children[2].hasError);
     });
   });
 
-  describe('.isError()', () => {
+  describe('.isError', () => {
     it('returns true if the node is an error', () => {
       tree = parser.parse('2 * * 3');
       const node = tree.rootNode;
@@ -278,15 +278,15 @@ describe('Node', () => {
       );
 
       const multi = node.firstChild.firstChild;
-      assert(multi.hasError());
-      assert(!multi.children[0].isError());
-      assert(!multi.children[1].isError());
-      assert(multi.children[2].isError());
-      assert(!multi.children[3].isError());
+      assert(multi.hasError);
+      assert(!multi.children[0].isError);
+      assert(!multi.children[1].isError);
+      assert(multi.children[2].isError);
+      assert(!multi.children[3].isError);
     });
   });
 
-  describe('.isMissing()', () => {
+  describe('.isMissing', () => {
     it('returns true if the node is missing from the source and was inserted via error recovery', () => {
       tree = parser.parse('(2 ||)');
       const node = tree.rootNode;
@@ -297,10 +297,10 @@ describe('Node', () => {
 
       const sum = node.firstChild.firstChild.firstNamedChild;
       assert.equal(sum.type, 'binary_expression');
-      assert(sum.hasError());
-      assert(!sum.children[0].isMissing());
-      assert(!sum.children[1].isMissing());
-      assert(sum.children[2].isMissing());
+      assert(sum.hasError);
+      assert(!sum.children[0].isMissing);
+      assert(!sum.children[1].isMissing);
+      assert(sum.children[2].isMissing);
     });
   });
 

--- a/lib/binding_web/test/tree-test.js
+++ b/lib/binding_web/test/tree-test.js
@@ -316,26 +316,26 @@ describe('Tree', () => {
       cursor.gotoFirstChild();
       cursor.gotoFirstChild();
 
-      assert.equal(cursor.currentNode().type, 'call_expression');
-      assert.equal(cursor.currentFieldName(), null);
+      assert.equal(cursor.currentNode.type, 'call_expression');
+      assert.equal(cursor.currentFieldName, null);
 
       cursor.gotoFirstChild();
-      assert.equal(cursor.currentNode().type, 'member_expression');
-      assert.equal(cursor.currentFieldName(), 'function');
+      assert.equal(cursor.currentNode.type, 'member_expression');
+      assert.equal(cursor.currentFieldName, 'function');
 
       cursor.gotoFirstChild();
-      assert.equal(cursor.currentNode().type, 'identifier');
-      assert.equal(cursor.currentFieldName(), 'object');
+      assert.equal(cursor.currentNode.type, 'identifier');
+      assert.equal(cursor.currentFieldName, 'object');
 
       cursor.gotoNextSibling();
       cursor.gotoNextSibling();
-      assert.equal(cursor.currentNode().type, 'property_identifier');
-      assert.equal(cursor.currentFieldName(), 'property');
+      assert.equal(cursor.currentNode.type, 'property_identifier');
+      assert.equal(cursor.currentFieldName, 'property');
 
       cursor.gotoParent();
       cursor.gotoNextSibling();
-      assert.equal(cursor.currentNode().type, 'arguments');
-      assert.equal(cursor.currentFieldName(), 'arguments');
+      assert.equal(cursor.currentNode.type, 'arguments');
+      assert.equal(cursor.currentFieldName, 'arguments');
     });
 
     it('returns a cursor that can be reset anywhere in the tree', () => {
@@ -429,9 +429,9 @@ function assertCursorState(cursor, params) {
   assert.deepEqual(cursor.startIndex, params.startIndex);
   assert.deepEqual(cursor.endIndex, params.endIndex);
 
-  const node = cursor.currentNode();
+  const node = cursor.currentNode;
   assert.equal(node.type, params.nodeType);
-  assert.equal(node.isNamed(), params.nodeIsNamed);
+  assert.equal(node.isNamed, params.nodeIsNamed);
   assert.deepEqual(node.startPosition, params.startPosition);
   assert.deepEqual(node.endPosition, params.endPosition);
   assert.deepEqual(node.startIndex, params.startIndex);

--- a/lib/binding_web/tree-sitter-web.d.ts
+++ b/lib/binding_web/tree-sitter-web.d.ts
@@ -1,7 +1,7 @@
 declare module 'web-tree-sitter' {
   class Parser {
     /**
-     * 
+     *
      * @param moduleOptions Optional emscripten module-object, see https://emscripten.org/docs/api_reference/module.html
      */
     static init(moduleOptions?: object): Promise<void>;
@@ -27,10 +27,10 @@ declare module 'web-tree-sitter' {
     };
 
     export type Range = {
-      startPosition: Point;
-      endPosition: Point;
-      startIndex: number;
-      endIndex: number;
+      startIndex: number,
+      endIndex: number,
+      startPosition: Point,
+      endPosition: Point
     };
 
     export type Edit = {
@@ -55,11 +55,16 @@ declare module 'web-tree-sitter' {
     ) => string | null;
 
     export interface SyntaxNode {
-      typeId: number;
       grammarId: number;
       tree: Tree;
       type: string;
+      typeId: number;
       grammarType: string;
+      isNamed: boolean;
+      isMissing: boolean;
+      hasChanges: boolean;
+      hasError: boolean;
+      isError: boolean;
       text: string;
       parseState: number;
       nextParseState: number;
@@ -81,12 +86,7 @@ declare module 'web-tree-sitter' {
       previousSibling: SyntaxNode | null;
       previousNamedSibling: SyntaxNode | null;
 
-      hasChanges(): boolean;
-      hasError(): boolean;
       equals(other: SyntaxNode): boolean;
-      isError(): boolean;
-      isMissing(): boolean;
-      isNamed(): boolean;
       toString(): string;
       child(index: number): SyntaxNode | null;
       namedChild(index: number): SyntaxNode | null;
@@ -95,13 +95,13 @@ declare module 'web-tree-sitter' {
 
       descendantForIndex(index: number): SyntaxNode;
       descendantForIndex(startIndex: number, endIndex: number): SyntaxNode;
-      descendantsOfType(type: string | Array<string>, startPosition?: Point, endPosition?: Point): Array<SyntaxNode>;
       namedDescendantForIndex(index: number): SyntaxNode;
       namedDescendantForIndex(startIndex: number, endIndex: number): SyntaxNode;
       descendantForPosition(position: Point): SyntaxNode;
       descendantForPosition(startPosition: Point, endPosition: Point): SyntaxNode;
       namedDescendantForPosition(position: Point): SyntaxNode;
       namedDescendantForPosition(startPosition: Point, endPosition: Point): SyntaxNode;
+      descendantsOfType(types: String | Array<String>, startPosition?: Point, endPosition?: Point): Array<SyntaxNode>;
 
       walk(): TreeCursor;
     }
@@ -118,13 +118,13 @@ declare module 'web-tree-sitter' {
       endPosition: Point;
       startIndex: number;
       endIndex: number;
+      readonly currentNode: SyntaxNode;
+      readonly currentFieldId: number;
+      readonly currentFieldName: string;
 
       reset(node: SyntaxNode): void;
       resetTo(cursor: TreeCursor): void;
       delete(): void;
-      currentNode(): SyntaxNode;
-      currentFieldId(): number;
-      currentFieldName(): string;
       gotoParent(): boolean;
       gotoFirstChild(): boolean;
       gotoLastChild(): boolean;


### PR DESCRIPTION
This is a breaking change to make the Wasm and Node bindings more interchangeable

Closes #2195