### PR TITLE
fix(lib): allow hiding symbols

### DIFF
--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -1341,7 +1341,9 @@ impl Generator {
             add_line!(self, "");
         }
 
-        add_line!(self, "#ifdef _WIN32");
+        add_line!(self, "#ifdef TREE_SITTER_HIDE_SYMBOLS");
+        add_line!(self, "#define TS_PUBLIC");
+        add_line!(self, "#elif defined(_WIN32)");
         add_line!(self, "#define TS_PUBLIC __declspec(dllexport)");
         add_line!(self, "#else");
         add_line!(

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -1,8 +1,10 @@
 #ifndef TREE_SITTER_API_H_
 #define TREE_SITTER_API_H_
 
+#ifndef TREE_SITTER_HIDE_SYMBOLS
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC visibility push(default)
+#endif
 #endif
 
 #ifdef __cplusplus
@@ -1255,8 +1257,10 @@ void ts_set_allocator(
 }
 #endif
 
+#ifndef TREE_SITTER_HIDE_SYMBOLS
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC visibility pop
+#endif
 #endif
 
 #endif  // TREE_SITTER_API_H_

--- a/lib/src/alloc.h
+++ b/lib/src/alloc.h
@@ -9,7 +9,7 @@ extern "C" {
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifdef _WIN32
+#if defined(TREE_SITTER_HIDDEN_SYMBOLS) || defined(_WIN32)
 #define TS_PUBLIC
 #else
 #define TS_PUBLIC __attribute__((visibility("default")))


### PR DESCRIPTION
### Problem

Python extensions should only export the module function (`PyInit_foo`), but the library bindings currently export all the `ts_*` symbols and the parser bindings export the `tree_sitter_foo` and `ts_current_*` symbols.

### Solution

Add a `TREE_SITTER_HIDDEN_SYMBOLS` flag that can be defined to hide the core symbols.