### PR TITLE
fix(rust): use unix/wasi instead of not windows for fd

### DIFF
--- a/lib/binding_rust/ffi.rs
+++ b/lib/binding_rust/ffi.rs
@@ -8,7 +8,7 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 #[cfg(not(feature = "bindgen"))]
 include!("./bindings.rs");
 
-#[cfg(not(windows))]
+#[cfg(any(unix, target_os = "wasi"))]
 extern "C" {
     pub(crate) fn _ts_dup(fd: std::os::raw::c_int) -> std::os::raw::c_int;
 }

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -3,7 +3,7 @@
 pub mod ffi;
 mod util;
 
-#[cfg(not(windows))]
+#[cfg(any(unix, target_os = "wasi"))]
 use std::os::fd::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawHandle;
@@ -533,10 +533,10 @@ impl Parser {
     #[doc(alias = "ts_parser_print_dot_graphs")]
     pub fn print_dot_graphs(
         &mut self,
-        #[cfg(not(windows))] file: &impl AsRawFd,
+        #[cfg(any(unix, target_os = "wasi"))] file: &impl AsRawFd,
         #[cfg(windows)] file: &impl AsRawHandle,
     ) {
-        #[cfg(not(windows))]
+        #[cfg(any(unix, target_os = "wasi"))]
         {
             let fd = file.as_raw_fd();
             unsafe {
@@ -942,10 +942,10 @@ impl Tree {
     #[doc(alias = "ts_tree_print_dot_graph")]
     pub fn print_dot_graph(
         &self,
-        #[cfg(not(windows))] file: &impl AsRawFd,
+        #[cfg(any(unix, target_os = "wasi"))] file: &impl AsRawFd,
         #[cfg(windows)] file: &impl AsRawHandle,
     ) {
-        #[cfg(not(windows))]
+        #[cfg(any(unix, target_os = "wasi"))]
         {
             let fd = file.as_raw_fd();
             unsafe { ffi::ts_tree_print_dot_graph(self.0.as_ptr(), fd) }


### PR DESCRIPTION
`not(windows)` includes non-wasi web assembly which causes issues when using the rust bindings from web non-wasi assembly.

In lib.rs, `AsRawFd` does not exist for wasm so it was causing the build to fail.

I also changed ffi.rs `_ts_dup` for consistency even though that does not cause a build issue.

This does lead to the situation where if you are not on either of those platforms, print_dot_graphs has no parameter to take a file. While odd, I think that does successfully convey that the current platform is not supported to use that function.