### PR TITLE
chore(bindings): more small changes

### DIFF
--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -75,7 +75,7 @@ const BINDING_GYP_TEMPLATE: &str = include_str!("./templates/binding.gyp");
 const BINDING_TEST_JS_TEMPLATE: &str = include_str!("./templates/binding_test.js");
 
 const MAKEFILE_TEMPLATE: &str = include_str!("./templates/makefile");
-const CMAKELISTS_TXT_TEMPLATE: &str = include_str!("./templates/cmakelists.txt");
+const CMAKELISTS_TXT_TEMPLATE: &str = include_str!("./templates/cmakelists.cmake");
 const PARSER_NAME_H_TEMPLATE: &str = include_str!("./templates/PARSER_NAME.h");
 const PARSER_NAME_PC_IN_TEMPLATE: &str = include_str!("./templates/PARSER_NAME.pc.in");
 

--- a/cli/src/templates/binding_test.js
+++ b/cli/src/templates/binding_test.js
@@ -1,9 +1,9 @@
-/// <reference types="node" />
-
 const assert = require("node:assert");
 const { test } = require("node:test");
 
+const Parser = require("tree-sitter");
+
 test("can load grammar", () => {
-  const parser = new (require("tree-sitter"))();
+  const parser = new Parser();
   assert.doesNotThrow(() => parser.setLanguage(require(".")));
 });

--- a/cli/src/templates/cmakelists.cmake
+++ b/cli/src/templates/cmakelists.cmake
@@ -56,5 +56,3 @@ install(TARGETS tree-sitter-PARSER_NAME
 add_custom_target(test "${TREE_SITTER_CLI}" test
                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                   COMMENT "tree-sitter test")
-
-# vim:ft=cmake:

--- a/cli/src/templates/package.json
+++ b/cli/src/templates/package.json
@@ -27,7 +27,7 @@
     "*.wasm"
   ],
   "dependencies": {
-    "node-addon-api": "^8.1.0",
+    "node-addon-api": "^8.2.1",
     "node-gyp-build": "^4.8.2"
   },
   "devDependencies": {

--- a/cli/src/templates/pyproject.toml
+++ b/cli/src/templates/pyproject.toml
@@ -9,7 +9,6 @@ version = "PARSER_VERSION"
 keywords = ["incremental", "parsing", "tree-sitter", "PARSER_NAME"]
 classifiers = [
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Topic :: Software Development :: Compilers",
   "Topic :: Text Processing :: Linguistic",
   "Typing :: Typed",


### PR DESCRIPTION
- Rename cmakelists.txt to cmakelists.cmake
- Bump node-addon-api version in package.json
- Remove License classifier from pyproject.toml
- Move require call to top level in Node.js test