### PR TITLE
feat(lib): add the language name

### DIFF
--- a/cli/generate/src/render.rs
+++ b/cli/generate/src/render.rs
@@ -20,6 +20,7 @@ const SMALL_STATE_THRESHOLD: usize = 64;
 const ABI_VERSION_MIN: usize = 14;
 const ABI_VERSION_MAX: usize = tree_sitter::LANGUAGE_VERSION;
 const BUILD_VERSION: &str = env!("CARGO_PKG_VERSION");
+const ABI_VERSION_WITH_METADATA: usize = 15;
 
 macro_rules! add {
     ($this: tt, $($arg: tt)*) => {{
@@ -1436,6 +1437,11 @@ impl Generator {
         }
 
         add_line!(self, ".primary_state_ids = ts_primary_state_ids,");
+
+        if self.abi_version >= ABI_VERSION_WITH_METADATA {
+            add_line!(self, ".name = \"{}\",", self.language_name);
+        }
+
         dedent!(self);
         add_line!(self, "}};");
         add_line!(self, "return &language;");

--- a/cli/src/templates/index.d.ts
+++ b/cli/src/templates/index.d.ts
@@ -19,7 +19,6 @@ type NodeInfo =
     });
 
 type Language = {
-  name: string;
   language: unknown;
   nodeTypeInfo: NodeInfo[];
 };

--- a/cli/src/templates/js-binding.cc
+++ b/cli/src/templates/js-binding.cc
@@ -10,7 +10,6 @@ const napi_type_tag LANGUAGE_TYPE_TAG = {
 };
 
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
-    exports["name"] = Napi::String::New(env, "PARSER_NAME");
     auto language = Napi::External<TSLanguage>::New(env, tree_sitter_PARSER_NAME());
     language.TypeTag(&LANGUAGE_TYPE_TAG);
     exports["language"] = language;

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -1142,6 +1142,11 @@ uint32_t ts_language_version(const TSLanguage *self);
 */
 TSStateId ts_language_next_state(const TSLanguage *self, TSStateId state, TSSymbol symbol);
 
+/**
+ * Get the name of this language. This returns `NULL` in older parsers.
+ */
+const char *ts_language_name(const TSLanguage *self);
+
 /********************************/
 /* Section - Lookahead Iterator */
 /********************************/

--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -28,6 +28,10 @@ uint32_t ts_language_version(const TSLanguage *self) {
   return self->version;
 }
 
+const char *ts_language_name(const TSLanguage *self) {
+  return self->version >= LANGUAGE_VERSION_WITH_METADATA ? self->name : NULL;
+}
+
 uint32_t ts_language_field_count(const TSLanguage *self) {
   return self->field_count;
 }

--- a/lib/src/language.h
+++ b/lib/src/language.h
@@ -10,6 +10,7 @@ extern "C" {
 
 #define ts_builtin_sym_error_repeat (ts_builtin_sym_error - 1)
 
+#define LANGUAGE_VERSION_WITH_METADATA 15
 #define LANGUAGE_VERSION_WITH_PRIMARY_STATES 14
 
 typedef struct {

--- a/lib/src/parser.h
+++ b/lib/src/parser.h
@@ -129,6 +129,7 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
+  const char *name;
 };
 
 static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {


### PR DESCRIPTION
## Problem

Bindings have no way of retrieving the name of the language.
The only exception is Node which wraps it in a N-API object.

## Solution

Add a `name` field to the generated struct and a `ts_language_name` function to retrieve it.
This should be backwards compatible since it will just return `NULL` if unset.