### PR TITLE
style(bindings): fix indent & line endings

### DIFF
--- a/cli/src/generate/templates/.editorconfig
+++ b/cli/src/generate/templates/.editorconfig
@@ -2,9 +2,6 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
 
 [*.{json,toml,yml,gyp}]
 indent_style = space
@@ -14,11 +11,11 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 
-[*.rs]
+[*.{c,cc,h}]
 indent_style = space
 indent_size = 4
 
-[*.{c,cc,h}]
+[*.rs]
 indent_style = space
 indent_size = 4
 
@@ -37,3 +34,6 @@ indent_size = 8
 [Makefile]
 indent_style = tab
 indent_size = 8
+
+[parser.c]
+indent_size = 2

--- a/cli/src/generate/templates/gitattributes
+++ b/cli/src/generate/templates/gitattributes
@@ -1,4 +1,4 @@
-* text eol=lf
+* text=auto eol=lf
 
 src/*.json linguist-generated
 src/parser.c linguist-generated

--- a/cli/src/generate/templates/js-binding.cc
+++ b/cli/src/generate/templates/js-binding.cc
@@ -6,7 +6,7 @@ extern "C" TSLanguage *tree_sitter_PARSER_NAME();
 
 // "tree-sitter", "language" hashed with BLAKE2
 const napi_type_tag LANGUAGE_TYPE_TAG = {
-  0x8AF2E5212AD58ABF, 0xD5006CAD83ABBA16
+    0x8AF2E5212AD58ABF, 0xD5006CAD83ABBA16
 };
 
 Napi::Object Init(Napi::Env env, Napi::Object exports) {


### PR DESCRIPTION
This makes those files consistent with the core codebase and the generated `parser.c` which use 2 spaces.

However, most scanners tend to use 4 spaces from what I can tell.
Anyone who wants 4 spaces can add this to the end of `.editorconfig`:
```ini
[src/parser.c]
indent_size = 2
```

_Can be squashed._