### PR TITLE
fix: do not generate large character sets for unused variables

### DIFF
--- a/cli/src/generate/build_tables/build_lex_table.rs
+++ b/cli/src/generate/build_tables/build_lex_table.rs
@@ -10,6 +10,7 @@ use crate::generate::{
     dedup::split_state_id_groups,
     grammars::{LexicalGrammar, SyntaxGrammar},
     nfa::{CharacterSet, NfaCursor},
+    prepare_grammar::symbol_is_used,
     rules::{Symbol, TokenSet},
     tables::{AdvanceAction, LexState, LexTable, ParseStateId, ParseTable},
 };
@@ -93,6 +94,9 @@ pub fn build_lex_table(
     let mut large_character_sets = Vec::new();
     for (variable_ix, _variable) in lexical_grammar.variables.iter().enumerate() {
         let symbol = Symbol::terminal(variable_ix);
+        if !symbol_is_used(&syntax_grammar.variables, symbol) {
+            continue;
+        }
         builder.reset();
         builder.add_state_for_tokens(&TokenSet::from_iter([symbol]));
         for state in &builder.table.states {

--- a/cli/src/generate/prepare_grammar/flatten_grammar.rs
+++ b/cli/src/generate/prepare_grammar/flatten_grammar.rs
@@ -173,7 +173,7 @@ fn flatten_variable(variable: Variable) -> SyntaxVariable {
     }
 }
 
-fn symbol_is_used(variables: &[SyntaxVariable], symbol: Symbol) -> bool {
+pub fn symbol_is_used(variables: &[SyntaxVariable], symbol: Symbol) -> bool {
     for variable in variables {
         for production in &variable.productions {
             for step in &production.steps {

--- a/cli/src/generate/prepare_grammar/mod.rs
+++ b/cli/src/generate/prepare_grammar/mod.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
+pub(super) use flatten_grammar::symbol_is_used;
 
 pub use self::expand_tokens::expand_tokens;
 use self::{


### PR DESCRIPTION
This partially fixes #768, but not entirely. It fixes the case outlined where there is a specific regex assigned to a rule that is unused ([here](https://github.com/tree-sitter/tree-sitter/issues/768#issuecomment-2161295941)). 

## Problem

The problem is, when we generate a large character set from this token, we try to fetch the name of the symbol on [this](https://github.com/tree-sitter/tree-sitter/blob/10e474f4886bd599a2ff4168209dc566f3024258/cli/src/generate/render.rs#L259) line, but it does not exist because we only populate this map of symbols to strings with symbols that are actually *used*, thus causing a panic by trying to access an entry that does not exist for the given key.

## Solution

The solution is to just not add entries to the large character sets if the symbol is not used. I believe this also fixes the panic in #3404 because moving from regex_syntax's ast to hir changed a symbol in TypeScript's grammar to become a large character set. While this discrepancy still needs to be investigated and solved, it is something useful to note.