### PR TITLE
feat: add shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8937760c3f4c60871870b8c3ee5f9b30771f792a7045c48bcbba999d7d6b3b8e"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,6 +1477,7 @@ dependencies = [
  "anyhow",
  "bstr",
  "clap",
+ "clap_complete",
  "ctor",
  "ctrlc",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ clap = { version = "4.5.18", features = [
   "help",
   "unstable-styles",
 ] }
+clap_complete = "4.5.29"
 ctor = "0.2.8"
 ctrlc = { version = "3.4.5", features = ["termination"] }
 dirs = "5.0.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,6 +29,7 @@ anstyle.workspace = true
 anyhow.workspace = true
 bstr.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 ctor.workspace = true
 ctrlc.workspace = true
 dirs.workspace = true


### PR DESCRIPTION
Closes #2608

Completions can now be generated with `tree-sitter complete --shell <shell>` (or `comp` for short), where shell is one of `bash`, `elvish`, `fish`, `powershell`, or `zsh`.