### PR TITLE
fix(lib): Add range checks for some functions

### DIFF
--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -1996,6 +1996,7 @@ fn test_query_matches_within_byte_range() {
             ]
         );
 
+        // An end byte of zero indicates there is no end
         let matches =
             cursor
                 .set_byte_range(12..0)

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -708,19 +708,20 @@ extern "C" {
     pub fn ts_query_cursor_timeout_micros(self_: *const TSQueryCursor) -> u64;
 }
 extern "C" {
-    #[doc = " Set the range of bytes or (row, column) positions in which the query\n will be executed."]
+    #[doc = " Set the range of bytes in which the query will be executed.\n\n This will return `false` if the start byte is greater than the end byte, otherwise\n it will return `true`."]
     pub fn ts_query_cursor_set_byte_range(
         self_: *mut TSQueryCursor,
         start_byte: u32,
         end_byte: u32,
-    );
+    ) -> bool;
 }
 extern "C" {
+    #[doc = " Set the range of (row, column) positions in which the query will be executed.\n\n This will return `false` if the start point is greater than the end point, otherwise\n it will return `true`."]
     pub fn ts_query_cursor_set_point_range(
         self_: *mut TSQueryCursor,
         start_point: TSPoint,
         end_point: TSPoint,
-    );
+    ) -> bool;
 }
 extern "C" {
     #[doc = " Advance to the next match of the currently running query.\n\n If there is a match, write it to `*match` and return `true`.\n Otherwise, return `false`."]
@@ -731,7 +732,7 @@ extern "C" {
     pub fn ts_query_cursor_remove_match(self_: *mut TSQueryCursor, match_id: u32);
 }
 extern "C" {
-    #[doc = " Advance to the next capture of the currently running query.\n\n If there is a capture, write its match to `*match` and its index within\n the matche's capture list to `*capture_index`. Otherwise, return `false`."]
+    #[doc = " Advance to the next capture of the currently running query.\n\n If there is a capture, write its match to `*match` and its index within\n the match's capture list to `*capture_index`. Otherwise, return `false`."]
     pub fn ts_query_cursor_next_capture(
         self_: *mut TSQueryCursor,
         match_: *mut TSQueryMatch,

--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -1280,6 +1280,13 @@ class Query {
     if (typeof matchLimit !== 'number') {
       throw new Error('Arguments must be numbers');
     }
+    if (endIndex != 0 && startIndex > endIndex) {
+      throw new Error('`startIndex` cannot be greater than `endIndex`');
+    }
+    if (endPosition != ZERO_POINT && (startPosition.row > endPosition.row ||
+      (startPosition.row == endPosition.row && startPosition.column > endPosition.row))) {
+      throw new Error('`startPosition` cannot be greater than `endPosition`');
+    }
 
     marshalNode(node);
 
@@ -1344,6 +1351,13 @@ class Query {
   ) {
     if (typeof matchLimit !== 'number') {
       throw new Error('Arguments must be numbers');
+    }
+    if (endIndex != 0 && startIndex > endIndex) {
+      throw new Error('`startIndex` cannot be greater than `endIndex`');
+    }
+    if (endPosition != ZERO_POINT && (startPosition.row > endPosition.row ||
+      (startPosition.row == endPosition.row && startPosition.column > endPosition.row))) {
+      throw new Error('`startPosition` cannot be greater than `endPosition`');
     }
 
     marshalNode(node);

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -1089,11 +1089,20 @@ void ts_query_cursor_set_timeout_micros(TSQueryCursor *self, uint64_t timeout_mi
 uint64_t ts_query_cursor_timeout_micros(const TSQueryCursor *self);
 
 /**
- * Set the range of bytes or (row, column) positions in which the query
- * will be executed.
+ * Set the range of bytes in which the query will be executed.
+ *
+ * This will return `false` if the start byte is greater than the end byte, otherwise
+ * it will return `true`.
  */
-void ts_query_cursor_set_byte_range(TSQueryCursor *self, uint32_t start_byte, uint32_t end_byte);
-void ts_query_cursor_set_point_range(TSQueryCursor *self, TSPoint start_point, TSPoint end_point);
+bool ts_query_cursor_set_byte_range(TSQueryCursor *self, uint32_t start_byte, uint32_t end_byte);
+
+/**
+ * Set the range of (row, column) positions in which the query will be executed.
+ *
+ * This will return `false` if the start point is greater than the end point, otherwise
+ * it will return `true`.
+ */
+bool ts_query_cursor_set_point_range(TSQueryCursor *self, TSPoint start_point, TSPoint end_point);
 
 /**
  * Advance to the next match of the currently running query.
@@ -1108,7 +1117,7 @@ void ts_query_cursor_remove_match(TSQueryCursor *self, uint32_t match_id);
  * Advance to the next capture of the currently running query.
  *
  * If there is a capture, write its match to `*match` and its index within
- * the matche's capture list to `*capture_index`. Otherwise, return `false`.
+ * the match's capture list to `*capture_index`. Otherwise, return `false`.
  */
 bool ts_query_cursor_next_capture(
   TSQueryCursor *self,

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -1,4 +1,5 @@
 #include <stdbool.h>
+#include "./point.h"
 #include "./subtree.h"
 #include "./tree.h"
 #include "./language.h"

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -348,6 +348,9 @@ static inline TSNode ts_node__descendant_for_byte_range(
   uint32_t range_end,
   bool include_anonymous
 ) {
+  if (range_start > range_end) {
+    return ts_node__null();
+  }
   TSNode node = self;
   TSNode last_visible_node = self;
 
@@ -391,6 +394,9 @@ static inline TSNode ts_node__descendant_for_point_range(
   TSPoint range_end,
   bool include_anonymous
 ) {
+  if (point_gt(range_start, range_end)) {
+    return ts_node__null();
+  }
   TSNode node = self;
   TSNode last_visible_node = self;
 

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -3103,7 +3103,7 @@ void ts_query_cursor_exec_with_options(
   }
 }
 
-void ts_query_cursor_set_byte_range(
+bool ts_query_cursor_set_byte_range(
   TSQueryCursor *self,
   uint32_t start_byte,
   uint32_t end_byte
@@ -3111,11 +3111,15 @@ void ts_query_cursor_set_byte_range(
   if (end_byte == 0) {
     end_byte = UINT32_MAX;
   }
+  if (start_byte > end_byte) {
+    return false;
+  }
   self->start_byte = start_byte;
   self->end_byte = end_byte;
+  return true;
 }
 
-void ts_query_cursor_set_point_range(
+bool ts_query_cursor_set_point_range(
   TSQueryCursor *self,
   TSPoint start_point,
   TSPoint end_point
@@ -3123,8 +3127,12 @@ void ts_query_cursor_set_point_range(
   if (end_point.row == 0 && end_point.column == 0) {
     end_point = POINT_MAX;
   }
+  if (point_gt(start_point, end_point)) {
+    return false;
+  }
   self->start_point = start_point;
   self->end_point = end_point;
+  return true;
 }
 
 // Search through all of the in-progress states, and find the captured


### PR DESCRIPTION
It's possible to pass in an invalid range to `ts_node_descendant_for_point_range()` and `ts_node_descendant_for_byte_range()`, leading to non-intuitive/ incorrect results. This PR adds early checks for such incorrect ranges and returns a null node in such cases. 

The same potential issue is also present in `ts_query_cursor_set_byte_range()` and `ts_query_cursor_set_point_range()`. These functions now return a `bool` to indicate whether the range was set.

Closes https://github.com/tree-sitter/tree-sitter/issues/3412