### PR TITLE
fix(generate): do not set the unit reduction symbol if it's in the extras array

### DIFF
--- a/cli/generate/src/build_tables/minimize_parse_table.rs
+++ b/cli/generate/src/build_tables/minimize_parse_table.rs
@@ -70,18 +70,17 @@ impl Minimizer<'_> {
                             production_id: 0,
                             symbol,
                             ..
-                        } => {
-                            if !self.simple_aliases.contains_key(symbol)
-                                && !self.syntax_grammar.supertype_symbols.contains(symbol)
-                                && !aliased_symbols.contains(symbol)
-                                && self.syntax_grammar.variables[symbol.index].kind
-                                    != VariableType::Named
-                                && (unit_reduction_symbol.is_none()
-                                    || unit_reduction_symbol == Some(symbol))
-                            {
-                                unit_reduction_symbol = Some(symbol);
-                                continue;
-                            }
+                        } if !self.simple_aliases.contains_key(symbol)
+                            && !self.syntax_grammar.supertype_symbols.contains(symbol)
+                            && !self.syntax_grammar.extra_symbols.contains(symbol)
+                            && !aliased_symbols.contains(symbol)
+                            && self.syntax_grammar.variables[symbol.index].kind
+                                != VariableType::Named
+                            && (unit_reduction_symbol.is_none()
+                                || unit_reduction_symbol == Some(symbol)) =>
+                        {
+                            unit_reduction_symbol = Some(symbol);
+                            continue;
                         }
                         _ => {}
                     }


### PR DESCRIPTION
- Closes #990
- Closes #1062
- Closes #1165
- Closes #1371

### Problem

When a hidden rule is added to the extras array, parser generation hangs, as observed in the linked issues.

### Solution

The reason it hangs is because the unit reduction function tries to update a state that contains a non terminal extra, and when doing so, the closure passed in [here](https://github.com/tree-sitter/tree-sitter/blob/310a9f0704aeb8d9b1e32ff2bf9b6bd03c8032eb/cli/generate/src/build_tables/minimize_parse_table.rs#L113) receives a `GotoAction::ShiftExtra`, which should not even be processed in here. So, we just skip any symbols that are in the grammar's `extra_symbols` array here.