### PR TITLE
fix(lib): properly reset the lexer's start postiion

### DIFF
--- a/lib/src/lexer.c
+++ b/lib/src/lexer.c
@@ -367,7 +367,10 @@ void ts_lexer_finish(Lexer *self, uint32_t *lookahead_end_byte) {
   // If the token ended at an included range boundary, then its end position
   // will have been reset to the end of the preceding range. Reset the start
   // position to match.
-  if (self->token_end_position.bytes < self->token_start_position.bytes) {
+  if (
+    self->token_end_position.bytes < self->token_start_position.bytes ||
+    point_lt(self->token_end_position.extent, self->token_start_position.extent)
+  ) {
     self->token_start_position = self->token_end_position;
   }
 


### PR DESCRIPTION
Closes #3620

### Problem

In the linked issue above, the author noted that when parsing a `HEEX` document with particular ranges, the parser will hang. The problem I noticed while debugging this is that for some odd reason, with several hundred tokens lexed, the length of the subtree is zero when we call `ts_subtree_total_bytes(result).bytes` [here](https://github.com/tree-sitter/tree-sitter/blob/b7a00527bef4070e48dc945e5755f8ace1038053/lib/src/parser.c#L689). This stems from the size of the subtree actually being 512, but it's being used in an inline node whose `size_bytes` field is a `uint8_t` - 512 is much larger than `UINT8_MAX`. 

So, something is amiss - and indeed if we actually print the size we see this: `size=Length {.bytes = 512, .extent = {0, 14}}`. To me, an extent of 0, 14 feels odd for a byte size of 512, so if we actually print out the lexer's start and end position, we get the following: `self->lexer.token_start_position.bytes:395 {3, 72}, self->lexer.token_end_position.bytes:907 {1, 86}`. 

We can see that the end position's bytes looks okay, but the end position's length is way less than the start position's length, which doesn't make sense - the start position should be updated to be at the end position if either the bytes or the extent is less than the start point's in this [condition](https://github.com/tree-sitter/tree-sitter/blob/b7a00527bef4070e48dc945e5755f8ace1038053/lib/src/lexer.c#L370).

### Solution

A check is added that checks that the end position's extent is also less than the start position's, and if it is we reset the start position to the end position.