### PR TITLE
fix(cli): dedup `preceding_auxiliary_symbols`

### DIFF
--- a/cli/src/generate/build_tables/build_parse_table.rs
+++ b/cli/src/generate/build_tables/build_parse_table.rs
@@ -32,7 +32,7 @@ type SymbolSequence = Vec<Symbol>;
 type AuxiliarySymbolSequence = Vec<AuxiliarySymbolInfo>;
 pub type ParseStateInfo<'a> = (SymbolSequence, ParseItemSet<'a>);
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 struct AuxiliarySymbolInfo {
     auxiliary_symbol: Symbol,
     parent_symbols: Vec<Symbol>,
@@ -193,7 +193,7 @@ impl<'a> ParseTableBuilder<'a> {
     fn add_actions(
         &mut self,
         mut preceding_symbols: SymbolSequence,
-        mut preceding_auxiliary_symbols: Vec<AuxiliarySymbolInfo>,
+        mut preceding_auxiliary_symbols: AuxiliarySymbolSequence,
         state_id: ParseStateId,
         item_set: &ParseItemSet<'a>,
     ) -> Result<()> {
@@ -310,6 +310,8 @@ impl<'a> ParseTableBuilder<'a> {
                 }
             }
         }
+
+        preceding_auxiliary_symbols.dedup();
 
         // Having computed the successor item sets for each symbol, add a new
         // parse state for each of these item sets, and add a corresponding Shift


### PR DESCRIPTION
Closes #1890

This PR fixes memory-related issues noticed in several grammars - notably, when generating the C# and QMLJS grammars.

## Problem

The problem is that the C# grammar takes almost 30GB and over a minute to generate - this is a clear outlier and the grammar doesn't have an exorbitant amount of parse states, so something is definitely amiss.

## Investigation

First, building the CLI with a release profile that includes debug symbols is a prerequisite. This way, we can simulate real-world usage of the CLI w.r.t. performance, while still having the program be debuggable. Then, by using valgrind with massif, I can generate a report that shows me the memory usage of the program during generation, and see where the hotspots for allocations are. After running `valgrind --tool=massif tree-sitter g` and `ms_print massif.out.232180 > massif.out`, we can look at the `massif.out` file and notice something peculiar:

![image](https://github.com/user-attachments/assets/7c168ece-08c3-4395-9501-76349286e1ee)

A clone in line 185 of build_parse_table.rs is the source of most of the allocations, and if we look at that [line](https://github.com/tree-sitter/tree-sitter/blob/ff8b50caa64a8f5ee65ad5cbf676791f4c5f9c79/cli/src/generate/build_tables/build_parse_table.rs#L185) we can see the problem is the `preceding_auxiliary_symbols` array being cloned ends up being very expensive in the C# grammar. So the next step was to figure out what's the average size of the array when this code path is reached for the C# grammar and for another grammar - this turned out to be 700+ vs <100 for other grammars. Afterwards, printing out the contents of this array proved to be insightful - there were many, many duplicates in the array, especially so for the C# grammar.

## Solution

Since we now know that the problem stems from the fact that there are many duplicate items in the array - calling `dedup` (and deriving `PartialEq` on `AuxiliarySymbolInfo`) fixes this problem, with no unexpected changes to `parser.c`. The table below shows the generate time and memory usage before and after this PR, and we can clearly see C#, TSX, and TypeScript benefit greatly from this change.

`tree-sitter generate` (time in seconds, memory in MB):

| Grammar | Time (old) | Time (new) | Memory (old) | Memory (new) |
|:---|---:|---:|---:|---:|
| Bash | 1.88 | 1.77 | 150.78 | 149.52 |
| C | 1.00 | 1.00 | 164.57 | 163.60 |
| C++ | 8.40 | 8.17 | 909.53 | 900.94 |
| C# | 75.15 | 19.68 | 27396.8 | 3686.46 |
| CSS | 0.06 | 0.05 | 66.62 | 66.57 |
| Embedded Template | 0.02 | 0.02 | 61.44 | 61.44 |
| Go | 0.46 | 0.47 | 71.52 | 71.39 |
| Haskell | 3.88 | 3.74 | 460.73 | 455.31 |
| HTML | 0.03 | 0.03 | 61.16 | 61.39 |
| Java | 0.94 | 0.97 | 166.37 | 166.00 |
| JavaScript | 0.74 | 0.72 | 126.55 | 125.81 |
| JSDoc | 0.03 | 0.03 | 61.45 | 61.24 |
| Julia | 44.22 | 44.28 | 2605.96 | 2603.27 |
| OCaml | 10.44 | 9.92 | 866.02 | 860.83 |
| PHP | 4.68 | 4.77 | 564.82 | 561.02 |
| Python | 0.54 | 0.60 | 83.23 | 82.79 |
| Regex | 0.03 | 0.03 | 66.52 | 66.50 |
| Ruby | 18.30 | 18.48 | 1612.30 | 1609.65 |
| Rust | 2.04 | 2.12 | 286.86 | 287.25 |
| Scala | 13.46 | 11.72 | 811.42 | 634.24 |
| TOML | 0.04 | 0.04 | 66.58 | 66.55 |
| TSX | 8.00 | 4.06 | 3866.44 | 378.34  |
| TypeScript | 8.02 | 4.04 | 3873.18 | 358.16 |
