### PR TITLE
fix(wasm): fix memory errors in wasm_store

### DIFF
--- a/lib/src/wasm_store.c
+++ b/lib/src/wasm_store.c
@@ -864,7 +864,7 @@ TSWasmStore *ts_wasm_store_new(TSWasmEngine *engine, TSWasmError *wasm_error) {
 
   // Add all of the lexer callback functions to the function table. Store their function table
   // indices on the in-memory lexer.
-  uint32_t table_index;
+  uint64_t table_index;
   error = wasmtime_table_grow(context, &function_table, lexer_definitions_len, &initializer, &table_index);
   if (error) {
     wasmtime_error_message(error, &message);
@@ -965,7 +965,7 @@ static bool ts_wasm_store__instantiate(
 
   // Grow the function table to make room for the new functions.
   wasmtime_val_t initializer = {.kind = WASMTIME_FUNCREF};
-  uint32_t prev_table_size;
+  uint64_t prev_table_size;
   error = wasmtime_table_grow(context, &self->function_table, dylink_info->table_size, &initializer, &prev_table_size);
   if (error) {
     format(error_message, "invalid function table size %u", dylink_info->table_size);


### PR DESCRIPTION
In version 25 of wasmtime, `wasmtime_table_grow` was changed to take `uint64_t*` instead of `uint32_t*`. As a result, the passed pointer is now too small to contain the result, and unrelated memory is being overwritten.

This PR resolves these issues, but I would advise that `incompatible-pointer-types` be raised from a warning to an error.

```
In file included from tree_sitter/core/lib/src/lib.c:14:
tree_sitter/core/lib/src/./wasm_store.c:868:94: warning: incompatible pointer types passing 'uint32_t *' (aka 'unsigned int *') to parameter of type 'uint64_t *' (aka 'unsigned long long *') [-Wincompatible-pointer-types]
  error = wasmtime_table_grow(context, &function_table, lexer_definitions_len, &initializer, &table_index);
                                                                                             ^~~~~~~~~~~~
/Users/rpatterson/Projects/amel/py-tree-sitter/.direnv/python-3.11/include/wasmtime/table.h:105:31: note: passing argument to parameter 'prev_size' here
                    uint64_t *prev_size);
                              ^
In file included from tree_sitter/core/lib/src/lib.c:14:
tree_sitter/core/lib/src/./wasm_store.c:969:102: warning: incompatible pointer types passing 'uint32_t *' (aka 'unsigned int *') to parameter of type 'uint64_t *' (aka 'unsigned long long *') [-Wincompatible-pointer-types]
  error = wasmtime_table_grow(context, &self->function_table, dylink_info->table_size, &initializer, &prev_table_size);
                                                                                                     ^~~~~~~~~~~~~~~~
/Users/rpatterson/Projects/amel/py-tree-sitter/.direnv/python-3.11/include/wasmtime/table.h:105:31: note: passing argument to parameter 'prev_size' here
                    uint64_t *prev_size);
                              ^
2 warnings generated.
```