### PR TITLE
Use tabs only in recipes so as to avoid confusing 'make'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@ PCLIBDIR ?= $(LIBDIR)/pkgconfig
 
 # collect sources
 ifneq ($(AMALGAMATED),1)
-	SRC := $(wildcard lib/src/*.c)
-	# do not double-include amalgamation
-	SRC := $(filter-out lib/src/lib.c,$(SRC))
+  SRC := $(wildcard lib/src/*.c)
+  # do not double-include amalgamation
+  SRC := $(filter-out lib/src/lib.c,$(SRC))
 else
-	# use amalgamated build
-	SRC := lib/src/lib.c
+  # use amalgamated build
+  SRC := lib/src/lib.c
 endif
 OBJ := $(SRC:.c=.o)
 
@@ -29,20 +29,20 @@ SONAME_MINOR := $(word 2,$(subst ., ,$(VERSION)))
 
 # OS-specific bits
 ifeq ($(OS),Windows_NT)
-	$(error "Windows is not supported")
+  $(error "Windows is not supported")
 else ifeq ($(shell uname),Darwin)
-	SOEXT = dylib
-	SOEXTVER_MAJOR = $(SONAME_MAJOR).dylib
-	SOEXTVER = $(SONAME_MAJOR).$(SONAME_MINOR).dylib
-	LINKSHARED += -dynamiclib -Wl,-install_name,$(LIBDIR)/libtree-sitter.$(SONAME_MAJOR).dylib
+  SOEXT = dylib
+  SOEXTVER_MAJOR = $(SONAME_MAJOR).dylib
+  SOEXTVER = $(SONAME_MAJOR).$(SONAME_MINOR).dylib
+  LINKSHARED += -dynamiclib -Wl,-install_name,$(LIBDIR)/libtree-sitter.$(SONAME_MAJOR).dylib
 else
-	SOEXT = so
-	SOEXTVER_MAJOR = so.$(SONAME_MAJOR)
-	SOEXTVER = so.$(SONAME_MAJOR).$(SONAME_MINOR)
-	LINKSHARED += -shared -Wl,-soname,libtree-sitter.so.$(SONAME_MAJOR)
+  SOEXT = so
+  SOEXTVER_MAJOR = so.$(SONAME_MAJOR)
+  SOEXTVER = so.$(SONAME_MAJOR).$(SONAME_MINOR)
+  LINKSHARED += -shared -Wl,-soname,libtree-sitter.so.$(SONAME_MAJOR)
 endif
 ifneq ($(filter $(shell uname),FreeBSD NetBSD DragonFly),)
-	PCLIBDIR := $(PREFIX)/libdata/pkgconfig
+  PCLIBDIR := $(PREFIX)/libdata/pkgconfig
 endif
 
 all: libtree-sitter.a libtree-sitter.$(SOEXT) tree-sitter.pc


### PR DESCRIPTION
Some version of `make` that we run on Windows (Cygwin) chokes on a tab on line 32 with the following error message:
```
Makefile:32: *** recipe commences before first target.  Stop.
```
I don't know why this problem is showing up only now. Also, we don't have this error on other platforms (Linux, MacOS). We're in the process of upgrading tree-sitter from 0.20 to 0.22.6. I didn't spot a change in the makefile that would suddenly cause this error.

I apologize for not taking the time to reproduce the error outside of our private CI system. However, I think it's good hygiene to not use tabs outside of recipes anyway.