### PR TITLE
fix: don't error out on missing/malformed tree-sitter fields when `--no-bindings` is passed in

### DIFF
--- a/cli/src/generate/grammar_files.rs
+++ b/cli/src/generate/grammar_files.rs
@@ -243,7 +243,11 @@ pub fn generate_grammar_files(
         },
     )?;
 
-    let (_, package_json) = lookup_package_json_for_path(package_json_path_state.as_path())?;
+    let package_json = match lookup_package_json_for_path(package_json_path_state.as_path()) {
+        Ok((_, p)) => p,
+        Err(e) if generate_bindings => return Err(e),
+        _ => return Ok(()),
+    };
 
     // Do not create a grammar.js file in a repo with multiple language configs
     if !package_json.has_multiple_language_configs() {


### PR DESCRIPTION
If `--no-bindings` is passed in, a default tree-sitter field doesn't get inserted, which can lead to build issues only in *this* case