### PR TITLE
docs: creating parser: setup instruction: need to add …

### DIFF
--- a/docs/section-3-creating-parsers.md
+++ b/docs/section-3-creating-parsers.md
@@ -53,6 +53,12 @@ The last command will install the CLI into the `node_modules` folder in your wor
 export PATH=$PATH:./node_modules/.bin
 ```
 
+Next, add the following entry to your `package.json`:
+```js
+// In package.json
+"tree-sitter": []
+```
+
 Once you have the CLI installed, create a file called `grammar.js` with the following contents:
 
 ```js


### PR DESCRIPTION
… "tree-sitter" entry to package.json

Otherwise, when you do`tree-sitter generate`, it will fail with the following message:

```
Failed to locate a package.json file that has a "tree-sitter" section, please ensure you have one, and if you don't then consult the docs
```