### PR TITLE
fix(lib): an empty root node should not precede an empty range

### DIFF
--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -5194,3 +5194,17 @@ fn test_query_wildcard_with_immediate_first_child() {
         ],
     );
 }
+
+#[test]
+fn test_query_on_empty_source_code() {
+    let language = get_language("javascript");
+    let source_code = "";
+    let query = r#"(program) @program"#;
+    let query = Query::new(&language, query).unwrap();
+    assert_query_matches(
+        &language,
+        &query,
+        source_code,
+        &[(0, vec![("program", "")])],
+    );
+}


### PR DESCRIPTION
The problem is, given an empty file, the root node of this file spans 0 bytes. As such, the logic for determining whether or not the node precedes the range fails, and is true when it should be false. Later on, the logic for determining whether a node intersects the range fails because of this edge case, when it shouldn't, and a state is not added to the query cursor.

By checking if the node is empty (end byte is the same as the start byte) in the logic for determining whether a node precedes a range, we can avoid this issue.

Closes #3448