### PR TITLE
fix(cli): remove duplicate short options from `fuzz` command

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -243,7 +243,7 @@ struct Fuzz {
     pub skip: Option<Vec<String>>,
     #[arg(long, help = "Subdirectory to the language")]
     pub subdir: Option<String>,
-    #[arg(long, short, help = "Maximum number of edits to perform per fuzz test")]
+    #[arg(long, help = "Maximum number of edits to perform per fuzz test")]
     pub edits: Option<usize>,
     #[arg(long, short, help = "Number of fuzzing iterations to run per test")]
     pub iterations: Option<usize>,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -245,7 +245,7 @@ struct Fuzz {
     pub subdir: Option<String>,
     #[arg(long, help = "Maximum number of edits to perform per fuzz test")]
     pub edits: Option<usize>,
-    #[arg(long, short, help = "Number of fuzzing iterations to run per test")]
+    #[arg(long, help = "Number of fuzzing iterations to run per test")]
     pub iterations: Option<usize>,
     #[arg(
         long,


### PR DESCRIPTION
The `exclude` option was added the `fuzz` command in #3604. This option was added with the clap derive `short`, conflicting with the already existing short option for the `edits` option. When you run `tree-sitter fuzz` now, you get the following error:

```shell
thread 'main' panicked at /home/lillis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.15/src/builder/debug_asserts.rs:112:17:
Command fuzz: Short option names must be unique for each argument, but '-e' is in use by both 'edits' and 'exclude'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This is fixed by simply removing the `short` derive from one of the options. I've opted to remove it from `edits` in this PR for the sake of parity with options in other commands, but if it should be removed from `excludes` instead I'm happy to make the swap.

EDIT: Looks like `iterations` and `include` had the same problem.