### PR TITLE
perf(loader): improve language lookup speed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,7 @@ dependencies = [
  "dirs",
  "fs4",
  "indoc",
+ "lazy_static",
  "libloading",
  "once_cell",
  "path-slash",

--- a/cli/loader/Cargo.toml
+++ b/cli/loader/Cargo.toml
@@ -27,6 +27,7 @@ cc.workspace = true
 dirs.workspace = true
 fs4.workspace = true
 indoc.workspace = true
+lazy_static.workspace = true
 libloading.workspace = true
 once_cell.workspace = true
 path-slash.workspace = true

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -1,6 +1,5 @@
 use std::{
-    fs::{self, File},
-    io::BufReader,
+    fs,
     path::{Path, PathBuf},
     str::{self, FromStr},
 };
@@ -213,9 +212,9 @@ pub fn migrate_package_json(repo_path: &Path) -> Result<bool> {
         root_path.join("tree-sitter.json"),
     );
 
-    let old_config = serde_json::from_reader::<_, PackageJSON>(
-        File::open(&package_json_path)
-            .with_context(|| format!("Failed to open package.json in {}", root_path.display()))?,
+    let old_config = serde_json::from_str::<PackageJSON>(
+        &fs::read_to_string(&package_json_path)
+            .with_context(|| format!("Failed to read package.json in {}", root_path.display()))?,
     )?;
 
     if old_config.tree_sitter.is_none() {
@@ -340,9 +339,9 @@ pub fn migrate_package_json(repo_path: &Path) -> Result<bool> {
     )?;
 
     // Remove the `tree-sitter` field in-place
-    let mut package_json = serde_json::from_reader::<_, Map<String, Value>>(
-        File::open(&package_json_path)
-            .with_context(|| format!("Failed to open package.json in {}", root_path.display()))?,
+    let mut package_json = serde_json::from_str::<Map<String, Value>>(
+        &fs::read_to_string(&package_json_path)
+            .with_context(|| format!("Failed to read package.json in {}", root_path.display()))?,
     )
     .unwrap();
     package_json.remove("tree-sitter");
@@ -387,9 +386,9 @@ pub fn generate_grammar_files(
         },
     )?;
 
-    let tree_sitter_config = serde_json::from_reader::<_, TreeSitterJSON>(
-        File::open(tree_sitter_config.as_path())
-            .with_context(|| "Failed to open tree-sitter.json")?,
+    let tree_sitter_config = serde_json::from_str::<TreeSitterJSON>(
+        &fs::read_to_string(tree_sitter_config.as_path())
+            .with_context(|| "Failed to read tree-sitter.json")?,
     )?;
 
     let authors = tree_sitter_config.metadata.authors.as_ref();
@@ -659,15 +658,14 @@ pub fn get_root_path(path: &Path) -> Result<PathBuf> {
         let json = pathbuf
             .exists()
             .then(|| {
-                let file = File::open(pathbuf.as_path())
-                    .with_context(|| format!("Failed to open {filename}"))?;
-                let reader = BufReader::new(file);
+                let contents = fs::read_to_string(pathbuf.as_path())
+                    .with_context(|| format!("Failed to read {filename}"))?;
                 if is_package_json {
-                    serde_json::from_reader::<_, Map<String, Value>>(reader)
+                    serde_json::from_str::<Map<String, Value>>(&contents)
                         .context(format!("Failed to parse {filename}"))
                         .map(|v| v.contains_key("tree-sitter"))
                 } else {
-                    serde_json::from_reader::<_, TreeSitterJSON>(reader)
+                    serde_json::from_str::<TreeSitterJSON>(&contents)
                         .context(format!("Failed to parse {filename}"))
                         .map(|_| true)
                 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -667,11 +667,11 @@ impl Init {
 
             (opts.name.clone(), Some(opts))
         } else {
-            let json = serde_json::from_reader::<_, TreeSitterJSON>(
-                fs::File::open(current_dir.join("tree-sitter.json"))
-                    .with_context(|| "Failed to open tree-sitter.json")?,
+            let mut json = serde_json::from_str::<TreeSitterJSON>(
+                &fs::read_to_string(current_dir.join("tree-sitter.json"))
+                    .with_context(|| "Failed to read tree-sitter.json")?,
             )?;
-            (json.grammars[0].name.clone(), None)
+            (json.grammars.swap_remove(0).name, None)
         };
 
         generate_grammar_files(


### PR DESCRIPTION
### Problem

While running a `release-dev` build to test changes at a faster rate, I noticed that the `parse` subcommand felt like it was hanging for a little bit. Turns out, it was around ~100ms after checking with `hyperfine`:
![image](https://github.com/user-attachments/assets/99250dfa-904c-46d2-a09b-fb81ca83ee6c)


 I decided to poke around and see what was causing the slowdown with a flamegraph, and got something that looked like this:
 
![image](https://github.com/user-attachments/assets/11eb801a-e8ee-4184-a936-3cbb448a5cd8)

It becomes pretty evident that the majority of the time spent here is in serde's `deserialize`, which is called in `find_language_configurations_at_path` in the loader crate. If we take a look, we see there are three spots we use serde's deserialize: [here](https://github.com/tree-sitter/tree-sitter/blob/fe92e978f922b7c8caf8d43604d39f419f963749/cli/loader/src/lib.rs#L1136), [here](https://github.com/tree-sitter/tree-sitter/blob/fe92e978f922b7c8caf8d43604d39f419f963749/cli/loader/src/lib.rs#L1148), and [here](https://github.com/tree-sitter/tree-sitter/blob/fe92e978f922b7c8caf8d43604d39f419f963749/cli/loader/src/lib.rs#L1243).

The first case is not the problem, since we are loading a relatively small file, but the other two are loading a grammar.json file, and in fact, it's the same file being deserialized *twice*. It becomes pretty clear that the first one isn't needed, we deserialize `grammar.json` just to read the name field when we've already successfully parser a config file - we should use the name in the config file instead.

However, this does not solve the ~100ms avg parse subcommand time, because, as one would expect, release-like profiles likely (don't quote me) optimize the two deserialize calls into one as an optimization, since it's the same path we're reading from. So, the real problem is that we're reading potentially thousands of lines long grammar files *just* to extract the field name, and nothing else.

### Solution

Instead of reading & deserializing thousands of lines into memory to extract one field, we can rely on the invariant that if a grammar.json was generated with tree-sitter cli (why wouldn't it be? ;) ), the name field is *always* within the first three lines. We can just read three lines and extract the name field with a simple regex. The results are great: with `release-dev`, the `parse` subcommand goes down from 100ms to 2.3ms, and is just under 2ms with the `release` profile on a Ryzen 9 9950x:
![image](https://github.com/user-attachments/assets/3d5995aa-76bd-4f83-80da-202bfba49d96)
![image](https://github.com/user-attachments/assets/01e88182-3dd2-4494-a7c6-433015684b88)

Another small finding that was observed when playing around with serde's deserialization is that `serde_json::from_reader` with a `BufReader` is a bit slower than `serde_json::from_str` with `fs::read_to_string`. In my testing, for `release-dev` it was ~3.5ms, compared to 2.3ms without it, so every usage of `from_reader` + `BufReader` was replaced with `from_str` + `fs::read_to_string`.
