### PR TITLE
fix(bindings): unable to build binding with rust target wasm32-wasi

### DIFF
--- a/lib/binding_rust/ffi.rs
+++ b/lib/binding_rust/ffi.rs
@@ -8,7 +8,7 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 #[cfg(not(feature = "bindgen"))]
 include!("./bindings.rs");
 
-#[cfg(unix)]
+#[cfg(not(windows))]
 extern "C" {
     pub(crate) fn _ts_dup(fd: std::os::raw::c_int) -> std::os::raw::c_int;
 }

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -3,8 +3,8 @@
 pub mod ffi;
 mod util;
 
-#[cfg(unix)]
-use std::os::unix::io::AsRawFd;
+#[cfg(not(windows))]
+use std::os::fd::io::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawHandle;
 use std::{
@@ -942,10 +942,10 @@ impl Tree {
     #[doc(alias = "ts_tree_print_dot_graph")]
     pub fn print_dot_graph(
         &self,
-        #[cfg(unix)] file: &impl AsRawFd,
+        #[cfg(not(windows))] file: &impl AsRawFd,
         #[cfg(windows)] file: &impl AsRawHandle,
     ) {
-        #[cfg(unix)]
+        #[cfg(not(windows))]
         {
             let fd = file.as_raw_fd();
             unsafe { ffi::ts_tree_print_dot_graph(self.0.as_ptr(), fd) }

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -4,7 +4,7 @@ pub mod ffi;
 mod util;
 
 #[cfg(not(windows))]
-use std::os::fd::io::AsRawFd;
+use std::os::fd::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawHandle;
 use std::{


### PR DESCRIPTION
Just updated to `0.22.4` from `0.20.10` and noticed rust bindings no longer build when targeting wasm32-wasi. The noted `unix` specific cfgs do also work in wasm32-wasi.