### PR TITLE
fix(lib): avoid possible UB of calling memset on a null ptr when 0 is passed into `array_grow_by`

### DIFF
--- a/lib/src/array.h
+++ b/lib/src/array.h
@@ -66,9 +66,12 @@ extern "C" {
 /// Increase the array's size by `count` elements.
 /// New elements are zero-initialized.
 #define array_grow_by(self, count) \
-  (_array__grow((Array *)(self), count, array_elem_size(self)), \
-   memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)), \
-   (self)->size += (count))
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
+    memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
+    (self)->size += (count); \
+  } while (0)
 
 /// Append all elements from one array to the end of another.
 #define array_push_all(self, other)                                       \


### PR DESCRIPTION
Closes #3175 @ahelwer

I guess the if check for contents being null isn't needed if we already bailed out earlier from checking if count is 0