### PR TITLE
feat(bindings): update npm scripts

### DIFF
--- a/cli/src/generate/templates/package.json
+++ b/cli/src/generate/templates/package.json
@@ -18,18 +18,19 @@
     "prebuilds/**",
     "bindings/node/*",
     "queries/*",
-    "src/**"
+    "src/**",
+    "*.wasm"
   ],
   "dependencies": {
-    "node-addon-api": "^7.1.0",
-    "node-gyp-build": "^4.8.0"
+    "node-addon-api": "^8.0.0",
+    "node-gyp-build": "^4.8.1"
   },
   "devDependencies": {
-    "prebuildify": "^6.0.0",
+    "prebuildify": "^6.0.1",
     "tree-sitter-cli": "^CLI_VERSION"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.21.0"
+    "tree-sitter": "^0.21.1"
   },
   "peerDependenciesMeta": {
     "tree-sitter": {
@@ -38,11 +39,9 @@
   },
   "scripts": {
     "install": "node-gyp-build",
-    "prebuildify": "prebuildify --napi --strip",
-    "build": "tree-sitter generate --no-bindings",
-    "build-wasm": "tree-sitter build --wasm",
-    "test": "tree-sitter test",
-    "parse": "tree-sitter parse"
+    "prestart": "tree-sitter build --wasm",
+    "start": "tree-sitter playground",
+    "test": "node --test bindings/node/*_test.js"
   },
   "tree-sitter": [
     {


### PR DESCRIPTION
* `npm run build` is removed
* `npm run parse` is removed
* `npm run prebuildify` is removed
  - use `npm x -- prebuildify ...` instead
* `npm start` will run `ts playground` (after `ts build --wasm`)
  - the build can be skipped with `npm start --ignore-scripts`
* `npm test` will run `node --test` instead of `ts t`
  - requires #3178
  
  tree-sitter commands can be run with `npm x -- tree-sitter ...`