### PR TITLE
feat(grammar): add "inherits" field if available

### DIFF
--- a/cli/src/generate/dsl.js
+++ b/cli/src/generate/dsl.js
@@ -223,6 +223,8 @@ function RuleBuilder(ruleMap) {
 }
 
 function grammar(baseGrammar, options) {
+  let inherits = null;
+
   if (!options) {
     options = baseGrammar;
     baseGrammar = {
@@ -237,6 +239,7 @@ function grammar(baseGrammar, options) {
     };
   } else {
     baseGrammar = baseGrammar.grammar;
+    inherits = baseGrammar.name;
   }
 
   let externals = baseGrammar.externals;
@@ -277,6 +280,14 @@ function grammar(baseGrammar, options) {
 
   if (!/^[a-zA-Z_]\w*$/.test(name)) {
     throw new Error("Grammar's 'name' property must not start with a digit and cannot contain non-word characters.");
+  }
+
+  if (inherits && typeof inherits !== "string") {
+    throw new Error("Base grammar's 'name' property must be a string.");
+  }
+
+  if (inherits && !/^[a-zA-Z_]\w*$/.test(name)) {
+    throw new Error("Base grammar's 'name' property must not start with a digit and cannot contain non-word characters.");
   }
 
   const rules = Object.assign({}, baseGrammar.rules);
@@ -407,7 +418,7 @@ function grammar(baseGrammar, options) {
     throw new Error("Grammar must have at least one rule.");
   }
 
-  return { grammar: { name, word, rules, extras, conflicts, precedences, externals, inline, supertypes } };
+  return { grammar: { name, inherits, word, rules, extras, conflicts, precedences, externals, inline, supertypes } };
 }
 
 function checkArguments(args, ruleCount, caller, callerName, suffix = '', argType = 'rule') {

--- a/cli/src/generate/grammar-schema.json
+++ b/cli/src/generate/grammar-schema.json
@@ -14,6 +14,12 @@
       "pattern": "^[a-zA-Z_]\\w*"
     },
 
+    "inherits": {
+      "description": "the name of the parent grammar",
+      "type": "string",
+      "pattern": "^[a-zA-Z_]\\w*"
+    },
+
     "rules": {
       "type": "object",
       "patternProperties": {


### PR DESCRIPTION
The field can be excluded entirely by changing `null` to `undefined` if we want that.

Closes #3294.