### PR TITLE
Include header files in Python bindings package source distributions

### DIFF
--- a/cli/src/generate/templates/setup.py
+++ b/cli/src/generate/templates/setup.py
@@ -29,6 +29,16 @@ setup(
         "tree_sitter_LOWER_PARSER_NAME": ["*.pyi", "py.typed"],
         "tree_sitter_LOWER_PARSER_NAME.queries": ["*.scm"],
     },
+    data_files=[
+        (
+            "src/tree_sitter",
+            [
+                "src/tree_sitter/alloc.h",
+                "src/tree_sitter/array.h",
+                "src/tree_sitter/parser.h",
+            ],
+        )
+    ],
     ext_package="tree_sitter_LOWER_PARSER_NAME",
     ext_modules=[
         Extension(


### PR DESCRIPTION
Including the headers allows the Python package to be build from the source distribution.

Before, the following would fail when using [`build`](https://build.pypa.io/en/stable/index.html) for Python.

```bash
mkdir tree-sitter-foo
cd tree-sitter-foo
tree-sitter generate
python -m build
```