### PR TITLE
Swap `sprintf()` for `snprintf()`

### DIFF
--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -33,7 +33,11 @@
   if (self->lexer.logger.log || self->dot_graph_file) {       \
     char *buf = self->lexer.debug_buffer;                     \
     const char *symbol = symbol_name;                         \
-    int off = sprintf(buf, "lexed_lookahead sym:");           \
+    int off = snprintf(                                       \
+      buf,                                                    \
+      TREE_SITTER_SERIALIZATION_BUFFER_SIZE,                  \
+      "lexed_lookahead sym:"                                  \
+    );                                                        \
     for (                                                     \
       int i = 0;                                              \
       symbol[i] != '\0'                                       \


### PR DESCRIPTION
Closes https://github.com/tree-sitter/tree-sitter/issues/3426

(Matched the style of the other `snprintf()` call below this one)