### PR TITLE
Bump prebuildify version to fix breaking change on windows

### DIFF
--- a/cli/src/generate/grammar_files.rs
+++ b/cli/src/generate/grammar_files.rs
@@ -142,7 +142,7 @@ pub fn generate_grammar_files(
                     .unwrap();
                 if !dev_dependencies.contains_key("prebuildify") {
                     eprintln!("Adding prebuildify devDependency to package.json");
-                    dev_dependencies.insert("prebuildify".to_string(), "^6.0.0".into());
+                    dev_dependencies.insert("prebuildify".to_string(), "^6.0.1".into());
                     updated = true;
                 }
 

--- a/cli/src/generate/templates/package.json
+++ b/cli/src/generate/templates/package.json
@@ -25,7 +25,7 @@
     "node-gyp-build": "^4.8.0"
   },
   "devDependencies": {
-    "prebuildify": "^6.0.0",
+    "prebuildify": "^6.0.1",
     "tree-sitter-cli": "^CLI_VERSION"
   },
   "peerDependencies": {


### PR DESCRIPTION
[This](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high) recent node.js security fix causes prebuildify 6.0.0 to fail when running on windows. It will have the following error message:
```
Run npm x -- prebuildify --strip --arch x64
node:internal/child_process:414
    throw errnoException(err, 'spawn');
    ^

Error: spawn EINVAL
    at ChildProcess.spawn (node:internal/child_process:414:11)
    at Object.spawn (node:child_process:761:9)
    at D:\a\tree-sitter-tlaplus\tree-sitter-tlaplus\node_modules\prebuildify\index.js:230:22
    at D:\a\tree-sitter-tlaplus\tree-sitter-tlaplus\node_modules\mkdirp-classic\index.js:30:20
    at FSReqCallback.oncomplete (node:fs:192:23) {
  errno: -4071,
  code: 'EINVAL',
  syscall: 'spawn'
}

Node.js v18.20.2
```