### PR TITLE
Some init command improvements

### DIFF
--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -159,7 +159,7 @@ impl TreeSitterJSON {
 pub struct Grammar {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub upper_camel_name: Option<String>,
+    pub camelcase: Option<String>,
     pub scope: String,
     pub path: PathBuf,
     #[serde(default, skip_serializing_if = "PathsJSON::is_empty")]
@@ -192,7 +192,8 @@ pub struct Metadata {
     pub authors: Option<Vec<Author>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<Links>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip)]
     pub namespace: Option<String>,
 }
 
@@ -217,7 +218,9 @@ pub struct Links {
 pub struct Bindings {
     pub c: bool,
     pub go: bool,
+    #[serde(skip)]
     pub java: bool,
+    #[serde(skip)]
     pub kotlin: bool,
     pub node: bool,
     pub python: bool,

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -131,7 +131,7 @@ fn insert_after(
 #[derive(Serialize, Deserialize, Clone)]
 pub struct JsonConfigOpts {
     pub name: String,
-    pub upper_camel_name: String,
+    pub camelcase: String,
     pub description: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repository: Option<Url>,
@@ -151,7 +151,7 @@ impl JsonConfigOpts {
         TreeSitterJSON {
             grammars: vec![Grammar {
                 name: self.name.clone(),
-                upper_camel_name: Some(self.upper_camel_name),
+                camelcase: Some(self.camelcase),
                 scope: self.scope,
                 path: PathBuf::from("."),
                 external_files: PathsJSON::Empty,
@@ -194,7 +194,7 @@ impl Default for JsonConfigOpts {
     fn default() -> Self {
         Self {
             name: String::new(),
-            upper_camel_name: String::new(),
+            camelcase: String::new(),
             description: String::new(),
             repository: None,
             scope: String::new(),
@@ -245,7 +245,7 @@ pub fn migrate_package_json(repo_path: &Path) -> Result<bool> {
             .into_iter()
             .map(|l| Grammar {
                 name: name.clone(),
-                upper_camel_name: Some(name.to_upper_camel_case()),
+                camelcase: Some(name.to_upper_camel_case()),
                 scope: l.scope.unwrap_or_else(|| format!("source.{name}")),
                 path: l.path,
                 external_files: l.external_files,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -443,15 +443,8 @@ impl InitConfig {
 
 impl Init {
     fn run(self, current_dir: &Path, migrated: bool) -> Result<()> {
-        let configure_json = if current_dir.join("tree-sitter.json").exists() {
-            Confirm::with_theme(&ColorfulTheme::default())
-                .with_prompt("It looks like you already have a `tree-sitter.json` file. Do you want to re-configure it?")
-                .interact()?
-        } else if current_dir.join("package.json").exists() {
-            !migrated
-        } else {
-            true
-        };
+        let configure_json = !current_dir.join("tree-sitter.json").exists()
+            && (!current_dir.join("package.json").exists() || !migrated);
 
         let (language_name, json_config_opts) = if configure_json {
             let mut opts = JsonConfigOpts::default();

--- a/cli/src/templates/gitattributes
+++ b/cli/src/templates/gitattributes
@@ -8,4 +8,6 @@ bindings/** linguist-generated
 binding.gyp linguist-generated
 setup.py linguist-generated
 Makefile linguist-generated
+CMakeLists.txt linguist-generated
 Package.swift linguist-generated
+go.mod linguist-generated

--- a/docs/assets/schemas/config.schema.json
+++ b/docs/assets/schemas/config.schema.json
@@ -2,6 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "grammars": {
       "type": "array",
       "items": {
@@ -132,6 +135,7 @@
             "description": "A regex pattern that will be tested against the contents of the file in order to break ties in cases where multiple grammars matched the file."
           }
         },
+        "additionalProperties": false,
         "required": [
           "name",
           "scope"
@@ -174,6 +178,7 @@
               "description": "The project's homepage."
             }
           },
+          "additionalProperties": false,
           "required": [
             "repository"
           ]
@@ -196,6 +201,7 @@
                 "format": "uri"
               }
             },
+            "additionalProperties": false,
             "required": [
               "name"
             ]
@@ -209,6 +215,7 @@
           "$comment": "Used as is in the Maven/Gradle group name and transformed accordingly for the package names and directories (e.g. io.github.treesitter.jtreesitter.html - src/main/java/io/github/treesitter/jtreesitter/html)."
         }
       },
+      "additionalProperties": false,
       "required": [
         "version",
         "links"
@@ -230,11 +237,11 @@
         },
         "java": {
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "kotlin": {
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "node": {
           "type": "boolean",
@@ -256,9 +263,11 @@
           "type": "boolean",
           "default": true
         }
-      }
+      },
+      "additionalProperties": false
     }
   },
+  "additionalProperties": false,
   "required": [
     "grammars",
     "metadata"

--- a/docs/assets/schemas/grammar.schema.json
+++ b/docs/assets/schemas/grammar.schema.json
@@ -8,6 +8,10 @@
   "additionalProperties": false,
 
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
+
     "name": {
       "description": "The name of the grammar",
       "type": "string",


### PR DESCRIPTION
- Validate CamelCase name, TextMate scope
- Skip serialization of unused properties
- Disallow additional properties in schema
- Don't prompt the user to reconfigure