### PR TITLE
fix(lib): fix api header C++ interop

### DIFF
--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -7,13 +7,13 @@
 #endif
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /****************************/
 /* Section - ABI Versioning */


### PR DESCRIPTION
Apple Clang complains about C header files being included with an extern "C" linkage block when consuming those headers as part of Swift modules with C++/Objective-C++ interoperability. 

This blocks Swift projects that consume SwiftTreeSitter, either directly or indirectly, from enabling C++ interoperability mode.
