### PR TITLE
fix: Add lifetime to matches function

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -2336,8 +2336,8 @@ impl QueryCursor {
     /// Because multiple patterns can match the same set of nodes, one match may contain
     /// captures that appear *before* some of the captures from a previous match.
     #[doc(alias = "ts_query_cursor_exec")]
-    pub fn matches<'query, 'tree, T: TextProvider<I>, I: AsRef<[u8]>>(
-        &mut self,
+    pub fn matches<'query, 'cursor: 'query, 'tree, T: TextProvider<I>, I: AsRef<[u8]>>(
+        &'cursor mut self,
         query: &'query Query,
         node: Node<'tree>,
         text_provider: T,


### PR DESCRIPTION
This fixes an issue where a `QueryCursor` can be dropped but still have `.matches()` called on it, leading to an attempt to index into a zero-length array in the C library. [My comment](https://github.com/tree-sitter/tree-sitter/issues/3253#issuecomment-2036006041) in the issue reporting the bug has a more in-depth explanation.

Closes #3253 
