### PR TITLE
Type tag the language in the node bindings

### DIFF
--- a/cli/src/generate/templates/js-binding.cc
+++ b/cli/src/generate/templates/js-binding.cc
@@ -4,11 +4,7 @@ typedef struct TSLanguage TSLanguage;
 
 extern "C" TSLanguage *tree_sitter_PARSER_NAME();
 
-// tstag() {
-//   b2sum -l64 <(printf tree-sitter) <(printf "$1") | \
-//   awk '{printf "0x" toupper($1) (NR == 1 ? ", " : "\n")}'
-// }
-// tstag language # => 0x8AF2E5212AD58ABF, 0xD5006CAD83ABBA16
+// "tree-sitter", "language" hashed with BLAKE2
 const napi_type_tag LANGUAGE_TYPE_TAG = {
   0x8AF2E5212AD58ABF, 0xD5006CAD83ABBA16
 };

--- a/cli/src/generate/templates/js-binding.cc
+++ b/cli/src/generate/templates/js-binding.cc
@@ -4,8 +4,13 @@ typedef struct TSLanguage TSLanguage;
 
 extern "C" TSLanguage *tree_sitter_PARSER_NAME();
 
+// tstag() {
+//   b2sum -l64 <(printf tree-sitter) <(printf "$1") | \
+//   awk '{printf "0x" toupper($1) (NR == 1 ? ", " : "\n")}'
+// }
+// tstag language # => 0x8AF2E5212AD58ABF, 0xD5006CAD83ABBA16
 const napi_type_tag LANGUAGE_TYPE_TAG = {
-  0x95840BEBF71E4E90, 0x9DC9419B874C0271
+  0x8AF2E5212AD58ABF, 0xD5006CAD83ABBA16
 };
 
 Napi::Object Init(Napi::Env env, Napi::Object exports) {

--- a/cli/src/generate/templates/js-binding.cc
+++ b/cli/src/generate/templates/js-binding.cc
@@ -4,9 +4,15 @@ typedef struct TSLanguage TSLanguage;
 
 extern "C" TSLanguage *tree_sitter_PARSER_NAME();
 
+const napi_type_tag LANGUAGE_TYPE_TAG = {
+  0x95840BEBF71E4E90, 0x9DC9419B874C0271
+};
+
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
     exports["name"] = Napi::String::New(env, "PARSER_NAME");
-    exports["language"] = Napi::External<TSLanguage>::New(env, tree_sitter_PARSER_NAME());
+    auto language = Napi::External<TSLanguage>::New(env, tree_sitter_PARSER_NAME());
+    language.TypeTag(&LANGUAGE_TYPE_TAG);
+    exports["language"] = language;
     return exports;
 }
 


### PR DESCRIPTION
This will help make sure we won't unwrap unrelated external objects if they are passed and possibly seg fault. To be used by https://github.com/segevfiner/node-tree-sitter/pull/1