### PR TITLE
Code-format repro commands in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: "Steps to reproduce"
       placeholder: |
-        ```
+        ```sh
         git clone --depth=1 https://github.com/tree-sitter/tree-sitter-ruby
         cd tree-sitter-ruby
         tree-sitter generate

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,9 +13,11 @@ body:
     attributes:
       label: "Steps to reproduce"
       placeholder: |
+        ```
         git clone --depth=1 https://github.com/tree-sitter/tree-sitter-ruby
         cd tree-sitter-ruby
         tree-sitter generate
+        ```
     validations:
       required: true
 


### PR DESCRIPTION
Currently the issue template is a bit confusing since its placeholder text for "Steps to reproduce" is a sequence of commands, but does not have any triple backticks. This PR adds triple backticks to that placeholder to reduce confusion.