### PR TITLE
fix(wasm): use / paths for workdir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,6 +961,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1520,7 @@ dependencies = [
  "indoc",
  "libloading",
  "once_cell",
+ "path-slash",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ libloading = "0.8.5"
 log = { version = "0.4.22", features = ["std"] }
 memchr = "2.7.4"
 once_cell = "1.19.0"
+path-slash = "0.2.1"
 pretty_assertions = "1.4.1"
 rand = "0.8.5"
 regex = "1.10.6"

--- a/cli/loader/Cargo.toml
+++ b/cli/loader/Cargo.toml
@@ -26,6 +26,7 @@ fs4.workspace = true
 indoc.workspace = true
 libloading.workspace = true
 once_cell.workspace = true
+path-slash.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -23,6 +23,7 @@ use fs4::FileExt;
 use indoc::indoc;
 use libloading::{Library, Symbol};
 use once_cell::unsync::OnceCell;
+use path_slash::PathBufExt as _;
 use regex::{Regex, RegexBuilder};
 use serde::{Deserialize, Deserializer, Serialize};
 use tree_sitter::Language;
@@ -818,7 +819,7 @@ impl Loader {
                     path.push(src_path.strip_prefix(root_path).unwrap());
                     path
                 };
-                command.args(["--workdir", &workdir.to_string_lossy()]);
+                command.args(["--workdir", &workdir.to_slash_lossy()]);
 
                 // Mount the root directory as a volume, which is the repo root
                 let mut volume_string = OsString::from(&root_path);


### PR DESCRIPTION
Reimplemented the fix from #2183 to fix building WASM files with Docker on Windows again. The --workdir argument gives a path inside the Docker container, so it must use forward slashes regardless of the default path separator on the host OS.

Fixes #3657