### PR TITLE
Fix some bugs with ts nodes

### DIFF
--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -249,6 +249,24 @@ fn test_node_parent_of_child_by_field_name() {
 }
 
 #[test]
+fn test_parent_of_zero_width_node() {
+    let code = "def dupa(foo):";
+
+    let mut parser = Parser::new();
+    parser.set_language(&get_language("python")).unwrap();
+
+    let tree = parser.parse(code, None).unwrap();
+    let root = tree.root_node();
+    let function_definition = root.child(0).unwrap();
+    let block = function_definition.child(4).unwrap();
+    let block_parent = block.parent().unwrap();
+
+    assert_eq!(block.to_string(), "(block)");
+    assert_eq!(block_parent.kind(), "function_definition");
+    assert_eq!(block_parent.to_string(), "(function_definition name: (identifier) parameters: (parameters (identifier)) body: (block))");
+}
+
+#[test]
 fn test_node_field_name_for_child() {
     let mut parser = Parser::new();
     parser.set_language(&get_language("c")).unwrap();

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -107,7 +107,7 @@ pub struct TSNode {
 pub struct TSTreeCursor {
     pub tree: *const ::std::os::raw::c_void,
     pub id: *const ::std::os::raw::c_void,
-    pub context: [u32; 2usize],
+    pub context: [u32; 3usize],
 }
 #[repr(C)]
 #[derive(Debug)]

--- a/lib/binding_web/binding.c
+++ b/lib/binding_web/binding.c
@@ -53,6 +53,7 @@ static inline void marshal_cursor(const TSTreeCursor *cursor) {
   TRANSFER_BUFFER[0] = cursor->id;
   TRANSFER_BUFFER[1] = (const void *)cursor->context[0];
   TRANSFER_BUFFER[2] = (const void *)cursor->context[1];
+  TRANSFER_BUFFER[3] = (const void *)cursor->context[2];
 }
 
 static inline TSTreeCursor unmarshal_cursor(const void **buffer, const TSTree *tree) {
@@ -60,6 +61,7 @@ static inline TSTreeCursor unmarshal_cursor(const void **buffer, const TSTree *t
   cursor.id = buffer[0];
   cursor.context[0] = (uint32_t)buffer[1];
   cursor.context[1] = (uint32_t)buffer[2];
+  cursor.context[2] = (uint32_t)buffer[3];
   cursor.tree = tree;
   return cursor;
 }
@@ -276,7 +278,7 @@ void ts_tree_cursor_reset_wasm(const TSTree *tree) {
 
 void ts_tree_cursor_reset_to_wasm(const TSTree *_dst, const TSTree *_src) {
   TSTreeCursor cursor = unmarshal_cursor(TRANSFER_BUFFER, _dst);
-  TSTreeCursor src = unmarshal_cursor(&TRANSFER_BUFFER[3], _src);
+  TSTreeCursor src = unmarshal_cursor(&TRANSFER_BUFFER[4], _src);
   ts_tree_cursor_reset_to(&cursor, &src);
   marshal_cursor(&cursor);
 }

--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -6,7 +6,7 @@
 const C = Module;
 const INTERNAL = {};
 const SIZE_OF_INT = 4;
-const SIZE_OF_CURSOR = 3 * SIZE_OF_INT;
+const SIZE_OF_CURSOR = 4 * SIZE_OF_INT;
 const SIZE_OF_NODE = 5 * SIZE_OF_INT;
 const SIZE_OF_POINT = 2 * SIZE_OF_INT;
 const SIZE_OF_RANGE = 2 * SIZE_OF_INT + 2 * SIZE_OF_POINT;
@@ -1493,12 +1493,14 @@ function marshalTreeCursor(cursor, address = TRANSFER_BUFFER) {
   setValue(address + 0 * SIZE_OF_INT, cursor[0], 'i32'),
   setValue(address + 1 * SIZE_OF_INT, cursor[1], 'i32'),
   setValue(address + 2 * SIZE_OF_INT, cursor[2], 'i32');
+  setValue(address + 3 * SIZE_OF_INT, cursor[3], 'i32');
 }
 
 function unmarshalTreeCursor(cursor) {
   cursor[0] = getValue(TRANSFER_BUFFER + 0 * SIZE_OF_INT, 'i32'),
   cursor[1] = getValue(TRANSFER_BUFFER + 1 * SIZE_OF_INT, 'i32'),
   cursor[2] = getValue(TRANSFER_BUFFER + 2 * SIZE_OF_INT, 'i32');
+  cursor[3] = getValue(TRANSFER_BUFFER + 3 * SIZE_OF_INT, 'i32');
 }
 
 function marshalPoint(address, point) {

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -105,7 +105,7 @@ typedef struct TSNode {
 typedef struct TSTreeCursor {
   const void *tree;
   const void *id;
-  uint32_t context[2];
+  uint32_t context[3];
 } TSTreeCursor;
 
 typedef struct TSQueryCapture {

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -513,7 +513,7 @@ TSNode ts_node_parent(TSNode self) {
         ts_node_start_byte(child) > ts_node_start_byte(self) ||
         child.id == self.id
       ) break;
-      if (iterator.position.bytes >= end_byte) {
+      if (iterator.position.bytes >= end_byte && ts_node_child_count(child) > 0) {
         node = child;
         if (ts_node__is_relevant(child, true)) {
           last_visible_node = node;

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -439,7 +439,14 @@ const char *ts_node_grammar_type(TSNode self) {
 }
 
 char *ts_node_string(TSNode self) {
-  return ts_subtree_string(ts_node__subtree(self), self.tree->language, false);
+  TSSymbol alias_symbol = ts_node__alias(&self);
+  return ts_subtree_string(
+    ts_node__subtree(self),
+    alias_symbol,
+    ts_language_symbol_metadata(self.tree->language, alias_symbol).visible,
+    self.tree->language,
+    false
+  );
 }
 
 bool ts_node_eq(TSNode self, TSNode other) {

--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -890,9 +890,15 @@ static size_t ts_subtree__write_to_string(
       }
     }
   } else if (is_root) {
-    TSSymbol symbol = ts_subtree_symbol(self);
+    TSSymbol symbol = alias_symbol ? alias_symbol : ts_subtree_symbol(self);
     const char *symbol_name = ts_language_symbol_name(language, symbol);
-    cursor += snprintf(*writer, limit, "(\"%s\")", symbol_name);
+    if (ts_subtree_child_count(self) > 0) {
+      cursor += snprintf(*writer, limit, "(%s", symbol_name);
+    } else if (ts_subtree_named(self)) {
+      cursor += snprintf(*writer, limit, "(%s)", symbol_name);
+    } else {
+      cursor += snprintf(*writer, limit, "(\"%s\")", symbol_name);
+    }
   }
 
   if (ts_subtree_child_count(self)) {
@@ -947,6 +953,8 @@ static size_t ts_subtree__write_to_string(
 
 char *ts_subtree_string(
   Subtree self,
+  TSSymbol alias_symbol,
+  bool alias_is_named,
   const TSLanguage *language,
   bool include_all
 ) {
@@ -954,13 +962,13 @@ char *ts_subtree_string(
   size_t size = ts_subtree__write_to_string(
     self, scratch_string, 1,
     language, include_all,
-    0, false, ROOT_FIELD
+    alias_symbol, alias_is_named, ROOT_FIELD
   ) + 1;
   char *result = ts_malloc(size * sizeof(char));
   ts_subtree__write_to_string(
     self, result, size,
     language, include_all,
-    0, false, ROOT_FIELD
+    alias_symbol, alias_is_named, ROOT_FIELD
   );
   return result;
 }

--- a/lib/src/subtree.h
+++ b/lib/src/subtree.h
@@ -206,7 +206,7 @@ void ts_subtree_summarize(MutableSubtree, const Subtree *, uint32_t, const TSLan
 void ts_subtree_summarize_children(MutableSubtree, const TSLanguage *);
 void ts_subtree_balance(Subtree, SubtreePool *, const TSLanguage *);
 Subtree ts_subtree_edit(Subtree, const TSInputEdit *edit, SubtreePool *);
-char *ts_subtree_string(Subtree, const TSLanguage *, bool include_all);
+char *ts_subtree_string(Subtree, TSSymbol, bool, const TSLanguage *, bool include_all);
 void ts_subtree_print_dot_graph(Subtree, const TSLanguage *, FILE *);
 Subtree ts_subtree_last_external_token(Subtree);
 const ExternalScannerState *ts_subtree_external_scanner_state(Subtree self);

--- a/lib/src/tree.c
+++ b/lib/src/tree.c
@@ -102,8 +102,8 @@ TSRange *ts_tree_included_ranges(const TSTree *self, uint32_t *length) {
 }
 
 TSRange *ts_tree_get_changed_ranges(const TSTree *old_tree, const TSTree *new_tree, uint32_t *length) {
-  TreeCursor cursor1 = {NULL, array_new()};
-  TreeCursor cursor2 = {NULL, array_new()};
+  TreeCursor cursor1 = {NULL, array_new(), 0};
+  TreeCursor cursor2 = {NULL, array_new(), 0};
   ts_tree_cursor_init(&cursor1, ts_tree_root_node(old_tree));
   ts_tree_cursor_init(&cursor2, ts_tree_root_node(new_tree));
 

--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -151,7 +151,7 @@ static inline bool ts_tree_cursor_child_iterator_previous(
 // TSTreeCursor - lifecycle
 
 TSTreeCursor ts_tree_cursor_new(TSNode node) {
-  TSTreeCursor self = {NULL, NULL, {0, 0}};
+  TSTreeCursor self = {NULL, NULL, {0, 0, 0}};
   ts_tree_cursor_init((TreeCursor *)&self, node);
   return self;
 }
@@ -162,6 +162,7 @@ void ts_tree_cursor_reset(TSTreeCursor *_self, TSNode node) {
 
 void ts_tree_cursor_init(TreeCursor *self, TSNode node) {
   self->tree = node.tree;
+  self->root_alias_symbol = node.context[3];
   array_clear(&self->stack);
   array_push(&self->stack, ((TreeCursorEntry) {
     .subtree = (const Subtree *)node.id,
@@ -474,7 +475,7 @@ uint32_t ts_tree_cursor_current_descendant_index(const TSTreeCursor *_self) {
 TSNode ts_tree_cursor_current_node(const TSTreeCursor *_self) {
   const TreeCursor *self = (const TreeCursor *)_self;
   TreeCursorEntry *last_entry = array_back(&self->stack);
-  TSSymbol alias_symbol = 0;
+  TSSymbol alias_symbol = self->root_alias_symbol;
   if (self->stack.size > 1 && !ts_subtree_extra(*last_entry->subtree)) {
     TreeCursorEntry *parent_entry = &self->stack.contents[self->stack.size - 2];
     alias_symbol = ts_language_alias_at(
@@ -697,6 +698,7 @@ TSTreeCursor ts_tree_cursor_copy(const TSTreeCursor *_cursor) {
   TSTreeCursor res = {NULL, NULL, {0, 0}};
   TreeCursor *copy = (TreeCursor *)&res;
   copy->tree = cursor->tree;
+  copy->root_alias_symbol = cursor->root_alias_symbol;
   array_init(&copy->stack);
   array_push_all(&copy->stack, &cursor->stack);
   return res;
@@ -706,6 +708,7 @@ void ts_tree_cursor_reset_to(TSTreeCursor *_dst, const TSTreeCursor *_src) {
   const TreeCursor *cursor = (const TreeCursor *)_src;
   TreeCursor *copy = (TreeCursor *)_dst;
   copy->tree = cursor->tree;
+  copy->root_alias_symbol = cursor->root_alias_symbol;
   array_clear(&copy->stack);
   array_push_all(&copy->stack, &cursor->stack);
 }

--- a/lib/src/tree_cursor.h
+++ b/lib/src/tree_cursor.h
@@ -14,6 +14,7 @@ typedef struct {
 typedef struct {
   const TSTree *tree;
   Array(TreeCursorEntry) stack;
+  TSSymbol root_alias_symbol;
 } TreeCursor;
 
 typedef enum {


### PR DESCRIPTION
- Closes #1057 (last comment that's related to #2580)
- Closes #2580
- Closes #3185

It seems like inlined nodes weren't taken into account when going to a node's parent, and getting the string representation of a node didn't take into account if the root node wasn't the actual root node, but rather a child node that is either a) aliased, or b) has children (both cases had bugs). This issue with aliased root nodes was also present when resetting a tree cursor to one of these nodes, thus making queries that are run on a node where the root node is an alias and queries for this root node invalid. This PR fixes these problems (after several hours of debugging... :sleeping:)