### PR TITLE
feat: improve warning report for unnecessary seq/choice wrapping

### DIFF
--- a/cli/src/generate/nfa.rs
+++ b/cli/src/generate/nfa.rs
@@ -1,5 +1,4 @@
 use std::{
-    char,
     cmp::{max, Ordering},
     fmt,
     iter::ExactSizeIterator,


### PR DESCRIPTION
## Background

This PR doesn't exactly fix #3455, but definitely improves on the warning emitted when a rule contains an unnecessary sequence or choice wrapping a single terminal (stemming from the changes in #2577). It also does not produce the warning if this seq/choice is within a `token`, since it does not alter runtime behavior in this case (only when a terminal is "absorbed" does it actually impact behavior).

## Impact

Given the Clojure grammar, I've taken it as is and only wrapped a single string (that being `"~@"`) in `unquote_splicing_lit` with a `seq`  to demonstrate the before and after. This is because the other rule (`char_lit`) being marked as having an unnecessary seq is part of a `token` construct, and so the warning isn't necessary in this case. After the PR, we can see there being only one warning that *should* exist, and it also attaches useful information about where the problem lies, in case the rule is large or built with constants defined all over the place (thus making it harder to track down)

Output before the PR:

![image](https://github.com/tree-sitter/tree-sitter/assets/29718261/d4defc07-56d7-43b0-8d0c-254586282f86)

```
Warning: rule char_lit is just a `seq` or `choice` rule with a single element. This is unnecessary.
Warning: rule unquote_splicing_lit is just a `seq` or `choice` rule with a single element. This is unnecessary.
```

After:

![image](https://github.com/tree-sitter/tree-sitter/assets/29718261/97134770-df16-426d-a8db-2681ff872cea)

```
Warning: rule `unquote_splicing_lit` contains a `seq` or `choice` rule with a single element. Wrapping the element with this function is unnecessary.
seq(repeat(), field('marker', seq('~@')), alias($._form, 'value'), repeat(), field('value', $._form))
                              ^^^^^^^^^
```

The "reconstruction" of the JavaScript code by implementing `ToString` for `Rule` will never be 100% accurate, but a majority of the time it will be, and it'd still be useful enough to aid grammar authors in debugging even if it doesn't match the original source code 1:1, especially when they're reusing constants defined elsewhere.