### PR TITLE
Fix refcounting in `Parser::language()` getter

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -496,9 +496,9 @@ impl Parser {
     /// Get the parser's current language.
     #[doc(alias = "ts_parser_language")]
     #[must_use]
-    pub fn language(&self) -> Option<Language> {
+    pub fn language(&self) -> Option<LanguageRef<'_>> {
         let ptr = unsafe { ffi::ts_parser_language(self.0.as_ptr()) };
-        (!ptr.is_null()).then(|| Language(ptr))
+        (!ptr.is_null()).then_some(LanguageRef(ptr, PhantomData))
     }
 
     /// Get the parser's current logger.


### PR DESCRIPTION
`ts_parser_language` doesn't do any refcounting, so we can't return the resulting pointer as an owned `Language` object (or would have to clone the LanguageRef's target to keep API compatibility).