### PR TITLE
Added `--overview-only` to `test` subcommand

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -251,6 +251,8 @@ struct Test {
     pub show_fields: bool,
     #[arg(short, long, help = "Force rebuild the parser")]
     pub rebuild: bool,
+    #[arg(long, help = "Show only the pass-fail overview tree")]
+    pub overview_only: bool,
 }
 
 #[derive(Args)]
@@ -710,6 +712,7 @@ impl Test {
                 color,
                 test_num: 1,
                 show_fields: self.show_fields,
+                overview_only: self.overview_only,
             };
 
             test::run_tests_at_path(&mut parser, &mut opts)?;

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -107,6 +107,7 @@ pub struct TestOptions<'a> {
     pub color: bool,
     pub test_num: usize,
     pub show_fields: bool,
+    pub overview_only: bool,
 }
 
 pub fn run_tests_at_path(parser: &mut Parser, opts: &mut TestOptions) -> Result<()> {
@@ -159,33 +160,35 @@ pub fn run_tests_at_path(parser: &mut Parser, opts: &mut TestOptions) -> Result<
         } else {
             has_parse_errors = opts.update && has_parse_errors;
 
-            if !has_parse_errors {
-                if failures.len() == 1 {
-                    println!("1 failure:");
-                } else {
-                    println!("{} failures:", failures.len());
+            if !opts.overview_only {
+                if !has_parse_errors {
+                    if failures.len() == 1 {
+                        println!("1 failure:");
+                    } else {
+                        println!("{} failures:", failures.len());
+                    }
                 }
-            }
 
-            if opts.color {
-                print_diff_key();
-            }
-            for (i, (name, actual, expected)) in failures.iter().enumerate() {
-                if expected == "NO ERROR" {
-                    println!("\n  {}. {name}:\n", i + 1);
-                    println!("  Expected an ERROR node, but got:");
-                    println!(
-                        "  {}",
-                        paint(
-                            opts.color.then_some(AnsiColor::Red),
-                            &format_sexp(actual, 2)
-                        )
-                    );
-                } else {
-                    println!("\n  {}. {name}:", i + 1);
-                    let actual = format_sexp(actual, 2);
-                    let expected = format_sexp(expected, 2);
-                    print_diff(&actual, &expected, opts.color);
+                if opts.color {
+                    print_diff_key();
+                }
+                for (i, (name, actual, expected)) in failures.iter().enumerate() {
+                    if expected == "NO ERROR" {
+                        println!("\n  {}. {name}:\n", i + 1);
+                        println!("  Expected an ERROR node, but got:");
+                        println!(
+                            "  {}",
+                            paint(
+                                opts.color.then_some(AnsiColor::Red),
+                                &format_sexp(actual, 2)
+                            )
+                        );
+                    } else {
+                        println!("\n  {}. {name}:", i + 1);
+                        let actual = format_sexp(actual, 2);
+                        let expected = format_sexp(expected, 2);
+                        print_diff(&actual, &expected, opts.color);
+                    }
                 }
             }
 


### PR DESCRIPTION
`tree-sitter test --overview-only`

Adds the option to only show the pass-fail tree - something I frequently find myself wanting when I'm only concerned with the pass-fail status and don't want to scroll back up through a sea of color-diffs.