### PR TITLE
Recommend `--locked` for `cargo install`

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -14,7 +14,7 @@ The Tree-sitter CLI allows you to develop, test, and use Tree-sitter grammars fr
 You can install the `tree-sitter-cli` with `cargo`:
 
 ```sh
-cargo install tree-sitter-cli
+cargo install --locked tree-sitter-cli
 ```
 
 or with `npm`:


### PR DESCRIPTION
This PR changes `cli/README.md` so it recommends users pass the [`--locked`](https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile) flag to `cargo install`, which could prevent some surprises.