### PR TITLE
fix(dsl): fix types for RuleBuilder

### DIFF
--- a/cli/npm/dsl.d.ts
+++ b/cli/npm/dsl.d.ts
@@ -42,7 +42,7 @@ type GrammarSymbols<RuleName extends string> = {
 
 type RuleBuilder<RuleName extends string> = (
   $: GrammarSymbols<RuleName>,
-  previous: Rule,
+  previous?: Rule,
 ) => RuleOrLiteral;
 
 type RuleBuilders<


### PR DESCRIPTION
The second parameter to RuleBuilder should be optional. Fixes #3811.