### PR TITLE
test: run cmake tests with ctest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,8 @@ test:
 	cargo xtask generate-fixtures
 	cargo xtask test
 
-test_wasm:
-	cargo xtask generate-fixtures-wasm
+test-wasm:
+	cargo xtask generate-fixtures --wasm
 	cargo xtask test-wasm
 
 lint:

--- a/cli/src/templates/cmakelists.cmake
+++ b/cli/src/templates/cmakelists.cmake
@@ -45,7 +45,6 @@ configure_file(bindings/c/tree-sitter-PARSER_NAME.pc.in
                "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-PARSER_NAME.pc" @ONLY)
 
 include(GNUInstallDirs)
-
 install(FILES bindings/c/tree-sitter-PARSER_NAME.h
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tree_sitter")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-PARSER_NAME.pc"
@@ -53,6 +52,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-PARSER_NAME.pc"
 install(TARGETS tree-sitter-PARSER_NAME
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
-add_custom_target(test "${TREE_SITTER_CLI}" test
-                  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-                  COMMENT "tree-sitter test")
+include(CTest)
+add_test(NAME parser
+         COMMAND "${TREE_SITTER_CLI}" test
+         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -73,8 +73,7 @@ if(TREE_SITTER_FEATURE_WASM)
   endif()
 endif()
 
-set_target_properties(tree-sitter
-                      PROPERTIES
+set_target_properties(tree-sitter PROPERTIES
                       C_STANDARD 11
                       C_VISIBILITY_PRESET hidden
                       POSITION_INDEPENDENT_CODE ON
@@ -86,10 +85,49 @@ target_compile_definitions(tree-sitter PRIVATE _POSIX_C_SOURCE=200112L _DEFAULT_
 configure_file(tree-sitter.pc.in "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter.pc" @ONLY)
 
 include(GNUInstallDirs)
-
 install(FILES include/tree_sitter/api.h
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tree_sitter")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter.pc"
         DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig")
 install(TARGETS tree-sitter
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+
+include(CTest)
+if(BUILD_TESTING)
+  find_program(CARGO cargo DOC "cargo executable")
+  get_filename_component(PROJECT_BASE_DIR "${PROJECT_SOURCE_DIR}" DIRECTORY CACHE)
+
+  add_test(NAME fetch-fixtures
+           COMMAND "${CARGO}" xtask fetch-fixtures
+           WORKING_DIRECTORY "${PROJECT_BASE_DIR}")
+  set_tests_properties(fetch-fixtures PROPERTIES
+                       FIXTURES_SETUP "fixtures;fixtures-wasm")
+
+  add_test(NAME generate-fixtures
+           COMMAND "${CARGO}" xtask generate-fixtures
+           WORKING_DIRECTORY "${PROJECT_BASE_DIR}")
+  set_tests_properties(generate-fixtures PROPERTIES
+                       DEPENDS fetch-fixtures
+                       FIXTURES_SETUP fixtures)
+
+  add_test(NAME test
+           COMMAND "${CARGO}" xtask test
+           WORKING_DIRECTORY "${PROJECT_BASE_DIR}")
+  set_tests_properties(test PROPERTIES
+                       FIXTURES_REQUIRED fixtures)
+
+  if(TREE_SITTER_FEATURE_WASM)
+    add_test(NAME generate-fixtures-wasm
+             COMMAND cargo xtask generate-fixtures --wasm
+             WORKING_DIRECTORY "${PROJECT_BASE_DIR}")
+    set_tests_properties(generate-fixtures-wasm PROPERTIES
+                         DEPENDS fetch-fixtures
+                         FIXTURES_SETUP fixtures-wasm)
+
+    add_test(NAME test-wasm
+             COMMAND "${CARGO}" xtask test-wasm
+             WORKING_DIRECTORY "${PROJECT_BASE_DIR}")
+    set_tests_properties(test-wasm PROPERTIES
+                         FIXTURES_REQUIRED fixtures-wasm)
+  endif()
+endif()


### PR DESCRIPTION
This does add a lot more lines to `CMakeLists.txt`. Maybe we should only do this for bindings?