### PR TITLE
style(lib): add parameter names in declarations that are missing them

### DIFF
--- a/lib/src/alloc.h
+++ b/lib/src/alloc.h
@@ -15,10 +15,10 @@ extern "C" {
 #define TS_PUBLIC __attribute__((visibility("default")))
 #endif
 
-TS_PUBLIC extern void *(*ts_current_malloc)(size_t);
-TS_PUBLIC extern void *(*ts_current_calloc)(size_t, size_t);
-TS_PUBLIC extern void *(*ts_current_realloc)(void *, size_t);
-TS_PUBLIC extern void (*ts_current_free)(void *);
+TS_PUBLIC extern void *(*ts_current_malloc)(size_t size);
+TS_PUBLIC extern void *(*ts_current_calloc)(size_t count, size_t size);
+TS_PUBLIC extern void *(*ts_current_realloc)(void *ptr, size_t size);
+TS_PUBLIC extern void (*ts_current_free)(void *ptr);
 
 // Allow clients to override allocation functions
 #ifndef ts_malloc

--- a/lib/src/language.h
+++ b/lib/src/language.h
@@ -35,13 +35,11 @@ typedef struct {
   uint16_t action_count;
 } LookaheadIterator;
 
-void ts_language_table_entry(const TSLanguage *, TSStateId, TSSymbol, TableEntry *);
+void ts_language_table_entry(const TSLanguage *self, TSStateId state, TSSymbol symbol, TableEntry *result);
 
-TSSymbolMetadata ts_language_symbol_metadata(const TSLanguage *, TSSymbol);
+TSSymbolMetadata ts_language_symbol_metadata(const TSLanguage *self, TSSymbol symbol);
 
-TSSymbol ts_language_public_symbol(const TSLanguage *, TSSymbol);
-
-TSStateId ts_language_next_state(const TSLanguage *self, TSStateId state, TSSymbol symbol);
+TSSymbol ts_language_public_symbol(const TSLanguage *self, TSSymbol symbol);
 
 static inline bool ts_language_is_symbol_external(const TSLanguage *self, TSSymbol symbol) {
   return 0 < symbol && symbol < self->external_token_count + 1;

--- a/lib/src/lexer.h
+++ b/lib/src/lexer.h
@@ -31,14 +31,14 @@ typedef struct {
   char debug_buffer[TREE_SITTER_SERIALIZATION_BUFFER_SIZE];
 } Lexer;
 
-void ts_lexer_init(Lexer *);
-void ts_lexer_delete(Lexer *);
-void ts_lexer_set_input(Lexer *, TSInput);
-void ts_lexer_reset(Lexer *, Length);
-void ts_lexer_start(Lexer *);
-void ts_lexer_finish(Lexer *, uint32_t *);
-void ts_lexer_advance_to_end(Lexer *);
-void ts_lexer_mark_end(Lexer *);
+void ts_lexer_init(Lexer *self);
+void ts_lexer_delete(Lexer *self);
+void ts_lexer_set_input(Lexer *self, TSInput input);
+void ts_lexer_reset(Lexer *self, Length position);
+void ts_lexer_start(Lexer *self);
+void ts_lexer_finish(Lexer *self, uint32_t *lookahead_end_byte);
+void ts_lexer_advance_to_end(Lexer *self);
+void ts_lexer_mark_end(Lexer *self);
 bool ts_lexer_set_included_ranges(Lexer *self, const TSRange *ranges, uint32_t count);
 TSRange *ts_lexer_included_ranges(const Lexer *self, uint32_t *count);
 

--- a/lib/src/stack.h
+++ b/lib/src/stack.h
@@ -7,7 +7,6 @@ extern "C" {
 
 #include "./array.h"
 #include "./subtree.h"
-#include "./error_costs.h"
 #include <stdio.h>
 
 typedef struct Stack Stack;
@@ -29,23 +28,23 @@ typedef struct {
 typedef Array(StackSummaryEntry) StackSummary;
 
 // Create a stack.
-Stack *ts_stack_new(SubtreePool *);
+Stack *ts_stack_new(SubtreePool *subtree_pool);
 
 // Release the memory reserved for a given stack.
-void ts_stack_delete(Stack *);
+void ts_stack_delete(Stack *self);
 
 // Get the stack's current number of versions.
-uint32_t ts_stack_version_count(const Stack *);
+uint32_t ts_stack_version_count(const Stack *self);
 
 // Get the state at the top of the given version of the stack. If the stack is
 // empty, this returns the initial state, 0.
-TSStateId ts_stack_state(const Stack *, StackVersion);
+TSStateId ts_stack_state(const Stack *self, StackVersion version);
 
 // Get the last external token associated with a given version of the stack.
-Subtree ts_stack_last_external_token(const Stack *, StackVersion);
+Subtree ts_stack_last_external_token(const Stack *self, StackVersion version);
 
 // Set the last external token associated with a given version of the stack.
-void ts_stack_set_last_external_token(Stack *, StackVersion, Subtree );
+void ts_stack_set_last_external_token(Stack *self, StackVersion version, Subtree token);
 
 // Get the position of the given version of the stack within the document.
 Length ts_stack_position(const Stack *, StackVersion);
@@ -55,76 +54,74 @@ Length ts_stack_position(const Stack *, StackVersion);
 // This transfers ownership of the tree to the Stack. Callers that
 // need to retain ownership of the tree for their own purposes should
 // first retain the tree.
-void ts_stack_push(Stack *, StackVersion, Subtree , bool, TSStateId);
+void ts_stack_push(Stack *self, StackVersion version, Subtree subtree, bool pending, TSStateId state);
 
 // Pop the given number of entries from the given version of the stack. This
 // operation can increase the number of stack versions by revealing multiple
 // versions which had previously been merged. It returns an array that
 // specifies the index of each revealed version and the trees that were
 // removed from that version.
-StackSliceArray ts_stack_pop_count(Stack *, StackVersion, uint32_t count);
+StackSliceArray ts_stack_pop_count(Stack *self, StackVersion version, uint32_t count);
 
 // Remove an error at the top of the given version of the stack.
-SubtreeArray ts_stack_pop_error(Stack *, StackVersion);
+SubtreeArray ts_stack_pop_error(Stack *self, StackVersion version);
 
 // Remove any pending trees from the top of the given version of the stack.
-StackSliceArray ts_stack_pop_pending(Stack *, StackVersion);
+StackSliceArray ts_stack_pop_pending(Stack *self, StackVersion version);
 
-// Remove any all trees from the given version of the stack.
-StackSliceArray ts_stack_pop_all(Stack *, StackVersion);
+// Remove all trees from the given version of the stack.
+StackSliceArray ts_stack_pop_all(Stack *self, StackVersion version);
 
 // Get the maximum number of tree nodes reachable from this version of the stack
 // since the last error was detected.
-unsigned ts_stack_node_count_since_error(const Stack *, StackVersion);
+unsigned ts_stack_node_count_since_error(const Stack *self, StackVersion version);
 
-int ts_stack_dynamic_precedence(Stack *, StackVersion);
+int ts_stack_dynamic_precedence(Stack *self, StackVersion version);
 
-bool ts_stack_has_advanced_since_error(const Stack *, StackVersion);
+bool ts_stack_has_advanced_since_error(const Stack *self, StackVersion version);
 
 // Compute a summary of all the parse states near the top of the given
 // version of the stack and store the summary for later retrieval.
-void ts_stack_record_summary(Stack *, StackVersion, unsigned max_depth);
+void ts_stack_record_summary(Stack *self, StackVersion version, unsigned max_depth);
 
 // Retrieve a summary of all the parse states near the top of the
 // given version of the stack.
-StackSummary *ts_stack_get_summary(Stack *, StackVersion);
+StackSummary *ts_stack_get_summary(Stack *self, StackVersion version);
 
 // Get the total cost of all errors on the given version of the stack.
-unsigned ts_stack_error_cost(const Stack *, StackVersion version);
+unsigned ts_stack_error_cost(const Stack *self, StackVersion version);
 
 // Merge the given two stack versions if possible, returning true
 // if they were successfully merged and false otherwise.
-bool ts_stack_merge(Stack *, StackVersion, StackVersion);
+bool ts_stack_merge(Stack *self, StackVersion version1, StackVersion version2);
 
 // Determine whether the given two stack versions can be merged.
-bool ts_stack_can_merge(Stack *, StackVersion, StackVersion);
+bool ts_stack_can_merge(Stack *self, StackVersion version1, StackVersion version2);
 
-Subtree ts_stack_resume(Stack *, StackVersion);
+Subtree ts_stack_resume(Stack *self, StackVersion version);
 
-void ts_stack_pause(Stack *, StackVersion, Subtree);
+void ts_stack_pause(Stack *self, StackVersion version, Subtree lookahead);
 
-void ts_stack_halt(Stack *, StackVersion);
+void ts_stack_halt(Stack *self, StackVersion version);
 
-bool ts_stack_is_active(const Stack *, StackVersion);
+bool ts_stack_is_active(const Stack *self, StackVersion version);
 
-bool ts_stack_is_paused(const Stack *, StackVersion);
+bool ts_stack_is_paused(const Stack *self, StackVersion version);
 
-bool ts_stack_is_halted(const Stack *, StackVersion);
+bool ts_stack_is_halted(const Stack *self, StackVersion version);
 
-void ts_stack_renumber_version(Stack *, StackVersion, StackVersion);
+void ts_stack_renumber_version(Stack *self, StackVersion v1, StackVersion v2);
 
-void ts_stack_swap_versions(Stack *, StackVersion, StackVersion);
+void ts_stack_swap_versions(Stack *, StackVersion v1, StackVersion v2);
 
-StackVersion ts_stack_copy_version(Stack *, StackVersion);
+StackVersion ts_stack_copy_version(Stack *self, StackVersion version);
 
 // Remove the given version from the stack.
-void ts_stack_remove_version(Stack *, StackVersion);
+void ts_stack_remove_version(Stack *self, StackVersion version);
 
-void ts_stack_clear(Stack *);
+void ts_stack_clear(Stack *self);
 
-bool ts_stack_print_dot_graph(Stack *, const TSLanguage *, FILE *);
-
-typedef void (*StackIterateCallback)(void *, TSStateId, uint32_t);
+bool ts_stack_print_dot_graph(Stack *self, const TSLanguage *language, FILE *f);
 
 #ifdef __cplusplus
 }

--- a/lib/src/tree.h
+++ b/lib/src/tree.h
@@ -21,8 +21,8 @@ struct TSTree {
   unsigned included_range_count;
 };
 
-TSTree *ts_tree_new(Subtree root, const TSLanguage *language, const TSRange *, unsigned);
-TSNode ts_node_new(const TSTree *, const Subtree *, Length, TSSymbol);
+TSTree *ts_tree_new(Subtree root, const TSLanguage *language, const TSRange *included_ranges, unsigned included_range_count);
+TSNode ts_node_new(const TSTree *tree, const Subtree *subtree, Length position, TSSymbol alias);
 
 #ifdef __cplusplus
 }

--- a/lib/src/tree_cursor.h
+++ b/lib/src/tree_cursor.h
@@ -23,19 +23,19 @@ typedef enum {
   TreeCursorStepVisible,
 } TreeCursorStep;
 
-void ts_tree_cursor_init(TreeCursor *, TSNode);
+void ts_tree_cursor_init(TreeCursor *self, TSNode node);
 void ts_tree_cursor_current_status(
-  const TSTreeCursor *,
-  TSFieldId *,
-  bool *,
-  bool *,
-  bool *,
-  TSSymbol *,
-  unsigned *
+  const TSTreeCursor *_self,
+  TSFieldId *field_id,
+  bool *has_later_siblings,
+  bool *has_later_named_siblings,
+  bool *can_have_later_siblings_with_this_field,
+  TSSymbol *supertypes,
+  unsigned *supertype_count
 );
 
-TreeCursorStep ts_tree_cursor_goto_first_child_internal(TSTreeCursor *);
-TreeCursorStep ts_tree_cursor_goto_next_sibling_internal(TSTreeCursor *);
+TreeCursorStep ts_tree_cursor_goto_first_child_internal(TSTreeCursor *_self);
+TreeCursorStep ts_tree_cursor_goto_next_sibling_internal(TSTreeCursor *_self);
 
 static inline Subtree ts_tree_cursor_current_subtree(const TSTreeCursor *_self) {
   const TreeCursor *self = (const TreeCursor *)_self;
@@ -43,6 +43,6 @@ static inline Subtree ts_tree_cursor_current_subtree(const TSTreeCursor *_self) 
   return *last_entry->subtree;
 }
 
-TSNode ts_tree_cursor_parent_node(const TSTreeCursor *);
+TSNode ts_tree_cursor_parent_node(const TSTreeCursor *_self);
 
 #endif  // TREE_SITTER_TREE_CURSOR_H_

--- a/lib/src/wasm_store.h
+++ b/lib/src/wasm_store.h
@@ -8,21 +8,21 @@ extern "C" {
 #include "tree_sitter/api.h"
 #include "./parser.h"
 
-bool ts_wasm_store_start(TSWasmStore *, TSLexer *, const TSLanguage *);
-void ts_wasm_store_reset(TSWasmStore *);
-bool ts_wasm_store_has_error(const TSWasmStore *);
+bool ts_wasm_store_start(TSWasmStore *self, TSLexer *lexer, const TSLanguage *language);
+void ts_wasm_store_reset(TSWasmStore *self);
+bool ts_wasm_store_has_error(const TSWasmStore *self);
 
-bool ts_wasm_store_call_lex_main(TSWasmStore *, TSStateId);
-bool ts_wasm_store_call_lex_keyword(TSWasmStore *, TSStateId);
+bool ts_wasm_store_call_lex_main(TSWasmStore *self, TSStateId state);
+bool ts_wasm_store_call_lex_keyword(TSWasmStore *self, TSStateId state);
 
-uint32_t ts_wasm_store_call_scanner_create(TSWasmStore *);
-void ts_wasm_store_call_scanner_destroy(TSWasmStore *, uint32_t);
-bool ts_wasm_store_call_scanner_scan(TSWasmStore *, uint32_t, uint32_t);
-uint32_t ts_wasm_store_call_scanner_serialize(TSWasmStore *, uint32_t, char *);
-void ts_wasm_store_call_scanner_deserialize(TSWasmStore *, uint32_t, const char *, unsigned);
+uint32_t ts_wasm_store_call_scanner_create(TSWasmStore *self);
+void ts_wasm_store_call_scanner_destroy(TSWasmStore *self, uint32_t scanner_address);
+bool ts_wasm_store_call_scanner_scan(TSWasmStore *self, uint32_t scanner_address, uint32_t valid_tokens_ix);
+uint32_t ts_wasm_store_call_scanner_serialize(TSWasmStore *self, uint32_t scanner_address, char *buffer);
+void ts_wasm_store_call_scanner_deserialize(TSWasmStore *self, uint32_t scanner, const char *buffer, unsigned length);
 
-void ts_wasm_language_retain(const TSLanguage *);
-void ts_wasm_language_release(const TSLanguage *);
+void ts_wasm_language_retain(const TSLanguage *self);
+void ts_wasm_language_release(const TSLanguage *self);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Mainly for consistency & as a nice to have