### PR TITLE
feat: allow css classes in HTML highlighter output, rather than inline styles

### DIFF
--- a/cli/src/highlight.rs
+++ b/cli/src/highlight.rs
@@ -407,11 +407,10 @@ pub fn html(
                 theme.styles[highlight.0]
                     .css
                     .as_ref()
-                    .map_or_else(|| "".as_bytes(), |css_style| css_style.as_bytes())
+                    .map_or_else(|| "".as_bytes(), |css_style| css_style.as_bytes()),
             );
             output.extend("'".as_bytes())
-        }
-        else {
+        } else {
             output.extend(b"class='");
             let mut parts = theme.highlight_names[highlight.0].split('.').peekable();
             while let Some(part) = parts.next() {

--- a/cli/src/highlight.rs
+++ b/cli/src/highlight.rs
@@ -409,9 +409,15 @@ pub fn html(
             );
         }
         else {
-            output.extend(b"data-tree-sitter-highlight=\"");
-            output.extend(theme.highlight_names[highlight.0].as_bytes());
-            output.extend(b"\"");
+            output.extend(b"class='");
+            let mut parts = theme.highlight_names[highlight.0].split('.').peekable();
+            while let Some(part) = parts.next() {
+                output.extend(part.as_bytes());
+                if parts.peek().is_some() {
+                    output.extend(b" ");
+                }
+            }
+            output.extend(b"'");
         }
     })?;
 

--- a/cli/src/highlight.rs
+++ b/cli/src/highlight.rs
@@ -270,7 +270,7 @@ fn hex_string_to_rgb(s: &str) -> Option<(u8, u8, u8)> {
 }
 
 fn style_to_css(style: anstyle::Style) -> String {
-    let mut result = "".to_string();
+    let mut result = String::new();
     let effects = style.get_effects();
     if effects.contains(Effects::UNDERLINE) {
         write!(&mut result, "text-decoration: underline;").unwrap();
@@ -402,14 +402,14 @@ pub fn html(
     let mut renderer = HtmlRenderer::new();
     renderer.render(events, source, &move |highlight, output| {
         if inline_styles {
-            output.extend("style='".as_bytes());
+            output.extend(b"style='");
             output.extend(
                 theme.styles[highlight.0]
                     .css
                     .as_ref()
-                    .map_or_else(|| "".as_bytes(), |css_style| css_style.as_bytes()),
+                    .map_or_else(|| "".as_bytes(), |css_style| css_style.as_bytes())
             );
-            output.extend("'".as_bytes())
+            output.extend(b"'")
         } else {
             output.extend(b"class='");
             let mut parts = theme.highlight_names[highlight.0].split('.').peekable();

--- a/cli/src/highlight.rs
+++ b/cli/src/highlight.rs
@@ -16,7 +16,7 @@ use serde_json::{json, Value};
 use tree_sitter_highlight::{HighlightConfiguration, HighlightEvent, Highlighter, HtmlRenderer};
 use tree_sitter_loader::Loader;
 
-pub const HTML_HEADER: &str = "
+pub const HTML_HEAD_HEADER: &str = "
 <!doctype HTML>
 <head>
   <title>Tree-sitter Highlighting</title>
@@ -33,7 +33,9 @@ pub const HTML_HEADER: &str = "
     .line {
       white-space: pre;
     }
-  </style>
+  </style>";
+
+pub const HTML_BODY_HEADER: &str = "
 </head>
 <body>
 ";
@@ -268,7 +270,7 @@ fn hex_string_to_rgb(s: &str) -> Option<(u8, u8, u8)> {
 }
 
 fn style_to_css(style: anstyle::Style) -> String {
-    let mut result = "style='".to_string();
+    let mut result = "".to_string();
     let effects = style.get_effects();
     if effects.contains(Effects::UNDERLINE) {
         write!(&mut result, "text-decoration: underline;").unwrap();
@@ -282,7 +284,6 @@ fn style_to_css(style: anstyle::Style) -> String {
     if let Some(color) = style.get_fg_color() {
         write_color(&mut result, color);
     }
-    result.push('\'');
     result
 }
 
@@ -401,12 +402,14 @@ pub fn html(
     let mut renderer = HtmlRenderer::new();
     renderer.render(events, source, &move |highlight, output| {
         if inline_styles {
+            output.extend("style='".as_bytes());
             output.extend(
                 theme.styles[highlight.0]
                     .css
                     .as_ref()
                     .map_or_else(|| "".as_bytes(), |css_style| css_style.as_bytes())
             );
+            output.extend("'".as_bytes())
         }
         else {
             output.extend(b"class='");
@@ -465,7 +468,7 @@ mod tests {
             style.ansi.get_fg_color(),
             Some(Color::Ansi256(Ansi256Color(36)))
         );
-        assert_eq!(style.css, Some("style=\'color: #00af87\'".to_string()));
+        assert_eq!(style.css, Some("color: #00af87".to_string()));
 
         // junglegreen is not an ANSI color and is preserved when the terminal supports it
         env::set_var("COLORTERM", "truecolor");
@@ -474,7 +477,7 @@ mod tests {
             style.ansi.get_fg_color(),
             Some(Color::Rgb(RgbColor(38, 166, 154)))
         );
-        assert_eq!(style.css, Some("style=\'color: #26a69a\'".to_string()));
+        assert_eq!(style.css, Some("color: #26a69a".to_string()));
 
         // junglegreen gets approximated as darkcyan when the terminal does not support it
         env::set_var("COLORTERM", "");
@@ -483,7 +486,7 @@ mod tests {
             style.ansi.get_fg_color(),
             Some(Color::Ansi256(Ansi256Color(36)))
         );
-        assert_eq!(style.css, Some("style=\'color: #26a69a\'".to_string()));
+        assert_eq!(style.css, Some("color: #26a69a".to_string()));
 
         if let Ok(environment_variable) = original_environment_variable {
             env::set_var("COLORTERM", environment_variable);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1215,7 +1215,7 @@ impl Highlight {
                     let styles = theme_config.theme.styles.iter();
                     for (name, style) in names.zip(styles) {
                         if let Some(css) = &style.css {
-                            println!("    .{} {{ {} }}", name, css);
+                            println!("    .{} {{ {}; }}", name, css);
                         }
                     }
                     println!("  </style>");

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1145,7 +1145,7 @@ impl Highlight {
         let paths = collect_paths(self.paths_file.as_deref(), self.paths)?;
 
         if html_mode && !quiet {
-            println!("{}", highlight::HTML_HEADER);
+            println!("{}", highlight::HTML_HEAD_HEADER);
         }
 
         let cancellation_flag = util::cancel_on_signal();
@@ -1207,6 +1207,19 @@ impl Highlight {
                             eprintln!("* {name}");
                         }
                     }
+                }
+
+                if html_mode && !quiet {
+                    println!("  <style>");
+                    let names  = theme_config.theme.highlight_names.iter();
+                    let styles = theme_config.theme.styles.iter();
+                    for (name, style) in names.zip(styles) {
+                        if let Some(css) = &style.css {
+                            println!("    .{} {{ {} }}", name, css);
+                        }
+                    }
+                    println!("  </style>");
+                    println!("{}", highlight::HTML_BODY_HEADER);
                 }
 
                 let source = fs::read(path)?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -361,8 +361,11 @@ struct Query {
 struct Highlight {
     #[arg(long, short = 'H', help = "Generate highlighting as an HTML document")]
     pub html: bool,
-    #[arg(long, help = "When generating HTML, use data-tree-sitter-highlight attributes, rather than inline styles")]
-    pub data_highlight: bool,
+    #[arg(
+        long,
+        help = "When generating HTML, use css classes, rather than inline styles"
+    )]
+    pub css_classes: bool,
     #[arg(
         long,
         help = "Check that highlighting captures conform strictly to standards"
@@ -1138,7 +1141,7 @@ impl Highlight {
 
         let quiet = self.quiet;
         let html_mode = quiet || self.html;
-        let inline_styles = !self.data_highlight;
+        let inline_styles = !self.css_classes;
         let paths = collect_paths(self.paths_file.as_deref(), self.paths)?;
 
         if html_mode && !quiet {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1211,7 +1211,7 @@ impl Highlight {
 
                 if html_mode && !quiet {
                     println!("  <style>");
-                    let names  = theme_config.theme.highlight_names.iter();
+                    let names = theme_config.theme.highlight_names.iter();
                     let styles = theme_config.theme.styles.iter();
                     for (name, style) in names.zip(styles) {
                         if let Some(css) = &style.css {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -363,7 +363,7 @@ struct Highlight {
     pub html: bool,
     #[arg(
         long,
-        help = "When generating HTML, use css classes, rather than inline styles"
+        help = "When generating HTML, use css classes rather than inline styles"
     )]
     pub css_classes: bool,
     #[arg(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -361,6 +361,8 @@ struct Query {
 struct Highlight {
     #[arg(long, short = 'H', help = "Generate highlighting as an HTML document")]
     pub html: bool,
+    #[arg(long, help = "When generating HTML, use data-tree-sitter-highlight attributes, rather than inline styles")]
+    pub data_highlight: bool,
     #[arg(
         long,
         help = "Check that highlighting captures conform strictly to standards"
@@ -1136,6 +1138,7 @@ impl Highlight {
 
         let quiet = self.quiet;
         let html_mode = quiet || self.html;
+        let inline_styles = !self.data_highlight;
         let paths = collect_paths(self.paths_file.as_deref(), self.paths)?;
 
         if html_mode && !quiet {
@@ -1211,6 +1214,7 @@ impl Highlight {
                         &source,
                         highlight_config,
                         quiet,
+                        inline_styles,
                         self.time,
                         Some(&cancellation_flag),
                     )?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1215,7 +1215,7 @@ impl Highlight {
                     let styles = theme_config.theme.styles.iter();
                     for (name, style) in names.zip(styles) {
                         if let Some(css) = &style.css {
-                            println!("    .{} {{ {}; }}", name, css);
+                            println!("    .{name} {{ {css}; }}");
                         }
                     }
                     println!("  </style>");
@@ -1224,14 +1224,17 @@ impl Highlight {
 
                 let source = fs::read(path)?;
                 if html_mode {
+                    let html_opts = highlight::HtmlOptions {
+                        inline_styles,
+                        quiet,
+                        print_time: self.time,
+                    };
                     highlight::html(
                         &loader,
                         &theme_config.theme,
                         &source,
                         highlight_config,
-                        quiet,
-                        inline_styles,
-                        self.time,
+                        &html_opts,
                         Some(&cancellation_flag),
                     )?;
                 } else {

--- a/cli/src/tests/highlight_test.rs
+++ b/cli/src/tests/highlight_test.rs
@@ -718,7 +718,9 @@ fn to_html<'a>(
             .map(Highlight),
     );
     renderer
-        .render(events, src, &|highlight, output| { output.extend(HTML_ATTRS[highlight.0].as_bytes()); })
+        .render(events, src, &|highlight, output| {
+            output.extend(HTML_ATTRS[highlight.0].as_bytes());
+        })
         .unwrap();
     Ok(renderer
         .lines()

--- a/cli/src/tests/highlight_test.rs
+++ b/cli/src/tests/highlight_test.rs
@@ -718,7 +718,7 @@ fn to_html<'a>(
             .map(Highlight),
     );
     renderer
-        .render(events, src, &|highlight| HTML_ATTRS[highlight.0].as_bytes())
+        .render(events, src, &|highlight, output| { output.extend(HTML_ATTRS[highlight.0].as_bytes()); })
         .unwrap();
     Ok(renderer
         .lines()

--- a/highlight/src/c_lib.rs
+++ b/highlight/src/c_lib.rs
@@ -304,9 +304,9 @@ impl TSHighlighter {
             output
                 .renderer
                 .set_carriage_return_highlight(self.carriage_return_index.map(Highlight));
-            let result = output
-                .renderer
-                .render(highlights, source_code, &|s, out| { out.extend(self.attribute_strings[s.0]); });
+            let result = output.renderer.render(highlights, source_code, &|s, out| {
+                out.extend(self.attribute_strings[s.0]);
+            });
             match result {
                 Err(Error::Cancelled | Error::Unknown) => ErrorCode::Timeout,
                 Err(Error::InvalidLanguage) => ErrorCode::InvalidLanguage,

--- a/highlight/src/c_lib.rs
+++ b/highlight/src/c_lib.rs
@@ -306,7 +306,7 @@ impl TSHighlighter {
                 .set_carriage_return_highlight(self.carriage_return_index.map(Highlight));
             let result = output
                 .renderer
-                .render(highlights, source_code, &|s| self.attribute_strings[s.0]);
+                .render(highlights, source_code, &|s, out| { out.extend(self.attribute_strings[s.0]); });
             match result {
                 Err(Error::Cancelled | Error::Unknown) => ErrorCode::Timeout,
                 Err(Error::InvalidLanguage) => ErrorCode::InvalidLanguage,

--- a/highlight/src/lib.rs
+++ b/highlight/src/lib.rs
@@ -1103,14 +1103,14 @@ impl HtmlRenderer {
         self.line_offsets.push(0);
     }
 
-    pub fn render<'a, F>(
+    pub fn render<F>(
         &mut self,
         highlighter: impl Iterator<Item = Result<HighlightEvent, Error>>,
-        source: &'a [u8],
+        source: &[u8],
         attribute_callback: &F,
     ) -> Result<(), Error>
     where
-        F: Fn(Highlight, &mut Vec<u8>) -> (),
+        F: Fn(Highlight, &mut Vec<u8>),
     {
         let mut highlights = Vec::new();
         for event in highlighter {
@@ -1153,9 +1153,9 @@ impl HtmlRenderer {
             })
     }
 
-    fn add_carriage_return<'a, F>(&mut self, attribute_callback: &F)
+    fn add_carriage_return<F>(&mut self, attribute_callback: &F)
     where
-        F: Fn(Highlight, &mut Vec<u8>) -> (),
+        F: Fn(Highlight, &mut Vec<u8>),
     {
         if let Some(highlight) = self.carriage_return_highlight {
             self.html.extend(b"<span ");
@@ -1164,9 +1164,9 @@ impl HtmlRenderer {
         }
     }
 
-    fn start_highlight<'a, F>(&mut self, h: Highlight, attribute_callback: &F)
+    fn start_highlight<F>(&mut self, h: Highlight, attribute_callback: &F)
     where
-        F: Fn(Highlight, &mut Vec<u8>) -> (),
+        F: Fn(Highlight, &mut Vec<u8>),
     {
         self.html.extend(b"<span ");
         (attribute_callback)(h, &mut self.html);
@@ -1177,9 +1177,9 @@ impl HtmlRenderer {
         self.html.extend(b"</span>");
     }
 
-    fn add_text<'a, F>(&mut self, src: &[u8], highlights: &[Highlight], attribute_callback: &F)
+    fn add_text<F>(&mut self, src: &[u8], highlights: &[Highlight], attribute_callback: &F)
     where
-        F: Fn(Highlight, &mut Vec<u8>) -> (),
+        F: Fn(Highlight, &mut Vec<u8>),
     {
         pub const fn html_escape(c: u8) -> Option<&'static [u8]> {
             match c as char {


### PR DESCRIPTION
fixes #553

when the `--data-highlight` flag is passed along with the `--html` flag, the highlighter will inject `data-tree-sitter-highlight` attributes into the `span` tags, rather than pulling inline styles from the theme.

this makes it significantly easier to use from downstream tools, because we can apply css to the output directly, rather than having the user provide TS with a theme.

only matches which have theme entries are considered for attributes.

Example Output _with_ flag
```html
<span data-tree-sitter-highlight="punctuation.bracket">(</span>
<span data-tree-sitter-highlight="function.builtin">sequence-map</span> 
 path-&gt;note _
<span data-tree-sitter-highlight="punctuation.bracket">)</span>
<span data-tree-sitter-highlight="punctuation.bracket">)</span>
<span data-tree-sitter-highlight="punctuation.bracket">)</span>
```

Original Output _without_ flag
```html
<span style='color: #4e4e4e'>(</span>
<span style='font-weight: bold;color: #005fd7'>sequence-map</span>
 path-&gt;note _
<span style='color: #4e4e4e'>)</span>
<span style='color: #4e4e4e'>)</span>
<span style='color: #4e4e4e'>)</span>
```