### PR TITLE
fix(bindings): fix scanner check in binding.gyp

### DIFF
--- a/cli/src/templates/binding.gyp
+++ b/cli/src/templates/binding.gyp
@@ -13,7 +13,7 @@
         "src/parser.c",
       ],
       "variables": {
-        "has_scanner": "<!(node -p \"fs.exists('src/scanner.c')\")"
+        "has_scanner": "<!(node -p \"fs.existsSync('src/scanner.c')\")"
       },
       "conditions": [
         ["has_scanner=='true'", {


### PR DESCRIPTION
Use `fs.existsSync` rather than `fs.exists`