### PR TITLE
feat(bindings): add query constants to python

### DIFF
--- a/cli/src/generate/templates/__init__.py
+++ b/cli/src/generate/templates/__init__.py
@@ -4,12 +4,27 @@ from importlib.resources import files as _files
 
 from ._binding import language
 
-# NOTE: uncomment these to include any queries that this grammar contains:
 
-# HIGHLIGHTS_QUERY = _files(f"{__package__}.queries").joinpath("highlights.scm").read_text()
-# INJECTIONS_QUERY = _files(f"{__package__}.queries").joinpath("injections.scm").read_text()
-# LOCALS_QUERY = _files(f"{__package__}.queries").joinpath("locals.scm").read_text()
-# TAGS_QUERY = _files(f"{__package__}.queries").joinpath("tags.scm").read_text()
+def _get_query(name, file):
+    query = _files(f"{__package__}.queries") / file
+    globals()[name] = query.read_text()
+    return globals()[name]
+
+
+def __getattr__(name):
+    # NOTE: uncomment these to include any queries that this grammar contains:
+
+    # if name == "HIGHLIGHTS_QUERY":
+    #     return _get_query("HIGHLIGHTS_QUERY", "highlights.scm")
+    # if name == "INJECTIONS_QUERY":
+    #     return _get_query("INJECTIONS_QUERY", "injections.scm")
+    # if name == "LOCALS_QUERY":
+    #     return _get_query("LOCALS_QUERY", "locals.scm")
+    # if name == "TAGS_QUERY":
+    #     return _get_query("TAGS_QUERY", "tags.scm")
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "language",
@@ -18,3 +33,10 @@ __all__ = [
     # "LOCALS_QUERY",
     # "TAGS_QUERY",
 ]
+
+
+def __dir__():
+    return sorted(__all__ + [
+        "__all__", "__builtins__", "__cached__", "__doc__", "__file__",
+        "__loader__", "__name__", "__package__", "__path__", "__spec__",
+    ])

--- a/cli/src/generate/templates/__init__.py
+++ b/cli/src/generate/templates/__init__.py
@@ -1,5 +1,20 @@
-"CAMEL_PARSER_NAME grammar for tree-sitter"
+"""CAMEL_PARSER_NAME grammar for tree-sitter"""
+
+from importlib.resources import files as _files
 
 from ._binding import language
 
-__all__ = ["language"]
+# NOTE: uncomment these to include any queries that this grammar contains:
+
+# HIGHLIGHTS_QUERY = _files(f"{__package__}.queries").joinpath("highlights.scm").read_text()
+# INJECTIONS_QUERY = _files(f"{__package__}.queries").joinpath("injections.scm").read_text()
+# LOCALS_QUERY = _files(f"{__package__}.queries").joinpath("locals.scm").read_text()
+# TAGS_QUERY = _files(f"{__package__}.queries").joinpath("tags.scm").read_text()
+
+__all__ = [
+    "language",
+    # "HIGHLIGHTS_QUERY",
+    # "INJECTIONS_QUERY",
+    # "LOCALS_QUERY",
+    # "TAGS_QUERY",
+]

--- a/cli/src/generate/templates/__init__.pyi
+++ b/cli/src/generate/templates/__init__.pyi
@@ -1,1 +1,10 @@
+from typing import Final
+
+# NOTE: uncomment these to include any queries that this grammar contains:
+
+# HIGHLIGHTS_QUERY: Final[str]
+# INJECTIONS_QUERY: Final[str]
+# LOCALS_QUERY: Final[str]
+# TAGS_QUERY: Final[str]
+
 def language() -> int: ...

--- a/cli/src/generate/templates/lib.rs
+++ b/cli/src/generate/templates/lib.rs
@@ -35,7 +35,7 @@ pub fn language() -> Language {
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
 pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
-// Uncomment these to include any queries that this grammar contains
+// NOTE: uncomment these to include any queries that this grammar contains:
 
 // pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
 // pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");

--- a/cli/src/generate/templates/py-binding.c
+++ b/cli/src/generate/templates/py-binding.c
@@ -4,7 +4,7 @@ typedef struct TSLanguage TSLanguage;
 
 TSLanguage *tree_sitter_LOWER_PARSER_NAME(void);
 
-static PyObject* _binding_language(PyObject *self, PyObject *args) {
+static PyObject* _binding_language(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args)) {
     return PyLong_FromVoidPtr(tree_sitter_LOWER_PARSER_NAME());
 }
 

--- a/cli/src/generate/templates/pyproject.toml
+++ b/cli/src/generate/templates/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Topic :: Text Processing :: Linguistic",
   "Typing :: Typed"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license.text = "MIT"
 readme = "README.md"
 
@@ -22,8 +22,8 @@ readme = "README.md"
 Homepage = "https://github.com/tree-sitter/tree-sitter-PARSER_NAME"
 
 [project.optional-dependencies]
-core = ["tree-sitter~=0.21"]
+core = ["tree-sitter~=0.22"]
 
 [tool.cibuildwheel]
-build = "cp38-*"
+build = "cp39-*"
 build-frontend = "build"

--- a/cli/src/generate/templates/setup.py
+++ b/cli/src/generate/templates/setup.py
@@ -18,7 +18,7 @@ class BdistWheel(bdist_wheel):
     def get_tag(self):
         python, abi, platform = super().get_tag()
         if python.startswith("cp"):
-            python, abi = "cp38", "abi3"
+            python, abi = "cp39", "abi3"
         return python, abi, platform
 
 
@@ -40,13 +40,15 @@ setup(
             ],
             extra_compile_args=[
                 "-std=c11",
+                "-fvisibility=hidden",
             ] if system() != "Windows" else [
                 "/std:c11",
                 "/utf-8",
             ],
             define_macros=[
-                ("Py_LIMITED_API", "0x03080000"),
-                ("PY_SSIZE_T_CLEAN", None)
+                ("Py_LIMITED_API", "0x03090000"),
+                ("PY_SSIZE_T_CLEAN", None),
+                ("TREE_SITTER_HIDE_SYMBOLS", None),
             ],
             include_dirs=["src"],
             py_limited_api=True,


### PR DESCRIPTION
Needs the next py-tree-sitter version because the [files] API does not exist in 3.8 and I'm not adding a fallback.

[files]: https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files