### PR TITLE
docs(rust): document optional features

### DIFF
--- a/cli/loader/Cargo.toml
+++ b/cli/loader/Cargo.toml
@@ -12,6 +12,10 @@ license.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lints]
 workspace = true
 

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(any(feature = "tree-sitter-highlight", feature = "tree-sitter-tags"))]
 use std::ops::Range;
@@ -406,6 +407,7 @@ impl Loader {
     }
 
     #[cfg(feature = "tree-sitter-highlight")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tree-sitter-highlight")))]
     pub fn configure_highlights(&mut self, names: &[String]) {
         self.use_all_highlight_names = false;
         let mut highlights = self.highlight_names.lock().unwrap();
@@ -415,6 +417,7 @@ impl Loader {
 
     #[must_use]
     #[cfg(feature = "tree-sitter-highlight")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tree-sitter-highlight")))]
     pub fn highlight_names(&self) -> Vec<String> {
         self.highlight_names.lock().unwrap().clone()
     }
@@ -1332,6 +1335,7 @@ impl Loader {
     }
 
     #[cfg(feature = "wasm")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "wasm")))]
     pub fn use_wasm(&mut self, engine: &tree_sitter::wasmtime::Engine) {
         *self.wasm_store.lock().unwrap() = Some(tree_sitter::WasmStore::new(engine).unwrap());
     }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -31,13 +31,18 @@ include = [
   "/include/tree_sitter/api.h",
 ]
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-gnu"]
+
 [lints]
 workspace = true
 
 [features]
 default = ["std"]
 std = ["regex/std", "regex/perf", "regex-syntax/unicode"]
-wasm = ["wasmtime-c-api"]
+wasm = ["std", "wasmtime-c-api"]
 
 [dependencies]
 regex = { version = "1.10.6", default-features = false, features = ["unicode"] }

--- a/lib/binding_rust/README.md
+++ b/lib/binding_rust/README.md
@@ -113,4 +113,4 @@ assert_eq!(
   - Error types implement the `std::error:Error` trait.
   - `regex` performance optimizations are enabled.
   - The DOT graph methods are enabled.
-- **wasm** - This feature is enabled for Wasm targets. `tree-sitter` to be built for Wasm targets using the `wasmtime-c-api` crate.
+- **wasm** - This feature allows `tree-sitter` to be built for Wasm targets using the `wasmtime-c-api` crate.


### PR DESCRIPTION
See https://users.rust-lang.org/t/how-to-document-optional-features-in-api-docs/64577/3

A few issues I noticed:

- Much of the API, notably the entire Wasm portion, is undocumented.
- The `wasm` library feature also requires `std` for `CString`. (fixed)
- `AsRawFd` is unnecessarily imported in the `wasi` target. (fixed)
- The CLI declares `wasm` as optional but cannot fully work without it.