### PR TITLE
Exclude APIs that dup given file descriptors from WASI builds

### DIFF
--- a/lib/binding_rust/ffi.rs
+++ b/lib/binding_rust/ffi.rs
@@ -8,7 +8,7 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 #[cfg(not(feature = "bindgen"))]
 include!("./bindings.rs");
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(unix)]
 #[cfg(feature = "std")]
 extern "C" {
     pub(crate) fn _ts_dup(fd: std::os::raw::c_int) -> std::os::raw::c_int;

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -551,13 +551,14 @@ impl Parser {
     /// want to pipe these graphs directly to a `dot(1)` process in order to
     /// generate SVG output.
     #[doc(alias = "ts_parser_print_dot_graphs")]
+    #[cfg(not(target_os = "wasi"))]
     #[cfg(feature = "std")]
     pub fn print_dot_graphs(
         &mut self,
-        #[cfg(any(unix, target_os = "wasi"))] file: &impl AsRawFd,
+        #[cfg(unix)] file: &impl AsRawFd,
         #[cfg(windows)] file: &impl AsRawHandle,
     ) {
-        #[cfg(any(unix, target_os = "wasi"))]
+        #[cfg(unix)]
         {
             let fd = file.as_raw_fd();
             unsafe {
@@ -949,13 +950,14 @@ impl Tree {
     /// graph directly to a `dot(1)` process in order to generate SVG
     /// output.
     #[doc(alias = "ts_tree_print_dot_graph")]
+    #[cfg(not(target_os = "wasi"))]
     #[cfg(feature = "std")]
     pub fn print_dot_graph(
         &self,
-        #[cfg(any(unix, target_os = "wasi"))] file: &impl AsRawFd,
+        #[cfg(unix)] file: &impl AsRawFd,
         #[cfg(windows)] file: &impl AsRawHandle,
     ) {
-        #[cfg(any(unix, target_os = "wasi"))]
+        #[cfg(unix)]
         {
             let fd = file.as_raw_fd();
             unsafe { ffi::ts_tree_print_dot_graph(self.0.as_ptr(), fd) }

--- a/lib/src/tree.c
+++ b/lib/src/tree.c
@@ -148,7 +148,7 @@ void ts_tree_print_dot_graph(const TSTree *self, int fd) {
   fclose(file);
 }
 
-#else
+#elif !defined(__wasi__) // WASI doesn't support dup
 
 #include <unistd.h>
 
@@ -160,6 +160,13 @@ void ts_tree_print_dot_graph(const TSTree *self, int file_descriptor) {
   FILE *file = fdopen(_ts_dup(file_descriptor), "a");
   ts_subtree_print_dot_graph(self->root, self->language, file);
   fclose(file);
+}
+
+#else
+
+void ts_tree_print_dot_graph(const TSTree *self, int file_descriptor) {
+  (void)self;
+  (void)file_descriptor;
 }
 
 #endif


### PR DESCRIPTION
WASI doesn't support `dup(2)` system call, so we cannot implement the `print_dot_graph` and `print_dot_graphs` functions with exactly the same semantics as in other platforms.

```
In file included from ChimeHQ/SwiftTreeSitter/Packages/tree-sitter/lib/src/lib.c:13:
ChimeHQ/SwiftTreeSitter/Packages/tree-sitter/lib/src/./tree.c:156:10: error: call to undeclared function 'dup'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  156 |   return dup(file_descriptor);
      |          ^
1 error generated.
```

If we really need those functionalities in WASI, we can provide new variants of them that consumes the given fds.

---

## Alternative consideration

If we can accept semantics changes on the fd consumption for those public APIs, we can provide those APIs without adding new variants. 