### PR TITLE
ci(dependabot): improve PR labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,17 +6,21 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "build(deps)"
+    labels:
+      - "dependencies"
+      - "cargo"
     groups:
       cargo:
-        patterns:
-        - "*"
+        patterns: ["*"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
     groups:
       actions:
-        patterns:
-        - "*"
+        patterns: ["*"]


### PR DESCRIPTION
`github_actions` -> `github-actions` for consistency
`rust` -> `cargo` so we can use `rust` for actual issues