### PR TITLE
fix(rust): change dependencies version in README's instruction up-to-date & compilable

### DIFF
--- a/lib/binding_rust/README.md
+++ b/lib/binding_rust/README.md
@@ -28,14 +28,14 @@ Then, add a language as a dependency:
 
 ```toml
 [dependencies]
-tree-sitter = "0.21.0"
-tree-sitter-rust = "0.20.4"
+tree-sitter = "0.22"
+tree-sitter-rust = "0.21"
 ```
 
 To then use a language, you assign them to the parser.
 
 ```rust
-parser.set_language(tree_sitter_rust::language()).expect("Error loading Rust grammar");
+parser.set_language(&tree_sitter_rust::language()).expect("Error loading Rust grammar");
 ```
 
 Now you can parse source code:


### PR DESCRIPTION
Fixes #3306