### PR TITLE
Add Swift's `.build` to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@ docs/assets/js/tree-sitter.js
 *.lib
 *.wasm
 .swiftpm
+.build
 zig-*


### PR DESCRIPTION
The VSCode extension for Swift seems to eagerly create this output directory since this repo contains a Swift package. To avoid accidentally committing it, this adds it to the `.gitignore`.