### PR TITLE
feat!: properly handle UTF-16 endianness encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ OBJ := $(SRC:.c=.o)
 ARFLAGS := rcs
 CFLAGS ?= -O3 -Wall -Wextra -Wshadow -pedantic
 override CFLAGS += -std=c11 -fPIC -fvisibility=hidden
+override CFLAGS += -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE
 override CFLAGS += -Ilib/src -Ilib/src/wasm -Ilib/include
 
 # ABI versioning

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,11 @@ let package = Package(
         .target(name: "TreeSitter",
                 path: "lib",
                 sources: ["src/lib.c"],
-                cSettings: [.headerSearchPath("src")]),
+                cSettings: [
+                        .headerSearchPath("src"),
+                        .define("_POSIX_C_SOURCE", to: "200112L"),
+                        .define("_DEFAULT_SOURCE"),
+                ]),
     ],
     cLanguageStandard: .c11
 )

--- a/build.zig
+++ b/build.zig
@@ -11,6 +11,8 @@ pub fn build(b: *std.Build) void {
     lib.addCSourceFile(.{ .file = b.path("lib/src/lib.c"), .flags = &.{"-std=c11"} });
     lib.addIncludePath(b.path("lib/include"));
     lib.addIncludePath(b.path("lib/src"));
+    lib.root_module.addCMacro("_POSIX_C_SOURCE", "200112L");
+    lib.root_module.addCMacro("_DEFAULT_SOURCE", "");
 
     lib.installHeadersDirectory(b.path("lib/include"), ".", .{});
 

--- a/cli/src/tests/parser_test.rs
+++ b/cli/src/tests/parser_test.rs
@@ -155,17 +155,19 @@ fn test_parsing_with_custom_utf8_input() {
 }
 
 #[test]
-fn test_parsing_with_custom_utf16_input() {
+fn test_parsing_with_custom_utf16le_input() {
     let mut parser = Parser::new();
     parser.set_language(&get_language("rust")).unwrap();
 
     let lines = ["pub fn foo() {", "  1", "}"]
         .iter()
-        .map(|s| s.encode_utf16().collect::<Vec<_>>())
+        .map(|s| s.encode_utf16().map(|u| u.to_le()).collect::<Vec<_>>())
         .collect::<Vec<_>>();
 
+    let newline = [('\n' as u16).to_le()];
+
     let tree = parser
-        .parse_utf16_with(
+        .parse_utf16_le_with(
             &mut |_, position| {
                 let row = position.row;
                 let column = position.column;
@@ -173,7 +175,7 @@ fn test_parsing_with_custom_utf16_input() {
                     if column < lines[row].len() {
                         &lines[row][column..]
                     } else {
-                        &[10]
+                        &newline
                     }
                 } else {
                     &[]
@@ -183,6 +185,47 @@ fn test_parsing_with_custom_utf16_input() {
         )
         .unwrap();
 
+    let root = tree.root_node();
+    assert_eq!(
+        root.to_sexp(),
+        "(source_file (function_item (visibility_modifier) name: (identifier) parameters: (parameters) body: (block (integer_literal))))"
+    );
+    assert_eq!(root.kind(), "source_file");
+    assert!(!root.has_error());
+    assert_eq!(root.child(0).unwrap().kind(), "function_item");
+}
+
+#[test]
+fn test_parsing_with_custom_utf16_be_input() {
+    let mut parser = Parser::new();
+    parser.set_language(&get_language("rust")).unwrap();
+
+    let lines: Vec<Vec<u16>> = ["pub fn foo() {", "  1", "}"]
+        .iter()
+        .map(|s| s.encode_utf16().collect::<Vec<_>>())
+        .map(|v| v.iter().map(|u| u.to_be()).collect())
+        .collect();
+
+    let newline = [('\n' as u16).to_be()];
+
+    let tree = parser
+        .parse_utf16_be_with(
+            &mut |_, position| {
+                let row = position.row;
+                let column = position.column;
+                if row < lines.len() {
+                    if column < lines[row].len() {
+                        &lines[row][column..]
+                    } else {
+                        &newline
+                    }
+                } else {
+                    &[]
+                }
+            },
+            None,
+        )
+        .unwrap();
     let root = tree.root_node();
     assert_eq!(
         root.to_sexp(),
@@ -221,7 +264,13 @@ fn test_parsing_text_with_byte_order_mark() {
 
     // Parse UTF16 text with a BOM
     let tree = parser
-        .parse_utf16("\u{FEFF}fn a() {}".encode_utf16().collect::<Vec<_>>(), None)
+        .parse_utf16_le(
+            "\u{FEFF}fn a() {}"
+                .encode_utf16()
+                .map(|u| u.to_le())
+                .collect::<Vec<_>>(),
+            None,
+        )
         .unwrap();
     assert_eq!(
         tree.root_node().to_sexp(),
@@ -1084,9 +1133,8 @@ fn test_parsing_error_in_invalid_included_ranges() {
 fn test_parsing_utf16_code_with_errors_at_the_end_of_an_included_range() {
     let source_code = "<script>a.</script>";
     let utf16_source_code = source_code
-        .as_bytes()
-        .iter()
-        .map(|c| u16::from(*c))
+        .encode_utf16()
+        .map(|u| u.to_le())
         .collect::<Vec<_>>();
 
     let start_byte = 2 * source_code.find("a.").unwrap();
@@ -1102,7 +1150,7 @@ fn test_parsing_utf16_code_with_errors_at_the_end_of_an_included_range() {
             end_point: Point::new(0, end_byte),
         }])
         .unwrap();
-    let tree = parser.parse_utf16(&utf16_source_code, None).unwrap();
+    let tree = parser.parse_utf16_le(&utf16_source_code, None).unwrap();
     assert_eq!(tree.root_node().to_sexp(), "(program (ERROR (identifier)))");
 }
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -71,6 +71,8 @@ set_target_properties(tree-sitter
                       POSITION_INDEPENDENT_CODE ON
                       SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
 
+target_compile_definitions(tree-sitter PRIVATE _POSIX_C_SOURCE=200112L _DEFAULT_SOURCE)
+
 configure_file(tree-sitter.pc.in "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter.pc" @ONLY)
 
 include(GNUInstallDirs)

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,6 +20,7 @@ include = [
   "/Cargo.toml",
   "/src/*.h",
   "/src/*.c",
+  "/src/portable/*",
   "/src/unicode/*",
   "/src/wasm/*",
   "/include/tree_sitter/api.h",

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -36,7 +36,8 @@ pub struct TSLookaheadIterator {
     _unused: [u8; 0],
 }
 pub const TSInputEncodingUTF8: TSInputEncoding = 0;
-pub const TSInputEncodingUTF16: TSInputEncoding = 1;
+pub const TSInputEncodingUTF16LE: TSInputEncoding = 1;
+pub const TSInputEncodingUTF16BE: TSInputEncoding = 2;
 pub type TSInputEncoding = ::core::ffi::c_uint;
 pub const TSSymbolTypeRegular: TSSymbolType = 0;
 pub const TSSymbolTypeAnonymous: TSSymbolType = 1;

--- a/lib/binding_rust/build.rs
+++ b/lib/binding_rust/build.rs
@@ -41,6 +41,8 @@ fn main() {
         .include(&src_path)
         .include(&wasm_path)
         .include(&include_path)
+        .define("_POSIX_C_SOURCE", "200112L")
+        .define("_DEFAULT_SOURCE", None)
         .warnings(false)
         .file(src_path.join("lib.c"))
         .compile("tree-sitter");

--- a/lib/binding_web/binding.c
+++ b/lib/binding_web/binding.c
@@ -172,7 +172,7 @@ TSTree *ts_parser_parse_wasm(
   TSInput input = {
     input_buffer,
     call_parse_callback,
-    TSInputEncodingUTF16
+    TSInputEncodingUTF16LE
   };
   if (range_count) {
     for (unsigned i = 0; i < range_count; i++) {

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -50,7 +50,8 @@ typedef struct TSLookaheadIterator TSLookaheadIterator;
 
 typedef enum TSInputEncoding {
   TSInputEncodingUTF8,
-  TSInputEncodingUTF16,
+  TSInputEncodingUTF16LE,
+  TSInputEncodingUTF16BE,
 } TSInputEncoding;
 
 typedef enum TSSymbolType {

--- a/lib/src/lexer.c
+++ b/lib/src/lexer.c
@@ -83,9 +83,9 @@ static void ts_lexer__get_lookahead(Lexer *self) {
   }
 
   const uint8_t *chunk = (const uint8_t *)self->chunk + position_in_chunk;
-  UnicodeDecodeFunction decode = self->input.encoding == TSInputEncodingUTF8
-    ? ts_decode_utf8
-    : ts_decode_utf16;
+  UnicodeDecodeFunction decode =
+    self->input.encoding == TSInputEncodingUTF8 ? ts_decode_utf8 :
+    self->input.encoding == TSInputEncodingUTF16LE ? ts_decode_utf16_le : ts_decode_utf16_be;
 
   self->lookahead_size = decode(chunk, size, &self->data.lookahead);
 

--- a/lib/src/lib.c
+++ b/lib/src/lib.c
@@ -1,5 +1,3 @@
-#define _POSIX_C_SOURCE 200112L
-
 #include "./alloc.c"
 #include "./get_changed_ranges.c"
 #include "./language.c"

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -1,5 +1,3 @@
-#define _POSIX_C_SOURCE 200112L
-
 #include <time.h>
 #include <stdio.h>
 #include <limits.h>

--- a/lib/src/portable/endian.h
+++ b/lib/src/portable/endian.h
@@ -1,0 +1,170 @@
+// "License": Public Domain
+// I, Mathias Panzenböck, place this file hereby into the public domain. Use it at your own risk for whatever you like.
+// In case there are jurisdictions that don't support putting things in the public domain you can also consider it to
+// be "dual licensed" under the BSD, MIT and Apache licenses, if you want to. This code is trivial anyway. Consider it
+// an example on how to get the endian conversion functions on different platforms.
+
+#ifndef PORTABLE_ENDIAN_H__
+#define PORTABLE_ENDIAN_H__
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+
+#    define __WINDOWS__
+
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__GNU__) || defined(__EMSCRIPTEN__)
+
+#    include <endian.h>
+
+#elif defined(__APPLE__)
+
+#    include <libkern/OSByteOrder.h>
+
+#    define htobe16(x) OSSwapHostToBigInt16(x)
+#    define htole16(x) OSSwapHostToLittleInt16(x)
+#    define be16toh(x) OSSwapBigToHostInt16(x)
+#    define le16toh(x) OSSwapLittleToHostInt16(x)
+ 
+#    define htobe32(x) OSSwapHostToBigInt32(x)
+#    define htole32(x) OSSwapHostToLittleInt32(x)
+#    define be32toh(x) OSSwapBigToHostInt32(x)
+#    define le32toh(x) OSSwapLittleToHostInt32(x)
+ 
+#    define htobe64(x) OSSwapHostToBigInt64(x)
+#    define htole64(x) OSSwapHostToLittleInt64(x)
+#    define be64toh(x) OSSwapBigToHostInt64(x)
+#    define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#    define __BYTE_ORDER    BYTE_ORDER
+#    define __BIG_ENDIAN    BIG_ENDIAN
+#    define __LITTLE_ENDIAN LITTLE_ENDIAN
+#    define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__OpenBSD__)
+
+#    include <endian.h>
+
+#    define __BYTE_ORDER    BYTE_ORDER
+#    define __BIG_ENDIAN    BIG_ENDIAN
+#    define __LITTLE_ENDIAN LITTLE_ENDIAN
+#    define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+
+#    include <sys/endian.h>
+
+#    define be16toh(x) betoh16(x)
+#    define le16toh(x) letoh16(x)
+
+#    define be32toh(x) betoh32(x)
+#    define le32toh(x) letoh32(x)
+
+#    define be64toh(x) betoh64(x)
+#    define le64toh(x) letoh64(x)
+
+#elif defined(__WINDOWS__)
+
+#    include <winsock2.h>
+#    ifdef __GNUC__
+#        include <sys/param.h>
+#    endif
+
+#    if BYTE_ORDER == LITTLE_ENDIAN
+
+#        define htobe16(x) htons(x)
+#        define htole16(x) (x)
+#        define be16toh(x) ntohs(x)
+#        define le16toh(x) (x)
+ 
+#        define htobe32(x) htonl(x)
+#        define htole32(x) (x)
+#        define be32toh(x) ntohl(x)
+#        define le32toh(x) (x)
+ 
+#        define htobe64(x) htonll(x)
+#        define htole64(x) (x)
+#        define be64toh(x) ntohll(x)
+#        define le64toh(x) (x)
+
+#    elif BYTE_ORDER == BIG_ENDIAN
+
+        /* that would be xbox 360 */
+#        define htobe16(x) (x)
+#        define htole16(x) __builtin_bswap16(x)
+#        define be16toh(x) (x)
+#        define le16toh(x) __builtin_bswap16(x)
+ 
+#        define htobe32(x) (x)
+#        define htole32(x) __builtin_bswap32(x)
+#        define be32toh(x) (x)
+#        define le32toh(x) __builtin_bswap32(x)
+ 
+#        define htobe64(x) (x)
+#        define htole64(x) __builtin_bswap64(x)
+#        define be64toh(x) (x)
+#        define le64toh(x) __builtin_bswap64(x)
+
+#    else
+
+#        error byte order not supported
+
+#    endif
+
+#    define __BYTE_ORDER    BYTE_ORDER
+#    define __BIG_ENDIAN    BIG_ENDIAN
+#    define __LITTLE_ENDIAN LITTLE_ENDIAN
+#    define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__QNXNTO__)
+
+#    include <gulliver.h>
+
+#    define __LITTLE_ENDIAN 1234
+#    define __BIG_ENDIAN    4321
+#    define __PDP_ENDIAN    3412
+
+#    if defined(__BIGENDIAN__)
+
+#        define __BYTE_ORDER __BIG_ENDIAN
+
+#        define htobe16(x) (x)
+#        define htobe32(x) (x)
+#        define htobe64(x) (x)
+
+#        define htole16(x) ENDIAN_SWAP16(x)
+#        define htole32(x) ENDIAN_SWAP32(x)
+#        define htole64(x) ENDIAN_SWAP64(x)
+
+#    elif defined(__LITTLEENDIAN__)
+
+#        define __BYTE_ORDER __LITTLE_ENDIAN
+
+#        define htole16(x) (x)
+#        define htole32(x) (x)
+#        define htole64(x) (x)
+
+#        define htobe16(x) ENDIAN_SWAP16(x)
+#        define htobe32(x) ENDIAN_SWAP32(x)
+#        define htobe64(x) ENDIAN_SWAP64(x)
+
+#    else
+
+#        error byte order not supported
+
+#    endif
+
+#    define be16toh(x) ENDIAN_BE16(x)
+#    define be32toh(x) ENDIAN_BE32(x)
+#    define be64toh(x) ENDIAN_BE64(x)
+#    define le16toh(x) ENDIAN_LE16(x)
+#    define le32toh(x) ENDIAN_LE32(x)
+#    define le64toh(x) ENDIAN_LE64(x)
+
+#else
+
+#    error platform not supported
+
+#endif
+
+#endif

--- a/lib/src/tree.c
+++ b/lib/src/tree.c
@@ -1,5 +1,3 @@
-#define _POSIX_C_SOURCE 200112L
-
 #include "tree_sitter/api.h"
 #include "./array.h"
 #include "./get_changed_ranges.h"

--- a/lib/src/unicode.h
+++ b/lib/src/unicode.h
@@ -12,6 +12,29 @@ extern "C" {
 #define U_EXPORT2
 #include "unicode/utf8.h"
 #include "unicode/utf16.h"
+#include "portable/endian.h"
+
+#define U16_NEXT_LE(s, i, length, c) UPRV_BLOCK_MACRO_BEGIN { \
+    (c)=le16toh((s)[(i)++]); \
+    if(U16_IS_LEAD(c)) { \
+        uint16_t __c2; \
+        if((i)!=(length) && U16_IS_TRAIL(__c2=(s)[(i)])) { \
+            ++(i); \
+            (c)=U16_GET_SUPPLEMENTARY((c), __c2); \
+        } \
+    } \
+} UPRV_BLOCK_MACRO_END
+
+#define U16_NEXT_BE(s, i, length, c) UPRV_BLOCK_MACRO_BEGIN { \
+    (c)=be16toh((s)[(i)++]); \
+    if(U16_IS_LEAD(c)) { \
+        uint16_t __c2; \
+        if((i)!=(length) && U16_IS_TRAIL(__c2=(s)[(i)])) { \
+            ++(i); \
+            (c)=U16_GET_SUPPLEMENTARY((c), __c2); \
+        } \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 static const int32_t TS_DECODE_ERROR = U_SENTINEL;
 
@@ -33,13 +56,23 @@ static inline uint32_t ts_decode_utf8(
   return i;
 }
 
-static inline uint32_t ts_decode_utf16(
+static inline uint32_t ts_decode_utf16_le(
   const uint8_t *string,
   uint32_t length,
   int32_t *code_point
 ) {
   uint32_t i = 0;
-  U16_NEXT(((uint16_t *)string), i, length, *code_point);
+  U16_NEXT_LE(((uint16_t *)string), i, length, *code_point);
+  return i * 2;
+}
+
+static inline uint32_t ts_decode_utf16_be(
+  const uint8_t *string,
+  uint32_t length,
+  int32_t *code_point
+) {
+  uint32_t i = 0;
+  U16_NEXT_BE(((uint16_t *)string), i, length, *code_point);
   return i * 2;
 }
 

--- a/script/build-wasm
+++ b/script/build-wasm
@@ -131,6 +131,8 @@ $emcc                                            \
   -std=c11                                       \
   -D 'fprintf(...)='                             \
   -D NDEBUG=                                     \
+  -D _POSIX_C_SOURCE=200112L                     \
+  -D _DEFAULT_SOURCE=                            \
   -I ${SRC_DIR}                                  \
   -I lib/include                                 \
   --js-library ${WEB_DIR}/imports.js             \


### PR DESCRIPTION
### Problem

Tree-sitter always treats UTF16 code as little endian. This is problematic since UTF16 text can be big endian encoded, which cannot be configured in the lib or CLI.

### Solution

A new enum member for UTF16-BE (`TSInputEncodingUTF16BE`) is added in `TSInputEncoding`, and the old `TSInputEncodingUTF16` member was renamed to `TSInputEncodingUTF16LE` in the lib. In the unicode header, we add an endian header that is portable (taken from https://gist.github.com/panzi/6856583) and separate decoding of UTF16-LE and UTF16-BE into two separate functions.

In the Rust side, we deprecate the `Parser::parse_utf16` and `Parser::parse_utf16_with` functions in favor of the `_le` and `_be` counterparts, to be removed in 0.26.

> [!NOTE]  
> On some platforms, the macro `_DEFAULT_SOURCE` needs to be defined. But this gets convoluted since depending on the order of header inclusions and macro definitions, `_POSIX_C_SOURCE` could be overwritten by a newer value, or the lib fails to build. As such, it's better to define these macros in the build process, and not in the actual source or header files themselves. This way we avoid having to define `_POSIX_C_SOURCE` and `_DEFAULT_SOURCE` in several places, and avoid having the former be overridden by the stdlib.