### PR TITLE
fix(lib):  #2869 restrict pattern_map optimization

### DIFF
--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -5171,3 +5171,29 @@ fn test_query_compiler_oob_access() {
     // UBSAN should not report any OOB access
     assert!(Query::new(&language, "(package_declaration _ (_) @name _)").is_ok());
 }
+
+// test for https://github.com/tree-sitter/tree-sitter/issues/2869
+#[test]
+fn test_query_first_immediate_pattern_map() {
+    let language = get_language("javascript");
+    
+    let source = "function name(one, two, three) { }";
+    let mut parser = Parser::new();
+    parser.set_language(&language).unwrap();
+    let tree = parser.parse(source, None).unwrap();
+
+    let query = Query::new(
+        &language,
+        "(_ . (identifier) @firstChild)",
+    )
+    .unwrap();
+
+    let mut cursor = QueryCursor::new();
+    let matches = cursor.matches(&query, tree.root_node(), source.as_bytes());
+    let matches = collect_matches(matches, &query, source);
+
+    assert_eq!(matches, &[
+        (0, vec![("firstChild", "name")]),
+        (0, vec![("firstChild", "one")]),
+    ]);
+}

--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -5176,24 +5176,23 @@ fn test_query_compiler_oob_access() {
 #[test]
 fn test_query_first_immediate_pattern_map() {
     let language = get_language("javascript");
-    
+
     let source = "function name(one, two, three) { }";
     let mut parser = Parser::new();
     parser.set_language(&language).unwrap();
     let tree = parser.parse(source, None).unwrap();
 
-    let query = Query::new(
-        &language,
-        "(_ . (identifier) @firstChild)",
-    )
-    .unwrap();
+    let query = Query::new(&language, "(_ . (identifier) @firstChild)").unwrap();
 
     let mut cursor = QueryCursor::new();
     let matches = cursor.matches(&query, tree.root_node(), source.as_bytes());
     let matches = collect_matches(matches, &query, source);
 
-    assert_eq!(matches, &[
-        (0, vec![("firstChild", "name")]),
-        (0, vec![("firstChild", "one")]),
-    ]);
+    assert_eq!(
+        matches,
+        &[
+            (0, vec![("firstChild", "name")]),
+            (0, vec![("firstChild", "one")]),
+        ]
+    );
 }

--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -5172,27 +5172,19 @@ fn test_query_compiler_oob_access() {
     assert!(Query::new(&language, "(package_declaration _ (_) @name _)").is_ok());
 }
 
-// test for https://github.com/tree-sitter/tree-sitter/issues/2869
 #[test]
-fn test_query_first_immediate_pattern_map() {
+fn test_query_wildcard_with_immediate_first_child() {
     let language = get_language("javascript");
-
-    let source = "function name(one, two, three) { }";
-    let mut parser = Parser::new();
-    parser.set_language(&language).unwrap();
-    let tree = parser.parse(source, None).unwrap();
-
     let query = Query::new(&language, "(_ . (identifier) @firstChild)").unwrap();
+    let source = "function name(one, two, three) { }";
 
-    let mut cursor = QueryCursor::new();
-    let matches = cursor.matches(&query, tree.root_node(), source.as_bytes());
-    let matches = collect_matches(matches, &query, source);
-
-    assert_eq!(
-        matches,
+    assert_query_matches(
+        &language,
+        &query,
+        source,
         &[
             (0, vec![("firstChild", "name")]),
             (0, vec![("firstChild", "one")]),
-        ]
+        ],
     );
 }

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -2740,7 +2740,7 @@ TSQuery *ts_query_new(
       // there is a parent node, and capture it if necessary.
       if (step->symbol == WILDCARD_SYMBOL && step->depth == 0 && !step->field) {
         QueryStep *second_step = &self->steps.contents[start_step_index + 1];
-        if (second_step->symbol != WILDCARD_SYMBOL && second_step->depth == 1) {
+        if (second_step->symbol != WILDCARD_SYMBOL && second_step->depth == 1 && !second_step->is_immediate) {
           wildcard_root_alternative_index = step->alternative_index;
           start_step_index += 1;
           step = second_step;


### PR DESCRIPTION
Fixing #2869 by restricting pattern_map optimization in `ts_query_new()`.

[`pattern_map`](https://github.com/tree-sitter/tree-sitter/blob/9d1ac2139221b2e19389ca620767c537607a2f63/lib/src/query.c#L287
) is used to efficiently spawn query states given the current node symbol.
As an additional optimization, [`it`](https://github.com/tree-sitter/tree-sitter/blob/9d1ac2139221b2e19389ca620767c537607a2f63/lib/src/query.c#L2743) also handles patterns with a wildcard root given that the first child is not a wildcard itself.
But for a pattern with a wildcard root, it is actually unsound to select a second step which is immediate,
because it will not be checked during the matching process [here](https://github.com/tree-sitter/tree-sitter/blob/9d1ac2139221b2e19389ca620767c537607a2f63/lib/src/query.c#L3624).

Moreover, it would be difficult to solve the unsoundness in `advance()`, and restricting the optimization should be a good enough trade-off.