### PR TITLE
Added debug messages for missing/misplaced test directories

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -650,6 +650,15 @@ fn run() -> Result<()> {
                 };
 
                 test::run_tests_at_path(&mut parser, &mut opts)?;
+            } else if test_options.debug {
+                println!(
+                    "Corpus test directory not found: `{}`",
+                    test_corpus_dir.display()
+                );
+                let old_corpus_dir = current_dir.join("corpus");
+                if old_corpus_dir.is_dir() {
+                    println!("Top-level Corpus test directories are no longer supported. Corpus files must be located in directory `{}`", test_corpus_dir.display());
+                }
             }
 
             // Check that all of the queries are valid.
@@ -667,6 +676,11 @@ fn run() -> Result<()> {
                     &test_highlight_dir,
                 )?;
                 parser = highlighter.parser;
+            } else if test_options.debug {
+                println!(
+                    "Highlights test directory not found: `{}`",
+                    test_highlight_dir.display()
+                );
             }
 
             let test_tag_dir = test_dir.join("tags");
@@ -674,6 +688,11 @@ fn run() -> Result<()> {
                 let mut tags_context = TagsContext::new();
                 tags_context.parser = parser;
                 test_tags::test_tags(&loader, &config.get()?, &mut tags_context, &test_tag_dir)?;
+            } else if test_options.debug {
+                println!(
+                    "Tags test directory not found: `{}`",
+                    test_tag_dir.display()
+                );
             }
         }
 


### PR DESCRIPTION
Using the `test --debug` now prints if a corpus/highlight/tags directory is not found. Also displays that top-level `corpus/` directories are no longer supported if `test/corpus/` is not found, but a top-level `corpus/` is.