### PR TITLE
fix: Account for nonterminal symbols in terminal symbol list

### DIFF
--- a/cli/generate/src/build_tables/mod.rs
+++ b/cli/generate/src/build_tables/mod.rs
@@ -192,6 +192,7 @@ fn populate_used_symbols(
             match symbol.kind {
                 SymbolType::Terminal => terminal_usages[symbol.index] = true,
                 SymbolType::External => external_usages[symbol.index] = true,
+                SymbolType::NonTerminal => non_terminal_usages[symbol.index] = true,
                 _ => {}
             }
         }


### PR DESCRIPTION
The problem appears to be that a *non*-terminal symbol is inserted into the *terminal* symbol list at generation time here. As a result, in the following loop, the index for said non-terminal symbol is never accounted for. 

https://github.com/tree-sitter/tree-sitter/blob/8500e331ebfd49e66dd935b8a9c7a58aba68af37/cli/generate/src/build_tables/mod.rs#L190-L201

I haven't been able to track down where/why the non-terminal symbol is being inserted into the terminal list yet, but just accounting for it here fixes the issue and doesn't appear to cause any other problems. If this is too much of a hack/ductape solution I can spend some more time digging into it. 

I tested this locally in a few ways. First I went through all of the full example grammars in #768. None of these crashed except https://github.com/tree-sitter/tree-sitter/issues/768#issuecomment-1336150844, which fails due to an external terminal symbol missing from the map. I haven't been able to track this one down yet (but I can spend some more time on it this week). Next, I generated the bash, c, cpp, embedded-template, go, html, java, javascript, jsdoc, json, python, ruby, rust, and typescript grammars (all the test fixtures besides PHP) and ran`tree-sitter test`. I'm expecting CI to fail here due to the unrelated PHP conflict issues, but everything else *should* be ok. 

Closes #768
Closes #1910 
