### PR TITLE
fix: support big endian machines

### DIFF
--- a/script/build-wasm
+++ b/script/build-wasm
@@ -119,6 +119,7 @@ $emcc                                            \
   -s WASM=1                                      \
   -s INITIAL_MEMORY=33554432                     \
   -s ALLOW_MEMORY_GROWTH=1                       \
+  -s SUPPORT_BIG_ENDIAN=1                        \
   -s MAIN_MODULE=2                               \
   -s FILESYSTEM=0                                \
   -s NODEJS_CATCH_EXIT=0                         \


### PR DESCRIPTION
With this fix, I'm able to use `bash-language-server` with `neovim` on a big endian s390x Linux machine. `bash-language-server` uses `web-tree-sitter`.