### PR TITLE
feat: add `field_name_for_named_child`

### DIFF
--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -374,6 +374,13 @@ extern "C" {
     ) -> *const ::core::ffi::c_char;
 }
 extern "C" {
+    #[doc = " Get the field name for node's named child at the given index, where zero\n represents the first named child. Returns NULL, if no field is found."]
+    pub fn ts_node_field_name_for_named_child(
+        self_: TSNode,
+        named_child_index: u32,
+    ) -> *const ::core::ffi::c_char;
+}
+extern "C" {
     #[doc = " Get the node's number of children."]
     pub fn ts_node_child_count(self_: TSNode) -> u32;
 }
@@ -642,7 +649,7 @@ extern "C" {
     pub fn ts_query_cursor_set_timeout_micros(self_: *mut TSQueryCursor, timeout_micros: u64);
 }
 extern "C" {
-    #[doc = " Get the duration in microseconds that query execution is allowed to take."]
+    #[doc = " Get the duration in microseconds that query execution is allowed to take.\n\n This is set via [`ts_query_cursor_set_timeout_micros`]."]
     pub fn ts_query_cursor_timeout_micros(self_: *const TSQueryCursor) -> u64;
 }
 extern "C" {

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1236,6 +1236,14 @@ impl<'tree> Node<'tree> {
         }
     }
 
+    /// Get the field name of this node's named child at the given index.
+    pub fn field_name_for_named_child(&self, named_child_index: u32) -> Option<&'static str> {
+        unsafe {
+            let ptr = ffi::ts_node_field_name_for_named_child(self.0, named_child_index);
+            (!ptr.is_null()).then(|| CStr::from_ptr(ptr).to_str().unwrap())
+        }
+    }
+
     /// Iterate over this node's children.
     ///
     /// A [`TreeCursor`] is used to retrieve the children efficiently. Obtain

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -571,6 +571,12 @@ TSNode ts_node_child(TSNode self, uint32_t child_index);
 const char *ts_node_field_name_for_child(TSNode self, uint32_t child_index);
 
 /**
+ * Get the field name for node's named child at the given index, where zero
+ * represents the first named child. Returns NULL, if no field is found.
+ */
+const char *ts_node_field_name_for_named_child(TSNode self, uint32_t named_child_index);
+
+/**
  * Get the node's number of children.
  */
 uint32_t ts_node_child_count(TSNode self);


### PR DESCRIPTION
Supersedes #1264

This PR adds a `field_name_for_named_child` API for parity with other APIs that have a `named` child variant. The implementation mostly copies the unnamed variant, but passes in false for `ts_node__is_relevant` and `ts_node__relevant_child_count` to signify we are *not* considering anonymous children here. The added test and diagram outlines the expected behavior given different constructs (with an unnamed child and an extra child)