### PR TITLE
fix(build): correct wasm root path lookup

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -20,9 +20,7 @@ use tree_sitter_cli::{
         LOG_GRAPH_ENABLED, START_SEED,
     },
     highlight,
-    init::{
-        generate_grammar_files, lookup_package_json_for_path, migrate_package_json, JsonConfigOpts,
-    },
+    init::{generate_grammar_files, get_root_path, migrate_package_json, JsonConfigOpts},
     logger,
     parse::{self, ParseFileOptions, ParseOutput},
     playground, query, tags,
@@ -710,8 +708,7 @@ impl Build {
 
         if self.wasm {
             let output_path = self.output.map(|path| current_dir.join(path));
-            let root_path = lookup_package_json_for_path(&grammar_path.join("package.json"))
-                .map(|(p, _)| p.parent().unwrap().to_path_buf())?;
+            let root_path = get_root_path(&grammar_path.join("tree-sitter.json"))?;
             wasm::compile_language_to_wasm(
                 &loader,
                 Some(&root_path),
@@ -1300,10 +1297,7 @@ fn run() -> Result<()> {
     let migrated = if !current_dir.join("tree-sitter.json").exists()
         && current_dir.join("package.json").exists()
     {
-        migrate_package_json(&current_dir).is_ok_and(|_| {
-            eprintln!("Failed to migrate package.json");
-            false
-        })
+        migrate_package_json(&current_dir).unwrap_or(false)
     } else {
         false
     };


### PR DESCRIPTION
Minor followup to #3700 - `lookup_package_json_for_path` is no longer needed with the migration to a tree-sitter.json config, and it's only used to fetch the path, so the signature is changed to fetch the root path of the grammar directory.