### PR TITLE
build(cmake): correct library scopes

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.13)
 
 project(tree-sitter
         VERSION "0.24.1"
@@ -29,19 +29,26 @@ if(TREE_SITTER_FEATURE_WASM)
   if(NOT DEFINED CACHE{WASMTIME_INCLUDE_DIR})
     message(CHECK_START "Looking for wasmtime headers")
     find_path(WASMTIME_INCLUDE_DIR wasmtime.h
-              PATHS ENV DEP_WASMTIME_C_API_INCLUDE
-              REQUIRED)
+              PATHS ENV DEP_WASMTIME_C_API_INCLUDE)
+    if(NOT ${WASMTIME_INCLUDE_DIR})
+      unset(WASMTIME_INCLUDE_DIR CACHE)
+      message(FATAL_ERROR "Could not find wasmtime headers.\nDid you forget to set CMAKE_INCLUDE_PATH?")
+    endif()
     message(CHECK_PASS "found")
   endif()
 
   if(NOT DEFINED CACHE{WASMTIME_LIBRARY})
     message(CHECK_START "Looking for wasmtime library")
     if(BUILD_SHARED_LIBS)
-      find_library(WASMTIME_LIBRARY wasmtime REQUIRED)
+      find_library(WASMTIME_LIBRARY wasmtime)
     elseif(MSVC)
-      find_library(WASMTIME_LIBRARY wasmtime.lib REQUIRED)
+      find_library(WASMTIME_LIBRARY wasmtime.lib)
     else()
-      find_library(WASMTIME_LIBRARY libwasmtime.a REQUIRED)
+      find_library(WASMTIME_LIBRARY libwasmtime.a)
+    endif()
+    if(NOT ${WASMTIME_LIBRARY})
+      unset(WASMTIME_LIBRARY CACHE)
+      message(FATAL_ERROR "Could not find wasmtime library.\nDid you forget to set CMAKE_LIBRARY_PATH?")
     endif()
     message(CHECK_PASS "found")
   endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.18)
 
 project(tree-sitter
         VERSION "0.24.1"
@@ -25,14 +25,6 @@ if(NOT MSVC)
   target_compile_options(tree-sitter PRIVATE -Wall -Wextra -Wshadow -Wno-unused-parameter -pedantic)
 endif()
 
-if(NOT BUILD_SHARED_LIBS)
-  if(WIN32)
-    set(CMAKE_FIND_LIBRARY_SUFFIXES .lib .a)
-  else()
-    set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
-  endif()
-endif()
-
 if(TREE_SITTER_FEATURE_WASM)
   if(NOT DEFINED CACHE{WASMTIME_INCLUDE_DIR})
     message(CHECK_START "Looking for wasmtime headers")
@@ -44,22 +36,27 @@ if(TREE_SITTER_FEATURE_WASM)
 
   if(NOT DEFINED CACHE{WASMTIME_LIBRARY})
     message(CHECK_START "Looking for wasmtime library")
-    find_library(WASMTIME_LIBRARY wasmtime
-                 REQUIRED)
+    if(BUILD_SHARED_LIBS)
+      find_library(WASMTIME_LIBRARY wasmtime REQUIRED)
+    elseif(MSVC)
+      find_library(WASMTIME_LIBRARY wasmtime.lib REQUIRED)
+    else()
+      find_library(WASMTIME_LIBRARY libwasmtime.a REQUIRED)
+    endif()
     message(CHECK_PASS "found")
   endif()
 
   target_compile_definitions(tree-sitter PUBLIC TREE_SITTER_FEATURE_WASM)
   target_include_directories(tree-sitter SYSTEM PRIVATE "${WASMTIME_INCLUDE_DIR}")
-  target_link_libraries(tree-sitter PRIVATE "${WASMTIME_LIBRARY}")
+  target_link_libraries(tree-sitter PUBLIC "${WASMTIME_LIBRARY}")
   set_property(TARGET tree-sitter PROPERTY C_STANDARD_REQUIRED ON)
 
   if(NOT BUILD_SHARED_LIBS)
     if(WIN32)
       target_compile_definitions(tree-sitter PRIVATE WASM_API_EXTERN= WASI_API_EXTERN=)
-      target_link_libraries(tree-sitter PRIVATE ws2_32 advapi32 userenv ntdll shell32 ole32 bcrypt)
+      target_link_libraries(tree-sitter INTERFACE ws2_32 advapi32 userenv ntdll shell32 ole32 bcrypt)
     elseif(NOT APPLE)
-      target_link_libraries(tree-sitter PRIVATE pthread dl m)
+      target_link_libraries(tree-sitter INTERFACE pthread dl m)
     endif()
   endif()
 endif()
@@ -69,7 +66,8 @@ set_target_properties(tree-sitter
                       C_STANDARD 11
                       C_VISIBILITY_PRESET hidden
                       POSITION_INDEPENDENT_CODE ON
-                      SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
+                      SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
+                      DEFINE_SYMBOL "")
 
 configure_file(tree-sitter.pc.in "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter.pc" @ONLY)
 


### PR DESCRIPTION
For consumers of static tree-sitter + wasmtime.

---

PRIVATE: needed by the library but not its consumers
PUBLIC: needed by the library and its consumers
INTERFACE: needed only by the library's consumers

https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#target-command-scope