### PR TITLE
Add `*.scm` section to `.editorconfig` template

### DIFF
--- a/cli/src/templates/.editorconfig
+++ b/cli/src/templates/.editorconfig
@@ -11,6 +11,10 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 
+[*.scm]
+indent_style = space
+indent_size = 2
+
 [*.{c,cc,h}]
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
Since the `.editorconfig` file sets `root = true` no properties would get applied to query files, which is quite annoying.