### PR TITLE
Attach helpful context to `load_language_at_path`

### DIFF
--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -417,14 +417,14 @@ impl Loader {
         }
         let mut grammar_file = fs::File::open(grammar_path.clone()).with_context(|| {
             format!(
-                "Failed to read grammar.json file at the following path: {:?}",
+                "Failed to read grammar.json file at the following path:\n{:?}",
                 &grammar_path
             )
         })?;
         let grammar_json: GrammarJSON = serde_json::from_reader(BufReader::new(&mut grammar_file))
             .with_context(|| {
                 format!(
-                    "Failed to parse grammar.json file at the following path: {:?}",
+                    "Failed to parse grammar.json file at the following path:\n{:?}",
                     &grammar_path
                 )
             })?;

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -415,10 +415,19 @@ impl Loader {
         struct GrammarJSON {
             name: String,
         }
-        let mut grammar_file =
-            fs::File::open(grammar_path).with_context(|| "Failed to read grammar.json")?;
+        let mut grammar_file = fs::File::open(grammar_path.clone()).with_context(|| {
+            format!(
+                "Failed to read grammar.json file at the following path: {:?}",
+                &grammar_path
+            )
+        })?;
         let grammar_json: GrammarJSON = serde_json::from_reader(BufReader::new(&mut grammar_file))
-            .with_context(|| "Failed to parse grammar.json")?;
+            .with_context(|| {
+                format!(
+                    "Failed to parse grammar.json file at the following path: {:?}",
+                    &grammar_path
+                )
+            })?;
 
         config.name = grammar_json.name;
 

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -415,7 +415,7 @@ impl Loader {
         struct GrammarJSON {
             name: String,
         }
-        let mut grammar_file = fs::File::open(grammar_path.clone()).with_context(|| {
+        let mut grammar_file = fs::File::open(&grammar_path).with_context(|| {
             format!(
                 "Failed to read grammar.json file at the following path:\n{:?}",
                 &grammar_path


### PR DESCRIPTION
This will make the error messages of loader more helpful.

Before:

```sh
called `Result::unwrap()` on an `Err` value: Failed to read grammar.json

Caused by:
    No such file or directory (os error 2)
```

After:

```sh
called `Result::unwrap()` on an `Err` value: Failed to read grammar.json file at the following path: "/home/xxx/repos/tree-sitter-sal/src/src/grammar.json"

Caused by:
    No such file or directory (os error 2)
```