### PR TITLE
fix(lib): correct extra node creation from non-zero root-alias cursors

### DIFF
--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -475,8 +475,9 @@ uint32_t ts_tree_cursor_current_descendant_index(const TSTreeCursor *_self) {
 TSNode ts_tree_cursor_current_node(const TSTreeCursor *_self) {
   const TreeCursor *self = (const TreeCursor *)_self;
   TreeCursorEntry *last_entry = array_back(&self->stack);
-  TSSymbol alias_symbol = self->root_alias_symbol;
-  if (self->stack.size > 1 && !ts_subtree_extra(*last_entry->subtree)) {
+  bool is_extra = ts_subtree_extra(*last_entry->subtree);
+  TSSymbol alias_symbol = is_extra ? 0 : self->root_alias_symbol;
+  if (self->stack.size > 1 && !is_extra) {
     TreeCursorEntry *parent_entry = &self->stack.contents[self->stack.size - 2];
     alias_symbol = ts_language_alias_at(
       self->tree->language,


### PR DESCRIPTION
Closes #3555

## Problem

The problem is that the node created from a tree cursor in certain circumstances uses an alias symbol of the parent, thus leading to confusion as it seems like certain cursor operations like `goto_next_sibling` actually go to its parent. This problem requires pretty specific conditions to occur, that being:

- The cursor is created from a node that is an alias
- The cursor's current node is an `extra` node

Luckily, fixing this turns out to be quite easy.

## Solution

When we fetch the current node from the cursor, we should set the `alias_symbol` to 0 if it's an extra, otherwise set it to the `root_alias_symbol`.
