### PR TITLE
fix(bindings): update go bindings

### DIFF
--- a/cli/src/generate/templates/binding_test.go
+++ b/cli/src/generate/templates/binding_test.go
@@ -3,8 +3,8 @@ package tree_sitter_PARSER_NAME_test
 import (
 	"testing"
 
-	tree_sitter "github.com/smacker/go-tree-sitter"
-	"github.com/tree-sitter/tree-sitter-PARSER_NAME"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	tree_sitter_PARSER_NAME "github.com/tree-sitter/tree-sitter-PARSER_NAME/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {

--- a/cli/src/generate/templates/go.mod
+++ b/cli/src/generate/templates/go.mod
@@ -1,5 +1,5 @@
 module github.com/tree-sitter/tree-sitter-PARSER_NAME
 
-go 1.22
+go 1.23
 
-require github.com/smacker/go-tree-sitter v0.0.0-20230720070738-0d0a9f78d8f8
+require github.com/tree-sitter/go-tree-sitter v0.23


### PR DESCRIPTION
Now with the advent of https://github.com/tree-sitter/go-tree-sitter Go users will have a much easier time using tree-sitter :slightly_smiling_face: 