### PR TITLE
store ref of parent in subtree

### DIFF
--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -391,6 +391,10 @@ void ts_subtree_summarize_children(
   for (uint32_t i = 0; i < self.ptr->child_count; i++) {
     Subtree child = children[i];
 
+    MutableSubtree mchild = ts_subtree_to_mut_unsafe(child);
+    mchild.ptr->parent = ts_malloc(sizeof(Subtree));
+    *mchild.ptr->parent = ts_subtree_from_mut(self);
+
     if (
       self.ptr->size.extent.row == 0 &&
       ts_subtree_depends_on_column(child)

--- a/lib/src/subtree.h
+++ b/lib/src/subtree.h
@@ -103,6 +103,8 @@ struct SubtreeInlineData {
 #undef SUBTREE_BITS
 #undef SUBTREE_SIZE
 
+typedef union Subtree Subtree;
+
 // A heap-allocated representation of a subtree.
 //
 // This representation is used for parent nodes, external tokens,
@@ -117,6 +119,7 @@ typedef struct {
   uint32_t child_count;
   TSSymbol symbol;
   TSStateId parse_state;
+  Subtree *parent;
 
   bool visible : 1;
   bool named : 1;
@@ -154,10 +157,10 @@ typedef struct {
 } SubtreeHeapData;
 
 // The fundamental building block of a syntax tree.
-typedef union {
+union Subtree {
   SubtreeInlineData data;
   const SubtreeHeapData *ptr;
-} Subtree;
+};
 
 // Like Subtree, but mutable.
 typedef union {


### PR DESCRIPTION
Goal is to re-implement `ts_node_parent()` so it is more efficient.

Might not be possible.