### PR TITLE
Support darwin cross-compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ SONAME_MAJOR := $(word 1,$(subst ., ,$(VERSION)))
 SONAME_MINOR := $(word 2,$(subst ., ,$(VERSION)))
 
 # OS-specific bits
-ifeq ($(shell uname),Darwin)
+ifneq ($(findstring darwin,$(shell $(CC) -dumpmachine)),)
 	SOEXT = dylib
 	SOEXTVER_MAJOR = $(SONAME_MAJOR).$(SOEXT)
 	SOEXTVER = $(SONAME_MAJOR).$(SONAME_MINOR).$(SOEXT)


### PR DESCRIPTION
This is (very long) follow up on https://github.com/tree-sitter/tree-sitter/pull/1824 .

It seems to me that `-dumpmachine` is supported by both `GCC` and `clang`.