### PR TITLE
Fix `childrenFromFieldXXX` methods

### DIFF
--- a/lib/binding_web/tree-sitter-web.d.ts
+++ b/lib/binding_web/tree-sitter-web.d.ts
@@ -95,8 +95,8 @@ declare module 'web-tree-sitter' {
       childForFieldName(fieldName: string): SyntaxNode | null;
       childForFieldId(fieldId: number): SyntaxNode | null;
       fieldNameForChild(childIndex: number): string | null;
-      childrenForFieldName(fieldName: string, cursor: TreeCursor): Array<SyntaxNode>;
-      childrenForFieldId(fieldId: number, cursor: TreeCursor): Array<SyntaxNode>;
+      childrenForFieldName(fieldName: string): Array<SyntaxNode>;
+      childrenForFieldId(fieldId: number): Array<SyntaxNode>;
       firstChildForIndex(index: number): SyntaxNode | null;
       firstNamedChildForIndex(index: number): SyntaxNode | null;
 


### PR DESCRIPTION
These do not expect a `cursor` parameter, it's unclear to me why they're in that signature, see: 
https://github.com/tree-sitter/tree-sitter/blob/master/lib/binding_web/binding.js#L366