### PR TITLE
Remove unnecessary referencing/dereferencing from build_parse_table

### DIFF
--- a/cli/generate/src/build_tables/build_parse_table.rs
+++ b/cli/generate/src/build_tables/build_parse_table.rs
@@ -82,7 +82,7 @@ impl<'a> ParseTableBuilder<'a> {
             &Vec::new(),
             ParseItemSet::with(std::iter::once((
                 ParseItem::start(),
-                std::iter::once(&Symbol::end()).copied().collect(),
+                std::iter::once(Symbol::end()).collect(),
             ))),
         );
 
@@ -106,9 +106,7 @@ impl<'a> ParseTableBuilder<'a> {
                             step_index: 1,
                             has_preceding_inherited_fields: false,
                         },
-                        &std::iter::once(&Symbol::end_of_nonterminal_extra())
-                            .copied()
-                            .collect(),
+                        &std::iter::once(Symbol::end_of_nonterminal_extra()).collect(),
                     );
             }
         }


### PR DESCRIPTION
These were probably optimized away, and in any case are only run once, per CLI run, but may as well remove them.