### PR TITLE
fix(parser): fix variadic macro

### DIFF
--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -1296,7 +1296,11 @@ impl Generator {
                         production_id,
                         ..
                     } => {
-                        add!(self, "REDUCE({}, {child_count}", self.symbol_ids[&symbol]);
+                        add!(
+                            self,
+                            "REDUCE(.symbol = {}, .child_count = {child_count}",
+                            self.symbol_ids[&symbol]
+                        );
                         if dynamic_precedence != 0 {
                             add!(self, ", .dynamic_precedence = {dynamic_precedence}");
                         }

--- a/lib/src/parser.h
+++ b/lib/src/parser.h
@@ -203,12 +203,10 @@ struct TSLanguage {
     }                                 \
   }}
 
-#define REDUCE(symbol_val, child_count_val, ...) \
+#define REDUCE(...) \
   {{                                             \
     .reduce = {                                  \
       .type = TSParseActionTypeReduce,           \
-      .symbol = symbol_val,                      \
-      .child_count = child_count_val,            \
       __VA_ARGS__                                \
     },                                           \
   }}


### PR DESCRIPTION
## Problem

Compiling a parser with `-pedantic` warns that the `REDUCE` macro must have at least one variadic argument. This is innocuous since the macro does not expand into a function call, which prohibits trailing commas, but into a struct initialiser, where they are allowed. The warning can be [silenced](https://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-zero-variadic-macro-arguments) in clang but not in GCC. (MSVC [doesn't care](https://learn.microsoft.com/en-us/cpp/build/reference/zc-preprocessor?view=msvc-170).)

## Solution

Move all arguments into the variadic list.

Closes #3227 

### Alternatives

#### Separate into a macro with arguments and one without

That would make the generator more complicated.

#### Change the std to `gnu11`

No reason to do that just for this easily fixable warning.