### PR TITLE
chore(bindings): include tree-sitter.json file

### DIFF
--- a/cli/src/templates/_cargo.toml
+++ b/cli/src/templates/_cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 autoexamples = false
 
 build = "bindings/rust/build.rs"
-include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
+include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*", "tree-sitter.json"]
 
 [lib]
 path = "bindings/rust/lib.rs"

--- a/cli/src/templates/go.mod
+++ b/cli/src/templates/go.mod
@@ -2,4 +2,4 @@ module PARSER_URL_STRIPPED
 
 go 1.22
 
-require github.com/tree-sitter/go-tree-sitter v0.23.1
+require github.com/tree-sitter/go-tree-sitter v0.24.0

--- a/cli/src/templates/package.json
+++ b/cli/src/templates/package.json
@@ -19,6 +19,7 @@
   ],
   "files": [
     "grammar.js",
+    "tree-sitter.json",
     "binding.gyp",
     "prebuilds/**",
     "bindings/node/*",


### PR DESCRIPTION
For the Rust & Node bindings.