### PR TITLE
fix(bindings): drop pkg-config Requires field

### DIFF
--- a/cli/src/templates/PARSER_NAME.pc.in
+++ b/cli/src/templates/PARSER_NAME.pc.in
@@ -6,6 +6,5 @@ Name: tree-sitter-PARSER_NAME
 Description: @PROJECT_DESCRIPTION@
 URL: @PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
-Requires: @TS_REQUIRES@
 Libs: -L${libdir} -ltree-sitter-PARSER_NAME
 Cflags: -I${includedir}


### PR DESCRIPTION
The idea was that `tree-sitter` _might_ be specified there, but it's currently unused.