### PR TITLE
fix(cli): check more lines in grammar.json loader

### DIFF
--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -1252,9 +1252,10 @@ impl Loader {
             format!("Failed to open grammar.json at {}", grammar_path.display())
         })?;
 
-        let first_three_lines = BufReader::new(file)
+        let first_lines = BufReader::new(file)
             .lines()
-            .take(3)
+            // todo(clason): reduce to 3 after all parsers are fixed
+            .take(20)
             .collect::<Result<Vec<_>, _>>()
             .with_context(|| {
                 format!(
@@ -1265,7 +1266,7 @@ impl Loader {
             .join("\n");
 
         let name = GRAMMAR_NAME_REGEX
-            .captures(&first_three_lines)
+            .captures(&first_lines)
             .and_then(|c| c.get(1))
             .ok_or_else(|| {
                 anyhow!(


### PR DESCRIPTION
# Problem

The assumption that `grammar.json` contains the language name in the first three lines is wrong, since a sizable number of parsers store an inherited language name character by character _before_ the language name. This breaks building these parsers with `tree-sitter build`.

# Solution

Raise the number of lines to 20, which is still O(1) with respect to grammar size. This can be dropped again once all(!) grammars are regenerated so the inherited language is stored _after_ the language name.

Fixup for #3776

@amaanq
