### PR TITLE
docs: add typescript directives to grammar.js snippet in creating-parsers.md

### DIFF
--- a/docs/section-3-creating-parsers.md
+++ b/docs/section-3-creating-parsers.md
@@ -56,6 +56,12 @@ export PATH=$PATH:./node_modules/.bin
 Once you have the CLI installed, create a file called `grammar.js` with the following contents:
 
 ```js
+/// <reference types="tree-sitter-cli/dsl" />
+// @ts-check
+// NOTE: The above two lines are optional.
+// They allow your editor to provide type inference on this javascript file,
+// provided you have a TypeScript LSP installed.
+
 module.exports = grammar({
   name: 'YOUR_LANGUAGE_NAME',
 


### PR DESCRIPTION
Adds typescript comment directives to the grammar.js boilerplate, allowing  parser authors to get type inference if their editor has typescript lsp. These directives are mostly present in the major tree-sitter grammars. 

See [here](1) and [here](2).

[1]: https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-path-
[2]: https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html