### PR TITLE
refactor(tests): do not use `.as_bytes().len()` on strings

### DIFF
--- a/cli/src/tests/parser_test.rs
+++ b/cli/src/tests/parser_test.rs
@@ -124,7 +124,7 @@ fn test_parsing_with_custom_utf8_input() {
                 let row = position.row;
                 let column = position.column;
                 if row < lines.len() {
-                    if column < lines[row].as_bytes().len() {
+                    if column < lines[row].len() {
                         &lines[row].as_bytes()[column..]
                     } else {
                         b"\n"

--- a/cli/src/tests/tree_test.rs
+++ b/cli/src/tests/tree_test.rs
@@ -735,7 +735,7 @@ fn index_of(text: &[u8], substring: &str) -> usize {
 
 fn range_of(text: &[u8], substring: &str) -> Range {
     let start_byte = index_of(text, substring);
-    let end_byte = start_byte + substring.as_bytes().len();
+    let end_byte = start_byte + substring.len();
     Range {
         start_byte,
         end_byte,


### PR DESCRIPTION
`.len()` on a string already returns the number of bytes.