### PR TITLE
revert: "account for the root node of a tree cursor being an alias"

### DIFF
--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -107,7 +107,7 @@ pub struct TSNode {
 pub struct TSTreeCursor {
     pub tree: *const ::std::os::raw::c_void,
     pub id: *const ::std::os::raw::c_void,
-    pub context: [u32; 3usize],
+    pub context: [u32; 2usize],
 }
 #[repr(C)]
 #[derive(Debug)]

--- a/lib/binding_web/binding.c
+++ b/lib/binding_web/binding.c
@@ -53,7 +53,6 @@ static inline void marshal_cursor(const TSTreeCursor *cursor) {
   TRANSFER_BUFFER[0] = cursor->id;
   TRANSFER_BUFFER[1] = (const void *)cursor->context[0];
   TRANSFER_BUFFER[2] = (const void *)cursor->context[1];
-  TRANSFER_BUFFER[3] = (const void *)cursor->context[2];
 }
 
 static inline TSTreeCursor unmarshal_cursor(const void **buffer, const TSTree *tree) {
@@ -61,7 +60,6 @@ static inline TSTreeCursor unmarshal_cursor(const void **buffer, const TSTree *t
   cursor.id = buffer[0];
   cursor.context[0] = (uint32_t)buffer[1];
   cursor.context[1] = (uint32_t)buffer[2];
-  cursor.context[2] = (uint32_t)buffer[3];
   cursor.tree = tree;
   return cursor;
 }
@@ -278,7 +276,7 @@ void ts_tree_cursor_reset_wasm(const TSTree *tree) {
 
 void ts_tree_cursor_reset_to_wasm(const TSTree *_dst, const TSTree *_src) {
   TSTreeCursor cursor = unmarshal_cursor(TRANSFER_BUFFER, _dst);
-  TSTreeCursor src = unmarshal_cursor(&TRANSFER_BUFFER[4], _src);
+  TSTreeCursor src = unmarshal_cursor(&TRANSFER_BUFFER[3], _src);
   ts_tree_cursor_reset_to(&cursor, &src);
   marshal_cursor(&cursor);
 }

--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -6,7 +6,7 @@
 const C = Module;
 const INTERNAL = {};
 const SIZE_OF_INT = 4;
-const SIZE_OF_CURSOR = 4 * SIZE_OF_INT;
+const SIZE_OF_CURSOR = 3 * SIZE_OF_INT;
 const SIZE_OF_NODE = 5 * SIZE_OF_INT;
 const SIZE_OF_POINT = 2 * SIZE_OF_INT;
 const SIZE_OF_RANGE = 2 * SIZE_OF_INT + 2 * SIZE_OF_POINT;
@@ -1496,14 +1496,12 @@ function marshalTreeCursor(cursor, address = TRANSFER_BUFFER) {
   setValue(address + 0 * SIZE_OF_INT, cursor[0], 'i32');
   setValue(address + 1 * SIZE_OF_INT, cursor[1], 'i32');
   setValue(address + 2 * SIZE_OF_INT, cursor[2], 'i32');
-  setValue(address + 3 * SIZE_OF_INT, cursor[3], 'i32');
 }
 
 function unmarshalTreeCursor(cursor) {
   cursor[0] = getValue(TRANSFER_BUFFER + 0 * SIZE_OF_INT, 'i32');
   cursor[1] = getValue(TRANSFER_BUFFER + 1 * SIZE_OF_INT, 'i32');
   cursor[2] = getValue(TRANSFER_BUFFER + 2 * SIZE_OF_INT, 'i32');
-  cursor[3] = getValue(TRANSFER_BUFFER + 3 * SIZE_OF_INT, 'i32');
 }
 
 function marshalPoint(address, point) {

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -105,7 +105,7 @@ typedef struct TSNode {
 typedef struct TSTreeCursor {
   const void *tree;
   const void *id;
-  uint32_t context[3];
+  uint32_t context[2];
 } TSTreeCursor;
 
 typedef struct TSQueryCapture {

--- a/lib/src/tree.c
+++ b/lib/src/tree.c
@@ -102,8 +102,8 @@ TSRange *ts_tree_included_ranges(const TSTree *self, uint32_t *length) {
 }
 
 TSRange *ts_tree_get_changed_ranges(const TSTree *old_tree, const TSTree *new_tree, uint32_t *length) {
-  TreeCursor cursor1 = {NULL, array_new(), 0};
-  TreeCursor cursor2 = {NULL, array_new(), 0};
+  TreeCursor cursor1 = {NULL, array_new()};
+  TreeCursor cursor2 = {NULL, array_new()};
   ts_tree_cursor_init(&cursor1, ts_tree_root_node(old_tree));
   ts_tree_cursor_init(&cursor2, ts_tree_root_node(new_tree));
 

--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -151,7 +151,7 @@ static inline bool ts_tree_cursor_child_iterator_previous(
 // TSTreeCursor - lifecycle
 
 TSTreeCursor ts_tree_cursor_new(TSNode node) {
-  TSTreeCursor self = {NULL, NULL, {0, 0, 0}};
+  TSTreeCursor self = {NULL, NULL, {0, 0}};
   ts_tree_cursor_init((TreeCursor *)&self, node);
   return self;
 }
@@ -162,7 +162,6 @@ void ts_tree_cursor_reset(TSTreeCursor *_self, TSNode node) {
 
 void ts_tree_cursor_init(TreeCursor *self, TSNode node) {
   self->tree = node.tree;
-  self->root_alias_symbol = node.context[3];
   array_clear(&self->stack);
   array_push(&self->stack, ((TreeCursorEntry) {
     .subtree = (const Subtree *)node.id,
@@ -475,7 +474,7 @@ uint32_t ts_tree_cursor_current_descendant_index(const TSTreeCursor *_self) {
 TSNode ts_tree_cursor_current_node(const TSTreeCursor *_self) {
   const TreeCursor *self = (const TreeCursor *)_self;
   TreeCursorEntry *last_entry = array_back(&self->stack);
-  TSSymbol alias_symbol = self->root_alias_symbol;
+  TSSymbol alias_symbol = 0;
   if (self->stack.size > 1 && !ts_subtree_extra(*last_entry->subtree)) {
     TreeCursorEntry *parent_entry = &self->stack.contents[self->stack.size - 2];
     alias_symbol = ts_language_alias_at(
@@ -698,7 +697,6 @@ TSTreeCursor ts_tree_cursor_copy(const TSTreeCursor *_cursor) {
   TSTreeCursor res = {NULL, NULL, {0, 0}};
   TreeCursor *copy = (TreeCursor *)&res;
   copy->tree = cursor->tree;
-  copy->root_alias_symbol = cursor->root_alias_symbol;
   array_init(&copy->stack);
   array_push_all(&copy->stack, &cursor->stack);
   return res;
@@ -708,7 +706,6 @@ void ts_tree_cursor_reset_to(TSTreeCursor *_dst, const TSTreeCursor *_src) {
   const TreeCursor *cursor = (const TreeCursor *)_src;
   TreeCursor *copy = (TreeCursor *)_dst;
   copy->tree = cursor->tree;
-  copy->root_alias_symbol = cursor->root_alias_symbol;
   array_clear(&copy->stack);
   array_push_all(&copy->stack, &cursor->stack);
 }

--- a/lib/src/tree_cursor.h
+++ b/lib/src/tree_cursor.h
@@ -14,7 +14,6 @@ typedef struct {
 typedef struct {
   const TSTree *tree;
   Array(TreeCursorEntry) stack;
-  TSSymbol root_alias_symbol;
 } TreeCursor;
 
 typedef enum {


### PR DESCRIPTION
This reverts commit 09d2b23a640c60449b2b55ecae47d6483da82c95.
Should be un-reverted in ABI 15 (0.24?).

Fixes #3296 