### PR TITLE
feat(cli)!: add a separate build command to compile parsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "arbitrary"
@@ -980,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1257,18 +1257,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/benches/benchmark.rs
+++ b/cli/benches/benchmark.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 use std::{env, fs, str, usize};
 use tree_sitter::{Language, Parser, Query};
-use tree_sitter_loader::Loader;
+use tree_sitter_loader::{CompileConfig, Loader};
 
 include!("../src/tests/helpers/dirs.rs");
 
@@ -210,9 +210,9 @@ fn parse(path: &Path, max_path_length: usize, mut action: impl FnMut(&[u8])) -> 
 }
 
 fn get_language(path: &Path) -> Language {
-    let src_dir = GRAMMARS_DIR.join(path).join("src");
+    let src_path = GRAMMARS_DIR.join(path).join("src");
     TEST_LOADER
-        .load_language_at_path(&src_dir, &[&src_dir], None)
-        .with_context(|| format!("Failed to load language at path {src_dir:?}"))
+        .load_language_at_path(CompileConfig::new(&src_path, None, None))
+        .with_context(|| format!("Failed to load language at path {src_path:?}"))
         .unwrap()
 }

--- a/cli/src/generate/build_tables/mod.rs
+++ b/cli/src/generate/build_tables/mod.rs
@@ -97,7 +97,7 @@ fn populate_error_state(
 
     // First identify the *conflict-free tokens*: tokens that do not overlap with
     // any other token in any way, besides matching exactly the same string.
-    let conflict_free_tokens: TokenSet = (0..n)
+    let conflict_free_tokens = (0..n)
         .filter_map(|i| {
             let conflicts_with_other_tokens = (0..n).any(|j| {
                 j != i
@@ -114,7 +114,7 @@ fn populate_error_state(
                 Some(Symbol::terminal(i))
             }
         })
-        .collect();
+        .collect::<TokenSet>();
 
     let recover_entry = ParseTableEntry {
         reusable: false,
@@ -263,7 +263,7 @@ fn identify_keywords(
 
     // First find all of the candidate keyword tokens: tokens that start with
     // letters or underscore and can match the same string as a word token.
-    let keyword_candidates: TokenSet = lexical_grammar
+    let keyword_candidates = lexical_grammar
         .variables
         .iter()
         .enumerate()
@@ -282,10 +282,10 @@ fn identify_keywords(
                 None
             }
         })
-        .collect();
+        .collect::<TokenSet>();
 
     // Exclude keyword candidates that shadow another keyword candidate.
-    let keywords: TokenSet = keyword_candidates
+    let keywords = keyword_candidates
         .iter()
         .filter(|token| {
             for other_token in keyword_candidates.iter() {
@@ -302,7 +302,7 @@ fn identify_keywords(
             }
             true
         })
-        .collect();
+        .collect::<TokenSet>();
 
     // Exclude keyword candidates for which substituting the keyword capture
     // token would introduce new lexical conflicts with other tokens.

--- a/cli/src/generate/parse_grammar.rs
+++ b/cli/src/generate/parse_grammar.rs
@@ -92,7 +92,7 @@ pub(crate) struct GrammarJSON {
 }
 
 pub(crate) fn parse_grammar(input: &str) -> Result<InputGrammar> {
-    let grammar_json: GrammarJSON = serde_json::from_str(input)?;
+    let grammar_json = serde_json::from_str::<GrammarJSON>(input)?;
 
     let mut variables = Vec::with_capacity(grammar_json.rules.len());
     for (name, value) in grammar_json.rules {

--- a/cli/src/generate/templates/package.json
+++ b/cli/src/generate/templates/package.json
@@ -40,7 +40,7 @@
     "install": "node-gyp-build",
     "prebuildify": "prebuildify --napi --strip",
     "build": "tree-sitter generate --no-bindings",
-    "build-wasm": "tree-sitter build-wasm",
+    "build-wasm": "tree-sitter build --wasm",
     "test": "tree-sitter test",
     "parse": "tree-sitter parse"
   },

--- a/cli/src/tests/helpers/fixtures.rs
+++ b/cli/src/tests/helpers/fixtures.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::{env, fs};
 use tree_sitter::Language;
 use tree_sitter_highlight::HighlightConfiguration;
-use tree_sitter_loader::Loader;
+use tree_sitter_loader::{CompileConfig, Loader};
 use tree_sitter_tags::TagsConfiguration;
 
 include!("./dirs.rs");
@@ -32,13 +32,10 @@ pub fn scratch_dir() -> &'static Path {
 }
 
 pub fn get_language(name: &str) -> Language {
-    TEST_LOADER
-        .load_language_at_path(
-            &GRAMMARS_DIR.join(name).join("src"),
-            &[&HEADER_DIR, &GRAMMARS_DIR.join(name).join("src")],
-            None,
-        )
-        .unwrap()
+    let src_dir = GRAMMARS_DIR.join(name).join("src");
+    let mut config = CompileConfig::new(&src_dir, None, None);
+    config.header_paths.push(&HEADER_DIR);
+    TEST_LOADER.load_language_at_path(config).unwrap()
 }
 
 pub fn get_language_queries_path(language_name: &str) -> PathBuf {
@@ -141,7 +138,9 @@ pub fn get_test_language(name: &str, parser_code: &str, path: Option<&Path>) -> 
         vec![parser_path]
     };
 
-    TEST_LOADER
-        .load_language_at_path_with_name(&src_dir, &[&HEADER_DIR], name, Some(&paths_to_check))
-        .unwrap()
+    let mut config = CompileConfig::new(&src_dir, Some(&paths_to_check), None);
+    config.header_paths = vec![&HEADER_DIR];
+    config.name = name.to_string();
+
+    TEST_LOADER.load_language_at_path_with_name(config).unwrap()
 }

--- a/cli/src/tests/helpers/fixtures.rs
+++ b/cli/src/tests/helpers/fixtures.rs
@@ -7,6 +7,8 @@ use tree_sitter_highlight::HighlightConfiguration;
 use tree_sitter_loader::{CompileConfig, Loader};
 use tree_sitter_tags::TagsConfiguration;
 
+use crate::generate::ALLOC_HEADER;
+
 include!("./dirs.rs");
 
 lazy_static! {
@@ -105,32 +107,18 @@ pub fn get_test_language(name: &str, parser_code: &str, path: Option<&Path>) -> 
     let header_path = src_dir.join("tree_sitter");
     fs::create_dir_all(&header_path).unwrap();
 
-    fs::write(header_path.join("alloc.h"), tree_sitter::PARSER_HEADER)
-        .with_context(|| {
-            format!(
-                "Failed to write {:?}",
-                header_path.join("alloc.h").file_name().unwrap()
-            )
-        })
-        .unwrap();
-
-    fs::write(header_path.join("array.h"), tree_sitter::PARSER_HEADER)
-        .with_context(|| {
-            format!(
-                "Failed to write {:?}",
-                header_path.join("array.h").file_name().unwrap()
-            )
-        })
-        .unwrap();
-
-    fs::write(header_path.join("parser.h"), tree_sitter::PARSER_HEADER)
-        .with_context(|| {
-            format!(
-                "Failed to write {:?}",
-                header_path.join("parser.h").file_name().unwrap()
-            )
-        })
-        .unwrap();
+    [
+        ("alloc.h", ALLOC_HEADER),
+        ("array.h", tree_sitter::ARRAY_HEADER),
+        ("parser.h", tree_sitter::PARSER_HEADER),
+    ]
+    .iter()
+    .for_each(|(file, content)| {
+        let file = header_path.join(file);
+        fs::write(&file, content)
+            .with_context(|| format!("Failed to write {:?}", file.file_name().unwrap()))
+            .unwrap();
+    });
 
     let paths_to_check = if let Some(scanner_path) = &scanner_path {
         vec![parser_path, scanner_path.clone()]

--- a/cli/src/tests/tags_test.rs
+++ b/cli/src/tests/tags_test.rs
@@ -398,7 +398,7 @@ fn test_tags_via_c_api() {
         .unwrap();
 
         let syntax_types = unsafe {
-            let mut len: u32 = 0;
+            let mut len = 0;
             let ptr =
                 c::ts_tagger_syntax_kinds_for_scope_name(tagger, c_scope_name.as_ptr(), &mut len);
             slice::from_raw_parts(ptr, len as usize)

--- a/cli/src/wasm.rs
+++ b/cli/src/wasm.rs
@@ -1,6 +1,9 @@
 use super::generate::parse_grammar::GrammarJSON;
 use anyhow::{anyhow, Context, Result};
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 use tree_sitter::wasm_stdlib_symbols;
 use tree_sitter_loader::Loader;
 use wasmparser::Parser;
@@ -11,7 +14,7 @@ pub fn load_language_wasm_file(language_dir: &Path) -> Result<(String, Vec<u8>)>
         .unwrap();
     let wasm_filename = format!("tree-sitter-{grammar_name}.wasm");
     let contents = fs::read(language_dir.join(&wasm_filename)).with_context(|| {
-        format!("Failed to read {wasm_filename}. Run `tree-sitter build-wasm` first.",)
+        format!("Failed to read {wasm_filename}. Run `tree-sitter build --wasm` first.",)
     })?;
     Ok((grammar_name, contents))
 }
@@ -30,10 +33,12 @@ pub fn compile_language_to_wasm(
     loader: &Loader,
     language_dir: &Path,
     output_dir: &Path,
+    output_file: Option<PathBuf>,
     force_docker: bool,
 ) -> Result<()> {
     let grammar_name = get_grammar_name(language_dir)?;
-    let output_filename = output_dir.join(format!("tree-sitter-{grammar_name}.wasm"));
+    let output_filename =
+        output_file.unwrap_or_else(|| output_dir.join(format!("tree-sitter-{grammar_name}.wasm")));
     let src_path = language_dir.join("src");
     let scanner_path = loader.get_scanner_path(&src_path);
     loader.compile_parser_to_wasm(

--- a/docs/section-3-creating-parsers.md
+++ b/docs/section-3-creating-parsers.md
@@ -148,6 +148,24 @@ The first time you run `tree-sitter generate`, it will also generate a few other
 
 If there is an ambiguity or *local ambiguity* in your grammar, Tree-sitter will detect it during parser generation, and it will exit with a `Unresolved conflict` error message. See below for more information on these errors.
 
+### Command: `build`
+
+The `build` command compiles your parser into a dynamically-loadable library, either as a shared object (`.so`, `.dylib`, or `.dll`) or as a WASM module.
+
+You can specify whether to compile it as a wasm module with the `--wasm`/`-w` flag, and you can opt in to use docker or podman to supply emscripten with the `--docker`/`-d` flag. This removes the need to install emscripten on your machine locally.
+
+You can specify where to output the shared object file (native or WASM) with the `--output`/`-o` flag, which accepts either an absolute path or relative path. Note that if you don't supply this flag, the CLI will attempt to figure out what the language name is based on the parent directory (so building in `tree-sitter-javascript` will resolve to `javascript`) to use for the output file. If it can't figure it out, it will default to `parser`, thus generating `parser.so` or `parser.wasm` in the current working directory.
+
+Lastly, you can also specify a path to the actual grammar directory, in case you are not currently in one. This is done by providing a path as the first *positional* argument.
+
+Example:
+
+```sh
+tree-sitter build --wasm --output ./build/parser.wasm tree-sitter-javascript
+```
+
+Notice how the `tree-sitter-javascript` argument is the first positional argument.
+
 ### Command: `test`
 
 The `tree-sitter test` command allows you to easily test that your parser is working correctly.

--- a/lib/binding_web/README.md
+++ b/lib/binding_web/README.md
@@ -131,7 +131,7 @@ npm install --save-dev tree-sitter-cli tree-sitter-javascript
 Then just use tree-sitter cli tool to generate the `.wasm`.
 
 ```sh
-npx tree-sitter build-wasm node_modules/tree-sitter-javascript
+npx tree-sitter build --wasm node_modules/tree-sitter-javascript
 ```
 
 If everything is fine, file `tree-sitter-javascript.wasm` should be generated in current directory.

--- a/lib/binding_web/test/helper.js
+++ b/lib/binding_web/test/helper.js
@@ -7,7 +7,7 @@ function languageURL(name) {
 module.exports = Parser.init().then(async () => ({
   Parser,
   languageURL,
-  EmbeddedTemplate: await Parser.Language.load(languageURL('embedded_template')),
+  EmbeddedTemplate: await Parser.Language.load(languageURL('embedded-template')),
   HTML: await Parser.Language.load(languageURL('html')),
   JavaScript: await Parser.Language.load(languageURL('javascript')),
   JSON: await Parser.Language.load(languageURL('json')),

--- a/script/generate-fixtures
+++ b/script/generate-fixtures
@@ -30,4 +30,4 @@ while read -r grammar_file; do
     cd "$grammar_dir"
     "$tree_sitter" generate src/grammar.json --no-bindings --abi=latest
   )
-done <<< "$grammar_files"
+done <<<"$grammar_files"

--- a/script/generate-fixtures-wasm
+++ b/script/generate-fixtures-wasm
@@ -21,7 +21,7 @@ fi
 filter_grammar_name=$1
 
 grammars_dir=${root_dir}/test/fixtures/grammars
-grammar_files=$(find $grammars_dir -name grammar.js | grep -v node_modules)
+grammar_files=$(find "$grammars_dir" -name grammar.js | grep -v node_modules)
 
 while read -r grammar_file; do
   grammar_dir=$(dirname "$grammar_file")
@@ -32,7 +32,5 @@ while read -r grammar_file; do
   fi
 
   echo "Compiling ${grammar_name} parser to wasm"
-  "$tree_sitter" build-wasm $build_wasm_args $grammar_dir
-done <<< "$grammar_files"
-
-mv tree-sitter-*.wasm target/release/
+  "$tree_sitter" build --wasm $build_wasm_args -o target/release/tree-sitter-"${grammar_name}".wasm "$grammar_dir"
+done <<<"$grammar_files"


### PR DESCRIPTION
This allows users to build parsers without having to run `test` or `parse` to invoke the compilation process, and allows them to output the object file to wherever they like. The `build-wasm` command was merged into this by just specifying the `--wasm` flag.