### PR TITLE
feat(cli): Add `--show-fields` flag to cli `test` subcommand

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -252,7 +252,7 @@ struct Test {
     pub open_log: bool,
     #[arg(long, help = "The path to an alternative config.json file")]
     pub config_path: Option<PathBuf>,
-    #[arg(long, help = "force showing fields in test diffs")]
+    #[arg(long, help = "Force showing fields in test diffs")]
     pub show_fields: bool,
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -252,6 +252,8 @@ struct Test {
     pub open_log: bool,
     #[arg(long, help = "The path to an alternative config.json file")]
     pub config_path: Option<PathBuf>,
+    #[arg(long, help = "force showing fields in test diffs")]
+    pub show_fields: bool,
 }
 
 #[derive(Args)]
@@ -717,6 +719,7 @@ fn run() -> Result<()> {
                     languages: languages.iter().map(|(l, n)| (n.as_str(), l)).collect(),
                     color,
                     test_num: 1,
+                    show_fields: test_options.show_fields,
                 };
 
                 test::run_tests_at_path(&mut parser, &mut opts)?;

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -106,6 +106,7 @@ pub struct TestOptions<'a> {
     pub languages: BTreeMap<&'a str, &'a Language>,
     pub color: bool,
     pub test_num: usize,
+    pub show_fields: bool,
 }
 
 pub fn run_tests_at_path(parser: &mut Parser, opts: &mut TestOptions) -> Result<()> {
@@ -388,7 +389,9 @@ fn run_tests(
                     }
                 } else {
                     let mut actual = tree.root_node().to_sexp();
-                    if !has_fields {
+                    let show_fields = opts.show_fields || has_fields;
+
+                    if !show_fields {
                         actual = strip_sexp_fields(&actual);
                     }
 

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -389,9 +389,7 @@ fn run_tests(
                     }
                 } else {
                     let mut actual = tree.root_node().to_sexp();
-                    let show_fields = opts.show_fields || has_fields;
-
-                    if !show_fields {
+                    if !(opts.show_fields || has_fields) {
                         actual = strip_sexp_fields(&actual);
                     }
 


### PR DESCRIPTION
eg `tree-sitter test --show-fields`

Forces the test diff to output fields, regardless of their lack of presence in the test file's expected output section.