### PR TITLE
Conform LanguageFn to Copy

### DIFF
--- a/lib/language/language.rs
+++ b/lib/language/language.rs
@@ -1,6 +1,7 @@
 #![no_std]
 /// LanguageFn wraps a C function that returns a pointer to a tree-sitter grammer.
 #[repr(transparent)]
+#[derive(Clone, Copy)]
 pub struct LanguageFn(unsafe extern "C" fn() -> *const ());
 
 impl LanguageFn {


### PR DESCRIPTION
Allows a LanguageFn to be passed around and create multiple languages since Language::new consumes a LanguageFn

LanguageFn just wraps a function pointer, which already conforms to Copy so this is a simple addition.