### PR TITLE
build(zig): Git ignore updated Zig cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ log*.html
 *.xcodeproj
 .vscode
 .cache
+.zig-cache
 
 fuzz-results
 


### PR DESCRIPTION
Recent versions of Zig have renamed the previously used `zig-cache` directory to `.zig-cache`. While `zig-out` and `zig-cache` were covered by the previous `.gitignore`, the new `.zig-cache` also should be handled. 