### PR TITLE
fix(lib)!: child_containing_descendant now returns direct children

### DIFF
--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -182,7 +182,11 @@ fn test_node_child() {
         object_node.child_containing_descendant(null_node).unwrap(),
         pair_node
     );
-    assert_eq!(pair_node.child_containing_descendant(null_node), None);
+    assert_eq!(
+        pair_node.child_containing_descendant(null_node).unwrap(),
+        null_node
+    );
+    assert_eq!(null_node.child_containing_descendant(null_node), None);
 }
 
 #[test]
@@ -287,7 +291,13 @@ fn test_parent_of_zero_width_node() {
         root.child_containing_descendant(block).unwrap(),
         function_definition
     );
-    assert_eq!(function_definition.child_containing_descendant(block), None);
+    assert_eq!(
+        function_definition
+            .child_containing_descendant(block)
+            .unwrap(),
+        block
+    );
+    assert_eq!(block.child_containing_descendant(block), None);
 
     let code = "<script></script>";
     parser.set_language(&get_language("html")).unwrap();
@@ -480,7 +490,11 @@ fn test_node_named_child() {
         object_node.child_containing_descendant(null_node).unwrap(),
         pair_node
     );
-    assert_eq!(pair_node.child_containing_descendant(null_node), None);
+    assert_eq!(
+        pair_node.child_containing_descendant(null_node).unwrap(),
+        null_node
+    );
+    assert_eq!(null_node.child_containing_descendant(null_node), None);
 }
 
 #[test]

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -550,7 +550,7 @@ TSNode ts_node_parent(TSNode self) {
 
   while (true) {
    TSNode next_node = ts_node_child_containing_descendant(node, self);
-   if (ts_node_is_null(next_node)) break;
+   if (next_node.id == self.id) break;
    node = next_node;
   }
 
@@ -567,9 +567,11 @@ TSNode ts_node_child_containing_descendant(TSNode self, TSNode subnode) {
       if (
         !ts_node_child_iterator_next(&iter, &self)
         || ts_node_start_byte(self) > start_byte
-        || self.id == subnode.id
       ) {
         return ts_node__null();
+      }
+      if (self.id == subnode.id) {
+        return self;
       }
 
       // Here we check the current self node and *all* of its zero-width token siblings that follow.
@@ -585,7 +587,7 @@ TSNode ts_node_child_containing_descendant(TSNode self, TSNode subnode) {
         }
         ts_node_child_iterator_next(&iter, &self);
         if (self.id == subnode.id) {
-          return ts_node__null();
+          return self;
         }
       }
       self = old;


### PR DESCRIPTION
Previously, `child_containing_descendant` would return `null` when called on a node's direct parent. In my opinion, this doesn't make much sense; it seems like a node would contain itself. This commit changes the function so that it can return direct children.

This is helpful because we can now check if a node is an ancestor of another node with an $O(1)$ operation. Before, if we tried using `child_containing_descendant`, we would still need to access the child's parent ($O(n)$) to check if the function returned `null` because it was called on a direct parent, or on a non-ancestor