### PR TITLE
feat: move tree-sitter configuration to dedicated file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,7 @@ dependencies = [
  "tree-sitter-tags",
  "tree-sitter-tests-proc-macro",
  "unindent",
+ "url",
  "walkdir",
  "wasmparser",
  "webbrowser",
@@ -1649,6 +1650,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-highlight",
  "tree-sitter-tags",
+ "url",
 ]
 
 [[package]]
@@ -1720,6 +1722,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,9 +988,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -1045,6 +1048,12 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "postcard"
@@ -1179,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1191,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1202,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +461,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "fuzzy-matcher",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +518,12 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "equivalent"
@@ -549,6 +582,15 @@ checksum = "e8c6b3bd49c37d2aa3f3f2220233b29a7cd23f79d1fe70e5337d25fb390793de"
 dependencies = [
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -1209,6 +1251,9 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -1251,6 +1296,12 @@ checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"
@@ -1369,6 +1420,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tiny_http"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,6 +1545,7 @@ dependencies = [
  "clap_complete",
  "ctor",
  "ctrlc",
+ "dialoguer",
  "dirs",
  "filetime",
  "glob",
@@ -1580,6 +1642,7 @@ dependencies = [
  "once_cell",
  "path-slash",
  "regex",
+ "semver",
  "serde",
  "serde_json",
  "tempfile",
@@ -1629,6 +1692,12 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -2295,3 +2364,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,9 +1379,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ thiserror = "1.0.64"
 tiny_http = "0.12.0"
 toml = "0.8.19"
 unindent = "0.2.3"
+url = { version = "2.5.2", features = ["serde"] }
 walkdir = "2.5.0"
 wasmparser = "0.217.0"
 webbrowser = "1.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ clap = { version = "4.5.18", features = [
 clap_complete = "4.5.29"
 ctor = "0.2.8"
 ctrlc = { version = "3.4.5", features = ["termination"] }
+dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 dirs = "5.0.1"
 filetime = "0.2.25"
 fs4 = "0.9.1"
@@ -78,7 +79,7 @@ rand = "0.8.5"
 regex = "1.10.6"
 regex-syntax = "0.8.4"
 rustc-hash = "2.0.0"
-semver = "1.0.23"
+semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_derive = "1.0.210"
 serde_json = { version = "1.0.128", features = ["preserve_order"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -55,6 +55,7 @@ similar.workspace = true
 smallbitvec.workspace = true
 streaming-iterator.workspace = true
 tiny_http.workspace = true
+url.workspace = true
 walkdir.workspace = true
 wasmparser.workspace = true
 webbrowser.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -32,6 +32,7 @@ clap.workspace = true
 clap_complete.workspace = true
 ctor.workspace = true
 ctrlc.workspace = true
+dialoguer.workspace = true
 dirs.workspace = true
 filetime.workspace = true
 glob.workspace = true

--- a/cli/generate/Cargo.toml
+++ b/cli/generate/Cargo.toml
@@ -26,8 +26,6 @@ semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 smallbitvec.workspace = true
+url.workspace = true
 
 tree-sitter.workspace = true
-
-[target."cfg(windows)".dependencies]
-url = "2.5.2"

--- a/cli/loader/Cargo.toml
+++ b/cli/loader/Cargo.toml
@@ -32,6 +32,7 @@ semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
+url.workspace = true
 
 tree-sitter = { workspace = true }
 tree-sitter-highlight = { workspace = true, optional = true }

--- a/cli/loader/Cargo.toml
+++ b/cli/loader/Cargo.toml
@@ -28,10 +28,11 @@ libloading.workspace = true
 once_cell.workspace = true
 path-slash.workspace = true
 regex.workspace = true
+semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 
-tree-sitter = {workspace = true}
-tree-sitter-highlight = {workspace = true, optional = true}
-tree-sitter-tags = {workspace = true, optional = true}
+tree-sitter = { workspace = true }
+tree-sitter-highlight = { workspace = true, optional = true }
+tree-sitter-tags = { workspace = true, optional = true }

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -188,7 +188,8 @@ pub struct Metadata {
     pub license: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    pub authors: Vec<Author>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authors: Option<Vec<Author>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<Links>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -36,6 +36,7 @@ use tree_sitter::QueryErrorKind;
 use tree_sitter_highlight::HighlightConfiguration;
 #[cfg(feature = "tree-sitter-tags")]
 use tree_sitter_tags::{Error as TagsError, TagsConfiguration};
+use url::Url;
 
 pub const EMSCRIPTEN_TAG: &str = concat!("docker.io/emscripten/emsdk:", env!("EMSCRIPTEN_VERSION"));
 
@@ -197,7 +198,7 @@ pub struct Author {
 
 #[derive(Serialize, Deserialize)]
 pub struct Links {
-    pub repository: String,
+    pub repository: Url,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub homepage: Option<String>,
 }

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -97,6 +97,7 @@ pub struct PackageJSON {
     pub version: Version,
     pub description: Option<String>,
     pub author: Option<PackageJSONAuthor>,
+    pub maintainers: Option<Vec<PackageJSONAuthor>>,
     pub license: Option<String>,
     pub repository: Option<PackageJSONRepository>,
     #[serde(default)]

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -100,14 +100,8 @@ pub struct PackageJSON {
     pub license: Option<String>,
     pub repository: Option<PackageJSONRepository>,
     #[serde(default)]
-    #[serde(rename = "tree-sitter")]
+    #[serde(rename = "tree-sitter", skip_serializing_if = "Option::is_none")]
     pub tree_sitter: Option<Vec<LanguageConfigurationJSON>>,
-}
-
-impl PackageJSON {
-    pub fn has_multiple_language_configs(&self) -> bool {
-        self.tree_sitter.as_ref().is_some_and(|c| c.len() > 1)
-    }
 }
 
 fn default_path() -> PathBuf {
@@ -144,6 +138,12 @@ pub struct TreeSitterJSON {
     pub grammars: Vec<Grammar>,
     pub metadata: Metadata,
     pub bindings: Bindings,
+}
+
+impl TreeSitterJSON {
+    pub fn has_multiple_language_configs(&self) -> bool {
+        self.grammars.len() > 1
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -220,8 +220,8 @@ impl Default for Bindings {
         Self {
             c: true,
             go: true,
-            java: true,
-            kotlin: true,
+            java: false,
+            kotlin: false,
             node: true,
             python: true,
             rust: true,

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -278,8 +278,8 @@ pub fn migrate_package_json(repo_path: &Path) -> Result<bool> {
                     .clone()
                     .map(|r| match r {
                         PackageJSONRepository::String(s) => {
-                            if s.starts_with("github:") {
-                                let repo_name = &s["github:".len()..].trim();
+                            if let Some(stripped) = s.strip_prefix("github:") {
+                                let repo_name = stripped.trim();
                                 Url::parse(&format!("https://github.com/{repo_name}"))
                             } else {
                                 Url::parse(&s)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -476,7 +476,7 @@ impl Init {
 
             let description = |name: &str| {
                 Input::<String>::with_theme(&ColorfulTheme::default())
-                    .with_prompt("What is the description of your language?")
+                    .with_prompt("Description")
                     .default(format!(
                         "{} grammar for tree-sitter",
                         name.to_upper_camel_case()
@@ -488,9 +488,7 @@ impl Init {
 
             let repository = |name: &str| {
                 Input::<Url>::with_theme(&ColorfulTheme::default())
-                    .with_prompt(
-                        "What is the repository URL? (if you don't have one, just hit enter)",
-                    )
+                    .with_prompt("Repository URL")
                     .allow_empty(true)
                     .default(
                         Url::parse(&format!(
@@ -504,14 +502,14 @@ impl Init {
 
             let scope = |name: &str| {
                 Input::<String>::with_theme(&ColorfulTheme::default())
-                    .with_prompt("What is the scope of your language?")
+                    .with_prompt("TextMate scope")
                     .default(format!("source.{name}"))
                     .interact_text()
             };
 
             let file_types = |name: &str| {
                 Input::<String>::with_theme(&ColorfulTheme::default())
-                    .with_prompt("What file types are associated with your language? (space-separated, e.g. `.py .pyw`)")
+                    .with_prompt("File types (space-separated)")
                     .default(format!(".{name}"))
                     .interact_text()
                     .map(|ft| {
@@ -528,14 +526,14 @@ impl Init {
 
             let initial_version = || {
                 Input::<Version>::with_theme(&ColorfulTheme::default())
-                    .with_prompt("What is the initial version of your language?")
+                    .with_prompt("Version")
                     .default(Version::new(0, 1, 0))
                     .interact_text()
             };
 
             let license = || {
                 Input::<String>::with_theme(&ColorfulTheme::default())
-                    .with_prompt("What license will you use?")
+                    .with_prompt("License")
                     .default("MIT".to_string())
                     .allow_empty(true)
                     .interact()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -542,7 +542,8 @@ impl Init {
                 Input::<String>::with_theme(&ColorfulTheme::default())
                     .with_prompt("What license will you use?")
                     .default("MIT".to_string())
-                    .interact_text()
+                    .allow_empty(true)
+                    .interact()
             };
 
             let description = |name: &str| {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -33,6 +33,7 @@ use tree_sitter_config::Config;
 use tree_sitter_highlight::Highlighter;
 use tree_sitter_loader::{self as loader, TreeSitterJSON};
 use tree_sitter_tags::TagsContext;
+use url::Url;
 
 const BUILD_VERSION: &str = env!("CARGO_PKG_VERSION");
 const BUILD_SHA: Option<&'static str> = option_env!("BUILD_SHA");
@@ -557,12 +558,17 @@ impl Init {
             };
 
             let repository = |name: &str| {
-                Input::<String>::with_theme(&ColorfulTheme::default())
+                Input::<Url>::with_theme(&ColorfulTheme::default())
                     .with_prompt(
                         "What is the repository URL? (if you don't have one, just hit enter)",
                     )
                     .allow_empty(true)
-                    .default(format!("https://github.com/tree-sitter/tree-sitter-{name}"))
+                    .default(
+                        Url::parse(&format!(
+                            "https://github.com/tree-sitter/tree-sitter-{name}"
+                        ))
+                        .expect("Failed to parse default repository URL"),
+                    )
                     .show_default(false)
                     .interact_text()
             };
@@ -599,7 +605,7 @@ impl Init {
                         "file_types" => opts.file_types = file_types(&opts.name)?,
                         "license" => opts.license = license()?,
                         "description" => opts.description = description(&opts.name)?,
-                        "repository" => opts.repository = repository(&opts.name)?,
+                        "repository" => opts.repository = Some(repository(&opts.name)?),
                         "version" => opts.version = initial_version()?,
                         "exit" => break,
                         _ => unreachable!(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -530,7 +530,7 @@ impl Init {
                         let mut set = HashSet::new();
                         for ext in ft.split(',').flat_map(|part| part.split(' ')) {
                             let ext = ext.trim();
-                            if ext.len() > 0 {
+                            if !ext.is_empty() {
                                 set.insert(ext.to_string());
                             }
                         }

--- a/cli/src/templates/PARSER_NAME.pc.in
+++ b/cli/src/templates/PARSER_NAME.pc.in
@@ -3,7 +3,7 @@ libdir=@LIBDIR@
 includedir=@INCLUDEDIR@
 
 Name: tree-sitter-PARSER_NAME
-Description: CAMEL_PARSER_NAME grammar for tree-sitter
+Description: PARSER_DESCRIPTION
 URL: @URL@
 Version: @VERSION@
 Requires: @REQUIRES@

--- a/cli/src/templates/__init__.py
+++ b/cli/src/templates/__init__.py
@@ -1,4 +1,4 @@
-"""CAMEL_PARSER_NAME grammar for tree-sitter"""
+"""PARSER_DESCRIPTION"""
 
 from importlib.resources import files as _files
 

--- a/cli/src/templates/_cargo.toml
+++ b/cli/src/templates/_cargo.toml
@@ -2,7 +2,7 @@
 name = "tree-sitter-PARSER_NAME"
 description = "PARSER_DESCRIPTION"
 version = "0.0.1"
-authors = ["PARSER_AUTHOR_NAME PARSER_AUTHOR_EMAIL_ANGLED"]
+authors = ["PARSER_AUTHOR_NAME PARSER_AUTHOR_EMAIL"]
 license = "PARSER_LICENSE"
 readme = "README.md"
 keywords = ["incremental", "parsing", "tree-sitter", "PARSER_NAME"]

--- a/cli/src/templates/_cargo.toml
+++ b/cli/src/templates/_cargo.toml
@@ -7,7 +7,7 @@ license = "PARSER_LICENSE"
 readme = "README.md"
 keywords = ["incremental", "parsing", "tree-sitter", "PARSER_NAME"]
 categories = ["parsing", "text-editors"]
-repository = "https://github.com/tree-sitter/tree-sitter-PARSER_NAME"
+repository = "PARSER_URL"
 edition = "2021"
 autoexamples = false
 

--- a/cli/src/templates/_cargo.toml
+++ b/cli/src/templates/_cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "tree-sitter-PARSER_NAME"
-description = "CAMEL_PARSER_NAME grammar for tree-sitter"
+description = "PARSER_DESCRIPTION"
 version = "0.0.1"
-license = "MIT"
+authors = ["PARSER_AUTHOR_NAME PARSER_AUTHOR_EMAIL_ANGLED"]
+license = "PARSER_LICENSE"
 readme = "README.md"
 keywords = ["incremental", "parsing", "tree-sitter", "PARSER_NAME"]
 categories = ["parsing", "text-editors"]

--- a/cli/src/templates/binding_test.go
+++ b/cli/src/templates/binding_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
-	tree_sitter_LOWER_PARSER_NAME "github.com/tree-sitter/tree-sitter-PARSER_NAME/bindings/go"
+	tree_sitter_LOWER_PARSER_NAME "PARSER_URL_STRIPPED/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {

--- a/cli/src/templates/go.mod
+++ b/cli/src/templates/go.mod
@@ -1,4 +1,4 @@
-module github.com/tree-sitter/tree-sitter-LOWER_PARSER_NAME
+module PARSER_URL_STRIPPED
 
 go 1.23
 

--- a/cli/src/templates/grammar.js
+++ b/cli/src/templates/grammar.js
@@ -1,3 +1,9 @@
+/**
+ * @file CAMEL_PARSER_NAME grammar for tree-sitter
+ * @author PARSER_AUTHOR_NAME PARSER_AUTHOR_EMAIL_ANGLED
+ * @license PARSER_LICENSE
+ */
+
 /// <reference types="tree-sitter-cli/dsl" />
 // @ts-check
 

--- a/cli/src/templates/grammar.js
+++ b/cli/src/templates/grammar.js
@@ -1,6 +1,6 @@
 /**
  * @file CAMEL_PARSER_NAME grammar for tree-sitter
- * @author PARSER_AUTHOR_NAME PARSER_AUTHOR_EMAIL_ANGLED
+ * @author PARSER_AUTHOR_NAME PARSER_AUTHOR_EMAIL
  * @license PARSER_LICENSE
  */
 

--- a/cli/src/templates/grammar.js
+++ b/cli/src/templates/grammar.js
@@ -1,5 +1,5 @@
 /**
- * @file CAMEL_PARSER_NAME grammar for tree-sitter
+ * @file PARSER_DESCRIPTION
  * @author PARSER_AUTHOR_NAME PARSER_AUTHOR_EMAIL
  * @license PARSER_LICENSE
  */

--- a/cli/src/templates/package.json
+++ b/cli/src/templates/package.json
@@ -1,9 +1,13 @@
 {
   "name": "tree-sitter-PARSER_NAME",
   "version": "0.0.1",
-  "description": "CAMEL_PARSER_NAME grammar for tree-sitter",
+  "description": "PARSER_DESCRIPTION",
   "repository": "github:tree-sitter/tree-sitter-PARSER_NAME",
-  "license": "MIT",
+  "license": "PARSER_LICENSE",
+  "author": {
+    "name": "PARSER_AUTHOR_NAME",
+    "email": "PARSER_AUTHOR_EMAIL"
+  },
   "main": "bindings/node",
   "types": "bindings/node",
   "keywords": [

--- a/cli/src/templates/package.json
+++ b/cli/src/templates/package.json
@@ -6,7 +6,8 @@
   "license": "PARSER_LICENSE",
   "author": {
     "name": "PARSER_AUTHOR_NAME",
-    "email": "PARSER_AUTHOR_EMAIL"
+    "email": "PARSER_AUTHOR_EMAIL",
+    "url": "PARSER_AUTHOR_URL"
   },
   "main": "bindings/node",
   "types": "bindings/node",

--- a/cli/src/templates/pyproject.toml
+++ b/cli/src/templates/pyproject.toml
@@ -20,7 +20,7 @@ license.text = "PARSER_LICENSE"
 readme = "README.md"
 
 [project.urls]
-Homepage = "https://github.com/tree-sitter/tree-sitter-PARSER_NAME"
+Homepage = "PARSER_URL"
 
 [project.optional-dependencies]
 core = ["tree-sitter~=0.22"]

--- a/cli/src/templates/pyproject.toml
+++ b/cli/src/templates/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tree-sitter-PARSER_NAME"
-description = "CAMEL_PARSER_NAME grammar for tree-sitter"
+description = "PARSER_DESCRIPTION"
 version = "0.0.1"
 keywords = ["incremental", "parsing", "tree-sitter", "PARSER_NAME"]
 classifiers = [
@@ -12,10 +12,11 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Topic :: Software Development :: Compilers",
   "Topic :: Text Processing :: Linguistic",
-  "Typing :: Typed"
+  "Typing :: Typed",
 ]
+authors = [{ name = "PARSER_AUTHOR_NAME", email = "PARSER_AUTHOR_EMAIL" }]
 requires-python = ">=3.9"
-license.text = "MIT"
+license.text = "PARSER_LICENSE"
 readme = "README.md"
 
 [project.urls]

--- a/cli/src/tests/detect_language.rs
+++ b/cli/src/tests/detect_language.rs
@@ -20,8 +20,7 @@ fn detect_language_by_first_line_regex() {
     }
   ],
   "metadata": {
-    "version": "0.0.1",
-    "authors": []
+    "version": "0.0.1"
   }
 }
 "#,
@@ -71,8 +70,7 @@ fn detect_language_by_first_line_regex() {
     }
   ],
   "metadata": {
-    "version": "0.0.1",
-    "authors": []
+    "version": "0.0.1"
   }
 }
 "#,

--- a/cli/src/tests/detect_language.rs
+++ b/cli/src/tests/detect_language.rs
@@ -8,17 +8,21 @@ use crate::tests::helpers::fixtures::scratch_dir;
 fn detect_language_by_first_line_regex() {
     let strace_dir = tree_sitter_dir(
         r#"{
-  "name": "tree-sitter-strace",
-  "version": "0.0.1",
-  "tree-sitter": [
+  "grammars": [
     {
+      "name": "strace",
+      "path": ".",
       "scope": "source.strace",
       "file-types": [
         "strace"
       ],
       "first-line-regex":  "[0-9:.]* *execve"
     }
-  ]
+  ],
+  "metadata": {
+    "version": "0.0.1",
+    "authors": []
+  }
 }
 "#,
         "strace",
@@ -56,16 +60,20 @@ fn detect_language_by_first_line_regex() {
 
     let dummy_dir = tree_sitter_dir(
         r#"{
-  "name": "tree-sitter-dummy",
-  "version": "0.0.1",
-  "tree-sitter": [
+  "grammars": [
     {
+      "name": "dummy",
       "scope": "source.dummy",
+      "path": ".",
       "file-types": [
         "dummy"
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "version": "0.0.1",
+    "authors": []
+  }
 }
 "#,
         "dummy",
@@ -83,9 +91,9 @@ fn detect_language_by_first_line_regex() {
     );
 }
 
-fn tree_sitter_dir(package_json: &str, name: &str) -> tempfile::TempDir {
+fn tree_sitter_dir(tree_sitter_json: &str, name: &str) -> tempfile::TempDir {
     let temp_dir = tempfile::tempdir().unwrap();
-    fs::write(temp_dir.path().join("package.json"), package_json).unwrap();
+    fs::write(temp_dir.path().join("tree-sitter.json"), tree_sitter_json).unwrap();
     fs::create_dir_all(temp_dir.path().join("src/tree_sitter")).unwrap();
     fs::write(
         temp_dir.path().join("src/grammar.json"),

--- a/docs/assets/schemas/config.schema.json
+++ b/docs/assets/schemas/config.schema.json
@@ -1,0 +1,266 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "grammars": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the grammar.",
+            "pattern": "^[a-z0-9_]+$"
+          },
+          "camelcase": {
+            "type": "string",
+            "description": "The name converted to CamelCase.",
+            "pattern": "^\\w+$",
+            "examples": [
+              "Rust",
+              "HTML"
+            ],
+            "$comment": "This is used in the description and the class names."
+          },
+          "scope": {
+            "type": "string",
+            "description": "The TextMate scope that represents this language.",
+            "pattern": "^(source|text)(\\.\\w+)+$",
+            "examples": [
+              "source.rust",
+              "text.html"
+            ]
+          },
+          "path": {
+            "type": "string",
+            "default": ".",
+            "description": "The relative path to the directory containing the grammar."
+          },
+          "external-files": {
+            "type": "array",
+            "description": "The relative paths to files that should be checked for modifications during recompilation.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          },
+          "file-types": {
+            "type": "array",
+            "description": "An array of filename suffix strings.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          },
+          "highlights": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1
+              }
+            ],
+            "default": "queries/highlights.scm",
+            "description": "The path(s) to the grammar's highlight queries."
+          },
+          "injections": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1
+              }
+            ],
+            "default": "queries/injections.scm",
+            "description": "The path(s) to the grammar's injection queries."
+          },
+          "locals": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1
+              }
+            ],
+            "default": "queries/locals.scm",
+            "description": "The path(s) to the grammar's local variable queries."
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1
+              }
+            ],
+            "default": "queries/tags.scm",
+            "description": "The path(s) to the grammar's code navigation queries."
+          },
+          "injection-regex": {
+            "type": "string",
+            "format": "regex",
+            "description": "A regex pattern that will be tested against a language name in order to determine whether this language should be used for a potential language injection site."
+          },
+          "first-line-regex": {
+            "type": "string",
+            "format": "regex",
+            "description": "A regex pattern that will be tested against the first line of a file in order to determine whether this language applies to the file."
+          },
+          "content-regex": {
+            "type": "string",
+            "format": "regex",
+            "description": "A regex pattern that will be tested against the contents of the file in order to break ties in cases where multiple grammars matched the file."
+          }
+        },
+        "required": [
+          "name",
+          "scope"
+        ]
+      },
+      "minItems": 1
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "The current version of the project.",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+          "$comment": "The CLI will use this version to update package.json, Cargo.toml, pyproject.toml, Makefile."
+        },
+        "license": {
+          "type": "string",
+          "default": "MIT",
+          "description": "The project's license."
+        },
+        "description": {
+          "type": "string",
+          "description": "The project's description.",
+          "examples": [
+            "Rust grammar for tree-sitter"
+          ]
+        },
+        "links": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "format": "uri",
+              "description": "The project's repository."
+            },
+            "homepage": {
+              "type": "string",
+              "format": "uri",
+              "description": "The project's homepage."
+            }
+          },
+          "required": [
+            "repository"
+          ]
+        },
+        "authors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "The project's author(s).",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "url": {
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "minItems": 1
+        },
+        "namespace": {
+          "type": "string",
+          "description": "The namespace for the Java & Kotlin packages.",
+          "default": "io.github.tree-sitter",
+          "$comment": "Used as is in the Maven/Gradle group name and transformed accordingly for the package names and directories (e.g. io.github.treesitter.jtreesitter.html - src/main/java/io/github/treesitter/jtreesitter/html)."
+        }
+      },
+      "required": [
+        "version",
+        "links"
+      ]
+    },
+    "bindings": {
+      "type": "object",
+      "description": "The language bindings that will be generated.",
+      "properties": {
+        "c": {
+          "type": "boolean",
+          "default": true,
+          "const": true,
+          "$comment": "Always generated"
+        },
+        "go": {
+          "type": "boolean",
+          "default": true
+        },
+        "java": {
+          "type": "boolean",
+          "default": true
+        },
+        "kotlin": {
+          "type": "boolean",
+          "default": true
+        },
+        "node": {
+          "type": "boolean",
+          "default": true,
+          "const": true,
+          "$comment": "Always generated (for now)"
+        },
+        "python": {
+          "type": "boolean",
+          "default": true
+        },
+        "rust": {
+          "type": "boolean",
+          "default": true,
+          "const": true,
+          "$comment": "Always generated"
+        },
+        "swift": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    }
+  },
+  "required": [
+    "grammars",
+    "metadata"
+  ]
+}

--- a/docs/section-3-creating-parsers.md
+++ b/docs/section-3-creating-parsers.md
@@ -33,27 +33,14 @@ mkdir tree-sitter-${YOUR_LANGUAGE_NAME}
 cd tree-sitter-${YOUR_LANGUAGE_NAME}
 ```
 
-You can use the `npm` command line tool to create a `package.json` file that describes your project, and allows your parser to be used from Node.js.
+You can use the `tree-sitter` CLI tool to set up your project, and allows your parser to be used from multiple languages.
 
 ```sh
 # This will prompt you for input
-npm init
-
-# This installs a small module that lets your parser be used from Node
-npm install --save nan
-
-# This installs the Tree-sitter CLI itself
-npm install --save-dev tree-sitter-cli
+tree-sitter init
 ```
 
-The last command will install the CLI into the `node_modules` folder in your working directory. An executable program called `tree-sitter` will be created inside of `node_modules/.bin/`. You may want to follow the Node.js convention of adding that folder to your `PATH` so that you can easily run this program when working in this directory.
-
-```sh
-# In your shell profile script
-export PATH=$PATH:./node_modules/.bin
-```
-
-Once you have the CLI installed, create a file called `grammar.js` with the following contents:
+Once you have installed the CLI and run through the `init` command's prompts, a file called `grammar.js` should exist with the following contents:
 
 ```js
 /// <reference types="tree-sitter-cli/dsl" />
@@ -69,7 +56,7 @@ module.exports = grammar({
 });
 ```
 
-Then run the following command:
+Now, run the following command:
 
 ```sh
 tree-sitter generate
@@ -102,6 +89,80 @@ You now have a working parser.
 ## Tool Overview
 
 Let's go over all of the functionality of the `tree-sitter` command line tool.
+
+### Command: `init`
+
+The first command you will likely run is the `init` command. This command sets up an empty repository with everything you need to get going with a grammar repository.
+It only has one optional argument, `--update`, which will update outdated generated files, if needed.
+
+The main file of interest for users to configure is `tree-sitter.json`, which tells the CLI information about your grammar, such as the queries.
+
+#### Structure of `tree-sitter.json`
+
+##### The `grammars` field
+
+This field is an array of objects, you typically only need one object in this array, unless your repo has multiple grammars (e.g. like `Typescript` and `TSX`)
+
+###### Basics
+
+These keys specify basic information about the parser:
+
+* `scope` (required) - A string like `"source.js"` that identifies the language. Currently, we strive to match the scope names used by popular [TextMate grammars](https://macromates.com/manual/en/language_grammars) and by the [Linguist](https://github.com/github/linguist) library.
+
+* `path` - A relative path from the directory containing `tree-sitter.json` to another directory containing the `src/` folder, which contains the actual generated parser. The default value is `"."` (so that `src/` is in the same folder as `tree-sitter.json`), and this very rarely needs to be overridden.
+
+* `external-files` - A list of relative paths from the root dir of a
+parser to files that should be checked for modifications during recompilation.
+This is useful during development to have changes to other files besides scanner.c
+be picked up by the cli.
+
+###### Language Detection
+
+These keys help to decide whether the language applies to a given file:
+
+* `file-types` - An array of filename suffix strings. The grammar will be used for files whose names end with one of these suffixes. Note that the suffix may match an *entire* filename.
+
+* `first-line-regex` - A regex pattern that will be tested against the first line of a file in order to determine whether this language applies to the file. If present, this regex will be used for any file whose language does not match any grammar's `file-types`.
+
+* `content-regex` - A regex pattern that will be tested against the contents of the file in order to break ties in cases where multiple grammars matched the file using the above two criteria. If the regex matches, this grammar will be preferred over another grammar with no `content-regex`. If the regex does not match, a grammar with no `content-regex` will be preferred over this one.
+
+* `injection-regex` - A regex pattern that will be tested against a *language name* in order to determine whether this language should be used for a potential *language injection* site. Language injection is described in more detail in [a later section](#language-injection).
+
+###### Query Paths
+
+These keys specify relative paths from the directory containing `tree-sitter.json` to the files that control syntax highlighting:
+
+* `highlights` - Path to a *highlight query*. Default: `queries/highlights.scm`
+* `locals` - Path to a *local variable query*. Default: `queries/locals.scm`.
+* `injections` - Path to an *injection query*. Default: `queries/injections.scm`.
+
+The behaviors of these three files are described in the next section.
+
+##### The `metadata` field
+
+This field contains information that tree-sitter will use to populate relevant bindings' files, especially their versions. A future
+`bump-version` and `publish` subcommand will leverage this version information as well. Typically, this will all be set up when you
+run `tree-sitter init`, but you are welcome to update it as you see fit.
+
+* `version` (required) - The current version of your grammar, which should follow [semver](https://semver.org)
+* `license` - The license of your grammar, which should be a valid [SPDX license](https://spdx.org/licenses)
+* `description` - The brief description of your grammar
+* `authors` (required) - An array of objects that contain a `name` field, and optionally an `email` and `url` field. Each field is a string
+* `links` - An object that contains a `repository` field, and optionally a `homepage` field. Each field is a string
+* `namespace` - The namespace for the `Java` and `Kotlin` bindings, defaults to `io.github.tree-sitter` if not provided
+
+##### The `bindings` field
+
+This field controls what bindings are generated when the `init` command is run. Each key is a language name, and the value is a boolean.
+
+* `c` (default: `true`)
+* `go` (default: `true`)
+* `java` (default: `false`)
+* `kotlin` (default: `false`)
+* `node` (default: `true`)
+* `python` (default: `true`)
+* `rust` (default: `true`)
+* `swift` (default: `false`)
 
 ### Command: `generate`
 
@@ -254,12 +315,12 @@ A couple of attributes also take in a parameter, which require the use of parent
 
 The following attributes are available:
 
-- `:skip` — This attribute will skip the test when running `tree-sitter test`.
+* `:skip` — This attribute will skip the test when running `tree-sitter test`.
   This is useful when you want to temporarily disable running a test without deleting it.
-- `:error` — This attribute will assert that the parse tree contains an error. It's useful to just validate that a certain input is invalid without displaying the whole parse tree, as such you should omit the parse tree below the `---` line.
-- `:fail-fast` — This attribute will stop the testing additional tests if the test marked with this attribute fails.
-- `:language(LANG)` — This attribute will run the tests using the parser for the specified language. This is useful for multi-parser repos, such as XML and DTD, or Typescript and TSX. The default parser will be the first entry in the `tree-sitter` field in the root `package.json`, so having a way to pick a second or even third parser is useful.
-- `:platform(PLATFORM)` — This attribute specifies the platform on which the test should run. It is useful to test platform-specific behavior (e.g. Windows newlines are different from Unix). This attribute must match up with Rust's [`std::env::consts::OS`](https://doc.rust-lang.org/std/env/consts/constant.OS.html).
+* `:error` — This attribute will assert that the parse tree contains an error. It's useful to just validate that a certain input is invalid without displaying the whole parse tree, as such you should omit the parse tree below the `---` line.
+* `:fail-fast` — This attribute will stop the testing additional tests if the test marked with this attribute fails.
+* `:language(LANG)` — This attribute will run the tests using the parser for the specified language. This is useful for multi-parser repos, such as XML and DTD, or Typescript and TSX. The default parser used will always be the first entry in the `grammars` field in the `tree-sitter.json` config file, so having a way to pick a second or even third parser is useful.
+* `:platform(PLATFORM)` — This attribute specifies the platform on which the test should run. It is useful to test platform-specific behavior (e.g. Windows newlines are different from Unix). This attribute must match up with Rust's [`std::env::consts::OS`](https://doc.rust-lang.org/std/env/consts/constant.OS.html).
 
 Examples using attributes:
 
@@ -855,7 +916,7 @@ This function is responsible for recognizing external tokens. It should return `
 * **`uint32_t (*get_column)(TSLexer *)`** - A function for querying the current column position of the lexer. It returns the number of codepoints since the start of the current line. The codepoint position is recalculated on every call to this function by reading from the start of the line.
 * **`bool (*is_at_included_range_start)(const TSLexer *)`** - A function for checking whether the parser has just skipped some characters in the document. When parsing an embedded document using the `ts_parser_set_included_ranges` function (described in the [multi-language document section][multi-language-section]), the scanner may want to apply some special behavior when moving to a disjoint part of the document. For example, in [EJS documents][ejs], the JavaScript parser uses this function to enable inserting automatic semicolon tokens in between the code directives, delimited by `<%` and `%>`.
 * **`bool (*eof)(const TSLexer *)`** - A function for determining whether the lexer is at the end of the file. The value of `lookahead` will be `0` at the end of a file, but this function should be used instead of checking for that value because the `0` or "NUL" value is also a valid character that could be present in the file being parsed.
-- **`void (*log)(const TSLexer *, const char * format, ...)`** - A `printf`-like function for logging. The log is viewable through e.g. `tree-sitter parse --debug` or the browser's console after checking the `log` option in the [Playground](./playground).
+* **`void (*log)(const TSLexer *, const char * format, ...)`** - A `printf`-like function for logging. The log is viewable through e.g. `tree-sitter parse --debug` or the browser's console after checking the `log` option in the [Playground](./playground).
 
 The third argument to the `scan` function is an array of booleans that indicates which of external tokens are currently expected by the parser. You should only look for a given token if it is valid according to this array. At the same time, you cannot backtrack, so you may need to combine certain pieces of logic.
 
@@ -994,11 +1055,9 @@ Be very careful when emitting zero-width tokens from your external scanner, and 
 [antlr]: https://www.antlr.org
 [bison-dprec]: https://www.gnu.org/software/bison/manual/html_node/Generalized-LR-Parsing.html
 [bison]: https://en.wikipedia.org/wiki/GNU_bison
-[c-linkage]: https://en.cppreference.com/w/cpp/language/language_linkage
 [cargo]: https://doc.rust-lang.org/cargo/getting-started/installation.html
 [crate]: https://crates.io/crates/tree-sitter-cli
 [cst]: https://en.wikipedia.org/wiki/Parse_tree
-[dfa]: https://en.wikipedia.org/wiki/Deterministic_finite_automaton
 [ebnf]: https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form
 [ecmascript-spec]: https://262.ecma-international.org/6.0/
 [ejs]: https://ejs.co
@@ -1014,7 +1073,6 @@ Be very careful when emitting zero-width tokens from your external scanner, and 
 [multi-language-section]: ./using-parsers#multi-language-documents
 [named-vs-anonymous-nodes-section]: ./using-parsers#named-vs-anonymous-nodes
 [field-names-section]: ./using-parsers#node-field-names
-[nan]: https://github.com/nodejs/nan
 [node-module]: https://www.npmjs.com/package/tree-sitter-cli
 [node.js]: https://nodejs.org
 [static-node-types]: ./using-parsers#static-node-types

--- a/docs/section-4-syntax-highlighting.md
+++ b/docs/section-4-syntax-highlighting.md
@@ -14,10 +14,10 @@ This document explains how the Tree-sitter syntax highlighting system works, usi
 All of the files needed to highlight a given language are normally included in the same git repository as the Tree-sitter grammar for that language (for example, [`tree-sitter-javascript`](https://github.com/tree-sitter/tree-sitter-javascript), [`tree-sitter-ruby`](https://github.com/tree-sitter/tree-sitter-ruby)). In order to run syntax highlighting from the command-line, three types of files are needed:
 
 1. Per-user configuration in `~/.config/tree-sitter/config.json`
-2. Language configuration in grammar repositories' `package.json` files.
+2. Language configuration in grammar repositories' `tree-sitter.json` files.
 3. Tree queries in the grammars repositories' `queries` folders.
 
-For an example of the language-specific files, see the [`package.json` file](https://github.com/tree-sitter/tree-sitter-ruby/blob/master/package.json) and [`queries` directory](https://github.com/tree-sitter/tree-sitter-ruby/tree/master/queries) in the `tree-sitter-ruby` repository. The following sections describe the behavior of each file.
+For an example of the language-specific files, see the [`tree-sitter.json` file](https://github.com/tree-sitter/tree-sitter-ruby/blob/master/tree-sitter.json) and [`queries` directory](https://github.com/tree-sitter/tree-sitter-ruby/tree/master/queries) in the `tree-sitter-ruby` repository. The following sections describe the behavior of each file.
 
 ## Per-user Configuration
 
@@ -82,7 +82,7 @@ Styling values can be any of the following:
 
 ## Language Configuration
 
-The `package.json` file is used by package managers like `npm`. Within this file, the Tree-sitter CLI looks for data nested under the top-level `"tree-sitter"` key. This key is expected to contain an array of objects with the following keys:
+The `tree-sitter.json` file is used by the Tree-sitter CLI. Within this file, the CLI looks for data nested under the top-level `"grammars"` key. This key is expected to contain an array of objects with the following keys:
 
 ### Basics
 
@@ -90,7 +90,7 @@ These keys specify basic information about the parser:
 
 * `scope` (required) - A string like `"source.js"` that identifies the language. Currently, we strive to match the scope names used by popular [TextMate grammars](https://macromates.com/manual/en/language_grammars) and by the [Linguist](https://github.com/github/linguist) library.
 
-* `path` (optional) - A relative path from the directory containing `package.json` to another directory containing the `src/` folder, which contains the actual generated parser. The default value is `"."` (so that `src/` is in the same folder as `package.json`), and this very rarely needs to be overridden.
+* `path` (optional) - A relative path from the directory containing `tree-sitter.json` to another directory containing the `src/` folder, which contains the actual generated parser. The default value is `"."` (so that `src/` is in the same folder as `tree-sitter.json`), and this very rarely needs to be overridden.
 
 * `external-files` (optional) - A list of relative paths from the root dir of a
 parser to files that should be checked for modifications during recompilation.
@@ -111,7 +111,7 @@ These keys help to decide whether the language applies to a given file:
 
 ### Query Paths
 
-These keys specify relative paths from the directory containing `package.json` to the files that control syntax highlighting:
+These keys specify relative paths from the directory containing `tree-sitter.json` to the files that control syntax highlighting:
 
 * `highlights` - Path to a *highlight query*. Default: `queries/highlights.scm`
 * `locals` - Path to a *local variable query*. Default: `queries/locals.scm`.


### PR DESCRIPTION
Closes #3637

### Problem

The current way to configure a tree-sitter grammar repo is by adding a `tree-sitter` section to the `package.json`. This is unideal because it increases coupling to node and confuses newcomers as to why changing stuff in a `package.json` file influences CLI behavior. Adding more fields to the `package.json` also increases complexity of a file that, ideally, should stick to node-related configuration data only. Moving to a dedicated file will make it clear that all tree-sitter related configuration is held in this file, and it also makes it easier for us to automatically derive more data to populate in other bindings files (license info, author, etc).

### Solution

We will now migrate to a dedicated `tree-sitter.json` configuration file. This file is created and populated when a user runs `tree-sitter init`, of which now `init` prompts the user for input much like `npm init` does. Additionally, if `init` is ran and a `package.json` file *is* detected, the user is prompted for whether or not they'd like the CLI to automatically migrate their config to the new `tree-sitter.json` file. The package.json is parsed and the key fields for migration are extracted, including information such as the author, version, description, name, and repository url.

The loader now holds all the relevant data structures that represent the old package.json tree-sitter fields and new tree-sitter.json fields. Compatibility is retained for the old `tree-sitter` field in a `package.json` file until 0.25, at which point that will be removed. 

I'm putting this PR up now and not once I've finished the docs so that people can take a look and review it.

### TODO

- [x] Doc updates