### PR TITLE
fix(cli): use `contains` over `is` in warning

### DIFF
--- a/cli/generate/src/prepare_grammar/intern_symbols.rs
+++ b/cli/generate/src/prepare_grammar/intern_symbols.rs
@@ -149,7 +149,7 @@ impl Interner<'_> {
     fn check_single(&self, elements: &[Rule], name: Option<&str>) {
         if elements.len() == 1 && matches!(elements[0], Rule::String(_) | Rule::Pattern(_, _)) {
             eprintln!(
-                "Warning: rule {} is just a `seq` or `choice` rule with a single element. This is unnecessary.",
+                "Warning: rule {} contains a `seq` or `choice` rule with a single element. This is unnecessary.",
                 name.unwrap_or_default()
             );
         }


### PR DESCRIPTION
Closes #3455