### PR TITLE
fix(lib): correct descendant-for-range behavior with zero-width tokens

### DIFF
--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -658,6 +658,26 @@ fn test_node_descendant_for_range() {
     assert_eq!(pair_node.end_byte(), string_index + 9);
     assert_eq!(pair_node.start_position(), Point::new(6, 4));
     assert_eq!(pair_node.end_position(), Point::new(6, 13));
+
+    // Zero-width token
+    {
+        let code = "<script></script>";
+        let mut parser = Parser::new();
+        parser.set_language(&get_language("html")).unwrap();
+
+        let tree = parser.parse(code, None).unwrap();
+        let root = tree.root_node();
+
+        let child = root
+            .named_descendant_for_point_range(Point::new(0, 8), Point::new(0, 8))
+            .unwrap();
+        assert_eq!(child.kind(), "raw_text");
+
+        let child2 = root.named_descendant_for_byte_range(8, 8).unwrap();
+        assert_eq!(child2.kind(), "raw_text");
+
+        assert_eq!(child, child2);
+    }
 }
 
 #[test]

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -375,9 +375,13 @@ static inline TSNode ts_node__descendant_for_byte_range(
       uint32_t node_end = iterator.position.bytes;
 
       // The end of this node must extend far enough forward to touch
-      // the end of the range and exceed the start of the range.
+      // the end of the range
       if (node_end < range_end) continue;
-      if (node_end <= range_start) continue;
+
+      // ...and exceed the start of the range, unless the node itself is
+      // empty, in which case it must at least be equal to the start of the range.
+      bool is_empty = ts_node_start_byte(child) == node_end;
+      if (is_empty ? node_end < range_start : node_end <= range_start) continue;
 
       // The start of this node must extend far enough backward to
       // touch the start of the range.
@@ -414,9 +418,15 @@ static inline TSNode ts_node__descendant_for_point_range(
       TSPoint node_end = iterator.position.extent;
 
       // The end of this node must extend far enough forward to touch
-      // the end of the range and exceed the start of the range.
+      // the end of the range
       if (point_lt(node_end, range_end)) continue;
-      if (point_lte(node_end, range_start)) continue;
+
+      // ...and exceed the start of the range, unless the node itself is
+      // empty, in which case it must at least be equal to the start of the range.
+      bool is_empty =  point_eq(ts_node_start_point(child), node_end);
+      if (is_empty ? point_lt(node_end, range_start) : point_lte(node_end, range_start)) {
+        continue;
+      }
 
       // The start of this node must extend far enough backward to
       // touch the start of the range.


### PR DESCRIPTION
Closes #1871

### Problem

Given a tree with a zero-width token (the source of many problems lately :laughing:), calling `descendant_for_{byte,point}_range` with the start and end byte/point of the zero-width token does *not* return the zero-width token in question, but instead it returns the next sibling, if any, or the parent. This is because a comparison to see if we've found the target node by checking if the range is less than or equal to the range start is incorrect in the case of a zero-width token, and it should instead special-case this and only check if the node's end range is strictly *less than* the range start.

### Solution

If the size of the node is zero (when the start and end range are equal), we do a strict *less than* comparison with the node's end range against the input start range.