### PR TITLE
fix: don't use `__declspec(dllexport)` on windows

### DIFF
--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -1346,7 +1346,7 @@ impl Generator {
         add_line!(self, "#endif");
         add_line!(self, "");
         add_line!(self, "#ifdef _WIN32");
-        add_line!(self, "#define TS_PUBLIC __declspec(dllexport)");
+        add_line!(self, "#define TS_PUBLIC");
         add_line!(self, "#else");
         add_line!(
             self,

--- a/cli/src/generate/templates/alloc.h
+++ b/cli/src/generate/templates/alloc.h
@@ -10,7 +10,7 @@ extern "C" {
 #include <stdlib.h>
 
 #ifdef _WIN32
-#define TS_PUBLIC __declspec(dllexport)
+#define TS_PUBLIC
 #else
 #define TS_PUBLIC __attribute__((visibility("default")))
 #endif

--- a/lib/src/alloc.h
+++ b/lib/src/alloc.h
@@ -10,7 +10,7 @@ extern "C" {
 #include <stdlib.h>
 
 #ifdef _WIN32
-#define TS_PUBLIC __declspec(dllexport)
+#define TS_PUBLIC
 #else
 #define TS_PUBLIC __attribute__((visibility("default")))
 #endif


### PR DESCRIPTION
using this makes every other symbol hidden by default; for whatever reason microsoft exposes every symbol unless `__declspec(dllexport)` is used, then only those marked with this are exported

Closes #3127