### PR TITLE
chore: remove `compile_flags.txt`

### DIFF
--- a/lib/compile_flags.txt
+++ b/lib/compile_flags.txt
@@ -1,4 +1,0 @@
--std=c11
--Isrc/wasm
--Iinclude
--D TREE_SITTER_FEATURE_WASM


### PR DESCRIPTION
This is no longer needed for LSPs to pick up the build configuration given that we have a Makefile & CMakeList.txt