### PR TITLE
Replace nerd font symbols with Unicode symbols, and count skipped tests correctly

### DIFF
--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -358,7 +358,7 @@ fn run_tests(
 
             if attributes.skip {
                 println!(
-                    "{:>3}.  {}",
+                    "{:>3}. ⌀ {}",
                     opts.test_num,
                     paint(opts.color.then_some(AnsiColor::Yellow), &name),
                 );
@@ -367,7 +367,7 @@ fn run_tests(
 
             if !attributes.platform {
                 println!(
-                    "{:>3}.  {}",
+                    "{:>3}. ⌀ {}",
                     opts.test_num,
                     paint(opts.color.then_some(AnsiColor::Magenta), &name),
                 );
@@ -387,7 +387,7 @@ fn run_tests(
                 if attributes.error {
                     if tree.root_node().has_error() {
                         println!(
-                            "{:>3}.  {}",
+                            "{:>3}. ✓ {}",
                             opts.test_num,
                             paint(opts.color.then_some(AnsiColor::Green), &name)
                         );
@@ -418,7 +418,7 @@ fn run_tests(
                             ));
                         }
                         println!(
-                            "{:>3}.  {}",
+                            "{:>3}. ✗ {}",
                             opts.test_num,
                             paint(opts.color.then_some(AnsiColor::Red), &name)
                         );

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -362,6 +362,7 @@ fn run_tests(
                     opts.test_num,
                     paint(opts.color.then_some(AnsiColor::Yellow), &name),
                 );
+                opts.test_num += 1;
                 return Ok(true);
             }
 
@@ -371,6 +372,7 @@ fn run_tests(
                     opts.test_num,
                     paint(opts.color.then_some(AnsiColor::Magenta), &name),
                 );
+                opts.test_num += 1;
                 return Ok(true);
             }
 
@@ -529,7 +531,6 @@ fn run_tests(
             let mut advance_counter = opts.test_num;
             let failure_count = failures.len();
             let mut has_printed = false;
-            let mut skipped_tests = 0;
 
             let matches_filter = |name: &str, opts: &TestOptions| {
                 if let Some(include) = &opts.include {
@@ -576,7 +577,6 @@ fn run_tests(
                         ));
 
                         opts.test_num += 1;
-                        skipped_tests += 1;
 
                         continue;
                     }
@@ -599,8 +599,6 @@ fn run_tests(
                     return Ok(false);
                 }
             }
-
-            opts.test_num += skipped_tests;
 
             if let Some(file_path) = file_path {
                 if opts.update && failures.len() - failure_count > 0 {


### PR DESCRIPTION
I noticed the test attributes introduced in https://github.com/tree-sitter/tree-sitter/pull/3060 use Unicode PUA code points. These require Nerd Fonts to render properly. I propose replacing these code points with more compatible Unicode symbols. Here's how this looks in a couple different terminal emulators without Nerd Fonts installed:
| Before PR | After PR |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/f2142c8d-a4af-4a97-9f87-4c3715c1c9fa)| ![image](https://github.com/user-attachments/assets/2a820fc9-946e-47a1-a822-a543797cf3b9)  |
| ![image](https://github.com/user-attachments/assets/dcc49d72-adca-489c-8ab4-7692d2d1fa49) | ![image](https://github.com/user-attachments/assets/e9a519e7-18ed-4f85-beb7-56ff1d17ed17) |

I also found the 🖵️ symbol a bit unclear when indicating the `platform` attribute, so I replaced that with a simple `P`.