### PR TITLE
feat: bump version to 0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-cli"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-config"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-generate"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -1632,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-highlight"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "lazy_static",
  "regex",
@@ -1647,7 +1647,7 @@ version = "0.1.2"
 
 [[package]]
 name = "tree-sitter-loader"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-tags"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "memchr",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.24.1"
+version = "0.25.0"
 authors = ["Max Brunsfeld <maxbrunsfeld@gmail.com>"]
 edition = "2021"
 rust-version = "1.74.1"
@@ -96,9 +96,9 @@ walkdir = "2.5.0"
 wasmparser = "0.217.0"
 webbrowser = "1.0.2"
 
-tree-sitter = { version = "0.24.0", path = "./lib" }
-tree-sitter-generate = { version = "0.24.0", path = "./cli/generate" }
-tree-sitter-loader = { version = "0.24.0", path = "./cli/loader" }
-tree-sitter-config = { version = "0.24.0", path = "./cli/config" }
-tree-sitter-highlight = { version = "0.24.0", path = "./highlight" }
-tree-sitter-tags = { version = "0.24.0", path = "./tags" }
+tree-sitter = { version = "0.25.0", path = "./lib" }
+tree-sitter-generate = { version = "0.25.0", path = "./cli/generate" }
+tree-sitter-loader = { version = "0.25.0", path = "./cli/loader" }
+tree-sitter-config = { version = "0.25.0", path = "./cli/config" }
+tree-sitter-highlight = { version = "0.25.0", path = "./highlight" }
+tree-sitter-tags = { version = "0.25.0", path = "./tags" }

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ifeq ($(OS),Windows_NT)
 $(error Windows is not supported)
 endif
 
-VERSION := 0.24.1
+VERSION := 0.25.0
 DESCRIPTION := An incremental parsing system for programming tools
 HOMEPAGE_URL := https://tree-sitter.github.io/tree-sitter/
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "tree-sitter",
-    .version = "0.24.1",
+    .version = "0.25.0",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/cli/npm/package.json
+++ b/cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-cli",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "author": "Max Brunsfeld",
   "license": "MIT",
   "repository": {

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(tree-sitter
-        VERSION "0.24.1"
+        VERSION "0.25.0"
         DESCRIPTION "An incremental parsing system for programming tools"
         HOMEPAGE_URL "https://tree-sitter.github.io/tree-sitter/"
         LANGUAGES C)

--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-tree-sitter",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "Tree-sitter bindings for the web",
   "main": "tree-sitter.js",
   "types": "tree-sitter-web.d.ts",


### PR DESCRIPTION
Note that a release isn't happening, but this is being done to signal that the current master branch is on development *for* 0.25. Other projects do something similar, and it's a nice signal to people what the next version will be, and how one can get started *using* that version today, instead of confusingly using an older, already published, version.