### PR TITLE
fix(loader): don't print warnings if the file is not found

### DIFF
--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -1217,10 +1217,16 @@ impl Loader {
                 }
             }
         } else if let Err(e) = ts_json {
-            eprintln!(
-                "Warning: Failed to read {} -- {e}",
-                parser_path.join("tree-sitter.json").display()
-            );
+            match e.downcast_ref::<std::io::Error>() {
+                // This is noisy, and not really an issue.
+                Some(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                _ => {
+                    eprintln!(
+                        "Warning: Failed to parse {} -- {e}",
+                        parser_path.join("tree-sitter.json").display()
+                    );
+                }
+            }
         }
 
         // If we didn't find any language configurations in the tree-sitter.json file,


### PR DESCRIPTION
Follow up to #3897

If a user has a lot of grammars in their parser directories that have not migrated to the new config file, a lot of warnings will be printed about the file `tree-sitter.json` not being found. This remedies that noise.