### PR TITLE
fix(docs): Update link for "Error Detection and Recovery in LR Parsers"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -64,5 +64,5 @@ The design of Tree-sitter was greatly influenced by the following research paper
 * [Context Aware Scanning for Parsing Extensible Languages](https://www-users.cse.umn.edu/~evw/pubs/vanwyk07gpce/vanwyk07gpce.pdf)
 * [Efficient and Flexible Incremental Parsing](https://harmonia.cs.berkeley.edu/papers/twagner-parsing.pdf)
 * [Incremental Analysis of Real Programming Languages](https://harmonia.cs.berkeley.edu/papers/twagner-glr.pdf)
-* [Error Detection and Recovery in LR Parsers](https://what-when-how.com/compiler-writing/bottom-up-parsing-compiler-writing-part-13)
+* [Error Detection and Recovery in LR Parsers](https://web.archive.org/web/20240302031213/https://what-when-how.com/compiler-writing/bottom-up-parsing-compiler-writing-part-13/)
 * [Error Recovery for LR Parsers](https://apps.dtic.mil/sti/pdfs/ADA043470.pdf)


### PR DESCRIPTION
This just replaces the stale link with the one from web archive. (Thanks @sogaiu!)

Closes https://github.com/tree-sitter/tree-sitter/issues/3535