### PR TITLE
refactor: improve the grammar schema

### DIFF
--- a/cli/generate/src/dsl.js
+++ b/cli/generate/src/dsl.js
@@ -485,7 +485,11 @@ globalThis.grammar = grammar;
 globalThis.field = field;
 
 const result = await import(getEnv("TREE_SITTER_GRAMMAR_PATH"));
-const output = JSON.stringify(result.default?.grammar ?? result.grammar);
+const object = {
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
+  ...(result.default?.grammar ?? result.grammar)
+};
+const output = JSON.stringify(object);
 
 if (globalThis.process) { // Node/Bun
   process.stdout.write(output);

--- a/docs/assets/schemas/grammar.schema.json
+++ b/docs/assets/schemas/grammar.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "tree-sitter grammar specification",
+  "title": "Tree-sitter grammar specification",
   "type": "object",
 
   "required": ["name", "rules"],
@@ -9,13 +9,13 @@
 
   "properties": {
     "name": {
-      "description": "the name of the grammar",
+      "description": "The name of the grammar",
       "type": "string",
       "pattern": "^[a-zA-Z_]\\w*"
     },
 
     "inherits": {
-      "description": "the name of the parent grammar",
+      "description": "The name of the parent grammar",
       "type": "string",
       "pattern": "^[a-zA-Z_]\\w*"
     },
@@ -93,7 +93,7 @@
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "description": "the name of a rule in `rules` or `extras`",
+        "description": "The name of a rule in `rules` or `extras`",
         "type": "string"
       }
     }
@@ -105,7 +105,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "pattern": "^BLANK$"
+          "const": "BLANK"
         }
       },
       "required": ["type"]
@@ -116,7 +116,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "pattern": "^STRING$"
+          "const": "STRING"
         },
         "value": {
           "type": "string"
@@ -130,7 +130,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "pattern": "^PATTERN$"
+          "const": "PATTERN"
         },
         "value": { "type": "string" },
         "flags": { "type": "string" }
@@ -143,7 +143,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "pattern": "^SYMBOL$"
+          "const": "SYMBOL"
         },
         "name": { "type": "string" }
       },
@@ -155,7 +155,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "pattern": "^SEQ$"
+          "const": "SEQ"
         },
         "members": {
           "type": "array",
@@ -172,7 +172,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "pattern": "^CHOICE$"
+          "const": "CHOICE"
         },
         "members": {
           "type": "array",
@@ -189,14 +189,10 @@
       "properties": {
         "type": {
           "type": "string",
-          "pattern": "^ALIAS$"
+          "const": "ALIAS"
         },
-        "value": {
-          "type": "string"
-        },
-        "named": {
-          "type": "boolean"
-        },
+        "value": { "type": "string" },
+        "named": { "type": "boolean" },
         "content": {
           "$ref": "#/definitions/rule"
         }
@@ -209,7 +205,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "pattern": "^REPEAT$"
+          "const": "REPEAT"
         },
         "content": {
           "$ref": "#/definitions/rule"
@@ -223,7 +219,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "pattern": "^REPEAT1$"
+          "const": "REPEAT1"
         },
         "content": {
           "$ref": "#/definitions/rule"
@@ -237,7 +233,10 @@
       "properties": {
         "type": {
           "type": "string",
-          "pattern": "^(TOKEN|IMMEDIATE_TOKEN)$"
+          "enum": [
+            "TOKEN",
+            "IMMEDIATE_TOKEN"
+          ]
         },
         "content": {
           "$ref": "#/definitions/rule"
@@ -251,7 +250,7 @@
         "name": { "type": "string" },
         "type": {
           "type": "string",
-          "pattern": "^FIELD$"
+          "const": "FIELD"
         },
         "content": {
           "$ref": "#/definitions/rule"
@@ -265,7 +264,12 @@
       "properties": {
         "type": {
           "type": "string",
-          "pattern": "^(PREC|PREC_LEFT|PREC_RIGHT|PREC_DYNAMIC)$"
+          "enum": [
+            "PREC",
+            "PREC_LEFT",
+            "PREC_RIGHT",
+            "PREC_DYNAMIC"
+          ]
         },
         "value": {
           "oneof": [

--- a/docs/section-5-implementation.md
+++ b/docs/section-5-implementation.md
@@ -21,7 +21,7 @@ The `tree-sitter` CLI's most important feature is the `generate` subcommand. Thi
 
 ### Parsing a Grammar
 
-First, Tree-sitter must evaluate the JavaScript code in `grammar.js` and convert the grammar to a JSON format. It does this by shelling out to `node`. The format of the grammars is formally specified by the JSON schema in [grammar-schema.json](https://github.com/tree-sitter/tree-sitter/blob/master/cli/src/generate/grammar-schema.json). The parsing is implemented in [parse_grammar.rs](https://github.com/tree-sitter/tree-sitter/blob/master/cli/src/generate/parse_grammar.rs).
+First, Tree-sitter must evaluate the JavaScript code in `grammar.js` and convert the grammar to a JSON format. It does this by shelling out to `node`. The format of the grammars is formally specified by the JSON schema in [grammar.schema.json](https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json). The parsing is implemented in [parse_grammar.rs](https://github.com/tree-sitter/tree-sitter/blob/master/cli/src/generate/parse_grammar.rs).
 
 ### Grammar Rules
 

--- a/docs/section-5-implementation.md
+++ b/docs/section-5-implementation.md
@@ -21,15 +21,15 @@ The `tree-sitter` CLI's most important feature is the `generate` subcommand. Thi
 
 ### Parsing a Grammar
 
-First, Tree-sitter must evaluate the JavaScript code in `grammar.js` and convert the grammar to a JSON format. It does this by shelling out to `node`. The format of the grammars is formally specified by the JSON schema in [grammar.schema.json](https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json). The parsing is implemented in [parse_grammar.rs](https://github.com/tree-sitter/tree-sitter/blob/master/cli/src/generate/parse_grammar.rs).
+First, Tree-sitter must evaluate the JavaScript code in `grammar.js` and convert the grammar to a JSON format. It does this by shelling out to `node`. The format of the grammars is formally specified by the JSON schema in [grammar.schema.json](https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json). The parsing is implemented in [parse_grammar.rs](https://github.com/tree-sitter/tree-sitter/blob/master/cli/generate/src/parse_grammar.rs).
 
 ### Grammar Rules
 
-A Tree-sitter grammar is composed of a set of *rules* - objects that describe how syntax nodes can be composed from other syntax nodes. There are several types of rules: symbols, strings, regexes, sequences, choices, repetitions, and a few others. Internally, these are all represented using an [enum](https://doc.rust-lang.org/book/ch06-01-defining-an-enum.html) called [`Rule`](https://github.com/tree-sitter/tree-sitter/blob/master/cli/src/generate/rules.rs).
+A Tree-sitter grammar is composed of a set of *rules* - objects that describe how syntax nodes can be composed from other syntax nodes. There are several types of rules: symbols, strings, regexes, sequences, choices, repetitions, and a few others. Internally, these are all represented using an [enum](https://doc.rust-lang.org/book/ch06-01-defining-an-enum.html) called [`Rule`](https://github.com/tree-sitter/tree-sitter/blob/master/cli/generate/src/rules.rs).
 
 ### Preparing a Grammar
 
-Once a grammar has been parsed, it must be transformed in several ways before it can be used to generate a parser. Each transformation is implemented by a separate file in the [`prepare_grammar`](https://github.com/tree-sitter/tree-sitter/tree/master/cli/src/generate/prepare_grammar) directory, and the transformations are ultimately composed together in `prepare_grammar/mod.rs`.
+Once a grammar has been parsed, it must be transformed in several ways before it can be used to generate a parser. Each transformation is implemented by a separate file in the [`prepare_grammar`](https://github.com/tree-sitter/tree-sitter/tree/master/cli/generate/src/prepare_grammar) directory, and the transformations are ultimately composed together in `prepare_grammar/mod.rs`.
 
 At the end of these transformations, the initial grammar is split into two grammars: a *syntax grammar* and a *lexical grammar*. The syntax grammar describes how the language's [*non-terminal symbols*](https://en.wikipedia.org/wiki/Terminal_and_nonterminal_symbols) are constructed from other grammar symbols, and the lexical grammar describes how the grammar's *terminal symbols* (strings and regexes) can be composed from individual characters.
 

--- a/script/generate-unicode-categories-json
+++ b/script/generate-unicode-categories-json
@@ -2,10 +2,10 @@
 
 // This script generates a JSON file that is used by the CLI to handle unicode property escapes.
 
-const CATEGORY_OUTPUT_PATH = './cli/src/generate/prepare_grammar/unicode-categories.json'
-const PROPERTY_OUTPUT_PATH = './cli/src/generate/prepare_grammar/unicode-properties.json'
-const CATEGORY_ALIAS_OUTPUT_PATH = './cli/src/generate/prepare_grammar/unicode-category-aliases.json'
-const PROPERTY_ALIAS_OUTPUT_PATH = './cli/src/generate/prepare_grammar/unicode-property-aliases.json'
+const CATEGORY_OUTPUT_PATH = './cli/generate/src/prepare_grammar/unicode-categories.json'
+const PROPERTY_OUTPUT_PATH = './cli/generate/src/prepare_grammar/unicode-properties.json'
+const CATEGORY_ALIAS_OUTPUT_PATH = './cli/generate/src/prepare_grammar/unicode-category-aliases.json'
+const PROPERTY_ALIAS_OUTPUT_PATH = './cli/generate/src/prepare_grammar/unicode-property-aliases.json'
 
 const UNICODE_STANDARD_VERSION = '15.1.0';
 const CATEGORY_URL = `https://unicode.org/Public/${UNICODE_STANDARD_VERSION}/ucd/UnicodeData.txt`


### PR DESCRIPTION
- Publish on the GitHub page
- Specify in the generated file
- Use const/enum instead of pattern