### PR TITLE
fix(cli): properly account for multi-grammar repos when using docker to build a wasm parser

### DIFF
--- a/cli/src/generate/grammar_files.rs
+++ b/cli/src/generate/grammar_files.rs
@@ -60,7 +60,7 @@ const PACKAGE_SWIFT_TEMPLATE: &str = include_str!("./templates/Package.swift");
 struct LanguageConfiguration {}
 
 #[derive(Deserialize, Debug)]
-struct PackageJSON {
+pub struct PackageJSON {
     #[serde(rename = "tree-sitter")]
     tree_sitter: Option<Vec<LanguageConfiguration>>,
 }
@@ -458,7 +458,7 @@ pub fn generate_grammar_files(
     Ok(())
 }
 
-fn lookup_package_json_for_path(path: &Path) -> Result<(PathBuf, PackageJSON)> {
+pub fn lookup_package_json_for_path(path: &Path) -> Result<(PathBuf, PackageJSON)> {
     let mut pathbuf = path.to_owned();
     loop {
         let package_json = pathbuf

--- a/cli/src/generate/mod.rs
+++ b/cli/src/generate/mod.rs
@@ -28,6 +28,8 @@ mod render;
 mod rules;
 mod tables;
 
+pub use grammar_files::lookup_package_json_for_path;
+
 lazy_static! {
     static ref JSON_COMMENT_REGEX: Regex = RegexBuilder::new("^\\s*//.*")
         .multi_line(true)

--- a/cli/src/wasm.rs
+++ b/cli/src/wasm.rs
@@ -33,6 +33,7 @@ pub fn get_grammar_name(language_dir: &Path) -> Result<String> {
 
 pub fn compile_language_to_wasm(
     loader: &Loader,
+    root_dir: Option<&Path>,
     language_dir: &Path,
     output_dir: &Path,
     output_file: Option<PathBuf>,
@@ -45,6 +46,7 @@ pub fn compile_language_to_wasm(
     let scanner_path = loader.get_scanner_path(&src_path);
     loader.compile_parser_to_wasm(
         &grammar_name,
+        root_dir,
         &src_path,
         scanner_path
             .as_ref()


### PR DESCRIPTION
- Closes #3233 
- Closes #3338