### PR TITLE
fix(bindings): add utf-8 flag to python & node

### DIFF
--- a/cli/src/generate/templates/binding.gyp
+++ b/cli/src/generate/templates/binding.gyp
@@ -13,8 +13,17 @@
         "src/parser.c",
         # NOTE: if your language has an external scanner, add it here.
       ],
-      "cflags_c": [
-        "-std=c11",
+      "conditions": [
+        ["OS!='win'", {
+          "cflags_c": [
+            "-std=c11",
+          ],
+        }, { # OS == "win"
+          "cflags_c": [
+            "/std:c11",
+            "/utf-8",
+          ],
+        }],
       ],
     }
   ]

--- a/cli/src/generate/templates/setup.py
+++ b/cli/src/generate/templates/setup.py
@@ -38,9 +38,12 @@ setup(
                 "src/parser.c",
                 # NOTE: if your language uses an external scanner, add it here.
             ],
-            extra_compile_args=(
-                ["-std=c11"] if system() != 'Windows' else []
-            ),
+            extra_compile_args=[
+                "-std=c11",
+            ] if system() != "Windows" else [
+                "/std:c11",
+                "/utf-8",
+            ],
             define_macros=[
                 ("Py_LIMITED_API", "0x03080000"),
                 ("PY_SSIZE_T_CLEAN", None)


### PR DESCRIPTION
From what I can tell, python & node only support MSVC, go does not support it, and swift doesn't even support Windows.

These bindings will not be updated automatically.