### PR TITLE
Dot graph improvements

### DIFF
--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -122,8 +122,6 @@ pub fn parse_file_at_path(parser: &mut Parser, opts: &ParseFileOptions) -> Resul
         _ => parser.parse(&source_code, None),
     };
 
-    parser.stop_printing_dot_graphs();
-
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
 
@@ -141,6 +139,8 @@ pub fn parse_file_at_path(parser: &mut Parser, opts: &ParseFileOptions) -> Resul
                 println!("AFTER {i}:\n{}", String::from_utf8_lossy(&source_code));
             }
         }
+
+        parser.stop_printing_dot_graphs();
 
         let duration = time.elapsed();
         let duration_ms = duration.as_micros() as f64 / 1e3;
@@ -354,6 +354,8 @@ pub fn parse_file_at_path(parser: &mut Parser, opts: &ParseFileOptions) -> Resul
             bytes: source_code.len(),
             duration: Some(duration),
         });
+    } else {
+        parser.stop_printing_dot_graphs();
     }
 
     if opts.print_time {

--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -990,6 +990,7 @@ void ts_subtree__print_dot_graph(const Subtree *self, uint32_t start_offset,
 
   if (ts_subtree_child_count(*self) == 0) fprintf(f, ", shape=plaintext");
   if (ts_subtree_extra(*self)) fprintf(f, ", fontcolor=gray");
+  if (ts_subtree_has_changes(*self)) fprintf(f, ", color=green, penwidth=2");
 
   fprintf(f, ", tooltip=\""
     "range: %u - %u\n"


### PR DESCRIPTION
This PR has two minor changes

- In the lib, we wrap nodes that are denoted to have changes with a green circles (this was inspired by Max's slides in his strange loop talk, I found it to be quite a nice touch :slightly_smiling_face:)
- In the CLI's parse command, we do not stop printing graphs before parses after an edit have finished, so that we get this extra output in the log.html file

<details>
<summary>Example screenshot</summary>

![image](https://github.com/user-attachments/assets/c5a72944-c6d7-4bab-871d-808cffb4455e)
</details>