### PR TITLE
doc(xtask): update doc to use xtask, not scripts

### DIFF
--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -115,6 +115,12 @@ pub fn test_language_corpus(
     skipped: Option<&[&str]>,
     language_dir: Option<&str>,
 ) {
+    if let Some(filter) = LANGUAGE_FILTER.as_ref() {
+        if language_name != filter {
+            return;
+        }
+    }
+
     let language_dir = language_dir.unwrap_or_default();
 
     let grammars_dir = fixtures_dir().join("grammars");
@@ -341,7 +347,7 @@ fn test_feature_corpus_files() {
         let language_name = language_name.to_str().unwrap();
 
         if let Some(filter) = LANGUAGE_FILTER.as_ref() {
-            if language_name != filter.as_str() {
+            if language_name != filter {
                 continue;
             }
         }

--- a/docs/section-6-contributing.md
+++ b/docs/section-6-contributing.md
@@ -32,7 +32,7 @@ cd tree-sitter
 Optionally, build the WASM library. If you skip this step, then the `tree-sitter playground` command will require an internet connection. If you have emscripten installed, this will use your `emcc` compiler. Otherwise, it will use Docker or Podman:
 
 ```sh
-./script/build-wasm
+cargo xtask build-wasm
 ```
 
 Build the Rust libraries and the CLI:
@@ -48,48 +48,42 @@ This will create the `tree-sitter` CLI executable in the `target/release` folder
 Before you can run the tests, you need to clone some grammars that are used for testing:
 
 ```sh
-script/fetch-fixtures
+cargo xtask fetch-fixtures
 ```
 
 To test any changes you've made to the CLI, you can regenerate these parsers using your current CLI code:
 
 ```sh
-script/generate-fixtures
+cargo xtask generate-fixtures
 ```
 
 Then you can run the tests:
 
 ```sh
-script/test
+cargo xtask test
 ```
 
 Similarly, to test the WASM binding, you need to compile these parsers to WASM:
 
 ```sh
-script/generate-fixtures-wasm
-script/test-wasm
+cargo xtask generate-fixtures --wasm
+cargo xtask test-wasm
 ```
 
 ### Debugging
 
-The test script has a number of useful flags. You can list them all by running `script/test -h`. Here are some of the main flags:
+The test script has a number of useful flags. You can list them all by running `cargo xtask test -h`. Here are some of the main flags:
 
 If you want to run a specific unit test, pass its name (or part of its name) as an argument:
 
 ```sh
-script/test test_does_something
+cargo xtask test test_does_something
 ```
 
 You can run the tests under the debugger (either `lldb` or `gdb`) using the `-g` flag:
 
 ```sh
-script/test test_does_something -g
-```
-
-Part of the Tree-sitter test suite involves parsing the _corpus_ tests for several different languages and performing randomized edits to each example in the corpus. If you just want to run the tests for a particular _language_, you can pass the `-l` flag. And if you want to run a particular _example_ from the corpus, you can pass the `-e` flag:
-
-```sh
-script/test -l javascript -e Arrays
+cargo xtask test -g test_does_something
 ```
 
 ## Published Packages

--- a/docs/section-6-contributing.md
+++ b/docs/section-6-contributing.md
@@ -86,6 +86,12 @@ You can run the tests under the debugger (either `lldb` or `gdb`) using the `-g`
 cargo xtask test -g test_does_something
 ```
 
+Part of the Tree-sitter test suite involves parsing the _corpus_ tests for several different languages and performing randomized edits to each example in the corpus. If you just want to run the tests for a particular _language_, you can pass the `-l` flag. And if you want to run a particular _example_ from the corpus, you can pass the `-e` flag:
+
+```sh
+cargo xtask test -l javascript -e Arrays
+```
+
 ## Published Packages
 
 The main [`tree-sitter/tree-sitter`](https://github.com/tree-sitter/tree-sitter) repository contains the source code for several packages that are published to package registries for different languages:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -107,6 +107,9 @@ struct Test {
     /// Compile C code with the Clang address sanitizer.
     #[arg(long, short)]
     address_sanitizer: bool,
+    /// Run only the corpus tests for the given language.
+    #[arg(long, short)]
+    language: Option<String>,
     /// Run only the corpus tests whose name contain the given string.
     #[arg(long, short)]
     example: Option<String>,

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -45,8 +45,11 @@ pub fn run(args: &Test) -> Result<()> {
     } else {
         String::new()
     };
+    if let Some(language) = &args.language {
+        env::set_var("TREE_SITTER_LANGUAGE", language);
+    }
     if let Some(example) = &args.example {
-        env::set_var("TREE_SITTER_EXAMPLE", example);
+        env::set_var("TREE_SITTER_EXAMPLE_INCLUDE", example);
     }
     if let Some(seed) = args.seed {
         env::set_var("TREE_SITTER_SEED", seed.to_string());


### PR DESCRIPTION
Follow-up of dbe8bbf. Also removed `-l` flag since it's not used anymore.

Closes #3895.