### PR TITLE
build(swift): declare header search path

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,8 @@ let package = Package(
                     "src/tree.c",
                     "src/query.c"
                 ],
-                sources: ["src/lib.c"]),
+                sources: ["src/lib.c"],
+                cSettings: [.headerSearchPath("src")]),
     ],
     cLanguageStandard: .c11
 )


### PR DESCRIPTION
After ee9a3c0ebb218990cf391ed987be7f2448c54a73, a part of ICU sources are vendored in this repository, and the vendored sources include sibling headers in `#include <unicode/...>` form, so we need to include the "./lib/src" directory as a header search path.

Apple platform SDKs include ICU headers as a part of system headers, so it coincidentally worked on Apple platforms, but it didn't work on other platforms including Linux and WebAssembly. This change is a fix for those non-Apple platforms.