### PR TITLE
fix(xtask): Do not create an empty flag string argument to  `cargo test` in `xtask test`

### DIFF
--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -86,7 +86,11 @@ pub fn run(args: &Test) -> Result<()> {
         )?;
     } else {
         let mut cargo_cmd = Command::new("cargo");
-        cargo_cmd.arg("test").arg(test_flags).args(&args.args);
+        cargo_cmd.arg("test");
+        if !test_flags.is_empty() {
+            cargo_cmd.arg(test_flags);
+        }
+        cargo_cmd.args(&args.args);
         if args.nocapture {
             cargo_cmd.arg("--").arg("--nocapture");
         }


### PR DESCRIPTION
Stumbled upon this issue while trying to migrate the contributing documentation to `xtask`.

Reproduction steps: `cargo xtask test test_tree`
Expected behavior: construct `cargo test test_tree` and run the test with filters.
Actual behavior:
```
error: unexpected argument 'test_tree' found

Usage: cargo test [OPTIONS] [TESTNAME] [-- [ARGS]...]

For more information, try '--help'.
Failed to run "cargo" "test" "" "test_tree":
```

Problem: when no test flags are set, the `test_flags` string is empty, which constructs the empty string argument in `cargo test`. This seems to cause `cargo` to stop taking positional arguments (not sure if it's intended).

Fix: do not construct the empty string if no test flags are set.

Changed behavior: `cargo xtask test test_tree` runs correctly.