### PR TITLE
Remove dependency on which crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn",
- "which 4.4.2",
+ "which",
 ]
 
 [[package]]
@@ -1421,7 +1421,6 @@ dependencies = [
  "walkdir",
  "wasmparser 0.201.0",
  "webbrowser",
- "which 6.0.0",
 ]
 
 [[package]]
@@ -1461,7 +1460,6 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-highlight",
  "tree-sitter-tags",
- "which 6.0.0",
 ]
 
 [[package]]
@@ -1877,19 +1875,6 @@ dependencies = [
  "home",
  "once_cell",
  "rustix",
-]
-
-[[package]]
-name = "which"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa5e0c10bf77f44aac573e498d1a82d5fbd5e91f6fc0a99e7be4b38e85e101c"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
- "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,6 @@ unindent = "0.2.3"
 walkdir = "2.5.0"
 wasmparser = "0.201.0"
 webbrowser = "0.8.13"
-which = "6.0.0"
 
 tree-sitter = { version = "0.22.0", path = "./lib" }
 tree-sitter-loader = { version = "0.22.0", path = "./cli/loader" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -53,7 +53,6 @@ tiny_http.workspace = true
 walkdir.workspace = true
 wasmparser.workspace = true
 webbrowser.workspace = true
-which.workspace = true
 
 tree-sitter.workspace = true
 tree-sitter-config.workspace = true

--- a/cli/loader/Cargo.toml
+++ b/cli/loader/Cargo.toml
@@ -26,7 +26,6 @@ once_cell.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-which.workspace = true
 
 tree-sitter.workspace = true
 tree-sitter-highlight.workspace = true


### PR DESCRIPTION
We were just using it to check if `emcc`, `docker`, and `podman` were available, but that can be done more simply, by just invoking the commands and checking the result.

Soon, I may switch the wasm compilation to use `wasi-sdk` instead of emscripten anyway. At that point, I would just have the CLI download `wasi-sdk` automatically, instead of checking if it were on the PATH.

### MSRV

Unfortunately, even after removing `which`, our MSRV is still limited to >= 1.74, due to the `clap_builder` dependency.