### PR TITLE
Add some useful doc comments about node ids

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1493,10 +1493,14 @@ impl<'tree> Node<'tree> {
 
     /// Get a numeric id for this node that is unique.
     ///
-    /// Within a given syntax tree, no two nodes have the same id. However, if
-    /// a new tree is created based on an older tree, and a node from the old
-    /// tree is reused in the process, then that node will have the same id in
-    /// both trees.
+    /// Within a given syntax tree, no two nodes have the same id. However:
+    ///
+    /// - If a new tree is created based on an older tree, and a node from the old tree is reused in
+    ///   the process, then that node will have the same id in both trees.
+    ///
+    /// - A node not marked as having changes does not guarantee it was reused.
+    ///
+    /// - If a node is marked as having changed in the old tree, it will not be reused.
     #[must_use]
     pub fn id(&self) -> usize {
         self.0.id as usize


### PR DESCRIPTION
Hi! I'm currently using `tree-sitter` to power a plain-text presentation program I'm making, which has a Language Server integration. As a user is editing, I tried to associate slides with the `Node` IDs they corresponded to, that way I could easily update a slideshow preview on every keystroke

```
---------------- node id
{
    Title: ViewBox[0]^^..,
    Subtitle: ViewBox[1]__..,
}[]
----------------

---------------- node id
{
    Title: ViewBox[0]^^|,
    Subtitle: ViewBox[1]__|,
    NewText: Size[0]__..,
}[]
----------------
```

I found that this didn't work as expected, but it did work when I took the `Node` ID of a specific token within each slide, in my case, the first bracket

```
---------------- node id
{
----------------
    Title: ViewBox[0]^^..,
    Subtitle: ViewBox[1]__..,
}[]

---------------- node id
{
----------------
    Title: ViewBox[0]^^|,
    Subtitle: ViewBox[1]__|,
    NewText: Size[0]__..,
}[]
```

I was under the impression that if a Node was not marked as having changed, that it would always be reused. I found that this was not the case, and added some doc comments to the `id()` function under the `Node` struct. If there's anywhere else this information should go, I'll update this PR and put it there too. `tree-sitter` has been such an amazing tool to use, and integrate into everything I'm doing, and I can't thank y'all enough for making it :smile: 