### PR TITLE
fix: default output directory for `build --wasm` should use current_dir

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -28,6 +28,7 @@ enum Commands {
     InitConfig(InitConfig),
     Generate(Generate),
     Build(Build),
+    BuildWasm(BuildWasm),
     Parse(Parse),
     Test(Test),
     Query(Query),
@@ -113,6 +114,19 @@ struct Build {
         help = "Build the parser with `TREE_SITTER_INTERNAL_BUILD` defined"
     )]
     pub internal_build: bool,
+}
+
+#[derive(Args)]
+#[command(about = "Compile a parser to WASM", alias = "bw")]
+struct BuildWasm {
+    #[arg(
+        short,
+        long,
+        help = "Run emscripten via docker even if it is installed locally"
+    )]
+    pub docker: bool,
+    #[arg(index = 1, num_args = 1, help = "The path to output the wasm file")]
+    pub path: Option<String>,
 }
 
 #[derive(Args)]
@@ -492,6 +506,18 @@ fn run() -> Result<()> {
                     .compile_parser_at_path(&grammar_path, output_path, flags)
                     .unwrap();
             }
+        }
+
+        Commands::BuildWasm(wasm_options) => {
+            eprintln!("`build-wasm` is deprecated and will be removed in v0.24.0. You should use `build --wasm` instead");
+            let grammar_path = current_dir.join(wasm_options.path.unwrap_or_default());
+            wasm::compile_language_to_wasm(
+                &loader,
+                &grammar_path,
+                &current_dir,
+                None,
+                wasm_options.docker,
+            )?;
         }
 
         Commands::Parse(parse_options) => {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -444,15 +444,11 @@ fn run() -> Result<()> {
             if build_options.wasm {
                 let grammar_path =
                     current_dir.join(build_options.path.as_deref().unwrap_or_default());
-                let (output_dir, output_path) = if let Some(ref path) = build_options.output {
-                    (current_dir.clone(), Some(current_dir.join(path)))
-                } else {
-                    (loader.parser_lib_path.clone(), None)
-                };
+                let output_path = build_options.output.map(|path| current_dir.join(path));
                 wasm::compile_language_to_wasm(
                     &loader,
                     &grammar_path,
-                    &output_dir,
+                    &current_dir,
                     output_path,
                     build_options.docker,
                 )?;


### PR DESCRIPTION
Fix #3202

This PR has two commits:
3492a487e6733ec58d7e0f0ed325f2bfb91a21e9 is the minimal fix that fixes the problem.
452bac66179e47c6d6e2076eed5517e81d3d146f is the proper fix.