### PR TITLE
feat(loader): implement `language_for_configuration`

### DIFF
--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -602,6 +602,13 @@ impl Loader {
         }
     }
 
+    pub fn language_for_configuration(
+        &self,
+        configuration: &LanguageConfiguration,
+    ) -> Result<Language> {
+        self.language_for_id(configuration.language_id)
+    }
+
     fn language_for_id(&self, id: usize) -> Result<Language> {
         let (path, language, externals) = &self.languages_by_id[id];
         language


### PR DESCRIPTION
While diagnosing a breaking change introduced by v0.24 (specifically #3700; I left a [comment](/tree-sitter/tree-sitter/pull/3700#issuecomment-2427922990) there), I found that there is actually no way to directly load a `Language` from a given `LanguageConfiguration` (such as one returned from `Loader::get_all_language_configurations`). This PR trivially remedies that.