### PR TITLE
feat: reverse iteration through node parents

### DIFF
--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -165,6 +165,22 @@ fn test_node_child() {
     assert_eq!(object_node.parent().unwrap(), array_node);
     assert_eq!(array_node.parent().unwrap(), tree.root_node());
     assert_eq!(tree.root_node().parent(), None);
+
+    assert_eq!(
+        tree.root_node()
+            .child_containing_descendant(null_node)
+            .unwrap(),
+        array_node
+    );
+    assert_eq!(
+        array_node.child_containing_descendant(null_node).unwrap(),
+        object_node
+    );
+    assert_eq!(
+        object_node.child_containing_descendant(null_node).unwrap(),
+        pair_node
+    );
+    assert_eq!(pair_node.child_containing_descendant(null_node), None);
 }
 
 #[test]
@@ -264,6 +280,12 @@ fn test_parent_of_zero_width_node() {
     assert_eq!(block.to_string(), "(block)");
     assert_eq!(block_parent.kind(), "function_definition");
     assert_eq!(block_parent.to_string(), "(function_definition name: (identifier) parameters: (parameters (identifier)) body: (block))");
+
+    assert_eq!(
+        root.child_containing_descendant(block).unwrap(),
+        function_definition
+    );
+    assert_eq!(function_definition.child_containing_descendant(block), None);
 }
 
 #[test]
@@ -382,6 +404,22 @@ fn test_node_named_child() {
     assert_eq!(object_node.parent().unwrap(), array_node);
     assert_eq!(array_node.parent().unwrap(), tree.root_node());
     assert_eq!(tree.root_node().parent(), None);
+
+    assert_eq!(
+        tree.root_node()
+            .child_containing_descendant(null_node)
+            .unwrap(),
+        array_node
+    );
+    assert_eq!(
+        array_node.child_containing_descendant(null_node).unwrap(),
+        object_node
+    );
+    assert_eq!(
+        object_node.child_containing_descendant(null_node).unwrap(),
+        pair_node
+    );
+    assert_eq!(pair_node.child_containing_descendant(null_node), None);
 }
 
 #[test]

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -355,8 +355,12 @@ extern "C" {
     pub fn ts_node_next_parse_state(self_: TSNode) -> TSStateId;
 }
 extern "C" {
-    #[doc = " Get the node's immediate parent."]
+    #[doc = " Get the node's immediate parent.\n Prefer [`ts_node_child_containing_descendant`] for\n iterating over the node's ancestors."]
     pub fn ts_node_parent(self_: TSNode) -> TSNode;
+}
+extern "C" {
+    #[doc = " Get the node's child that contains `descendant`."]
+    pub fn ts_node_child_containing_descendant(self_: TSNode, descendant: TSNode) -> TSNode;
 }
 extern "C" {
     #[doc = " Get the node's child at the given index, where zero represents the first\n child."]

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1325,10 +1325,19 @@ impl<'tree> Node<'tree> {
     }
 
     /// Get this node's immediate parent.
+    /// Prefer [`child_containing_descendant`](Node::child_containing_descendant)
+    /// for iterating over this node's ancestors.
     #[doc(alias = "ts_node_parent")]
     #[must_use]
     pub fn parent(&self) -> Option<Self> {
         Self::new(unsafe { ffi::ts_node_parent(self.0) })
+    }
+
+    /// Get this node's child that contains `descendant`.
+    #[doc(alias = "ts_node_child_containing_descendant")]
+    #[must_use]
+    pub fn child_containing_descendant(&self, descendant: Self) -> Option<Self> {
+        Self::new(unsafe { ffi::ts_node_child_containing_descendant(self.0, descendant.0) })
     }
 
     /// Get this node's next sibling.

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -548,8 +548,15 @@ TSStateId ts_node_next_parse_state(TSNode self);
 
 /**
  * Get the node's immediate parent.
+ * Prefer [`ts_node_child_containing_descendant`] for
+ * iterating over the node's ancestors.
  */
 TSNode ts_node_parent(TSNode self);
+
+/**
+ * Get the node's child that contains `descendant`.
+ */
+TSNode ts_node_child_containing_descendant(TSNode self, TSNode descendant);
 
 /**
  * Get the node's child at the given index, where zero represents the first


### PR DESCRIPTION
Currently, to iterate over all parents of a given node, one would need to repeatedly call [`ts_node_parent()`](https://github.com/tree-sitter/tree-sitter/blob/b7fcf9878e1144a30e71ae94f951f163258770d9/lib/src/node.c#L506) on the node itself and on each of its parents.
This creates performance issues for deep trees (neovim/neovim#24965), as `ts_node_parent()` itself has to iterate over all the node's parents (in reverse order, from root to the node) to find the last one.
To address this performance issue, we can introduce a function that allows iterating over the node's parents in reverse order.