### PR TITLE
Swap `\s` for `\\s` in documentation example

### DIFF
--- a/docs/section-2-using-parsers.md
+++ b/docs/section-2-using-parsers.md
@@ -706,7 +706,7 @@ Here's an example finding potential documentation comments in C
 
 ```scheme
 ((comment)+ @comment.documentation
-  (#match? @comment.documentation "^///\s+.*"))
+  (#match? @comment.documentation "^///\\s+.*"))
 ```
 
 Here's another example finding Cgo comments to potentially inject with C


### PR DESCRIPTION
As discussed in https://github.com/tree-sitter/tree-sitter/issues/3309#issuecomment-2067197293