### PR TITLE
fix(make): Allow to override CFLAGS on the commandline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ OBJ := $(SRC:.c=.o)
 
 # define default flags, and override to append mandatory flags
 ARFLAGS := rcs
-CFLAGS := -O3 -Wall -Wextra -Wshadow -pedantic
+CFLAGS ?= -O3 -Wall -Wextra -Wshadow -pedantic
 override CFLAGS += -std=c11 -fPIC -fvisibility=hidden
 override CFLAGS += -Ilib/src -Ilib/src/wasm -Ilib/include
 


### PR DESCRIPTION
If you package tree-sitter for a distribution, the distribution is setting the CFLAGS which should be used for all packages.  Allow those flags to be used.