### PR TITLE
fix(lib): a null clock must have `tv_nsec` be 0 as well

### DIFF
--- a/lib/src/clock.h
+++ b/lib/src/clock.h
@@ -91,7 +91,7 @@ static inline TSClock clock_after(TSClock base, TSDuration duration) {
 }
 
 static inline bool clock_is_null(TSClock self) {
-  return !self.tv_sec;
+  return !self.tv_sec && !self.tv_nsec;
 }
 
 static inline bool clock_is_gt(TSClock self, TSClock other) {


### PR DESCRIPTION
Closes #3341 

In a WASM environment, it seems like calling `clock_gettime` with `CLOCK_MONOTONIC` gives us a really small time at first; it could be related to when the program starts, I'm not sure. The problem is our check for `clock_is_null` only checks if `tv_sec` is 0, and when we first set `end_clock`, it is set to a value where `tv_sec` is 0, and `tv_nsec` is some large number, around 0.05-0.1s in my testing. So we should also check for `tv_nsec` being non-zero before assuming a clock is null/none.