### PR TITLE
fix(lib): peek at the next sibling when iterating to find the child that contains a given descendant

### DIFF
--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -290,6 +290,16 @@ fn test_parent_of_zero_width_node() {
         function_definition
     );
     assert_eq!(function_definition.child_containing_descendant(block), None);
+
+    let code = "<script></script>";
+    parser.set_language(&get_language("html")).unwrap();
+
+    let tree = parser.parse(code, None).unwrap();
+    let root = tree.root_node();
+    let script_element = root.child(0).unwrap();
+    let raw_text = script_element.child(1).unwrap();
+    let parent = raw_text.parent().unwrap();
+    assert_eq!(parent, script_element);
 }
 
 #[test]


### PR DESCRIPTION
Closes #1378
Closes #1647
Closes #1872
Closes #3271

## Problem

Currently, the internal node child iterator which is used to find the parent or find the child containing a descendant is buggy when it comes to siblings that are zero-width tokens (ZWT) that are *adjacent* to the prior sibling. This has come up numerous times across many issues, and is frankly not an easy problem to solve. The issue is that the loop inside `ts_node_child_containing_descendant` does not advance to any more siblings if the current child node is one that touches the end boundary of the target subnode. This is problematic because if the ZWT sibling that is adjacent to this prior sibling *is* in fact the subnode, or *does* in fact contain the subnode, the returned data is incorrect. Therefore, there are many cases to consider when it comes to these ZWTs.

A) The case where we have a ZWT following a node of which said node's children contains the target subnode. Let's say our target node is A.2 in the figure below (2nd child of node A):
```
      A          B
(0    :    10)(10:10)
......................
 A.1     A.2   <------- Target
(0:3)   (3:10)
```

B) The case where the ZWT *is* the target subnode, so in the above diagram, that'd be `B`

C) The case where the ZWT is comprised of children that are all ZWTs, where one of these children is in fact the target subnode. I'm not sure if a grammar exists that has this construct.

## Solution

A function that peeks at the next sibling to see if it's an adjacent ZWT *and* is relevant has been added after the first if condition of the inner do-while loop of `ts_node_child_containing_descendant`. We fast-forward to process as *many* adjacent ZWTs as we can, checking to see if either a recursive call of `ts_node_child_containing_descendant` gives us a non-null node (case C) OR if the node id of the next ZWT(s) is **equal** to the target subnode's id (case B). The reason I looped in case A is because my initial implementation actually *failed* on that case (it was more like an iterator that only checked the siblings without descending into the prior sibling's subtrees).

This implementation is now a DFS (calling `ts_node_child_containing_descendant` inside this loop) that is performed `n` times where `n` is the number of ZWTs adjacent to the sibling + the current node. If no match was found or the node wasn't exactly the target subnode then we restore `self` with the `old` node that was the current node *prior* to entering this loop. This fixes case *A*. If we were to take Python for example and use the test case [here](https://github.com/tree-sitter/tree-sitter/issues/3271#issuecomment-2079772923), the parent of Python's `)` node in a `parameters` node would be `function_definition` and not `parameters` like we'd expect. Though, this test is a bit unfeasible to use here because it requires a patch to the Python grammar. So, I opted for the example in #1378, which is now fixed with this PR.

I will admit that this loop + the function `ts_node_child_iterator_next_sibling_is_empty_adjacent` is not the prettiest solution (and probably not the most possible performant one either), but I could not think of another way to solve all the cases I outlined above that was more performant & clearer, but I'm open to feedback :)



 