### PR TITLE
Support C99 (again, but for real this time!)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ OBJ := $(SRC:.c=.o)
 # define default flags, and override to append mandatory flags
 ARFLAGS := rcs
 CFLAGS ?= -O3 -Wall -Wextra -Wshadow -pedantic
-override CFLAGS += -std=c11 -fPIC -fvisibility=hidden
+override CFLAGS += -std=c99 -fPIC -fvisibility=hidden
 override CFLAGS += -Ilib/src -Ilib/src/wasm -Ilib/include
 
 # ABI versioning

--- a/Package.swift
+++ b/Package.swift
@@ -37,5 +37,5 @@ let package = Package(
                 ],
                 sources: ["src/lib.c"]),
     ],
-    cLanguageStandard: .c11
+    cLanguageStandard: .c99
 )

--- a/build.zig
+++ b/build.zig
@@ -8,7 +8,7 @@ pub fn build(b: *std.Build) void {
     });
 
     lib.linkLibC();
-    lib.addCSourceFile(.{ .file = .{ .path = "lib/src/lib.c" }, .flags = &.{"-std=c11"} });
+    lib.addCSourceFile(.{ .file = .{ .path = "lib/src/lib.c" }, .flags = &.{"-std=c99"} });
     lib.addIncludePath(.{ .path = "lib/include" });
     lib.addIncludePath(.{ .path = "lib/src" });
 

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -576,7 +576,7 @@ impl Loader {
                 cc_config.cpp(true);
                 eprintln!("Warning: Using a C++ scanner is now deprecated. Please migrate your scanner code to C, as C++ support will be removed in the near future.");
             } else {
-                cc_config.std("c11");
+                cc_config.std("c99");
             }
             cc_config.file(scanner_path);
         }

--- a/cli/src/generate/templates/Package.swift
+++ b/cli/src/generate/templates/Package.swift
@@ -43,5 +43,5 @@ let package = Package(
                 publicHeadersPath: "bindings/swift",
                 cSettings: [.headerSearchPath("src")])
     ],
-    cLanguageStandard: .c11
+    cLanguageStandard: .c99
 )

--- a/cli/src/generate/templates/binding.go
+++ b/cli/src/generate/templates/binding.go
@@ -1,6 +1,6 @@
 package tree_sitter_PARSER_NAME
 
-// #cgo CFLAGS: -std=c11 -fPIC
+// #cgo CFLAGS: -std=c99 -fPIC
 // #include "../../src/parser.c"
 // // NOTE: if your language has an external scanner, add it here.
 import "C"

--- a/cli/src/generate/templates/binding.gyp
+++ b/cli/src/generate/templates/binding.gyp
@@ -16,11 +16,11 @@
       "conditions": [
         ["OS!='win'", {
           "cflags_c": [
-            "-std=c11",
+            "-std=c99",
           ],
         }, { # OS == "win"
           "cflags_c": [
-            "/std:c11",
+            "/std:c99",
             "/utf-8",
           ],
         }],

--- a/cli/src/generate/templates/build.rs
+++ b/cli/src/generate/templates/build.rs
@@ -2,7 +2,7 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.std("c11").include(src_dir);
+    c_config.std("c99").include(src_dir);
 
     #[cfg(target_env = "msvc")]
     c_config.flag("-utf-8");

--- a/cli/src/generate/templates/makefile
+++ b/cli/src/generate/templates/makefile
@@ -34,7 +34,7 @@ OBJS := $(patsubst %.c,%.o,$(PARSER) $(EXTRAS))
 
 # flags
 ARFLAGS ?= rcs
-override CFLAGS += -I$(SRC_DIR) -std=c11 -fPIC
+override CFLAGS += -I$(SRC_DIR) -std=c99 -fPIC
 
 # OS-specific bits
 ifeq ($(OS),Windows_NT)

--- a/cli/src/generate/templates/setup.py
+++ b/cli/src/generate/templates/setup.py
@@ -39,9 +39,9 @@ setup(
                 # NOTE: if your language uses an external scanner, add it here.
             ],
             extra_compile_args=[
-                "-std=c11",
+                "-std=c99",
             ] if system() != "Windows" else [
-                "/std:c11",
+                "/std:c99",
                 "/utf-8",
             ],
             define_macros=[

--- a/lib/binding_rust/build.rs
+++ b/lib/binding_rust/build.rs
@@ -37,7 +37,7 @@ fn main() {
     }
 
     config
-        .flag_if_supported("-std=c11")
+        .flag_if_supported("-std=c99")
         .flag_if_supported("-fvisibility=hidden")
         .flag_if_supported("-Wshadow")
         .flag_if_supported("-Wno-unused-parameter")

--- a/lib/compile_flags.txt
+++ b/lib/compile_flags.txt
@@ -1,4 +1,4 @@
--std=c11
+-std=c99
 -Isrc/wasm
 -Iinclude
 -D TREE_SITTER_FEATURE_WASM

--- a/lib/src/get_changed_ranges.c
+++ b/lib/src/get_changed_ranges.c
@@ -160,7 +160,7 @@ static bool iterator_tree_is_visible(const Iterator *self) {
     Subtree parent = *self->cursor.stack.contents[self->cursor.stack.size - 2].subtree;
     return ts_language_alias_at(
       self->language,
-      parent.ptr->production_id,
+      parent.ptr->children_state.production_id,
       entry.structural_child_index
     ) != 0;
   }
@@ -187,7 +187,7 @@ static void iterator_get_visible_state(
       const Subtree *parent = self->cursor.stack.contents[i - 1].subtree;
       *alias_symbol = ts_language_alias_at(
         self->language,
-        parent->ptr->production_id,
+        parent->ptr->children_state.production_id,
         entry.structural_child_index
       );
     }

--- a/lib/src/get_changed_ranges.c
+++ b/lib/src/get_changed_ranges.c
@@ -160,7 +160,7 @@ static bool iterator_tree_is_visible(const Iterator *self) {
     Subtree parent = *self->cursor.stack.contents[self->cursor.stack.size - 2].subtree;
     return ts_language_alias_at(
       self->language,
-      parent.ptr->children_state.production_id,
+      parent.ptr->data.children_state.production_id,
       entry.structural_child_index
     ) != 0;
   }
@@ -187,7 +187,7 @@ static void iterator_get_visible_state(
       const Subtree *parent = self->cursor.stack.contents[i - 1].subtree;
       *alias_symbol = ts_language_alias_at(
         self->language,
-        parent->ptr->children_state.production_id,
+        parent->ptr->data.children_state.production_id,
         entry.structural_child_index
       );
     }

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -58,7 +58,7 @@ static inline NodeChildIterator ts_node_iterate_children(const TSNode *node) {
   }
   const TSSymbol *alias_sequence = ts_language_alias_sequence(
     node->tree->language,
-    subtree.ptr->children_state.production_id
+    subtree.ptr->data.children_state.production_id
   );
   return (NodeChildIterator) {
     .tree = node->tree,
@@ -124,9 +124,9 @@ static inline uint32_t ts_node__relevant_child_count(
   Subtree tree = ts_node__subtree(self);
   if (ts_subtree_child_count(tree) > 0) {
     if (include_anonymous) {
-      return tree.ptr->children_state.visible_child_count;
+      return tree.ptr->data.children_state.visible_child_count;
     } else {
-      return tree.ptr->children_state.named_child_count;
+      return tree.ptr->data.children_state.named_child_count;
     }
   } else {
     return 0;
@@ -551,7 +551,7 @@ recur:
   const TSFieldMapEntry *field_map, *field_map_end;
   ts_language_field_map(
     self.tree->language,
-    ts_node__subtree(self).ptr->children_state.production_id,
+    ts_node__subtree(self).ptr->data.children_state.production_id,
     &field_map,
     &field_map_end
   );
@@ -620,7 +620,7 @@ static inline const char *ts_node__field_name_from_language(TSNode self, uint32_
     const TSFieldMapEntry *field_map, *field_map_end;
     ts_language_field_map(
       self.tree->language,
-      ts_node__subtree(self).ptr->children_state.production_id,
+      ts_node__subtree(self).ptr->data.children_state.production_id,
       &field_map,
       &field_map_end
     );
@@ -690,7 +690,7 @@ TSNode ts_node_child_by_field_name(
 uint32_t ts_node_child_count(TSNode self) {
   Subtree tree = ts_node__subtree(self);
   if (ts_subtree_child_count(tree) > 0) {
-    return tree.ptr->children_state.visible_child_count;
+    return tree.ptr->data.children_state.visible_child_count;
   } else {
     return 0;
   }
@@ -699,7 +699,7 @@ uint32_t ts_node_child_count(TSNode self) {
 uint32_t ts_node_named_child_count(TSNode self) {
   Subtree tree = ts_node__subtree(self);
   if (ts_subtree_child_count(tree) > 0) {
-    return tree.ptr->children_state.named_child_count;
+    return tree.ptr->data.children_state.named_child_count;
   } else {
     return 0;
   }

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -58,7 +58,7 @@ static inline NodeChildIterator ts_node_iterate_children(const TSNode *node) {
   }
   const TSSymbol *alias_sequence = ts_language_alias_sequence(
     node->tree->language,
-    subtree.ptr->production_id
+    subtree.ptr->children_state.production_id
   );
   return (NodeChildIterator) {
     .tree = node->tree,
@@ -124,9 +124,9 @@ static inline uint32_t ts_node__relevant_child_count(
   Subtree tree = ts_node__subtree(self);
   if (ts_subtree_child_count(tree) > 0) {
     if (include_anonymous) {
-      return tree.ptr->visible_child_count;
+      return tree.ptr->children_state.visible_child_count;
     } else {
-      return tree.ptr->named_child_count;
+      return tree.ptr->children_state.named_child_count;
     }
   } else {
     return 0;
@@ -551,7 +551,7 @@ recur:
   const TSFieldMapEntry *field_map, *field_map_end;
   ts_language_field_map(
     self.tree->language,
-    ts_node__subtree(self).ptr->production_id,
+    ts_node__subtree(self).ptr->children_state.production_id,
     &field_map,
     &field_map_end
   );
@@ -620,7 +620,7 @@ static inline const char *ts_node__field_name_from_language(TSNode self, uint32_
     const TSFieldMapEntry *field_map, *field_map_end;
     ts_language_field_map(
       self.tree->language,
-      ts_node__subtree(self).ptr->production_id,
+      ts_node__subtree(self).ptr->children_state.production_id,
       &field_map,
       &field_map_end
     );
@@ -690,7 +690,7 @@ TSNode ts_node_child_by_field_name(
 uint32_t ts_node_child_count(TSNode self) {
   Subtree tree = ts_node__subtree(self);
   if (ts_subtree_child_count(tree) > 0) {
-    return tree.ptr->visible_child_count;
+    return tree.ptr->children_state.visible_child_count;
   } else {
     return 0;
   }
@@ -699,7 +699,7 @@ uint32_t ts_node_child_count(TSNode self) {
 uint32_t ts_node_named_child_count(TSNode self) {
   Subtree tree = ts_node__subtree(self);
   if (ts_subtree_child_count(tree) > 0) {
-    return tree.ptr->named_child_count;
+    return tree.ptr->children_state.named_child_count;
   } else {
     return 0;
   }

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -1,3 +1,5 @@
+#define _POSIX_C_SOURCE 200112L
+
 #include <time.h>
 #include <assert.h>
 #include <stdio.h>

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -413,8 +413,8 @@ static void ts_parser__external_scanner_deserialize(
   const char *data = NULL;
   uint32_t length = 0;
   if (external_token.ptr) {
-    data = ts_external_scanner_state_data(&external_token.ptr->external_scanner_state);
-    length = external_token.ptr->external_scanner_state.length;
+    data = ts_external_scanner_state_data(&external_token.ptr->data.external_scanner_state);
+    length = external_token.ptr->data.external_scanner_state.length;
   }
 
   if (ts_language_is_wasm(self->language)) {
@@ -674,7 +674,7 @@ static Subtree ts_parser__lex(
     if (found_external_token) {
       MutableSubtree mut_result = ts_subtree_to_mut_unsafe(result);
       ts_external_scanner_state_init(
-        &mut_result.ptr->external_scanner_state,
+        &mut_result.ptr->data.external_scanner_state,
         self->lexer.debug_buffer,
         external_scanner_state_len
       );
@@ -1008,7 +1008,7 @@ static StackVersion ts_parser__reduce(
     } else {
       parent.ptr->parse_state = state;
     }
-    parent.ptr->children_state.dynamic_precedence += dynamic_precedence;
+    parent.ptr->data.children_state.dynamic_precedence += dynamic_precedence;
 
     // Push the parent node onto the stack, along with any extra tokens that
     // were previously on top of the stack.
@@ -1058,7 +1058,7 @@ static void ts_parser__accept(
         root = ts_subtree_from_mut(ts_subtree_new_node(
           ts_subtree_symbol(tree),
           &trees,
-          tree.ptr->children_state.production_id,
+          tree.ptr->data.children_state.production_id,
           self->language
         ));
         ts_subtree_release(&self->tree_pool, tree);

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -1008,7 +1008,7 @@ static StackVersion ts_parser__reduce(
     } else {
       parent.ptr->parse_state = state;
     }
-    parent.ptr->dynamic_precedence += dynamic_precedence;
+    parent.ptr->children_state.dynamic_precedence += dynamic_precedence;
 
     // Push the parent node onto the stack, along with any extra tokens that
     // were previously on top of the stack.
@@ -1058,7 +1058,7 @@ static void ts_parser__accept(
         root = ts_subtree_from_mut(ts_subtree_new_node(
           ts_subtree_symbol(tree),
           &trees,
-          tree.ptr->production_id,
+          tree.ptr->children_state.production_id,
           self->language
         ));
         ts_subtree_release(&self->tree_pool, tree);

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -1,5 +1,3 @@
-#define _POSIX_C_SOURCE 200112L
-
 #include <time.h>
 #include <assert.h>
 #include <stdio.h>

--- a/lib/src/stack.c
+++ b/lib/src/stack.c
@@ -798,7 +798,7 @@ bool ts_stack_print_dot_graph(Stack *self, const TSLanguage *language, FILE *f) 
     }
 
     if (head->last_external_token.ptr) {
-      const ExternalScannerState *state = &head->last_external_token.ptr->external_scanner_state;
+      const ExternalScannerState *state = &head->last_external_token.ptr->data.external_scanner_state;
       const char *data = ts_external_scanner_state_data(state);
       fprintf(f, "\nexternal_scanner_state:");
       for (uint32_t j = 0; j < state->length; j++) fprintf(f, " %2X", data[j]);

--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -344,7 +344,7 @@ void ts_subtree_balance(Subtree self, SubtreePool *pool, const TSLanguage *langu
   while (pool->tree_stack.size > 0) {
     MutableSubtree tree = array_pop(&pool->tree_stack);
 
-    if (tree.ptr->repeat_depth > 0) {
+    if (tree.ptr->children_state.repeat_depth > 0) {
       Subtree child1 = ts_subtree_children(tree)[0];
       Subtree child2 = ts_subtree_children(tree)[tree.ptr->child_count - 1];
       long repeat_delta = (long)ts_subtree_repeat_depth(child1) - (long)ts_subtree_repeat_depth(child2);
@@ -373,18 +373,18 @@ void ts_subtree_summarize_children(
 ) {
   assert(!self.data.is_inline);
 
-  self.ptr->named_child_count = 0;
-  self.ptr->visible_child_count = 0;
+  self.ptr->children_state.named_child_count = 0;
+  self.ptr->children_state.visible_child_count = 0;
   self.ptr->error_cost = 0;
-  self.ptr->repeat_depth = 0;
-  self.ptr->visible_descendant_count = 0;
+  self.ptr->children_state.repeat_depth = 0;
+  self.ptr->children_state.visible_descendant_count = 0;
   self.ptr->has_external_tokens = false;
   self.ptr->depends_on_column = false;
   self.ptr->has_external_scanner_state_change = false;
-  self.ptr->dynamic_precedence = 0;
+  self.ptr->children_state.dynamic_precedence = 0;
 
   uint32_t structural_index = 0;
-  const TSSymbol *alias_sequence = ts_language_alias_sequence(language, self.ptr->production_id);
+  const TSSymbol *alias_sequence = ts_language_alias_sequence(language, self.ptr->children_state.production_id);
   uint32_t lookahead_end_byte = 0;
 
   const Subtree *children = ts_subtree_children(self);
@@ -430,27 +430,27 @@ void ts_subtree_summarize_children(
         if (ts_subtree_visible(child)) {
           self.ptr->error_cost += ERROR_COST_PER_SKIPPED_TREE;
         } else if (grandchild_count > 0) {
-          self.ptr->error_cost += ERROR_COST_PER_SKIPPED_TREE * child.ptr->visible_child_count;
+          self.ptr->error_cost += ERROR_COST_PER_SKIPPED_TREE * child.ptr->children_state.visible_child_count;
         }
       }
     }
 
-    self.ptr->dynamic_precedence += ts_subtree_dynamic_precedence(child);
-    self.ptr->visible_descendant_count += ts_subtree_visible_descendant_count(child);
+    self.ptr->children_state.dynamic_precedence += ts_subtree_dynamic_precedence(child);
+    self.ptr->children_state.visible_descendant_count += ts_subtree_visible_descendant_count(child);
 
     if (alias_sequence && alias_sequence[structural_index] != 0 && !ts_subtree_extra(child)) {
-      self.ptr->visible_descendant_count++;
-      self.ptr->visible_child_count++;
+      self.ptr->children_state.visible_descendant_count++;
+      self.ptr->children_state.visible_child_count++;
       if (ts_language_symbol_metadata(language, alias_sequence[structural_index]).named) {
-        self.ptr->named_child_count++;
+        self.ptr->children_state.named_child_count++;
       }
     } else if (ts_subtree_visible(child)) {
-      self.ptr->visible_descendant_count++;
-      self.ptr->visible_child_count++;
-      if (ts_subtree_named(child)) self.ptr->named_child_count++;
+      self.ptr->children_state.visible_descendant_count++;
+      self.ptr->children_state.visible_child_count++;
+      if (ts_subtree_named(child)) self.ptr->children_state.named_child_count++;
     } else if (grandchild_count > 0) {
-      self.ptr->visible_child_count += child.ptr->visible_child_count;
-      self.ptr->named_child_count += child.ptr->named_child_count;
+      self.ptr->children_state.visible_child_count += child.ptr->children_state.visible_child_count;
+      self.ptr->children_state.named_child_count += child.ptr->children_state.named_child_count;
     }
 
     if (ts_subtree_has_external_tokens(child)) self.ptr->has_external_tokens = true;
@@ -479,8 +479,8 @@ void ts_subtree_summarize_children(
     Subtree first_child = children[0];
     Subtree last_child = children[self.ptr->child_count - 1];
 
-    self.ptr->first_leaf.symbol = ts_subtree_leaf_symbol(first_child);
-    self.ptr->first_leaf.parse_state = ts_subtree_leaf_parse_state(first_child);
+    self.ptr->children_state.first_leaf.symbol = ts_subtree_leaf_symbol(first_child);
+    self.ptr->children_state.first_leaf.parse_state = ts_subtree_leaf_parse_state(first_child);
 
     if (ts_subtree_fragile_left(first_child)) self.ptr->fragile_left = true;
     if (ts_subtree_fragile_right(last_child)) self.ptr->fragile_right = true;
@@ -492,9 +492,9 @@ void ts_subtree_summarize_children(
       ts_subtree_symbol(first_child) == self.ptr->symbol
     ) {
       if (ts_subtree_repeat_depth(first_child) > ts_subtree_repeat_depth(last_child)) {
-        self.ptr->repeat_depth = ts_subtree_repeat_depth(first_child) + 1;
+        self.ptr->children_state.repeat_depth = ts_subtree_repeat_depth(first_child) + 1;
       } else {
-        self.ptr->repeat_depth = ts_subtree_repeat_depth(last_child) + 1;
+        self.ptr->children_state.repeat_depth = ts_subtree_repeat_depth(last_child) + 1;
       }
     }
   }
@@ -902,11 +902,11 @@ static size_t ts_subtree__write_to_string(
   }
 
   if (ts_subtree_child_count(self)) {
-    const TSSymbol *alias_sequence = ts_language_alias_sequence(language, self.ptr->production_id);
+    const TSSymbol *alias_sequence = ts_language_alias_sequence(language, self.ptr->children_state.production_id);
     const TSFieldMapEntry *field_map, *field_map_end;
     ts_language_field_map(
       language,
-      self.ptr->production_id,
+      self.ptr->children_state.production_id,
       &field_map,
       &field_map_end
     );

--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -26,34 +26,34 @@ typedef struct {
 
 void ts_external_scanner_state_init(ExternalScannerState *self, const char *data, unsigned length) {
   self->length = length;
-  if (length > sizeof(self->short_data)) {
-    self->long_data = ts_malloc(length);
-    memcpy(self->long_data, data, length);
+  if (length > sizeof(self->state.short_data)) {
+    self->state.long_data = ts_malloc(length);
+    memcpy(self->state.long_data, data, length);
   } else {
-    memcpy(self->short_data, data, length);
+    memcpy(self->state.short_data, data, length);
   }
 }
 
 ExternalScannerState ts_external_scanner_state_copy(const ExternalScannerState *self) {
   ExternalScannerState result = *self;
-  if (self->length > sizeof(self->short_data)) {
-    result.long_data = ts_malloc(self->length);
-    memcpy(result.long_data, self->long_data, self->length);
+  if (self->length > sizeof(self->state.short_data)) {
+    result.state.long_data = ts_malloc(self->length);
+    memcpy(result.state.long_data, self->state.long_data, self->length);
   }
   return result;
 }
 
 void ts_external_scanner_state_delete(ExternalScannerState *self) {
-  if (self->length > sizeof(self->short_data)) {
-    ts_free(self->long_data);
+  if (self->length > sizeof(self->state.short_data)) {
+    ts_free(self->state.long_data);
   }
 }
 
 const char *ts_external_scanner_state_data(const ExternalScannerState *self) {
-  if (self->length > sizeof(self->short_data)) {
-    return self->long_data;
+  if (self->length > sizeof(self->state.short_data)) {
+    return self->state.long_data;
   } else {
-    return self->short_data;
+    return self->state.short_data;
   }
 }
 

--- a/lib/src/subtree.h
+++ b/lib/src/subtree.h
@@ -32,7 +32,7 @@ typedef struct {
   union {
     char *long_data;
     char short_data[24];
-  };
+  } state;
   uint32_t length;
 } ExternalScannerState;
 

--- a/lib/src/subtree.h
+++ b/lib/src/subtree.h
@@ -143,7 +143,7 @@ typedef struct {
         TSSymbol symbol;
         TSStateId parse_state;
       } first_leaf;
-    };
+    } children_state;
 
     // External terminal subtrees (`child_count == 0 && has_external_tokens`)
     ExternalScannerState external_scanner_state;
@@ -248,13 +248,13 @@ static inline void ts_subtree_set_extra(MutableSubtree *self, bool is_extra) {
 static inline TSSymbol ts_subtree_leaf_symbol(Subtree self) {
   if (self.data.is_inline) return self.data.symbol;
   if (self.ptr->child_count == 0) return self.ptr->symbol;
-  return self.ptr->first_leaf.symbol;
+  return self.ptr->children_state.first_leaf.symbol;
 }
 
 static inline TSStateId ts_subtree_leaf_parse_state(Subtree self) {
   if (self.data.is_inline) return self.data.parse_state;
   if (self.ptr->child_count == 0) return self.ptr->parse_state;
-  return self.ptr->first_leaf.parse_state;
+  return self.ptr->children_state.first_leaf.parse_state;
 }
 
 static inline Length ts_subtree_padding(Subtree self) {
@@ -288,7 +288,7 @@ static inline uint32_t ts_subtree_child_count(Subtree self) {
 }
 
 static inline uint32_t ts_subtree_repeat_depth(Subtree self) {
-  return self.data.is_inline ? 0 : self.ptr->repeat_depth;
+  return self.data.is_inline ? 0 : self.ptr->children_state.repeat_depth;
 }
 
 static inline uint32_t ts_subtree_is_repetition(Subtree self) {
@@ -300,12 +300,12 @@ static inline uint32_t ts_subtree_is_repetition(Subtree self) {
 static inline uint32_t ts_subtree_visible_descendant_count(Subtree self) {
   return (self.data.is_inline || self.ptr->child_count == 0)
     ? 0
-    : self.ptr->visible_descendant_count;
+    : self.ptr->children_state.visible_descendant_count;
 }
 
 static inline uint32_t ts_subtree_visible_child_count(Subtree self) {
   if (ts_subtree_child_count(self) > 0) {
-    return self.ptr->visible_child_count;
+    return self.ptr->children_state.visible_child_count;
   } else {
     return 0;
   }
@@ -320,12 +320,12 @@ static inline uint32_t ts_subtree_error_cost(Subtree self) {
 }
 
 static inline int32_t ts_subtree_dynamic_precedence(Subtree self) {
-  return (self.data.is_inline || self.ptr->child_count == 0) ? 0 : self.ptr->dynamic_precedence;
+  return (self.data.is_inline || self.ptr->child_count == 0) ? 0 : self.ptr->children_state.dynamic_precedence;
 }
 
 static inline uint16_t ts_subtree_production_id(Subtree self) {
   if (ts_subtree_child_count(self) > 0) {
-    return self.ptr->production_id;
+    return self.ptr->children_state.production_id;
   } else {
     return 0;
   }

--- a/lib/src/subtree.h
+++ b/lib/src/subtree.h
@@ -150,7 +150,7 @@ typedef struct {
 
     // Error terminal subtrees (`child_count == 0 && symbol == ts_builtin_sym_error`)
     int32_t lookahead_char;
-  };
+  } data;
 } SubtreeHeapData;
 
 // The fundamental building block of a syntax tree.
@@ -248,13 +248,13 @@ static inline void ts_subtree_set_extra(MutableSubtree *self, bool is_extra) {
 static inline TSSymbol ts_subtree_leaf_symbol(Subtree self) {
   if (self.data.is_inline) return self.data.symbol;
   if (self.ptr->child_count == 0) return self.ptr->symbol;
-  return self.ptr->children_state.first_leaf.symbol;
+  return self.ptr->data.children_state.first_leaf.symbol;
 }
 
 static inline TSStateId ts_subtree_leaf_parse_state(Subtree self) {
   if (self.data.is_inline) return self.data.parse_state;
   if (self.ptr->child_count == 0) return self.ptr->parse_state;
-  return self.ptr->children_state.first_leaf.parse_state;
+  return self.ptr->data.children_state.first_leaf.parse_state;
 }
 
 static inline Length ts_subtree_padding(Subtree self) {
@@ -288,7 +288,7 @@ static inline uint32_t ts_subtree_child_count(Subtree self) {
 }
 
 static inline uint32_t ts_subtree_repeat_depth(Subtree self) {
-  return self.data.is_inline ? 0 : self.ptr->children_state.repeat_depth;
+  return self.data.is_inline ? 0 : self.ptr->data.children_state.repeat_depth;
 }
 
 static inline uint32_t ts_subtree_is_repetition(Subtree self) {
@@ -300,12 +300,12 @@ static inline uint32_t ts_subtree_is_repetition(Subtree self) {
 static inline uint32_t ts_subtree_visible_descendant_count(Subtree self) {
   return (self.data.is_inline || self.ptr->child_count == 0)
     ? 0
-    : self.ptr->children_state.visible_descendant_count;
+    : self.ptr->data.children_state.visible_descendant_count;
 }
 
 static inline uint32_t ts_subtree_visible_child_count(Subtree self) {
   if (ts_subtree_child_count(self) > 0) {
-    return self.ptr->children_state.visible_child_count;
+    return self.ptr->data.children_state.visible_child_count;
   } else {
     return 0;
   }
@@ -320,12 +320,12 @@ static inline uint32_t ts_subtree_error_cost(Subtree self) {
 }
 
 static inline int32_t ts_subtree_dynamic_precedence(Subtree self) {
-  return (self.data.is_inline || self.ptr->child_count == 0) ? 0 : self.ptr->children_state.dynamic_precedence;
+  return (self.data.is_inline || self.ptr->child_count == 0) ? 0 : self.ptr->data.children_state.dynamic_precedence;
 }
 
 static inline uint16_t ts_subtree_production_id(Subtree self) {
   if (ts_subtree_child_count(self) > 0) {
-    return self.ptr->children_state.production_id;
+    return self.ptr->data.children_state.production_id;
   } else {
     return 0;
   }

--- a/lib/src/tree.c
+++ b/lib/src/tree.c
@@ -1,3 +1,5 @@
+#define _POSIX_C_SOURCE 200112L
+
 #include "tree_sitter/api.h"
 #include "./array.h"
 #include "./get_changed_ranges.h"

--- a/lib/src/tree.c
+++ b/lib/src/tree.c
@@ -1,5 +1,3 @@
-#define _POSIX_C_SOURCE 200112L
-
 #include "tree_sitter/api.h"
 #include "./array.h"
 #include "./get_changed_ranges.h"

--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -24,7 +24,7 @@ static inline bool ts_tree_cursor_is_entry_visible(const TreeCursor *self, uint3
     TreeCursorEntry *parent_entry = &self->stack.contents[index - 1];
     return ts_language_alias_at(
       self->tree->language,
-      parent_entry->subtree->ptr->children_state.production_id,
+      parent_entry->subtree->ptr->data.children_state.production_id,
       entry->structural_child_index
     );
   } else {
@@ -39,7 +39,7 @@ static inline CursorChildIterator ts_tree_cursor_iterate_children(const TreeCurs
   }
   const TSSymbol *alias_sequence = ts_language_alias_sequence(
     self->tree->language,
-    last_entry->subtree->ptr->children_state.production_id
+    last_entry->subtree->ptr->data.children_state.production_id
   );
 
   uint32_t descendant_index = last_entry->descendant_index;
@@ -480,7 +480,7 @@ TSNode ts_tree_cursor_current_node(const TSTreeCursor *_self) {
     TreeCursorEntry *parent_entry = &self->stack.contents[self->stack.size - 2];
     alias_symbol = ts_language_alias_at(
       self->tree->language,
-      parent_entry->subtree->ptr->children_state.production_id,
+      parent_entry->subtree->ptr->data.children_state.production_id,
       last_entry->structural_child_index
     );
   }
@@ -519,7 +519,7 @@ void ts_tree_cursor_current_status(
 
     const TSSymbol *alias_sequence = ts_language_alias_sequence(
       self->tree->language,
-      parent_entry->subtree->ptr->children_state.production_id
+      parent_entry->subtree->ptr->data.children_state.production_id
     );
 
     #define subtree_symbol(subtree, structural_child_index) \
@@ -569,7 +569,7 @@ void ts_tree_cursor_current_status(
         } else if (ts_subtree_visible_child_count(sibling) > 0) {
           *has_later_siblings = true;
           if (*has_later_named_siblings) break;
-          if (sibling.ptr->children_state.named_child_count > 0) {
+          if (sibling.ptr->data.children_state.named_child_count > 0) {
             *has_later_named_siblings = true;
             break;
           }
@@ -584,7 +584,7 @@ void ts_tree_cursor_current_status(
       const TSFieldMapEntry *field_map, *field_map_end;
       ts_language_field_map(
         self->tree->language,
-        parent_entry->subtree->ptr->children_state.production_id,
+        parent_entry->subtree->ptr->data.children_state.production_id,
         &field_map, &field_map_end
       );
 
@@ -635,7 +635,7 @@ TSNode ts_tree_cursor_parent_node(const TSTreeCursor *_self) {
       TreeCursorEntry *parent_entry = &self->stack.contents[i - 1];
       alias_symbol = ts_language_alias_at(
         self->tree->language,
-        parent_entry->subtree->ptr->children_state.production_id,
+        parent_entry->subtree->ptr->data.children_state.production_id,
         entry->structural_child_index
       );
       is_visible = (alias_symbol != 0) || ts_subtree_visible(*entry->subtree);
@@ -671,7 +671,7 @@ TSFieldId ts_tree_cursor_current_field_id(const TSTreeCursor *_self) {
     const TSFieldMapEntry *field_map, *field_map_end;
     ts_language_field_map(
       self->tree->language,
-      parent_entry->subtree->ptr->children_state.production_id,
+      parent_entry->subtree->ptr->data.children_state.production_id,
       &field_map, &field_map_end
     );
     for (const TSFieldMapEntry *map = field_map; map < field_map_end; map++) {

--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -24,7 +24,7 @@ static inline bool ts_tree_cursor_is_entry_visible(const TreeCursor *self, uint3
     TreeCursorEntry *parent_entry = &self->stack.contents[index - 1];
     return ts_language_alias_at(
       self->tree->language,
-      parent_entry->subtree->ptr->production_id,
+      parent_entry->subtree->ptr->children_state.production_id,
       entry->structural_child_index
     );
   } else {
@@ -39,7 +39,7 @@ static inline CursorChildIterator ts_tree_cursor_iterate_children(const TreeCurs
   }
   const TSSymbol *alias_sequence = ts_language_alias_sequence(
     self->tree->language,
-    last_entry->subtree->ptr->production_id
+    last_entry->subtree->ptr->children_state.production_id
   );
 
   uint32_t descendant_index = last_entry->descendant_index;
@@ -480,7 +480,7 @@ TSNode ts_tree_cursor_current_node(const TSTreeCursor *_self) {
     TreeCursorEntry *parent_entry = &self->stack.contents[self->stack.size - 2];
     alias_symbol = ts_language_alias_at(
       self->tree->language,
-      parent_entry->subtree->ptr->production_id,
+      parent_entry->subtree->ptr->children_state.production_id,
       last_entry->structural_child_index
     );
   }
@@ -519,7 +519,7 @@ void ts_tree_cursor_current_status(
 
     const TSSymbol *alias_sequence = ts_language_alias_sequence(
       self->tree->language,
-      parent_entry->subtree->ptr->production_id
+      parent_entry->subtree->ptr->children_state.production_id
     );
 
     #define subtree_symbol(subtree, structural_child_index) \
@@ -569,7 +569,7 @@ void ts_tree_cursor_current_status(
         } else if (ts_subtree_visible_child_count(sibling) > 0) {
           *has_later_siblings = true;
           if (*has_later_named_siblings) break;
-          if (sibling.ptr->named_child_count > 0) {
+          if (sibling.ptr->children_state.named_child_count > 0) {
             *has_later_named_siblings = true;
             break;
           }
@@ -584,7 +584,7 @@ void ts_tree_cursor_current_status(
       const TSFieldMapEntry *field_map, *field_map_end;
       ts_language_field_map(
         self->tree->language,
-        parent_entry->subtree->ptr->production_id,
+        parent_entry->subtree->ptr->children_state.production_id,
         &field_map, &field_map_end
       );
 
@@ -635,7 +635,7 @@ TSNode ts_tree_cursor_parent_node(const TSTreeCursor *_self) {
       TreeCursorEntry *parent_entry = &self->stack.contents[i - 1];
       alias_symbol = ts_language_alias_at(
         self->tree->language,
-        parent_entry->subtree->ptr->production_id,
+        parent_entry->subtree->ptr->children_state.production_id,
         entry->structural_child_index
       );
       is_visible = (alias_symbol != 0) || ts_subtree_visible(*entry->subtree);
@@ -671,7 +671,7 @@ TSFieldId ts_tree_cursor_current_field_id(const TSTreeCursor *_self) {
     const TSFieldMapEntry *field_map, *field_map_end;
     ts_language_field_map(
       self->tree->language,
-      parent_entry->subtree->ptr->production_id,
+      parent_entry->subtree->ptr->children_state.production_id,
       &field_map, &field_map_end
     );
     for (const TSFieldMapEntry *map = field_map; map < field_map_end; map++) {

--- a/script/build-fuzzers
+++ b/script/build-fuzzers
@@ -42,7 +42,7 @@ for lang in ${languages[@]}; do
     $CXX $CXXFLAGS -g -O1 "-I${lang_dir}/src" -c "${lang_scanner}.cc" -o "${lang_scanner}.o"
     objects+=("${lang_scanner}.o")
   elif [ -e "${lang_scanner}.c" ]; then
-    $CC $CFLAGS -std=c11 -g -O1 "-I${lang_dir}/src" -c "${lang_scanner}.c" -o "${lang_scanner}.o"
+    $CC $CFLAGS -std=c99 -g -O1 "-I${lang_dir}/src" -c "${lang_scanner}.c" -o "${lang_scanner}.o"
     objects+=("${lang_scanner}.o")
   fi
 

--- a/script/build-wasm
+++ b/script/build-wasm
@@ -122,7 +122,7 @@ $emcc                                            \
   -s EXPORTED_RUNTIME_METHODS=$runtime_methods   \
   $emscripten_flags                              \
   -fno-exceptions                                \
-  -std=c11                                       \
+  -std=c99                                       \
   -D 'fprintf(...)='                             \
   -D NDEBUG=                                     \
   -I ${src_dir}                                  \


### PR DESCRIPTION
In https://github.com/tree-sitter/tree-sitter/pull/3088, there was a move to C11 over (officially) supporting C99.

I'd like to test the waters to see if there is some flexibility there, and make a request to more officially support C99 instead. If this is not something you are willing to consider, that's totally fine, but it didn't seem _too_ complicated to make it so that tree-sitter can compile with C99.

According to https://github.com/tree-sitter/tree-sitter/pull/2965#issuecomment-1934843618, there was some desire to "keep" tree-sitter C99 compliant, but in reality it hasn't been for awhile due to the usage of anonymous structs and unions, which was surfaced with the usage of `-pedantic` there.

This PR first has 3 commits that _name_ these anonymous structs and unions:
- A `state` union inside `ExternalScannerState`, which seemed to make sense as a name
- A `children_state` struct within a union, which I do think actually makes things more clear at its calls sites, because it is often guarded by something like `if (child_count > 0)`
- A `data` union inside `SubtreeHeapData`, which is actually what `children_state` lives in. This name goes along with the fact that you use `data` as a name in the inline case, i.e. typically something like `if (inlined) self->data else self->ptr->data`.

I will be the first to admit, having to name these structs and unions does make the code a little uglier because of the added indirection. But it might be worth this little bit of code style pain for C99 support.

The commits after those:
- Update everything from `std=c11` to `std=c99` everywhere I could find
- Removes some usages of `#define _POSIX_C_SOURCE 200112L`, added in https://github.com/tree-sitter/tree-sitter/pull/3088. Note that was using the 2001 standard, not 2011, so I'm not entirely sure if that commit was necessary in that PR. There is one other call to this in `lib.c` related to https://github.com/tree-sitter/tree-sitter/pull/295, which I left in place. (Update: Turns out this is required for `fdopen()` support in non-amalgamated builds, presumably where you didn't go through `lib.c` so you don't have `_POSIX_C_SOURCE` defined yet. I guess in theory you _only_ need to put `_POSIX_C_SOURCE` in the individual files where it is required rather than in `lib.c` itself, but I didn't touch that.)

---

My motivation for this is that I am working on wrapping tree-sitter in an R package, and R's history with C99 is a big gnarly. R is currently at R 4.4.0 (released a month ago). Only as of R 4.3.0 (last year) did package authors gain a way to specify the C std version with `USE_Cxx` here:
https://github.com/wch/r-source/blob/bacd56452465bd7fd95839c3e5dd1adf21be4de6/doc/NEWS.Rd#L1572-L1604

Additionally at that time, there was a change in R on Windows to allow the default C compiler to be used (typically C17), rather than always defaulting to C99. For Mac and Linux, it was already doing this:
https://github.com/wch/r-source/blob/bacd56452465bd7fd95839c3e5dd1adf21be4de6/doc/NEWS.Rd#L1545-L1548

Unfortunately, we typically try to support 5 minor versions of R, back to R 4.0.0 right now, so C99 support is actually still pretty important for us 😞 (R users are typically pretty slow to update their R version), which is what leads me here to see if tree-sitter can be tweaked for C99 support!