### PR TITLE
Use two macros for reduce, to restore positional arguments

### DIFF
--- a/cli/src/generate/render.rs
+++ b/cli/src/generate/render.rs
@@ -1296,11 +1296,12 @@ impl Generator {
                         production_id,
                         ..
                     } => {
-                        add!(
-                            self,
-                            "REDUCE(.symbol = {}, .child_count = {child_count}",
-                            self.symbol_ids[&symbol]
-                        );
+                        let name = if dynamic_precedence != 0 || production_id != 0 {
+                            "REDUCE_WITH"
+                        } else {
+                            "REDUCE"
+                        };
+                        add!(self, "{name}({}, {child_count}", self.symbol_ids[&symbol]);
                         if dynamic_precedence != 0 {
                             add!(self, ", .dynamic_precedence = {dynamic_precedence}");
                         }

--- a/lib/src/parser.h
+++ b/lib/src/parser.h
@@ -203,12 +203,23 @@ struct TSLanguage {
     }                                 \
   }}
 
-#define REDUCE(...) \
+#define REDUCE(symbol_val, child_count_val) \
   {{                                             \
     .reduce = {                                  \
       .type = TSParseActionTypeReduce,           \
-      __VA_ARGS__                                \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
     },                                           \
+  }}
+
+#define REDUCE_WITH(symbol_val, child_count_val, ...) \
+  {{                                                  \
+    .reduce = {                                       \
+      .type = TSParseActionTypeReduce,                \
+      .symbol = symbol_val,                           \
+      .child_count = child_count_val,                 \
+       __VA_ARGS__                                    \
+    },                                                \
   }}
 
 #define RECOVER()                    \


### PR DESCRIPTION
https://github.com/tree-sitter/tree-sitter/pull/3229

/cc  @ObserverOfTime @amaanq @DavisVaughan

I don't want to have the designated initializers for `.symbol` and `.child_count` in every `REDUCE` invocation in the parse table, because it makes those entries pretty verbose, and there are a lot of them.

