### PR TITLE
feat: Add CST pretty-printer for parser output

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,7 +22,7 @@ use tree_sitter_cli::{
     highlight,
     init::{generate_grammar_files, get_root_path, migrate_package_json, JsonConfigOpts},
     logger,
-    parse::{self, ParseFileOptions, ParseOutput},
+    parse::{self, ParseFileOptions, ParseOutput, ParseTheme},
     playground, query, tags,
     test::{self, TestOptions},
     test_highlight, test_tags, util, wasm,
@@ -801,6 +801,16 @@ impl Parse {
             ParseOutput::Normal
         };
 
+        let parse_theme = if color {
+            config
+                .get::<tree_sitter_cli::parse::Config>()
+                .with_context(|| "Failed to parse CST theme")?
+                .parse_theme
+                .into()
+        } else {
+            ParseTheme::blank()
+        };
+
         let encoding = self.encoding.map(|e| match e {
             Encoding::Utf8 => ffi::TSInputEncodingUTF8,
             Encoding::Utf16LE => ffi::TSInputEncodingUTF16LE,
@@ -876,6 +886,7 @@ impl Parse {
                 encoding,
                 open_log: self.open_log,
                 no_ranges: self.no_ranges,
+                parse_theme: &parse_theme,
             };
 
             let parse_result = parse::parse_file_at_path(&mut parser, &opts)?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -183,6 +183,12 @@ struct Parse {
         help = "Output the parse data in XML format"
     )]
     pub output_xml: bool,
+    #[arg(
+        long = "cst",
+        short = 'c',
+        help = "Output the parse data in a pretty-printed CST format"
+    )]
+    pub output_cst: bool,
     #[arg(long, short, help = "Show parsing statistic")]
     pub stat: bool,
     #[arg(long, help = "Interrupt the parsing process by timeout (µs)")]
@@ -787,6 +793,8 @@ impl Parse {
             ParseOutput::Dot
         } else if self.output_xml {
             ParseOutput::Xml
+        } else if self.output_cst {
+            ParseOutput::Cst
         } else if self.quiet {
             ParseOutput::Quiet
         } else {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -803,12 +803,13 @@ impl Parse {
 
         let parse_theme = if color {
             config
-                .get::<tree_sitter_cli::parse::Config>()
+                .get::<parse::Config>()
                 .with_context(|| "Failed to parse CST theme")?
                 .parse_theme
+                .unwrap_or_default()
                 .into()
         } else {
-            ParseTheme::blank()
+            ParseTheme::empty()
         };
 
         let encoding = self.encoding.map(|e| match e {

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -655,6 +655,7 @@ fn cst_render_node(
             )?;
         }
         let kind_color = if node.is_error() {
+            write!(stdout, "{}", paint(opts.parse_theme.error, "•"))?;
             opts.parse_theme.error
         } else if node.is_extra() || node.parent().is_some_and(|p| p.is_extra()) {
             opts.parse_theme.extra

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -567,9 +567,7 @@ fn write_node_text(
     text_info: (char, usize, usize),
 ) -> Result<()> {
     let (quote, row_width, indent_level) = text_info;
-    if (!source.is_empty() && source.find('\n') == Some(source.len() - 1))
-        || source.find('\n').is_none()
-    {
+    if source.ends_with('\n') || source.find('\n').is_none() {
         write!(
             stdout,
             "{quote}{}{quote}",

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -601,7 +601,6 @@ fn write_node_text(
         ('\"', color.map(|c| c.into()))
     };
 
-    // check if the source only has a single '\n' at the end
     if !is_named {
         write!(
             stdout,

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -41,16 +41,26 @@ impl fmt::Display for Stats {
     }
 }
 
+/// Sets the color used in the output of `tree-sitter parse --cst`
 #[derive(Debug, Copy, Clone)]
 pub struct ParseTheme {
+    /// The color of node kinds
     pub node_kind: Option<Color>,
+    /// The color of text associated with a node
     pub node_text: Option<Color>,
+    /// The color of node fields
     pub field: Option<Color>,
+    /// The color of token
     pub token: Option<Color>,
+    /// The color of the range information for unnamed nodes
     pub row_color: Option<Color>,
+    /// The color of the range information for named nodes
     pub row_color_named: Option<Color>,
+    /// The color of extra nodes
     pub extra: Option<Color>,
+    /// The color of ERROR nodes
     pub error: Option<Color>,
+    /// The color of MISSING nodes and their associated text
     pub warning: Option<Color>,
 }
 

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -564,18 +564,16 @@ fn write_node_text(
     is_named: bool,
     source: &str,
     color: Option<impl Into<Color> + Copy>,
-    // quote, row_width, indent_level
     text_info: (char, usize, usize),
 ) -> Result<()> {
+    let (quote, row_width, indent_level) = text_info;
     if (!source.is_empty() && source.find('\n') == Some(source.len() - 1))
         || source.find('\n').is_none()
     {
         write!(
             stdout,
-            "{}{}{}",
-            text_info.0,
-            paint(color, &render_node_text(source)),
-            text_info.0
+            "{quote}{}{quote}",
+            paint(color, &render_node_text(source))
         )?;
     } else {
         for line in source.split_inclusive('\n') {
@@ -585,21 +583,17 @@ fn write_node_text(
             if !opts.no_ranges {
                 write!(
                     stdout,
-                    "\n{}{}{}{}{}",
-                    render_node_range(opts, cursor, is_named, text_info.1),
-                    "  ".repeat(text_info.2 + 1),
-                    text_info.0,
+                    "\n{}{}{quote}{}{quote}",
+                    render_node_range(opts, cursor, is_named, row_width),
+                    "  ".repeat(indent_level + 1),
                     &paint(color, &render_node_text(line)),
-                    text_info.0
                 )?;
             } else {
                 write!(
                     stdout,
-                    "\n{}{}{}{}",
-                    "  ".repeat(text_info.2 + 1),
-                    text_info.0,
+                    "\n{}{quote}{}{quote}",
+                    "  ".repeat(indent_level + 1),
                     &paint(color, &render_node_text(line)),
-                    text_info.0
                 )?;
             }
         }

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -654,7 +654,7 @@ fn cst_render_node(
                 paint(opts.parse_theme.field, &format!("{field_name}: "))
             )?;
         }
-        let kind_color = if node.is_error() {
+        let kind_color = if node.has_error() {
             write!(stdout, "{}", paint(opts.parse_theme.error, "•"))?;
             opts.parse_theme.error
         } else if node.is_extra() || node.parent().is_some_and(|p| p.is_extra()) {

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -602,16 +602,12 @@ fn write_node_text(
     };
 
     // check if the source only has a single '\n' at the end
-    if (source.is_empty() && source.find('\n') == Some(source.len() - 1))
-        || source.find('\n').is_none()
-        || !is_named
-    {
-        let formatted_line = render_line_feed(source, opts);
+    if !is_named {
         write!(
             stdout,
             "{}{}{}",
             paint(quote_color, &String::from(quote)),
-            paint(color, &render_node_text(&formatted_line)),
+            paint(color, &render_node_text(source)),
             paint(quote_color, &String::from(quote)),
         )?;
     } else {

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -601,12 +601,17 @@ fn write_node_text(
         ('\"', color.map(|c| c.into()))
     };
 
-    if source.ends_with('\n') || source.find('\n').is_none() || !is_named {
+    // check if the source only has a single '\n' at the end
+    if (source.is_empty() && source.find('\n') == Some(source.len() - 1))
+        || source.find('\n').is_none()
+        || !is_named
+    {
+        let formatted_line = render_line_feed(source, opts);
         write!(
             stdout,
             "{}{}{}",
             paint(quote_color, &String::from(quote)),
-            paint(color, &render_node_text(source)),
+            paint(color, &render_node_text(&formatted_line)),
             paint(quote_color, &String::from(quote)),
         )?;
     } else {
@@ -670,19 +675,24 @@ fn render_node_range(
         opts.parse_theme.row_color
     };
 
-    let remaining_width = (total_width
+    let remaining_width_start = (total_width
         - (range.start_point.row as f64).log10() as usize
         - (range.start_point.column as f64).log10() as usize)
+        .max(1);
+    let remaining_width_end = (total_width
+        - (range.end_point.row as f64).log10() as usize
+        - (range.end_point.column as f64).log10() as usize)
         .max(1);
     paint(
         range_color,
         &format!(
-            "{}:{}{:remaining_width$}- {}:{:<3}",
+            "{}:{}{:remaining_width_start$}- {}:{}{:remaining_width_end$}",
             range.start_point.row,
             range.start_point.column,
             ' ',
             range.end_point.row,
             range.end_point.column,
+            ' ',
         ),
     )
 }

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -327,8 +327,8 @@ pub fn print_diff(actual: &str, expected: &str, use_color: bool) {
     println!();
 }
 
-pub fn paint(color: Option<AnsiColor>, text: &str) -> String {
-    let style = Style::new().fg_color(color.map(Color::Ansi));
+pub fn paint(color: Option<impl Into<Color>>, text: &str) -> String {
+    let style = Style::new().fg_color(color.map(Into::into));
     format!("{style}{text}{style:#}")
 }
 

--- a/docs/section-3-creating-parsers.md
+++ b/docs/section-3-creating-parsers.md
@@ -390,7 +390,7 @@ You can run your parser on an arbitrary file using `tree-sitter parse`. This wil
           (int_literal [1, 9] - [1, 10]))))))
 ```
 
-You can pass any number of file paths and glob patterns to `tree-sitter parse`, and it will parse all of the given files. The command will exit with a non-zero status code if any parse errors occurred. You can also prevent the syntax trees from being printed using the `--quiet` flag. Additionally, the `--stat` flag prints out aggregated parse success/failure information for all processed files. This makes `tree-sitter parse` usable as a secondary testing strategy: you can check that a large number of files parse without error:
+You can pass any number of file paths and glob patterns to `tree-sitter parse`, and it will parse all of the given files. The command will exit with a non-zero status code if any parse errors occurred. Passing the `--cst` flag will output a pretty-printed CST instead of the normal S-expression representation. You can also prevent the syntax trees from being printed using the `--quiet` flag. Additionally, the `--stat` flag prints out aggregated parse success/failure information for all processed files. This makes `tree-sitter parse` usable as a secondary testing strategy: you can check that a large number of files parse without error:
 
 ```sh
 tree-sitter parse 'examples/**/*.go' --quiet --stat

--- a/docs/section-4-syntax-highlighting.md
+++ b/docs/section-4-syntax-highlighting.md
@@ -60,7 +60,7 @@ In your config file, the `"theme"` value is an object whose keys are dot-separat
 
 ### Parse Theme
 
-The Tree-sitter `parse` command will output a pretty-printed CST when the `--cst` option is used. You can control which colors are used for various parts of the tree in your configuration file:
+The Tree-sitter `parse` command will output a pretty-printed CST when the `--cst` option is used. You can control which colors are used for various parts of the tree in your configuration file. Note that omitting a field will cause the relevant text to be rendered with its default color.
 
 ```json
 {
@@ -72,7 +72,8 @@ The Tree-sitter `parse` command will output a pretty-printed CST when the `--cst
     "row_color": [255, 255, 255],
     "row_color_named": [255, 130, 0],
     "extra": [0, 0, 0],
-    "error": [255, 0, 0]
+    "error": [255, 0, 0],
+    "warning": [153, 75, 0]
   }
 }
 ```

--- a/docs/section-4-syntax-highlighting.md
+++ b/docs/section-4-syntax-highlighting.md
@@ -66,23 +66,26 @@ The Tree-sitter `parse` command will output a pretty-printed CST when the `--cst
 {
   "parse-theme": {
     // The color of node kinds
-    "node_kind": [20, 20, 20],
+    "node-kind": [20, 20, 20],
     // The color of text associated with a node
-    "node_text": [255, 255, 255],
+    "node-text": [255, 255, 255],
     // The color of node fields
     "field": [42, 42, 42],
     // The color of token
     "token": [200, 200, 0],
     // The color of the range information for unnamed nodes
-    "row_color": [255, 255, 255],
+    "row-color": [255, 255, 255],
     // The color of the range information for named nodes
-    "row_color_named": [255, 130, 0],
+    "row-color_named": [255, 130, 0],
     // The color of extra nodes
-    "extra": [0, 0, 0],
+    "extra": [255, 0, 255],
     // The color of ERROR nodes
     "error": [255, 0, 0],
     // The color of MISSING nodes and their associated text
-    "warning": [153, 75, 0]
+    "missing": [153, 75, 0]
+    // The color of newline characters
+    "line-feed": [150, 150, 150],
+    "backtick": [0, 200, 0]
   }
 }
 ```

--- a/docs/section-4-syntax-highlighting.md
+++ b/docs/section-4-syntax-highlighting.md
@@ -71,22 +71,22 @@ The Tree-sitter `parse` command will output a pretty-printed CST when the `--cst
     "node-text": [255, 255, 255],
     // The color of node fields
     "field": [42, 42, 42],
-    // The color of token
-    "token": [200, 200, 0],
     // The color of the range information for unnamed nodes
     "row-color": [255, 255, 255],
     // The color of the range information for named nodes
-    "row-color_named": [255, 130, 0],
+    "row-color-named": [255, 130, 0],
     // The color of extra nodes
     "extra": [255, 0, 255],
     // The color of ERROR nodes
     "error": [255, 0, 0],
     // The color of MISSING nodes and their associated text
-    "missing": [153, 75, 0]
+    "missing": [153, 75, 0],
     // The color of newline characters
     "line-feed": [150, 150, 150],
     // The color of backtick characters
-    "backtick": [0, 200, 0]
+    "backtick": [0, 200, 0],
+    // The color of literals
+    "literal": [0, 0, 200],
   }
 }
 ```

--- a/docs/section-4-syntax-highlighting.md
+++ b/docs/section-4-syntax-highlighting.md
@@ -58,6 +58,25 @@ The Tree-sitter highlighting system works by annotating ranges of source code wi
 
 In your config file, the `"theme"` value is an object whose keys are dot-separated highlight names like `function.builtin` or `keyword`, and whose values are JSON expressions that represent text styling parameters.
 
+### Parse Theme
+
+The Tree-sitter `parse` command will output a pretty-printed CST when the `--cst` option is used. You can control which colors are used for various parts of the tree in your configuration file:
+
+```json
+{
+  "parse-theme": {
+    "node_kind": [20, 20, 20],
+    "node_text": [255, 255, 255],
+    "field": [42, 42, 42],
+    "token": [200, 200, 0],
+    "row_color": [255, 255, 255],
+    "row_color_named": [255, 130, 0],
+    "extra": [0, 0, 0],
+    "error": [255, 0, 0]
+  }
+}
+```
+
 #### Highlight Names
 
 A theme can contain multiple keys that share a common subsequence. Examples:

--- a/docs/section-4-syntax-highlighting.md
+++ b/docs/section-4-syntax-highlighting.md
@@ -62,17 +62,26 @@ In your config file, the `"theme"` value is an object whose keys are dot-separat
 
 The Tree-sitter `parse` command will output a pretty-printed CST when the `--cst` option is used. You can control which colors are used for various parts of the tree in your configuration file. Note that omitting a field will cause the relevant text to be rendered with its default color.
 
-```json
+```json5
 {
   "parse-theme": {
+    // The color of node kinds
     "node_kind": [20, 20, 20],
+    // The color of text associated with a node
     "node_text": [255, 255, 255],
+    // The color of node fields
     "field": [42, 42, 42],
+    // The color of token
     "token": [200, 200, 0],
+    // The color of the range information for unnamed nodes
     "row_color": [255, 255, 255],
+    // The color of the range information for named nodes
     "row_color_named": [255, 130, 0],
+    // The color of extra nodes
     "extra": [0, 0, 0],
+    // The color of ERROR nodes
     "error": [255, 0, 0],
+    // The color of MISSING nodes and their associated text
     "warning": [153, 75, 0]
   }
 }

--- a/docs/section-4-syntax-highlighting.md
+++ b/docs/section-4-syntax-highlighting.md
@@ -85,6 +85,7 @@ The Tree-sitter `parse` command will output a pretty-printed CST when the `--cst
     "missing": [153, 75, 0]
     // The color of newline characters
     "line-feed": [150, 150, 150],
+    // The color of backtick characters
     "backtick": [0, 200, 0]
   }
 }


### PR DESCRIPTION
This PR adds pretty-printing functionality for the `parse` command that can be accessed via `--cst` or `-c`.  Here's a quick example using a bare-bones C file:

```C
int main(int argc, char *argv[])
{
    return EXIT_SUCCESS;
}
```

Normal output:

![image](https://github.com/user-attachments/assets/4a9669df-79aa-412e-9141-157a90d7c0e5)

Pretty-printed:

![image](https://github.com/user-attachments/assets/fcb5d937-b67b-4a23-aceb-b12d2d15808b)

`ERROR` and `MISSING` nodes are highlighted in red (as well as invalid UTF8). For example, removing the semicolon from the above C code gives the following:

![image](https://github.com/user-attachments/assets/f9759215-0bb1-4994-aba3-378155c00c13)

(EDIT) ~~TODO: Configurable color scheme~~