### PR TITLE
build: simplify some cmake logic

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -6,41 +6,29 @@ project(tree-sitter
         HOMEPAGE_URL "https://tree-sitter.github.io/tree-sitter/"
         LANGUAGES C)
 
-if(NOT MSVC)
-  set(CMAKE_C_FLAGS "-O3 -Wall -Wextra -Wshadow -Wno-unused-parameter -pedantic")
-endif(NOT MSVC)
-
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 option(TREE_SITTER_FEATURE_WASM "Enable the Wasm feature" OFF)
 
-file(GLOB TS_SOURCE_FILES src/*.c)
-list(REMOVE_ITEM TS_SOURCE_FILES "${PROJECT_SOURCE_DIR}/src/lib.c")
-
-add_library(tree-sitter ${TS_SOURCE_FILES})
+add_library(tree-sitter src/lib.c)
 
 target_include_directories(tree-sitter PRIVATE src src/wasm include)
+if(NOT MSVC)
+  target_compile_options(tree-sitter PRIVATE -O3 -Wall -Wextra -Wshadow -Wno-unused-parameter -pedantic)
+endif()
 
 if(TREE_SITTER_FEATURE_WASM)
-  if(NOT DEFINED CACHE{WASMTIME_INCLUDE_DIR})
-    message(CHECK_START "Looking for wasmtime headers")
-    find_path(WASMTIME_INCLUDE_DIR wasmtime.h
-              PATHS ENV DEP_WASMTIME_C_API_INCLUDE
-              REQUIRED)
-    message(CHECK_PASS "found")
-  endif(NOT DEFINED CACHE{WASMTIME_INCLUDE_DIR})
+  find_path(WASMTIME_INCLUDE_DIR wasmtime.h
+            PATHS ENV DEP_WASMTIME_C_API_INCLUDE
+            REQUIRED)
 
-  if(NOT DEFINED CACHE{WASMTIME_LIBRARY})
-    message(CHECK_START "Looking for wasmtime library")
-    find_library(WASMTIME_LIBRARY wasmtime
-                 REQUIRED)
-    message(CHECK_PASS "found")
-  endif(NOT DEFINED CACHE{WASMTIME_LIBRARY})
+  find_library(WASMTIME_LIBRARY wasmtime
+               REQUIRED)
 
   target_compile_definitions(tree-sitter PUBLIC TREE_SITTER_FEATURE_WASM)
   target_include_directories(tree-sitter SYSTEM PRIVATE "${WASMTIME_INCLUDE_DIR}")
   target_link_libraries(tree-sitter PRIVATE "${WASMTIME_LIBRARY}")
-  set_property(TARGET tree-sitter PROPERTY C_STANDARD_REQUIRED ON)
-endif(TREE_SITTER_FEATURE_WASM)
+  set_target_properties(tree-sitter PROPERTIES C_STANDARD_REQUIRED ON)
+endif()
 
 set_target_properties(tree-sitter
                       PROPERTIES

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -9,6 +9,8 @@ project(tree-sitter
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 option(TREE_SITTER_FEATURE_WASM "Enable the Wasm feature" OFF)
 
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
 add_library(tree-sitter src/lib.c)
 
 target_include_directories(tree-sitter PRIVATE src src/wasm include)
@@ -17,16 +19,10 @@ if(NOT MSVC)
 endif()
 
 if(TREE_SITTER_FEATURE_WASM)
-  find_path(WASMTIME_INCLUDE_DIR wasmtime.h
-            PATHS ENV DEP_WASMTIME_C_API_INCLUDE
-            REQUIRED)
-
-  find_library(WASMTIME_LIBRARY wasmtime
-               REQUIRED)
+  find_package(Wasmtime)
+  target_link_libraries(tree-sitter PRIVATE wasmtime)
 
   target_compile_definitions(tree-sitter PUBLIC TREE_SITTER_FEATURE_WASM)
-  target_include_directories(tree-sitter SYSTEM PRIVATE "${WASMTIME_INCLUDE_DIR}")
-  target_link_libraries(tree-sitter PRIVATE "${WASMTIME_LIBRARY}")
   set_target_properties(tree-sitter PROPERTIES C_STANDARD_REQUIRED ON)
 endif()
 

--- a/lib/cmake/FindWasmtime.cmake
+++ b/lib/cmake/FindWasmtime.cmake
@@ -1,0 +1,23 @@
+include(FindPackageHandleStandardArgs)
+
+find_path(WASMTIME_INCLUDE_DIR wasmtime.h
+          PATHS ENV DEP_WASMTIME_C_API_INCLUDE
+          REQUIRED)
+
+find_library(WASMTIME_LIBRARY wasmtime
+             REQUIRED)
+
+if(WASMTIME_INCLUDE_DIR AND EXISTS "${WASMTIME_INCLUDE_DIR}/wasmtime.h")
+  file(STRINGS ${WASMTIME_INCLUDE_DIR}/wasmtime.h WASMTIME_VERSION REGEX "#define WASMTIME_VERSION")
+  string(REGEX MATCH "[0-9]+\.[0-9]\.[0-9]" WASMTIME_VERSION ${WASMTIME_VERSION})
+endif()
+
+find_package_handle_standard_args(Wasmtime
+  REQUIRED_VARS WASMTIME_INCLUDE_DIR WASMTIME_LIBRARY
+  VERSION_VAR WASMTIME_VERSION)
+
+add_library(wasmtime INTERFACE)
+target_include_directories(wasmtime SYSTEM BEFORE INTERFACE ${WASMTIME_INCLUDE_DIR})
+target_link_libraries(wasmtime INTERFACE ${WASMTIME_LIBRARY})
+
+mark_as_advanced(WASMTIME_INCLUDE_DIR WASMTIME_LIBRARY)


### PR DESCRIPTION
It's not needed to add logic around the find modules as they generally
behave like you want them, such as skipping a search if the cache
variable is already defined.

Also add only `src/lib.c` to the library since it by design includes the
necessary files to build the library. We could remove `src/lib.c` and
just add the necessary files as it is usually done, but if we already
have such a file it makes sense to use it to ensure it works as
expected.
