### PR TITLE
feat: add options to parsing and query execution

### DIFF
--- a/cli/src/tests/text_provider_test.rs
+++ b/cli/src/tests/text_provider_test.rs
@@ -20,7 +20,7 @@ where
     let language = get_language("c");
     let mut parser = Parser::new();
     parser.set_language(&language).unwrap();
-    let tree = parser.parse_with(callback, None).unwrap();
+    let tree = parser.parse_with_options(callback, None, None).unwrap();
     // eprintln!("{}", tree.clone().root_node().to_sexp());
     assert_eq!("comment", tree.root_node().child(0).unwrap().kind());
     (tree, language)

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -162,6 +162,19 @@ pub const TSQueryErrorCapture: TSQueryError = 4;
 pub const TSQueryErrorStructure: TSQueryError = 5;
 pub const TSQueryErrorLanguage: TSQueryError = 6;
 pub type TSQueryError = ::core::ffi::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSQueryCursorState {
+    pub payload: *mut ::core::ffi::c_void,
+    pub current_byte_offset: u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSQueryCursorOptions {
+    pub payload: *mut ::core::ffi::c_void,
+    pub progress_callback:
+        ::core::option::Option<unsafe extern "C" fn(state: *mut TSQueryCursorState) -> bool>,
+}
 extern "C" {
     #[doc = " Create a new parser."]
     pub fn ts_parser_new() -> *mut TSParser;
@@ -661,6 +674,15 @@ extern "C" {
 extern "C" {
     #[doc = " Start running a given query on a given node."]
     pub fn ts_query_cursor_exec(self_: *mut TSQueryCursor, query: *const TSQuery, node: TSNode);
+}
+extern "C" {
+    #[doc = " Start running a gievn query on a given node, with some options."]
+    pub fn ts_query_cursor_exec_with_options(
+        self_: *mut TSQueryCursor,
+        query: *const TSQuery,
+        node: TSNode,
+        options: *const TSQueryCursorOptions,
+    );
 }
 extern "C" {
     #[doc = " Manage the maximum number of in-progress matches allowed by this query\n cursor.\n\n Query cursors have an optional maximum capacity for storing lists of\n in-progress captures. If this capacity is exceeded, then the\n earliest-starting match will silently be dropped to make room for further\n matches. This maximum capacity is optional — by default, query cursors allow\n any number of pending matches, dynamically allocating new space for them as\n needed as the query is executed."]

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -217,7 +217,7 @@ extern "C" {
         self_: *mut TSParser,
         old_tree: *const TSTree,
         input: TSInput,
-        parse_options: *const TSParseOptions,
+        parse_options: TSParseOptions,
     ) -> *mut TSTree;
 }
 extern "C" {
@@ -244,19 +244,19 @@ extern "C" {
     pub fn ts_parser_reset(self_: *mut TSParser);
 }
 extern "C" {
-    #[doc = " Set the maximum duration in microseconds that parsing should be allowed to\n take before halting.\n\n If parsing takes longer than this, it will halt early, returning NULL.\n See [`ts_parser_parse`] for more information."]
+    #[doc = " @deprecated use [`ts_parser_parse_with_options`] and pass in a callback instead, this will be removed in 0.26.\n\n Set the maximum duration in microseconds that parsing should be allowed to\n take before halting.\n\n If parsing takes longer than this, it will halt early, returning NULL.\n See [`ts_parser_parse`] for more information."]
     pub fn ts_parser_set_timeout_micros(self_: *mut TSParser, timeout_micros: u64);
 }
 extern "C" {
-    #[doc = " Get the duration in microseconds that parsing is allowed to take."]
+    #[doc = " @deprecated use [`ts_parser_parse_with_options`] and pass in a callback instead, this will be removed in 0.26.\n\n Get the duration in microseconds that parsing is allowed to take."]
     pub fn ts_parser_timeout_micros(self_: *const TSParser) -> u64;
 }
 extern "C" {
-    #[doc = " Set the parser's current cancellation flag pointer.\n\n If a non-null pointer is assigned, then the parser will periodically read\n from this pointer during parsing. If it reads a non-zero value, it will\n halt early, returning NULL. See [`ts_parser_parse`] for more information."]
+    #[doc = " @deprecated use [`ts_parser_parse_with_options`] and pass in a callback instead, this will be removed in 0.26.\n\n Set the parser's current cancellation flag pointer.\n\n If a non-null pointer is assigned, then the parser will periodically read\n from this pointer during parsing. If it reads a non-zero value, it will\n halt early, returning NULL. See [`ts_parser_parse`] for more information."]
     pub fn ts_parser_set_cancellation_flag(self_: *mut TSParser, flag: *const usize);
 }
 extern "C" {
-    #[doc = " Get the parser's current cancellation flag pointer."]
+    #[doc = " @deprecated use [`ts_parser_parse_with_options`] and pass in a callback instead, this will be removed in 0.26.\n\n Get the parser's current cancellation flag pointer."]
     pub fn ts_parser_cancellation_flag(self_: *const TSParser) -> *const usize;
 }
 extern "C" {
@@ -681,7 +681,7 @@ extern "C" {
         self_: *mut TSQueryCursor,
         query: *const TSQuery,
         node: TSNode,
-        options: *const TSQueryCursorOptions,
+        query_options: *const TSQueryCursorOptions,
     );
 }
 extern "C" {
@@ -695,11 +695,11 @@ extern "C" {
     pub fn ts_query_cursor_set_match_limit(self_: *mut TSQueryCursor, limit: u32);
 }
 extern "C" {
-    #[doc = " Set the maximum duration in microseconds that query execution should be allowed to\n take before halting.\n\n If query execution takes longer than this, it will halt early, returning NULL.\n See [`ts_query_cursor_next_match`] or [`ts_query_cursor_next_capture`] for more information."]
+    #[doc = " @deprecated use [`ts_query_cursor_exec_with_options`] and pass in a callback instead, this will be removed in 0.26.\n\n Set the maximum duration in microseconds that query execution should be allowed to\n take before halting.\n\n If query execution takes longer than this, it will halt early, returning NULL.\n See [`ts_query_cursor_next_match`] or [`ts_query_cursor_next_capture`] for more information."]
     pub fn ts_query_cursor_set_timeout_micros(self_: *mut TSQueryCursor, timeout_micros: u64);
 }
 extern "C" {
-    #[doc = " Get the duration in microseconds that query execution is allowed to take.\n\n This is set via [`ts_query_cursor_set_timeout_micros`]."]
+    #[doc = " @deprecated use [`ts_query_cursor_exec_with_options`] and pass in a callback instead, this will be removed in 0.26.\n\n Get the duration in microseconds that query execution is allowed to take.\n\n This is set via [`ts_query_cursor_set_timeout_micros`]."]
     pub fn ts_query_cursor_timeout_micros(self_: *const TSQueryCursor) -> u64;
 }
 extern "C" {

--- a/lib/binding_rust/ffi.rs
+++ b/lib/binding_rust/ffi.rs
@@ -22,7 +22,8 @@ extern "C" {
 use core::{marker::PhantomData, mem::ManuallyDrop, ptr::NonNull, str};
 
 use crate::{
-    Language, LookaheadIterator, Node, Parser, Query, QueryCursor, QueryError, Tree, TreeCursor,
+    Language, LookaheadIterator, Node, ParseState, Parser, Query, QueryCursor, QueryCursorState,
+    QueryError, Tree, TreeCursor,
 };
 
 impl Language {
@@ -63,6 +64,24 @@ impl Parser {
     /// may cause issues like use after free.
     #[must_use]
     pub fn into_raw(self) -> *mut TSParser {
+        ManuallyDrop::new(self).0.as_ptr()
+    }
+}
+
+impl ParseState {
+    /// Reconstructs a [`ParseState`] from a raw pointer
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be non-null.
+    #[must_use]
+    pub const unsafe fn from_raw(ptr: *mut TSParseState) -> Self {
+        Self(NonNull::new_unchecked(ptr))
+    }
+
+    /// Consumes the [`ParseState`], returning a raw pointer to the underlying C structure.
+    #[must_use]
+    pub fn into_raw(self) -> *mut TSParseState {
         ManuallyDrop::new(self).0.as_ptr()
     }
 }
@@ -155,6 +174,24 @@ impl QueryCursor {
     #[must_use]
     pub fn into_raw(self) -> *mut TSQueryCursor {
         ManuallyDrop::new(self).ptr.as_ptr()
+    }
+}
+
+impl QueryCursorState {
+    /// Reconstructs a [`QueryCursorState`] from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be non-null.
+    #[must_use]
+    pub const unsafe fn from_raw(ptr: *mut TSQueryCursorState) -> Self {
+        Self(NonNull::new_unchecked(ptr))
+    }
+
+    /// Consumes the [`QueryCursorState`], returning a raw pointer to the underlying C structure.
+    #[must_use]
+    pub fn into_raw(self) -> *mut TSQueryCursorState {
+        ManuallyDrop::new(self).0.as_ptr()
     }
 }
 

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -79,6 +79,16 @@ typedef struct TSInput {
   TSInputEncoding encoding;
 } TSInput;
 
+typedef struct TSParseState {
+  void *payload;
+  uint32_t current_byte_offset;
+} TSParseState;
+
+typedef struct TSParseOptions {
+  void *payload;
+  bool (*progress_callback)(TSParseState *state);
+} TSParseOptions;
+
 typedef enum TSLogType {
   TSLogTypeParse,
   TSLogTypeLex,
@@ -247,7 +257,7 @@ const TSRange *ts_parser_included_ranges(
  *    `TSInputEncodingUTF8` or `TSInputEncodingUTF16`.
  *
  * This function returns a syntax tree on success, and `NULL` on failure. There
- * are three possible reasons for failure:
+ * are four possible reasons for failure:
  * 1. The parser does not have a language assigned. Check for this using the
       [`ts_parser_language`] function.
  * 2. Parsing was cancelled due to a timeout that was set by an earlier call to
@@ -259,6 +269,8 @@ const TSRange *ts_parser_included_ranges(
  *    earlier call to [`ts_parser_set_cancellation_flag`]. You can resume parsing
  *    from where the parser left out by calling [`ts_parser_parse`] again with
  *    the same arguments.
+ * 4. Parsing was cancelled due to the progress callback returning true. This callback
+ *    is passed in [`ts_parser_parse_with_options`] inside the [`TSParseOptions`] struct.
  *
  * [`read`]: TSInput::read
  * [`payload`]: TSInput::payload
@@ -269,6 +281,18 @@ TSTree *ts_parser_parse(
   TSParser *self,
   const TSTree *old_tree,
   TSInput input
+);
+
+/**
+ * Use the parser to parse some source code and create a syntax tree, with some options.
+ *
+ * See [`ts_parser_parse`] for more details.
+ */
+TSTree* ts_parser_parse_with_options(
+  TSParser *self,
+  const TSTree *old_tree,
+  TSInput input,
+  TSParseOptions parse_options
 );
 
 /**
@@ -310,6 +334,8 @@ TSTree *ts_parser_parse_string_encoding(
 void ts_parser_reset(TSParser *self);
 
 /**
+ * @deprecated use [`ts_parser_parse_with_options`] and pass in a callback instead, this will be removed in 0.26.
+ *
  * Set the maximum duration in microseconds that parsing should be allowed to
  * take before halting.
  *
@@ -319,11 +345,15 @@ void ts_parser_reset(TSParser *self);
 void ts_parser_set_timeout_micros(TSParser *self, uint64_t timeout_micros);
 
 /**
+ * @deprecated use [`ts_parser_parse_with_options`] and pass in a callback instead, this will be removed in 0.26.
+ *
  * Get the duration in microseconds that parsing is allowed to take.
  */
 uint64_t ts_parser_timeout_micros(const TSParser *self);
 
 /**
+ * @deprecated use [`ts_parser_parse_with_options`] and pass in a callback instead, this will be removed in 0.26.
+ *
  * Set the parser's current cancellation flag pointer.
  *
  * If a non-null pointer is assigned, then the parser will periodically read
@@ -333,6 +363,8 @@ uint64_t ts_parser_timeout_micros(const TSParser *self);
 void ts_parser_set_cancellation_flag(TSParser *self, const size_t *flag);
 
 /**
+ * @deprecated use [`ts_parser_parse_with_options`] and pass in a callback instead, this will be removed in 0.26.
+ *
  * Get the parser's current cancellation flag pointer.
  */
 const size_t *ts_parser_cancellation_flag(const TSParser *self);

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -161,6 +161,16 @@ typedef enum TSQueryError {
   TSQueryErrorLanguage,
 } TSQueryError;
 
+typedef struct TSQueryCursorState {
+  void *payload;
+  uint32_t current_byte_offset;
+} TSQueryCursorState;
+
+typedef struct TSQueryCursorOptions {
+  void *payload;
+  bool (*progress_callback)(TSQueryCursorState *state);
+} TSQueryCursorOptions;
+
 /********************/
 /* Section - Parser */
 /********************/
@@ -1021,6 +1031,16 @@ void ts_query_cursor_delete(TSQueryCursor *self);
 void ts_query_cursor_exec(TSQueryCursor *self, const TSQuery *query, TSNode node);
 
 /**
+ * Start running a gievn query on a given node, with some options.
+ */
+void ts_query_cursor_exec_with_options(
+  TSQueryCursor *self,
+  const TSQuery *query,
+  TSNode node,
+  const TSQueryCursorOptions *query_options
+);
+
+/**
  * Manage the maximum number of in-progress matches allowed by this query
  * cursor.
  *
@@ -1036,6 +1056,8 @@ uint32_t ts_query_cursor_match_limit(const TSQueryCursor *self);
 void ts_query_cursor_set_match_limit(TSQueryCursor *self, uint32_t limit);
 
 /**
+ * @deprecated use [`ts_query_cursor_exec_with_options`] and pass in a callback instead, this will be removed in 0.26.
+ *
  * Set the maximum duration in microseconds that query execution should be allowed to
  * take before halting.
  *
@@ -1045,6 +1067,8 @@ void ts_query_cursor_set_match_limit(TSQueryCursor *self, uint32_t limit);
 void ts_query_cursor_set_timeout_micros(TSQueryCursor *self, uint64_t timeout_micros);
 
 /**
+ * @deprecated use [`ts_query_cursor_exec_with_options`] and pass in a callback instead, this will be removed in 0.26.
+ *
  * Get the duration in microseconds that query execution is allowed to take.
  *
  * This is set via [`ts_query_cursor_set_timeout_micros`].


### PR DESCRIPTION
Closes #2541
Would like #3833 to extend upon this

### Problem

Currently, users have a hard time having manual control over when parsing or query execution is canceled. The API does offer a few ways to control this, typically by setting a timeout in microseconds or by setting a cancellation flag. However, this approach is very rigid, doesn't give the users flexibility to easily change this on the fly at runtime, and ties us to OS-specific time headers.

### Solution

In the core library, two new functions, `ts_parser_parse_with_options` & `ts_query_cursor_exec_with_options`, were added. These functions take in the same parameters as their -`_with_options` variants, plus an additional `parse_options` parameter of type `TSParseOptions` for the parse function, and a `query_options` parameter of type `TSQueryCursorOptions *`.

Currently, these options consist of a `payload` field, and an `interrupt_callback` field. If the interrupt callback is *not* null, it is invoked to check whether or not to halt parsing or query execution. The callback is to be set by the user, and takes in one parameter, `state`, of type `TSParseState`/`TSQueryCursorState`, which currently only has a `payload` field (which makes working with FFI code easier). This type can easily be extended upon, in case we want to add additional data later on.

The plan is to deprecate the `timeout_micros` and `cancellation_flag` functions for the next version, and then eventually get rid of these functions + the platform-specific time code (`clock.h`) in the following version.