### PR TITLE
docs: Add `ibmhlasm` language parser

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,7 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 * [Haskell](https://github.com/tree-sitter/tree-sitter-haskell)
 * [HCL](https://github.com/MichaHoffmann/tree-sitter-hcl)
 * [HTML](https://github.com/tree-sitter/tree-sitter-html)
+* [IBM z/os HLASM](https://github.com/janus-llm/tree-sitter-ibmhlasm)
 * [ISPC](https://github.com/fab4100/tree-sitter-ispc)
 * [Java](https://github.com/tree-sitter/tree-sitter-java)
 * [JavaScript](https://github.com/tree-sitter/tree-sitter-javascript)


### PR DESCRIPTION
Added the IBM z/OS High Level Assembly (HLASM) tree-sitter implementation to the `index.md` repository list.

Tree-sitter repo: https://github.com/janus-llm/tree-sitter-ibmhlasm

Originated with [this discussion](https://github.com/tree-sitter/tree-sitter/discussions/3198#discussioncomment-8853415).