### PR TITLE
fix!: revert interning of a sequence or choice of a single rule

### DIFF
--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -5017,7 +5017,7 @@ fn test_grammar_with_aliased_literal_query() {
     let (parser_name, parser_code) = generate_parser_for_grammar(
         r#"
         {
-            "name": "test_grammar_with_aliased_literal_query",
+            "name": "test",
             "rules": {
                 "source": {
                     "type": "REPEAT",
@@ -5077,69 +5077,7 @@ fn test_grammar_with_aliased_literal_query() {
         &language,
         r#"
         (compound_statement "}" @bracket1)
-        (expansion) @bracket2
-        "#,
-    );
-
-    assert!(query.is_ok());
-
-    let query = Query::new(
-        &language,
-        r#"
         (expansion "}" @bracket2)
-        "#,
-    );
-
-    assert!(query.is_err());
-}
-
-#[test]
-fn test_query_with_seq_or_choice_of_one_rule() {
-    // module.exports = grammar({
-    //   name: 'test',
-    //
-    //   rules: {
-    //     source: $ => choice($._seq, $._choice),
-    //
-    //     _seq: $ => seq("hi"),
-    //     _choice: $ => choice("bye"),
-    //   },
-    // });
-
-    let (parser_name, parser_code) = generate_parser_for_grammar(
-        r#"
-        {
-          "name": "test_query_with_seq_or_choice_of_one_rule",
-          "rules": {
-            "source": {
-              "type": "CHOICE",
-              "members": [
-                { "type": "SYMBOL", "name": "_seq" },
-                { "type": "SYMBOL", "name": "_choice" }
-              ]
-            },
-            "_seq": {
-              "type": "SEQ",
-              "members": [{ "type": "STRING", "value": "hi" }]
-            },
-            "_choice": {
-              "type": "CHOICE",
-              "members": [ { "type": "STRING", "value": "bye" } ]
-            }
-          },
-          "extras": [{ "type": "PATTERN", "value": "\\s" }]
-        }
-        "#,
-    )
-    .unwrap();
-
-    let language = get_test_language(&parser_name, &parser_code, None);
-
-    let query = Query::new(
-        &language,
-        r#"
-        "hi" @seq
-        "bye" @choice
         "#,
     );
 


### PR DESCRIPTION
This reverts #2577, as mentioned in #3456, it's too intrusive, albeit it corrects "UB" when it comes to querying these nodes.