### PR TITLE
ci: add bindgen workflow

### DIFF
--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -1,0 +1,24 @@
+name: Check Bindgen Output
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  check-bindgen:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up stable Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Generate bindings
+        run: cargo xtask generate-bindings
+
+      - name: Check if the bindgen output changed
+        run: git diff --exit-code lib/binding_rust/bindings.rs

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -761,6 +761,10 @@ extern "C" {
     ) -> TSStateId;
 }
 extern "C" {
+    #[doc = " Get the name of this language. This returns `NULL` in older parsers."]
+    pub fn ts_language_name(self_: *const TSLanguage) -> *const ::core::ffi::c_char;
+}
+extern "C" {
     #[doc = " Create a new lookahead iterator for the given language and parse state.\n\n This returns `NULL` if state is invalid for the language.\n\n Repeatedly using [`ts_lookahead_iterator_next`] and\n [`ts_lookahead_iterator_current_symbol`] will generate valid symbols in the\n given parse state. Newly created lookahead iterators will contain the `ERROR`\n symbol.\n\n Lookahead iterators can be useful to generate suggestions and improve syntax\n error diagnostics. To get symbols valid in an ERROR node, use the lookahead\n iterator on its first leaf node state. For `MISSING` nodes, a lookahead\n iterator created on the previous non-extra leaf node may be appropriate."]
     pub fn ts_lookahead_iterator_new(
         self_: *const TSLanguage,

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -301,6 +301,14 @@ impl Language {
         Self(unsafe { builder.into_raw()().cast() })
     }
 
+    /// Get the name of this language. This returns `None` in older parsers.
+    #[doc(alias = "ts_language_version")]
+    #[must_use]
+    pub fn name(&self) -> Option<&'static str> {
+        let ptr = unsafe { ffi::ts_language_name(self.0) };
+        (!ptr.is_null()).then(|| unsafe { CStr::from_ptr(ptr) }.to_str().unwrap())
+    }
+
     /// Get the ABI version number that indicates which version of the
     /// Tree-sitter CLI that was used to generate this [`Language`].
     #[doc(alias = "ts_language_version")]


### PR DESCRIPTION
### Problem

Currently, we could update our C code without updating the corresponding Rust bindgen header located at `lib/binding_rust/bindings.rs`. We should have a CI check in place that ensures these two files are not out of sync.

### Solution

This PR adds a CI job that verifies there are no changes after running `cargo xtask generate-bindings` when `api.h` is changed.

[Successful run](https://github.com/tree-sitter/tree-sitter/actions/runs/11582325859/job/32245115197?pr=3847) (there *was* an error) because the bindings weren't updated in #3184