### PR TITLE
Add nightly rustfmt to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: rustup toolchain install stable --profile minimal
+    - run: rustup toolchain install nightly --profile minimal
+    - run: rustup component add --toolchain nightly rustfmt
     - uses: Swatinem/rust-cache@v2
     - run: make lint
 

--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,11 @@ test_wasm:
 lint:
 	cargo update --workspace --locked --quiet
 	cargo check --workspace --all-targets
-	cargo fmt --all --check
+	cargo +nightly fmt --all --check
 	cargo clippy --workspace --all-targets -- -D warnings
 
 format:
-	cargo fmt --all
+	cargo +nightly fmt --all
 
 changelog:
 	@git-cliff --config script/cliff.toml --output CHANGELOG.md --latest --github-token $(shell gh auth token)


### PR DESCRIPTION
I noticed that invoking `rustfmt` from within my editor works as expected, but running `cargo fmt` from the command line leads to the following warnings:

```
Warning: can't set `wrap_comments = true`, unstable features are only available in nightly channel.
Warning: can't set `format_code_in_doc_comments = true`, unstable features are only available in nightly channel.
Warning: can't set `comment_width = 100`, unstable features are only available in nightly channel.
Warning: can't set `format_macro_matchers = true`, unstable features are only available in nightly channel.
....
Warning: can't set `format_macro_matchers = true`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
```

Running `cargo +nightly fmt` of course fixes this locally.

I then noticed that these same warnings appear on the CI runs, for example in the "Run make lint" step of [this workflow run](https://github.com/tree-sitter/tree-sitter/actions/runs/8905122927/job/24455355223#step:5:21). I did some testing within my fork and found that adding the changes in this PR fixes the issue, but I'm also not super familiar with Github workflows so I could also be missing something.