### PR TITLE
fix(lib): simplify edge cases with zero-width tokens

### DIFF
--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -1026,6 +1026,31 @@ fn test_node_numeric_symbols_respect_simple_aliases() {
     assert_eq!(unary_minus_node.kind_id(), binary_minus_node.kind_id());
 }
 
+#[test]
+fn test_hidden_zero_width_node_with_visible_child() {
+    let code = r"
+class Foo {
+  std::
+private:
+  std::string s;
+};
+";
+
+    let mut parser = Parser::new();
+    parser.set_language(&get_language("cpp")).unwrap();
+    let tree = parser.parse(code, None).unwrap();
+    let root = tree.root_node();
+
+    let class_specifier = root.child(0).unwrap();
+    let field_decl_list = class_specifier.child_by_field_name("body").unwrap();
+    let field_decl = field_decl_list.named_child(0).unwrap();
+    let field_ident = field_decl.child_by_field_name("declarator").unwrap();
+    assert_eq!(
+        field_decl.child_with_descendant(field_ident).unwrap(),
+        field_ident
+    );
+}
+
 fn get_all_nodes(tree: &Tree) -> Vec<Node> {
     let mut result = Vec::new();
     let mut visited_children = false;


### PR DESCRIPTION
This is the true solution for the bug discovered in https://github.com/neovim/neovim/issues/30956

### Problem

When a zero-width token is not relevant (hidden) but contains a child that *is* relevant, then there are cases where `child_{containing,with}_descendant` will return the wrong value. This is because the current implementation of checking zero-width tokens only takes into account those of which are relevant.

### Solution

Instead of adding more complex logic to `ts_node_child_iterator_next_sibling_is_empty_adjacent`, I realized the logic could be simplified by making 2 changes. One is to not exit the inner loop too early if the descendant node is empty, since we should be checking all nodes that *touch* this end byte range. Two is to simply check if the descendant is empty, and if it is, check if the current `self` node contains the descendant (as long as self has children). If it does (meaning the node is not null), return `self` if it's visible, else the `child`.