### PR TITLE
fix: syntax highlighting unit testing example

### DIFF
--- a/docs/section-4-syntax-highlighting.md
+++ b/docs/section-4-syntax-highlighting.md
@@ -445,7 +445,7 @@ var abc = function(d) {
   }
 
   baz();
-  ^ !variable
+  // <- !variable
 };
 ```
 


### PR DESCRIPTION
Fixed an example in the doc.