### PR TITLE
docs: Add `Ohm` language parser

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -111,6 +111,7 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 * [Objective-C](https://github.com/jiyee/tree-sitter-objc)
 * [OCaml](https://github.com/tree-sitter/tree-sitter-ocaml)
 * [Odin](https://github.com/amaanq/tree-sitter-odin)
+* [Ohm](https://github.com/novusnota/tree-sitter-ohm)
 * [Org](https://github.com/milisims/tree-sitter-org)
 * [P4](https://github.com/ace-design/tree-sitter-p4)
 * [Pascal](https://github.com/Isopod/tree-sitter-pascal)


### PR DESCRIPTION
## Brief description

Adding the complete parser of the [Ohm](https://ohmjs.org/) language.
It has highlights, locals and tags generic queries, as well as editor-specific ones.
Besides, the parser itself, tag and highlighting queries are test-covered.

## About the language

Ohm is a parsing toolkit consisting of a library and a domain-specific language. One can use it to parse custom file formats or quickly build parsers, interpreters, and compilers for programming languages.

The Ohm language is based on [parsing expression grammars](http://en.wikipedia.org/wiki/Parsing_expression_grammar) (PEGs), which are a formal way of describing syntax, similar to regular expressions and context-free grammars. The Ohm library provides a JavaScript interface for creating parsers, interpreters, and more from the grammars you write.