### PR TITLE
build(bindings): rename cmake test target

### DIFF
--- a/cli/src/templates/cmakelists.cmake
+++ b/cli/src/templates/cmakelists.cmake
@@ -53,6 +53,6 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-PARSER_NAME.pc"
 install(TARGETS tree-sitter-PARSER_NAME
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
-add_custom_target(test "${TREE_SITTER_CLI}" test
+add_custom_target(ts-test "${TREE_SITTER_CLI}" test
                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                   COMMENT "tree-sitter test")


### PR DESCRIPTION
CTest creates a test target which breaks the build when the parser is included via FetchContent in a CMake project that uses CTest