### PR TITLE
fix(zig): make usable as a zig dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -12,5 +12,7 @@ pub fn build(b: *std.Build) void {
     lib.addIncludePath(.{ .path = "lib/include" });
     lib.addIncludePath(.{ .path = "lib/src" });
 
+    lib.installHeadersDirectory(b.path("lib/include"), ".", .{});
+
     b.installArtifact(lib);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,10 @@
+.{
+    .name = "tree-sitter",
+    .version = "0.22.5",
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "lib/src",
+        "lib/include",
+    },
+}


### PR DESCRIPTION
Make this usable as a dependency of a zig 0.12 project:

- build.zig.zon must exist to be used as a zig dependency
- public headers need to be installed as part of the artifact