### PR TITLE
Reset language when resetting wasm store

### DIFF
--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -2144,11 +2144,19 @@ TSTree *ts_parser_parse_string_encoding(
 }
 
 void ts_parser_set_wasm_store(TSParser *self, TSWasmStore *store) {
+  if (self->language && ts_language_is_wasm(self->language)) {
+    ts_parser_set_language(self, NULL);
+  }
+
   ts_wasm_store_delete(self->wasm_store);
   self->wasm_store = store;
 }
 
 TSWasmStore *ts_parser_take_wasm_store(TSParser *self) {
+  if (self->language && ts_language_is_wasm(self->language)) {
+    ts_parser_set_language(self, NULL);
+  }
+
   TSWasmStore *result = self->wasm_store;
   self->wasm_store = NULL;
   return result;


### PR DESCRIPTION
This is necessary, otherwise [ts_wasm_store_start](https://github.com/tree-sitter/tree-sitter/blob/2512f3ab179867de282b89221a62c55ff6feffa3/lib/src/parser.c#L1909) will never have been called.