### PR TITLE
fix(cli): keep default cc flags in build 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         - { platform: windows-x64       , target: x86_64-pc-windows-msvc              , os: windows-latest , cli_features: wasm }
         - { platform: windows-x86       , target: i686-pc-windows-msvc                , os: windows-latest                      }
         - { platform: macos-arm64       , target: aarch64-apple-darwin                , os: macos-14       , cli_features: wasm }
-        - { platform: macos-x64         , target: x86_64-apple-darwin                 , os: macos-latest   , cli_features: wasm }
+        - { platform: macos-x64         , target: x86_64-apple-darwin                 , os: macos-12       , cli_features: wasm }
 
         # Cross compilers for C library
         - { platform: linux-arm64       , cc: aarch64-linux-gnu-gcc             , ar: aarch64-linux-gnu-ar           }

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -2,7 +2,7 @@ name: Sanitize
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-D warnings"
+  RUSTFLAGS: -D warnings
 
 on:
   workflow_call:
@@ -34,17 +34,13 @@ jobs:
 
     - name: Run main tests with undefined behaviour sanitizer (UBSAN)
       env:
-        UBSAN_OPTIONS: halt_on_error=1
         CFLAGS: -fsanitize=undefined
         RUSTFLAGS: ${{ env.RUSTFLAGS }} -lubsan
       run: cargo test -- --test-threads 1
 
     - name: Run main tests with address sanitizer (ASAN)
       env:
-        ASAN_OPTIONS: halt_on_error=1
+        ASAN_OPTIONS: verify_asan_link_order=0
         CFLAGS: -fsanitize=address
-        RUSTFLAGS: ${{ env.RUSTFLAGS }} -Zsanitizer=address --cfg=sanitizing
-      run: |
-        rustup install nightly
-        rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
-        cargo +nightly test -Z build-std --target x86_64-unknown-linux-gnu -- --test-threads 1
+        RUSTFLAGS: ${{ env.RUSTFLAGS }} -lasan --cfg sanitizing
+      run: cargo test -- --test-threads 1

--- a/cli/loader/build.rs
+++ b/cli/loader/build.rs
@@ -3,6 +3,10 @@ fn main() {
         "cargo:rustc-env=BUILD_TARGET={}",
         std::env::var("TARGET").unwrap()
     );
+    println!(
+        "cargo:rustc-env=BUILD_HOST={}",
+        std::env::var("HOST").unwrap()
+    );
 
     let emscripten_version = std::fs::read_to_string("emscripten-version").unwrap();
     println!("cargo:rustc-env=EMSCRIPTEN_VERSION={emscripten_version}");

--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -256,7 +256,7 @@ impl Generator {
                 .count()
                 + 1;
             let constant_name = if let Some(symbol) = symbol {
-                format!("{}_character_set_{}", self.symbol_ids[&symbol], count)
+                format!("{}_character_set_{}", self.symbol_ids[symbol], count)
             } else {
                 format!("extras_character_set_{}", count)
             };

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -500,7 +500,7 @@ fn run() -> Result<()> {
                         }
                         (true, false) => &["TREE_SITTER_REUSE_ALLOCATOR"],
                         (false, true) => &["TREE_SITTER_INTERNAL_BUILD"],
-                        (false, false) => &[""],
+                        (false, false) => &[],
                     };
 
                 let config = Config::load(None)?;

--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -76,10 +76,11 @@ fn test_corpus_for_json(seed: usize) {
     test_language_corpus("json", seed, None, None);
 }
 
-// #[test_with_seed(retry=10, seed=*START_SEED, seed_fn=new_seed)]
-// fn test_corpus_for_php(seed: usize) {
-//     test_language_corpus("php", seed, None, Some("php"));
-// }
+#[ignore]
+#[test_with_seed(retry=10, seed=*START_SEED, seed_fn=new_seed)]
+fn test_corpus_for_php(seed: usize) {
+    test_language_corpus("php", seed, None, Some("php"));
+}
 
 #[test_with_seed(retry=10, seed=*START_SEED, seed_fn=new_seed)]
 fn test_corpus_for_python(seed: usize) {

--- a/docs/section-3-creating-parsers.md
+++ b/docs/section-3-creating-parsers.md
@@ -152,7 +152,9 @@ If there is an ambiguity or *local ambiguity* in your grammar, Tree-sitter will 
 
 The `build` command compiles your parser into a dynamically-loadable library, either as a shared object (`.so`, `.dylib`, or `.dll`) or as a WASM module.
 
-You can specify whether to compile it as a wasm module with the `--wasm`/`-w` flag, and you can opt in to use docker or podman to supply emscripten with the `--docker`/`-d` flag. This removes the need to install emscripten on your machine locally.
+You can change the compiler executable via the `CC` environment variable and add extra flags via `CFLAGS`. For macOS or iOS, you can set `MACOSX_DEPLOYMENT_TARGET` or `IPHONEOS_DEPLOYMENT_TARGET` respectively to define the minimum supported version.
+
+You can specify whether to compile it as a wasm module with the `--wasm`/`-w` flag, and you can opt to use docker or podman to supply emscripten with the `--docker`/`-d` flag. This removes the need to install emscripten on your machine locally.
 
 You can specify where to output the shared object file (native or WASM) with the `--output`/`-o` flag, which accepts either an absolute path or relative path. Note that if you don't supply this flag, the CLI will attempt to figure out what the language name is based on the parent directory (so building in `tree-sitter-javascript` will resolve to `javascript`) to use for the output file. If it can't figure it out, it will default to `parser`, thus generating `parser.so` or `parser.wasm` in the current working directory.
 


### PR DESCRIPTION
<details>

<summary>Complete commands from CI</summary>

### i686-unknown-linux-gnu

#### release

```bash
i686-linux-gnu-gcc -O2 -ffunction-sections -fdata-sections -fPIC -m32 -march=i686 -std=c11 -I /project/test/fixtures/grammars/bash/src -Wall -DNDEBUG -Werror=implicit-function-declaration -shared /project/test/fixtures/grammars/bash/src/parser.c /project/test/fixtures/grammars/bash/src/scanner.c -o /project/parser.so
```

#### debug

```bash
i686-linux-gnu-gcc -O0 -ffunction-sections -fdata-sections -fPIC -gdwarf-4 -fno-omit-frame-pointer -m32 -march=i686 -std=c11 -I /project/test/fixtures/grammars/bash/src -Wall -Wextra -Werror=implicit-function-declaration -shared /project/test/fixtures/grammars/bash/src/parser.c /project/test/fixtures/grammars/bash/src/scanner.c -o /project/parser.so
```

### powerpc64-unknown-linux-gnu

#### release

```bash
powerpc64-linux-gnu-gcc -O2 -ffunction-sections -fdata-sections -fPIC -m64 -std=c11 -I /project/test/fixtures/grammars/bash/src -Wall -DNDEBUG -Werror=implicit-function-declaration -shared /project/test/fixtures/grammars/bash/src/parser.c /project/test/fixtures/grammars/bash/src/scanner.c -o /project/parser.so
```

#### debug

```bash
powerpc64-linux-gnu-gcc -O0 -ffunction-sections -fdata-sections -fPIC -gdwarf-4 -fno-omit-frame-pointer -m64 -std=c11 -I /project/test/fixtures/grammars/bash/src -Wall -Wextra -Werror=implicit-function-declaration -shared /project/test/fixtures/grammars/bash/src/parser.c /project/test/fixtures/grammars/bash/src/scanner.c -o /project/parser.so
```

### arm-unknown-linux-gnueabi

#### release

```bash
arm-linux-gnueabi-gcc -O2 -ffunction-sections -fdata-sections -fPIC -march=armv6 -marm -mfloat-abi=soft -std=c11 -I /project/test/fixtures/grammars/bash/src -Wall -DNDEBUG -Werror=implicit-function-declaration -shared /project/test/fixtures/grammars/bash/src/parser.c /project/test/fixtures/grammars/bash/src/scanner.c -o /project/parser.so
```

#### debug

```bash
arm-linux-gnueabi-gcc -O0 -ffunction-sections -fdata-sections -fPIC -gdwarf-4 -fno-omit-frame-pointer -march=armv6 -marm -mfloat-abi=soft -std=c11 -I /project/test/fixtures/grammars/bash/src -Wall -Wextra -Werror=implicit-function-declaration -shared /project/test/fixtures/grammars/bash/src/parser.c /project/test/fixtures/grammars/bash/src/scanner.c -o /project/parser.so
```

### aarch64-unknown-linux-gnu

#### release

```bash
aarch64-linux-gnu-gcc -O2 -ffunction-sections -fdata-sections -fPIC -std=c11 -I /project/test/fixtures/grammars/bash/src -Wall -DNDEBUG -Werror=implicit-function-declaration -shared /project/test/fixtures/grammars/bash/src/parser.c /project/test/fixtures/grammars/bash/src/scanner.c -o /project/parser.so
```

#### debug

```bash
aarch64-linux-gnu-gcc -O0 -ffunction-sections -fdata-sections -fPIC -gdwarf-4 -fno-omit-frame-pointer -std=c11 -I /project/test/fixtures/grammars/bash/src -Wall -Wextra -Werror=implicit-function-declaration -shared /project/test/fixtures/grammars/bash/src/parser.c /project/test/fixtures/grammars/bash/src/scanner.c -o /project/parser.so
```

### x86_64-unknown-linux-gnu

#### release

```bash
cc -O2 -ffunction-sections -fdata-sections -fPIC -m64 -std=c11 -I /home/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src -Wall -DNDEBUG -Werror=implicit-function-declaration -shared /home/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src/parser.c /home/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src/scanner.c -o /home/runner/work/tree-sitter/tree-sitter/parser.so
```

#### debug

```bash
cc -O0 -ffunction-sections -fdata-sections -fPIC -gdwarf-4 -fno-omit-frame-pointer -m64 -std=c11 -I /home/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src -Wall -Wextra -Werror=implicit-function-declaration -shared /home/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src/parser.c /home/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src/scanner.c -o /home/runner/work/tree-sitter/tree-sitter/parser.so
```

### aarch64-apple-darwin

#### release

```
cc -O2 -ffunction-sections -fdata-sections -fPIC --target=arm64-apple-darwin -mmacosx-version-min=10.13 -std=c11 -I /Users/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src -Wall -DNDEBUG -Werror=implicit-function-declaration -dynamiclib -UTREE_SITTER_REUSE_ALLOCATOR /Users/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src/parser.c /Users/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src/scanner.c -o /Users/runner/work/tree-sitter/tree-sitter/parser.dylib
```

#### debug

```bash
cc -O0 -ffunction-sections -fdata-sections -fPIC -gdwarf-2 -fno-omit-frame-pointer --target=arm64-apple-darwin -mmacosx-version-min=10.13 -std=c11 -I /Users/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src -Wall -Wextra -Werror=implicit-function-declaration -dynamiclib -UTREE_SITTER_REUSE_ALLOCATOR /Users/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src/parser.c /Users/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src/scanner.c -o /Users/runner/work/tree-sitter/tree-sitter/parser.dylib
```

### x86_64-apple-darwin

#### release

```
cc -O2 -ffunction-sections -fdata-sections -fPIC -m64 --target=x86_64-apple-darwin -mmacosx-version-min=10.13 -std=c11 -I /Users/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src -Wall -DNDEBUG -Werror=implicit-function-declaration -dynamiclib -UTREE_SITTER_REUSE_ALLOCATOR /Users/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src/parser.c /Users/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src/scanner.c -o /Users/runner/work/tree-sitter/tree-sitter/parser.dylib
```

#### debug

```bash
cc -O0 -ffunction-sections -fdata-sections -fPIC -gdwarf-2 -fno-omit-frame-pointer -m64 --target=x86_64-apple-darwin -mmacosx-version-min=10.13 -std=c11 -I /Users/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src -Wall -Wextra -Werror=implicit-function-declaration -dynamiclib -UTREE_SITTER_REUSE_ALLOCATOR /Users/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src/parser.c /Users/runner/work/tree-sitter/tree-sitter/test/fixtures/grammars/bash/src/scanner.c -o /Users/runner/work/tree-sitter/tree-sitter/parser.dylib
```

### i686-pc-windows-msvc

#### release

```cmd
C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.39.33519\\bin\\HostX64\\x86\\cl.exe -nologo -MD -O2 -Brepro -std:c11 -I D:\\a\\tree-sitter\\tree-sitter\\test/fixtures/grammars/bash\\src -W4 -DNDEBUG -LD -utf-8 D:\\a\\tree-sitter\\tree-sitter\\test/fixtures/grammars/bash\\src\\parser.c D:\\a\\tree-sitter\\tree-sitter\\test/fixtures/grammars/bash\\src\\scanner.c -link -out:D:\\a\\tree-sitter\\tree-sitter\\parser.dll
```

#### debug

```cmd
C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.39.33519\\bin\\HostX64\\x86\\cl.exe -nologo -MD -Z7 -Brepro -std:c11 -I D:\\a\\tree-sitter\\tree-sitter\\test/fixtures/grammars/bash\\src -W4 -LDd -utf-8 D:\\a\\tree-sitter\\tree-sitter\\test/fixtures/grammars/bash\\src\\parser.c D:\\a\\tree-sitter\\tree-sitter\\test/fixtures/grammars/bash\\src\\scanner.c -link -out:D:\\a\\tree-sitter\\tree-sitter\\parser.dll
```

### x86_64-pc-windows-msvc

#### release

```cmd
C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.39.33519\\bin\\HostX64\\x64\\cl.exe -nologo -MD -O2 -Brepro -std:c11 -I D:\\a\\tree-sitter\\tree-sitter\\test/fixtures/grammars/bash\\src -W4 -DNDEBUG -LD -utf-8 D:\\a\\tree-sitter\\tree-sitter\\test/fixtures/grammars/bash\\src\\parser.c D:\\a\\tree-sitter\\tree-sitter\\test/fixtures/grammars/bash\\src\\scanner.c -link -out:D:\\a\\tree-sitter\\tree-sitter\\parser.dll
```

#### debug

```cmd
C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.39.33519\\bin\\HostX64\\x64\\cl.exe -nologo -MD -Z7 -Brepro -std:c11 -I D:\\a\\tree-sitter\\tree-sitter\\test/fixtures/grammars/bash\\src -W4 -LDd -utf-8 D:\\a\\tree-sitter\\tree-sitter\\test/fixtures/grammars/bash\\src\\parser.c D:\\a\\tree-sitter\\tree-sitter\\test/fixtures/grammars/bash\\src\\scanner.c -link -out:D:\\a\\tree-sitter\\tree-sitter\\parser.dll
```

### aarch64-pc-windows-msvc

_Cannot run in CI_

</details>

_The `release` / `debug` variations need #3279_