### PR TITLE
doc(index): Added alternative VHDL link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -166,6 +166,7 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 * [USD](https://github.com/ColinKennedy/tree-sitter-usd)
 * [Verilog](https://github.com/tree-sitter/tree-sitter-verilog)
 * [VHDL](https://github.com/alemuller/tree-sitter-vhdl)
+* [VHDL](https://github.com/jpt13653903/tree-sitter-vhdl)
 * [Vue](https://github.com/ikatyang/tree-sitter-vue)
 * [Wasm](https://github.com/wasm-lsp/tree-sitter-wasm)
 * [WDL](https://github.com/jdidion/tree-sitter-wdl)


### PR DESCRIPTION
This adds a VHDL link to the new (and maintained) VHDL parser and highlight queries, currently in alpha-testing.

Ref: https://github.com/nvim-treesitter/nvim-treesitter/discussions/6701