### PR TITLE
feat: add `--no-position` flag to `Parse`

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -147,6 +147,7 @@ struct Parse {
     )]
     pub position: bool,
     #[arg(
+        long,
         num_args = 1..,
         help = "Apply edits in the format: \"row, col delcount insert_text\""
     )]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,6 @@
 use anstyle::{AnsiColor, Color, Style};
 use anyhow::{anyhow, Context, Result};
-use clap::{crate_authors, Args, Command, FromArgMatches as _, Subcommand};
+use clap::{crate_authors, ArgAction, Args, Command, FromArgMatches as _, Subcommand};
 use glob::glob;
 use regex::Regex;
 use std::collections::HashSet;
@@ -138,7 +138,15 @@ struct Parse {
     #[arg(long, short, help = "Suppress main output")]
     pub quiet: bool,
     #[arg(
-        long,
+        long = "no-position",
+        short,
+        help = "Suppress output node position",
+        conflicts_with = "quiet",
+        action = ArgAction::SetFalse,
+        default_value_t = true,
+    )]
+    pub position: bool,
+    #[arg(
         num_args = 1..,
         help = "Apply edits in the format: \"row, col delcount insert_text\""
     )]
@@ -508,6 +516,7 @@ fn run() -> Result<()> {
                     cancellation_flag: Some(&cancellation_flag),
                     encoding,
                     open_log: parse_options.open_log,
+                    position: parse_options.position,
                 };
 
                 let parse_result = parse::parse_file_at_path(&mut parser, &opts)?;

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -62,6 +62,7 @@ pub struct ParseFileOptions<'a> {
     pub cancellation_flag: Option<&'a AtomicUsize>,
     pub encoding: Option<u32>,
     pub open_log: bool,
+    pub position: bool,
 }
 
 #[derive(Copy, Clone)]
@@ -175,20 +176,24 @@ pub fn parse_file_at_path(parser: &mut Parser, opts: &ParseFileOptions) -> Resul
                         for _ in 0..indent_level {
                             stdout.write_all(b"  ")?;
                         }
-                        let start = node.start_position();
-                        let end = node.end_position();
                         if let Some(field_name) = cursor.field_name() {
                             write!(&mut stdout, "{field_name}: ")?;
                         }
-                        write!(
-                            &mut stdout,
-                            "({} [{}, {}] - [{}, {}]",
-                            node.kind(),
-                            start.row,
-                            start.column,
-                            end.row,
-                            end.column
-                        )?;
+                        if opts.position {
+                            let start = node.start_position();
+                            let end = node.end_position();
+                            write!(
+                                &mut stdout,
+                                "({} [{}, {}] - [{}, {}]",
+                                node.kind(),
+                                start.row,
+                                start.column,
+                                end.row,
+                                end.column
+                            )?;
+                        } else {
+                            write!(&mut stdout, "({}", node.kind())?;
+                        }
                         needs_newline = true;
                     }
                     if cursor.goto_first_child() {

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -263,12 +263,15 @@ pub fn parse_file_at_path(parser: &mut Parser, opts: &ParseFileOptions) -> Resul
                         if let Some(field_name) = cursor.field_name() {
                             write!(&mut stdout, " field=\"{field_name}\"")?;
                         }
-                        let start = node.start_position();
-                        let end = node.end_position();
-                        write!(&mut stdout, " srow=\"{}\"", start.row)?;
-                        write!(&mut stdout, " scol=\"{}\"", start.column)?;
-                        write!(&mut stdout, " erow=\"{}\"", end.row)?;
-                        write!(&mut stdout, " ecol=\"{}\"", end.column)?;
+                        if opts.position {
+                            let start = node.start_position();
+                            let end = node.end_position();
+                            write!(
+                                &mut stdout,
+                                r#" srow="{}" scol="{}" erow="{}" ecol="{}""#,
+                                start.row, start.column, end.row, end.column,
+                            )?;
+                        }
                         write!(&mut stdout, ">")?;
                         tags.push(node.kind());
                         needs_newline = true;


### PR DESCRIPTION
Added the ability to omit the byte range when calling `tree-sitter parse` to help with seeding corpus tests:
```
$ tree-sitter parse my.test --no-position
(source_file
  (test
    name: (text)
    (input)
    (output
      (node
        (identifier)
        (node
          (identifier)))))
  (comment)
  (test
    name: (text)
    (input)
    (output
      (node
        (identifier)
        (node
          (identifier))))))
```