### PR TITLE
Fix regression in `subtree_compare`

### DIFF
--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -629,9 +629,9 @@ int ts_subtree_compare(Subtree left, Subtree right, SubtreePool *pool) {
 
     int result = 0;
     if (ts_subtree_symbol(left) < ts_subtree_symbol(right)) result = -1;
-    if (ts_subtree_symbol(right) < ts_subtree_symbol(left)) result = 1;
-    if (ts_subtree_child_count(left) < ts_subtree_child_count(right)) result = -1;
-    if (ts_subtree_child_count(right) < ts_subtree_child_count(left)) result = 1;
+    else if (ts_subtree_symbol(right) < ts_subtree_symbol(left)) result = 1;
+    else if (ts_subtree_child_count(left) < ts_subtree_child_count(right)) result = -1;
+    else if (ts_subtree_child_count(right) < ts_subtree_child_count(left)) result = 1;
     if (result != 0) {
       array_clear(&pool->tree_stack);
       return result;


### PR DESCRIPTION
Fixes regression introduced by #2788, which changed comparison to last-one wins instead of first-one. We saw a regression in conditional (ternary) expressions where nested operator expressions in else branch would bind to the whole conditional expression instead of the else branch.