### PR TITLE
fix(go): update parser name in binding files, add to docs

### DIFF
--- a/cli/src/generate/grammar_files.rs
+++ b/cli/src/generate/grammar_files.rs
@@ -431,11 +431,27 @@ pub fn generate_grammar_files(
             generate_file(path, BINDING_GO_TEMPLATE, language_name)
         })?;
 
-        missing_path(path.join("binding_test.go"), |path| {
-            generate_file(path, BINDING_TEST_GO_TEMPLATE, language_name)
-        })?;
+        missing_path_else(
+            path.join("binding_test.go"),
+            |path| generate_file(path, BINDING_TEST_GO_TEMPLATE, language_name),
+            |path| {
+                let binding_test_go =
+                    fs::read_to_string(path).with_context(|| "Failed to read binding_test.go")?;
+                if binding_test_go.contains("smacker") {
+                    eprintln!("Replacing binding_test.go with new binding API");
+                    generate_file(path, BINDING_TEST_GO_TEMPLATE, language_name)?;
+                }
+                Ok(())
+            },
+        )?;
 
-        missing_path(path.join("go.mod"), |path| {
+        // Delete the old go.mod file that lives inside bindings/go, it now lives in the root dir
+        let go_mod_path = path.join("go.mod");
+        if go_mod_path.exists() {
+            fs::remove_file(go_mod_path).with_context(|| "Failed to remove old go.mod file")?;
+        }
+
+        missing_path(repo_path.join("go.mod"), |path| {
             generate_file(path, GO_MOD_TEMPLATE, language_name)
         })?;
 

--- a/cli/src/generate/templates/binding.go
+++ b/cli/src/generate/templates/binding.go
@@ -1,4 +1,4 @@
-package tree_sitter_PARSER_NAME
+package tree_sitter_LOWER_PARSER_NAME
 
 // #cgo CFLAGS: -std=c11 -fPIC
 // #include "../../src/parser.c"

--- a/cli/src/generate/templates/binding_test.go
+++ b/cli/src/generate/templates/binding_test.go
@@ -1,14 +1,14 @@
-package tree_sitter_PARSER_NAME_test
+package tree_sitter_LOWER_PARSER_NAME_test
 
 import (
 	"testing"
 
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
-	tree_sitter_PARSER_NAME "github.com/tree-sitter/tree-sitter-PARSER_NAME/bindings/go"
+	tree_sitter_LOWER_PARSER_NAME "github.com/tree-sitter/tree-sitter-PARSER_NAME/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {
-	language := tree_sitter.NewLanguage(tree_sitter_PARSER_NAME.Language())
+	language := tree_sitter.NewLanguage(tree_sitter_LOWER_PARSER_NAME.Language())
 	if language == nil {
 		t.Errorf("Error loading CAMEL_PARSER_NAME grammar")
 	}

--- a/cli/src/generate/templates/go.mod
+++ b/cli/src/generate/templates/go.mod
@@ -1,4 +1,4 @@
-module github.com/tree-sitter/tree-sitter-PARSER_NAME
+module github.com/tree-sitter/tree-sitter-LOWER_PARSER_NAME
 
 go 1.23
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ There are currently bindings that allow Tree-sitter to be used from the followin
 #### Official
 
 * [C#](https://github.com/tree-sitter/csharp-tree-sitter)
+* [Go](https://github.com/tree-sitter/go-tree-sitter)
 * [Haskell](https://github.com/tree-sitter/haskell-tree-sitter)
 * [Java (JDK 22)](https://github.com/tree-sitter/java-tree-sitter)
 * [JavaScript (Node.js)](https://github.com/tree-sitter/node-tree-sitter)


### PR DESCRIPTION
After this and a new release, every grammar w/ Go bindings will automatically be updated after a subsequent `generate` run