### PR TITLE
feat: add `version` subcommand for versioning grammars

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -13,6 +13,7 @@ pub mod test;
 pub mod test_highlight;
 pub mod test_tags;
 pub mod util;
+pub mod version;
 pub mod wasm;
 
 #[cfg(test)]

--- a/cli/src/tests/detect_language.rs
+++ b/cli/src/tests/detect_language.rs
@@ -101,7 +101,7 @@ fn tree_sitter_dir(tree_sitter_json: &str, name: &str) -> tempfile::TempDir {
     fs::write(
         temp_dir.path().join("src/parser.c"),
         format!(
-            r##"
+            r#"
                 #include "tree_sitter/parser.h"
                 #ifdef _WIN32
                 #define TS_PUBLIC __declspec(dllexport)
@@ -109,7 +109,7 @@ fn tree_sitter_dir(tree_sitter_json: &str, name: &str) -> tempfile::TempDir {
                 #define TS_PUBLIC __attribute__((visibility("default")))
                 #endif
                 TS_PUBLIC const TSLanguage *tree_sitter_{name}() {{}}
-            "##
+            "#
         ),
     )
     .unwrap();

--- a/cli/src/version.rs
+++ b/cli/src/version.rs
@@ -1,0 +1,260 @@
+use std::{fs, path::PathBuf, process::Command};
+
+use anyhow::{anyhow, Context, Result};
+use regex::Regex;
+use tree_sitter_loader::TreeSitterJSON;
+
+pub struct Version {
+    pub version: String,
+    pub current_dir: PathBuf,
+}
+
+impl Version {
+    #[must_use]
+    pub const fn new(version: String, current_dir: PathBuf) -> Self {
+        Self {
+            version,
+            current_dir,
+        }
+    }
+
+    pub fn run(self) -> Result<()> {
+        let tree_sitter_json = self.current_dir.join("tree-sitter.json");
+
+        let tree_sitter_json =
+            serde_json::from_str::<TreeSitterJSON>(&fs::read_to_string(tree_sitter_json)?)?;
+
+        let is_multigrammar = tree_sitter_json.grammars.len() > 1;
+
+        self.update_treesitter_json().with_context(|| {
+            format!(
+                "Failed to update tree-sitter.json at {}",
+                self.current_dir.display()
+            )
+        })?;
+        self.update_cargo_toml().with_context(|| {
+            format!(
+                "Failed to update Cargo.toml at {}",
+                self.current_dir.display()
+            )
+        })?;
+        self.update_package_json().with_context(|| {
+            format!(
+                "Failed to update package.json at {}",
+                self.current_dir.display()
+            )
+        })?;
+        self.update_makefile(is_multigrammar).with_context(|| {
+            format!(
+                "Failed to update Makefile at {}",
+                self.current_dir.display()
+            )
+        })?;
+        self.update_cmakelists_txt().with_context(|| {
+            format!(
+                "Failed to update CMakeLists.txt at {}",
+                self.current_dir.display()
+            )
+        })?;
+        self.update_pyproject_toml().with_context(|| {
+            format!(
+                "Failed to update pyproject.toml at {}",
+                self.current_dir.display()
+            )
+        })?;
+
+        Ok(())
+    }
+
+    fn update_treesitter_json(&self) -> Result<()> {
+        let tree_sitter_json = &fs::read_to_string(self.current_dir.join("tree-sitter.json"))?;
+
+        let tree_sitter_json = tree_sitter_json
+            .lines()
+            .map(|line| {
+                if line.contains("\"version\":") {
+                    let prefix_index = line.find("\"version\":").unwrap() + "\"version\":".len();
+                    let start_quote = line[prefix_index..].find('"').unwrap() + prefix_index + 1;
+                    let end_quote = line[start_quote + 1..].find('"').unwrap() + start_quote + 1;
+
+                    format!(
+                        "{}{}{}",
+                        &line[..start_quote],
+                        self.version,
+                        &line[end_quote..]
+                    )
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+
+        fs::write(self.current_dir.join("tree-sitter.json"), tree_sitter_json)?;
+
+        Ok(())
+    }
+
+    fn update_cargo_toml(&self) -> Result<()> {
+        if !self.current_dir.join("Cargo.toml").exists() {
+            return Ok(());
+        }
+
+        let cargo_toml = fs::read_to_string(self.current_dir.join("Cargo.toml"))?;
+
+        let cargo_toml = cargo_toml
+            .lines()
+            .map(|line| {
+                if line.starts_with("version =") {
+                    format!("version = \"{}\"", self.version)
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+
+        fs::write(self.current_dir.join("Cargo.toml"), cargo_toml)?;
+
+        if self.current_dir.join("Cargo.lock").exists() {
+            let Ok(cmd) = Command::new("cargo")
+                .arg("update")
+                .current_dir(&self.current_dir)
+                .output()
+            else {
+                return Ok(()); // cargo is not `executable`, ignore
+            };
+
+            if !cmd.status.success() {
+                let stderr = String::from_utf8_lossy(&cmd.stderr);
+                return Err(anyhow!("Failed to run `cargo update`:\n{stderr}"));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn update_package_json(&self) -> Result<()> {
+        if !self.current_dir.join("package.json").exists() {
+            return Ok(());
+        }
+
+        let package_json = &fs::read_to_string(self.current_dir.join("package.json"))?;
+
+        let package_json = package_json
+            .lines()
+            .map(|line| {
+                if line.contains("\"version\":") {
+                    let prefix_index = line.find("\"version\":").unwrap() + "\"version\":".len();
+                    let start_quote = line[prefix_index..].find('"').unwrap() + prefix_index + 1;
+                    let end_quote = line[start_quote + 1..].find('"').unwrap() + start_quote + 1;
+
+                    format!(
+                        "{}{}{}",
+                        &line[..start_quote],
+                        self.version,
+                        &line[end_quote..]
+                    )
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+
+        fs::write(self.current_dir.join("package.json"), package_json)?;
+
+        if self.current_dir.join("package-lock.json").exists() {
+            let Ok(cmd) = Command::new("npm")
+                .arg("install")
+                .current_dir(&self.current_dir)
+                .output()
+            else {
+                return Ok(()); // npm is not `executable`, ignore
+            };
+
+            if !cmd.status.success() {
+                let stderr = String::from_utf8_lossy(&cmd.stderr);
+                return Err(anyhow!("Failed to run `npm install`:\n{stderr}"));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn update_makefile(&self, is_multigrammar: bool) -> Result<()> {
+        let makefile = if is_multigrammar {
+            if !self.current_dir.join("common").join("common.mak").exists() {
+                return Ok(());
+            }
+
+            fs::read_to_string(self.current_dir.join("Makefile"))?
+        } else {
+            if !self.current_dir.join("Makefile").exists() {
+                return Ok(());
+            }
+
+            fs::read_to_string(self.current_dir.join("Makefile"))?
+        };
+
+        let makefile = makefile
+            .lines()
+            .map(|line| {
+                if line.starts_with("VERSION") {
+                    format!("VERSION := {}", self.version)
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+
+        fs::write(self.current_dir.join("Makefile"), makefile)?;
+
+        Ok(())
+    }
+
+    fn update_cmakelists_txt(&self) -> Result<()> {
+        if !self.current_dir.join("CMakeLists.txt").exists() {
+            return Ok(());
+        }
+
+        let cmake = fs::read_to_string(self.current_dir.join("CMakeLists.txt"))?;
+
+        let re = Regex::new(r#"(project\([^\n]*\n\s*VERSION\s+)"[0-9]+\.[0-9]+\.[0-9]+""#)?;
+        let cmake = re.replace(&cmake, format!(r#"$1"{}""#, self.version));
+
+        fs::write(self.current_dir.join("CMakeLists.txt"), cmake.as_bytes())?;
+
+        Ok(())
+    }
+
+    fn update_pyproject_toml(&self) -> Result<()> {
+        if !self.current_dir.join("pyproject.toml").exists() {
+            return Ok(());
+        }
+
+        let pyproject_toml = fs::read_to_string(self.current_dir.join("pyproject.toml"))?;
+
+        let pyproject_toml = pyproject_toml
+            .lines()
+            .map(|line| {
+                if line.starts_with("version =") {
+                    format!("version = \"{}\"", self.version)
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+
+        fs::write(self.current_dir.join("pyproject.toml"), pyproject_toml)?;
+
+        Ok(())
+    }
+}

--- a/docs/section-3-creating-parsers.md
+++ b/docs/section-3-creating-parsers.md
@@ -164,6 +164,28 @@ This field controls what bindings are generated when the `init` command is run. 
 * `rust` (default: `true`)
 * `swift` (default: `false`)
 
+### Command: `version`
+
+The `version` command prints the version of the `tree-sitter` CLI tool that you have installed.
+
+```sh
+tree-sitter version 1.0.0
+```
+
+The only argument is the version itself, which is the first positional argument.
+This will update the version in several files, if they exist:
+
+* tree-sitter.json
+* Cargo.toml
+* package.json
+* Makefile
+* CMakeLists.txt
+* pyproject.toml
+
+As a grammar author, you should keep the version of your grammar in sync across
+different bindings. However, doing so manually is error-prone and tedious, so
+this command takes care of the burden.
+
 ### Command: `generate`
 
 The most important command you'll use is `tree-sitter generate`. This command reads the `grammar.js` file in your current working directory and creates a file called `src/parser.c`, which implements the parser. After making changes to your grammar, just run `tree-sitter generate` again.


### PR DESCRIPTION
### Problem

Currently, there is no easy way for grammar authors to increment the version across every manifest file that requires it and call it a day, it involves manual changes which is error prone.

### Solution

A `version` subcommand has been added which takes 1 positional argument - the version to bump to. The only requirement is that it must be a valid semver version. The command then bumps the following files' versions, if present: `tree-sitter.json`, `Cargo.toml`, `Cargo.lock` (with `cargo update`), `package.json`, `package-lock.json` (with `npm install`), `Makefile` or `common.mak` (the latter for multi-grammar repos), `CMakeLists.txt`, and `pyproject.toml`.

This allows grammar authors to easily bump the version of their grammar without any manual intervention. Ideally, the author would then commit these files, tag the version accordingly, and allow a [release workflow](https://github.com/tree-sitter/workflows/blob/main/.github/workflows/release.yml) to run to auto-generate build artifacts like `parser.c`.