### PR TITLE
Don't minify JavaScript

### DIFF
--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -31,7 +31,6 @@
     "chai": "^4.3.7",
     "eslint": ">=8.56.0",
     "eslint-config-google": "^0.14.0",
-    "mocha": "^10.2.0",
-    "terser": "^5.16.6"
+    "mocha": "^10.2.0"
   }
 }

--- a/script/build-wasm
+++ b/script/build-wasm
@@ -33,15 +33,13 @@ WEB_DIR=lib/binding_web
 SRC_DIR=lib/src
 EMSCRIPTEN_VERSION=$(< cli/loader/emscripten-version)
 
-minify_js=1
 force_docker=0
-emscripten_flags=(-O3)
+emscripten_flags=(-O3 --minify 0)
 
 while (($# > 0)); do
   case "$1" in
     --debug)
-      minify_js=0
-      emscripten_flags=(-s ASSERTIONS=1 -s SAFE_HEAP=1 -O0)
+      emscripten_flags=(-s ASSERTIONS=1 -s SAFE_HEAP=1 -O0 -g)
       ;;
 
     --help)
@@ -137,20 +135,5 @@ $emcc                                            \
   ${WEB_DIR}/binding.c                           \
   -o target/scratch/tree-sitter.js
 
-# Use terser to write a minified version of `tree-sitter.js` into
-# the `lib/binding_web` directory.
-if [[ $minify_js == 1 ]]; then
-  if [[ ! -d ${WEB_DIR}/node_modules/terser ]]; then
-    (cd ${WEB_DIR} && npm install)
-  fi
-  ${WEB_DIR}/node_modules/.bin/terser   \
-    --compress                          \
-    --mangle                            \
-    --keep-classnames                   \
-    -- target/scratch/tree-sitter.js    \
-    > ${WEB_DIR}/tree-sitter.js
-else
-  cp target/scratch/tree-sitter.js ${WEB_DIR}/tree-sitter.js
-fi
-
+mv target/scratch/tree-sitter.js ${WEB_DIR}/tree-sitter.js
 mv target/scratch/tree-sitter.wasm ${WEB_DIR}/tree-sitter.wasm

--- a/script/build-wasm
+++ b/script/build-wasm
@@ -33,6 +33,7 @@ WEB_DIR=lib/binding_web
 SRC_DIR=lib/src
 EMSCRIPTEN_VERSION=$(< cli/loader/emscripten-version)
 
+verbose=0
 force_docker=0
 emscripten_flags=(-O3 --minify 0)
 
@@ -52,7 +53,7 @@ while (($# > 0)); do
       ;;
 
     -v|--verbose)
-      emscripten_flags+=(-s VERBOSE=1 -v)
+      verbose=1
       ;;
 
     *)
@@ -63,6 +64,10 @@ while (($# > 0)); do
   esac
   shift
 done
+
+if [[ $verbose == 1 ]]; then
+  emscripten_flags+=(-s VERBOSE=1 -v)
+fi
 
 emcc=
 docker=


### PR DESCRIPTION
The difference is 74KB (or 91KB without the terser step because -O3 already does minification https://github.com/emscripten-core/emscripten/issues/7916 ) vs 121KB. Users can minify their JavaScript themselves if they want to.

Fixes #3379