### PR TITLE
fix(lib): correct next sibling of zero width node

### DIFF
--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -307,6 +307,31 @@ fn test_parent_of_zero_width_node() {
 }
 
 #[test]
+fn test_next_sibling_of_zero_width_node() {
+    let grammar_json = load_grammar_file(
+        &fixtures_dir()
+            .join("test_grammars")
+            .join("next_sibling_from_zwt")
+            .join("grammar.js"),
+        None,
+    )
+    .unwrap();
+
+    let (parser_name, parser_code) = generate_parser_for_grammar(&grammar_json).unwrap();
+
+    let mut parser = Parser::new();
+    let language = get_test_language(&parser_name, &parser_code, None);
+    parser.set_language(&language).unwrap();
+
+    let tree = parser.parse("abdef", None).unwrap();
+
+    let root_node = tree.root_node();
+    let missing_c = root_node.child(2).unwrap();
+    let node_d = root_node.child(3).unwrap();
+    assert_eq!(missing_c.next_sibling().unwrap(), node_d);
+}
+
+#[test]
 fn test_node_field_name_for_child() {
     let mut parser = Parser::new();
     parser.set_language(&get_language("c")).unwrap();

--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -327,6 +327,8 @@ fn test_next_sibling_of_zero_width_node() {
 
     let root_node = tree.root_node();
     let missing_c = root_node.child(2).unwrap();
+    assert!(missing_c.is_missing());
+    assert_eq!(missing_c.kind(), "c");
     let node_d = root_node.child(3).unwrap();
     assert_eq!(missing_c.next_sibling().unwrap(), node_d);
 }

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -3,6 +3,7 @@
 #include "./subtree.h"
 #include "./tree.h"
 #include "./language.h"
+#include "tree_sitter/api.h"
 
 typedef struct {
   Subtree parent;
@@ -541,7 +542,7 @@ TSNode ts_node_parent(TSNode self) {
   if (node.id == self.id) return ts_node__null();
 
   while (true) {
-    TSNode next_node = ts_node_child_containing_descendant(node, self);
+    TSNode next_node = ts_node_child_with_descendant(node, self);
     if (next_node.id == self.id
         || ts_node_is_null(next_node)) break;
     node = next_node;

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -3,7 +3,6 @@
 #include "./subtree.h"
 #include "./tree.h"
 #include "./language.h"
-#include "tree_sitter/api.h"
 
 typedef struct {
   Subtree parent;

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -542,8 +542,7 @@ TSNode ts_node_parent(TSNode self) {
 
   while (true) {
     TSNode next_node = ts_node_child_with_descendant(node, self);
-    if (next_node.id == self.id
-        || ts_node_is_null(next_node)) break;
+    if (next_node.id == self.id || ts_node_is_null(next_node)) break;
     node = next_node;
   }
 

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -263,8 +263,8 @@ static inline TSNode ts_node__next_sibling(TSNode self, bool include_anonymous) 
     TSNode child;
     NodeChildIterator iterator = ts_node_iterate_children(&node);
     while (ts_node_child_iterator_next(&iterator, &child)) {
-      if (iterator.position.bytes < target_end_byte) continue;
-      if (ts_node_start_byte(child) <= ts_node_start_byte(self)) {
+      if (iterator.position.bytes <= target_end_byte) continue;
+      if (ts_node_start_byte(child) < ts_node_start_byte(self)) {
         if (ts_node__subtree(child).ptr != ts_node__subtree(self).ptr) {
           child_containing_target = child;
         }
@@ -542,7 +542,8 @@ TSNode ts_node_parent(TSNode self) {
 
   while (true) {
     TSNode next_node = ts_node_child_containing_descendant(node, self);
-    if (ts_node_is_null(next_node)) break;
+    if (next_node.id == self.id
+        || ts_node_is_null(next_node)) break;
     node = next_node;
   }
 

--- a/test/fixtures/test_grammars/next_sibling_from_zwt/corpus.txt
+++ b/test/fixtures/test_grammars/next_sibling_from_zwt/corpus.txt
@@ -1,0 +1,2 @@
+(source_file 
+    (MISSING "c"))

--- a/test/fixtures/test_grammars/next_sibling_from_zwt/corpus.txt
+++ b/test/fixtures/test_grammars/next_sibling_from_zwt/corpus.txt
@@ -1,2 +1,10 @@
-(source_file 
+===========================
+missing c node
+===========================
+
+abdef
+
+---
+
+(source
     (MISSING "c"))

--- a/test/fixtures/test_grammars/next_sibling_from_zwt/grammar.js
+++ b/test/fixtures/test_grammars/next_sibling_from_zwt/grammar.js
@@ -1,0 +1,22 @@
+module.exports = grammar({
+  name: "next_sibling_from_zwt",
+  extras: $ => [
+    /\s|\\\r?\n/,
+  ],
+
+  rules: {
+    source: $ => seq(
+      'a',
+      $._bc,
+      'd',
+      'e',
+      'f',
+    ),
+
+    _bc: $ => seq(
+      'b',
+      'c',
+    ),
+  }
+});
+


### PR DESCRIPTION
There seems to be two issues at play here. Using the example from https://github.com/tree-sitter/tree-sitter/issues/3732: The first is that the call to `ts_node_parent` on missing node `c` returns `c`, when it should instead return the tree's root node `source_file`. The second issue was some byte bounds checking for ZWTs inside `ts_node__next_sibling`.

Closes #3732
Closes #3930 