### PR TITLE
feat: get supertype info

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -18,6 +18,9 @@ runs:
           target/release/tree-sitter-*.wasm
         key: fixtures-${{ join(matrix.*, '_') }}-${{ hashFiles(
           'cli/generate/src/**',
+          'lib/src/parser.h',
+          'lib/src/array.h',
+          'lib/src/alloc.h',
           'xtask/src/*',
           'test/fixtures/grammars/*/**/src/*.c',
           '.github/actions/cache/action.yml') }}

--- a/cli/generate/src/lib.rs
+++ b/cli/generate/src/lib.rs
@@ -124,6 +124,8 @@ fn generate_parser_for_grammar_with_opts(
         &simple_aliases,
         &variable_info,
     );
+    let supertype_symbol_map =
+        node_types::get_supertype_symbol_map(&syntax_grammar, &simple_aliases, &variable_info);
     let tables = build_tables(
         &syntax_grammar,
         &lexical_grammar,
@@ -139,6 +141,7 @@ fn generate_parser_for_grammar_with_opts(
         lexical_grammar,
         simple_aliases,
         abi_version,
+        supertype_symbol_map,
     );
     Ok(GeneratedParser {
         c_code,

--- a/cli/src/tests/language_test.rs
+++ b/cli/src/tests/language_test.rs
@@ -95,3 +95,100 @@ fn test_symbol_metadata_checks() {
         }
     }
 }
+
+#[test]
+fn test_supertypes() {
+    let language = get_language("rust");
+    let supertypes = language.supertypes();
+
+    assert_eq!(supertypes.len(), 5);
+    assert_eq!(
+        supertypes
+            .iter()
+            .filter_map(|&s| language.node_kind_for_id(s))
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>(),
+        vec![
+            "_expression",
+            "_literal",
+            "_literal_pattern",
+            "_pattern",
+            "_type"
+        ]
+    );
+
+    for &supertype in supertypes {
+        let mut subtypes = language
+            .subtypes_for_supertype(supertype)
+            .iter()
+            .filter_map(|symbol| language.node_kind_for_id(*symbol))
+            .collect::<Vec<&str>>();
+        subtypes.sort_unstable();
+        subtypes.dedup();
+
+        match language.node_kind_for_id(supertype) {
+            Some("_literal") => {
+                assert_eq!(
+                    subtypes,
+                    &[
+                        "boolean_literal",
+                        "char_literal",
+                        "float_literal",
+                        "integer_literal",
+                        "raw_string_literal",
+                        "string_literal"
+                    ]
+                );
+            }
+            Some("_pattern") => {
+                assert_eq!(
+                    subtypes,
+                    &[
+                        "_",
+                        "_literal_pattern",
+                        "captured_pattern",
+                        "const_block",
+                        "identifier",
+                        "macro_invocation",
+                        "mut_pattern",
+                        "or_pattern",
+                        "range_pattern",
+                        "ref_pattern",
+                        "reference_pattern",
+                        "remaining_field_pattern",
+                        "scoped_identifier",
+                        "slice_pattern",
+                        "struct_pattern",
+                        "tuple_pattern",
+                        "tuple_struct_pattern",
+                    ]
+                );
+            }
+            Some("_type") => {
+                assert_eq!(
+                    subtypes,
+                    &[
+                        "abstract_type",
+                        "array_type",
+                        "bounded_type",
+                        "dynamic_type",
+                        "function_type",
+                        "generic_type",
+                        "macro_invocation",
+                        "metavariable",
+                        "never_type",
+                        "pointer_type",
+                        "primitive_type",
+                        "reference_type",
+                        "removed_trait_bound",
+                        "scoped_type_identifier",
+                        "tuple_type",
+                        "type_identifier",
+                        "unit_type"
+                    ]
+                );
+            }
+            _ => {}
+        }
+    }
+}

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -760,13 +760,6 @@ extern "C" {
     pub fn ts_language_state_count(self_: *const TSLanguage) -> u32;
 }
 extern "C" {
-    #[doc = " Get a node type string for the given numerical id."]
-    pub fn ts_language_symbol_name(
-        self_: *const TSLanguage,
-        symbol: TSSymbol,
-    ) -> *const ::core::ffi::c_char;
-}
-extern "C" {
     #[doc = " Get the numerical id for the given node type string."]
     pub fn ts_language_symbol_for_name(
         self_: *const TSLanguage,
@@ -793,6 +786,25 @@ extern "C" {
         name: *const ::core::ffi::c_char,
         name_length: u32,
     ) -> TSFieldId;
+}
+extern "C" {
+    #[doc = " Get a list of all supertype symbols for the language."]
+    pub fn ts_language_supertypes(self_: *const TSLanguage, length: *mut u32) -> *const TSSymbol;
+}
+extern "C" {
+    #[doc = " Get a list of all subtype symbol ids for a given supertype symbol.\n\n See [`ts_language_supertypes`] for fetching all supertype symbols."]
+    pub fn ts_language_subtypes(
+        self_: *const TSLanguage,
+        supertype: TSSymbol,
+        length: *mut u32,
+    ) -> *const TSSymbol;
+}
+extern "C" {
+    #[doc = " Get a node type string for the given numerical id."]
+    pub fn ts_language_symbol_name(
+        self_: *const TSLanguage,
+        symbol: TSSymbol,
+    ) -> *const ::core::ffi::c_char;
 }
 extern "C" {
     #[doc = " Check whether the given node type id belongs to named nodes, anonymous nodes,\n or a hidden nodes.\n\n See also [`ts_node_is_named`]. Hidden nodes are never returned from the API."]

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -420,6 +420,36 @@ impl Language {
         unsafe { ffi::ts_language_state_count(self.0) as usize }
     }
 
+    /// Get a list of all supertype symbols for the language.
+    #[doc(alias = "ts_language_supertypes")]
+    #[must_use]
+    pub fn supertypes(&self) -> &[u16] {
+        let mut length = 0u32;
+        unsafe {
+            let ptr = ffi::ts_language_supertypes(self.0, core::ptr::addr_of_mut!(length));
+            if length == 0 {
+                &[]
+            } else {
+                slice::from_raw_parts(ptr.cast_mut(), length as usize)
+            }
+        }
+    }
+
+    /// Get a list of all subtype symbol names for a given supertype symbol.
+    #[doc(alias = "ts_language_supertype_map")]
+    #[must_use]
+    pub fn subtypes_for_supertype(&self, supertype: u16) -> &[u16] {
+        unsafe {
+            let mut length = 0u32;
+            let ptr = ffi::ts_language_subtypes(self.0, supertype, core::ptr::addr_of_mut!(length));
+            if length == 0 {
+                &[]
+            } else {
+                slice::from_raw_parts(ptr.cast_mut(), length as usize)
+            }
+        }
+    }
+
     /// Get the name of the node kind for the given numerical id.
     #[doc(alias = "ts_language_symbol_name")]
     #[must_use]

--- a/lib/binding_web/binding.c
+++ b/lib/binding_web/binding.c
@@ -212,6 +212,20 @@ int ts_language_type_is_visible_wasm(const TSLanguage *self, TSSymbol typeId) {
   return symbolType <= TSSymbolTypeAnonymous;
 }
 
+void ts_language_supertypes_wasm(const TSLanguage *self) {
+  uint32_t length;
+  const TSSymbol *supertypes = ts_language_supertypes(self, &length);
+  TRANSFER_BUFFER[0] = (const void *)length;
+  TRANSFER_BUFFER[1] = supertypes;
+}
+
+void ts_language_subtypes_wasm(const TSLanguage *self, TSSymbol supertype) {
+  uint32_t length;
+  const TSSymbol *subtypes = ts_language_subtypes(self, supertype, &length);
+  TRANSFER_BUFFER[0] = (const void *)length;
+  TRANSFER_BUFFER[1] = subtypes;
+}
+
 /******************/
 /* Section - Tree */
 /******************/

--- a/lib/binding_web/binding.js
+++ b/lib/binding_web/binding.js
@@ -5,6 +5,7 @@
 
 const C = Module;
 const INTERNAL = {};
+const SIZE_OF_SHORT = 2;
 const SIZE_OF_INT = 4;
 const SIZE_OF_CURSOR = 4 * SIZE_OF_INT;
 const SIZE_OF_NODE = 5 * SIZE_OF_INT;
@@ -856,6 +857,40 @@ class Language {
 
   nodeTypeIsVisible(typeId) {
     return C._ts_language_type_is_visible_wasm(this[0], typeId) ? true : false;
+  }
+
+  get supertypes() {
+    C._ts_language_supertypes_wasm(this[0]);
+    const count = getValue(TRANSFER_BUFFER, 'i32');
+    const buffer = getValue(TRANSFER_BUFFER + SIZE_OF_INT, 'i32');
+    const result = new Array(count);
+
+    if (count > 0) {
+      let address = buffer;
+      for (let i = 0; i < count; i++) {
+        result[i] = getValue(address, 'i16');
+        address += SIZE_OF_SHORT;
+      }
+    }
+
+    return result;
+  }
+
+  subtypes(supertype) {
+    C._ts_language_subtypes_wasm(this[0], supertype);
+    const count = getValue(TRANSFER_BUFFER, 'i32');
+    const buffer = getValue(TRANSFER_BUFFER + SIZE_OF_INT, 'i32');
+    const result = new Array(count);
+
+    if (count > 0) {
+      let address = buffer;
+      for (let i = 0; i < count; i++) {
+        result[i] = getValue(address, 'i16');
+        address += SIZE_OF_SHORT;
+      }
+    }
+
+    return result;
   }
 
   nextState(stateId, typeId) {

--- a/lib/binding_web/exports.txt
+++ b/lib/binding_web/exports.txt
@@ -5,6 +5,8 @@
 "ts_language_type_is_visible_wasm",
 "ts_language_symbol_count",
 "ts_language_state_count",
+"ts_language_supertypes_wasm",
+"ts_language_subtypes_wasm",
 "ts_language_symbol_for_name",
 "ts_language_symbol_name",
 "ts_language_symbol_type",

--- a/lib/binding_web/test/helper.js
+++ b/lib/binding_web/test/helper.js
@@ -12,4 +12,5 @@ module.exports = Parser.init().then(async () => ({
   JavaScript: await Parser.Language.load(languageURL('javascript')),
   JSON: await Parser.Language.load(languageURL('json')),
   Python: await Parser.Language.load(languageURL('python')),
+  Rust: await Parser.Language.load(languageURL('rust')),
 }));

--- a/lib/binding_web/test/language-test.js
+++ b/lib/binding_web/test/language-test.js
@@ -2,7 +2,7 @@ const {assert} = require('chai');
 let JavaScript;
 
 describe('Language', () => {
-  before(async () => ({JavaScript} = await require('./helper')));
+  before(async () => ({JavaScript, Rust} = await require('./helper')));
 
   describe('.fieldIdForName, .fieldNameForId', () => {
     it('converts between the string and integer representations of fields', () => {
@@ -39,6 +39,80 @@ describe('Language', () => {
       assert.equal(null, JavaScript.nodeTypeForId(-1));
       assert.equal(null, JavaScript.nodeTypeForId(10000));
       assert.equal(null, JavaScript.idForNodeType('export_statement', false));
+    });
+  });
+
+  describe('Supertypes', () => {
+    it('gets the supertypes and subtypes of a parser', () => {
+      const supertypes = Rust.supertypes;
+      const names = supertypes.map((id) => Rust.nodeTypeForId(id));
+      assert.deepStrictEqual(
+        names,
+        ['_expression', '_literal', '_literal_pattern', '_pattern', '_type'],
+      );
+
+      for (const id of supertypes) {
+        const name = Rust.nodeTypeForId(id);
+        const subtypes = Rust.subtypes(id);
+        let subtypeNames = subtypes.map((id) => Rust.nodeTypeForId(id));
+        subtypeNames = [...new Set(subtypeNames)].sort(); // Remove duplicates & sort
+        switch (name) {
+          case '_literal':
+            assert.deepStrictEqual(subtypeNames, [
+              'boolean_literal',
+              'char_literal',
+              'float_literal',
+              'integer_literal',
+              'raw_string_literal',
+              'string_literal',
+            ]);
+            break;
+          case '_pattern':
+            assert.deepStrictEqual(subtypeNames, [
+              '_',
+              '_literal_pattern',
+              'captured_pattern',
+              'const_block',
+              'identifier',
+              'macro_invocation',
+              'mut_pattern',
+              'or_pattern',
+              'range_pattern',
+              'ref_pattern',
+              'reference_pattern',
+              'remaining_field_pattern',
+              'scoped_identifier',
+              'slice_pattern',
+              'struct_pattern',
+              'tuple_pattern',
+              'tuple_struct_pattern',
+            ]);
+            break;
+          case '_type':
+            assert.deepStrictEqual(subtypeNames, [
+              'abstract_type',
+              'array_type',
+              'bounded_type',
+              'dynamic_type',
+              'function_type',
+              'generic_type',
+              'macro_invocation',
+              'metavariable',
+              'never_type',
+              'pointer_type',
+              'primitive_type',
+              'reference_type',
+              'removed_trait_bound',
+              'scoped_type_identifier',
+              'tuple_type',
+              'type_identifier',
+              'unit_type',
+            ]);
+            break;
+          default:
+            break;
+        }
+      }
     });
   });
 });

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -1167,11 +1167,6 @@ uint32_t ts_language_symbol_count(const TSLanguage *self);
 uint32_t ts_language_state_count(const TSLanguage *self);
 
 /**
- * Get a node type string for the given numerical id.
- */
-const char *ts_language_symbol_name(const TSLanguage *self, TSSymbol symbol);
-
-/**
  * Get the numerical id for the given node type string.
  */
 TSSymbol ts_language_symbol_for_name(
@@ -1195,6 +1190,27 @@ const char *ts_language_field_name_for_id(const TSLanguage *self, TSFieldId id);
  * Get the numerical id for the given field name string.
  */
 TSFieldId ts_language_field_id_for_name(const TSLanguage *self, const char *name, uint32_t name_length);
+
+/**
+ * Get a list of all supertype symbols for the language.
+*/
+const TSSymbol *ts_language_supertypes(const TSLanguage *self, uint32_t *length);
+
+/**
+ * Get a list of all subtype symbol ids for a given supertype symbol.
+ *
+ * See [`ts_language_supertypes`] for fetching all supertype symbols.
+ */
+const TSSymbol *ts_language_subtypes(
+  const TSLanguage *self,
+  TSSymbol supertype,
+  uint32_t *length
+);
+
+/**
+ * Get a node type string for the given numerical id.
+ */
+const char *ts_language_symbol_name(const TSLanguage *self, TSSymbol symbol);
 
 /**
  * Check whether the given node type id belongs to named nodes, anonymous nodes,

--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -24,6 +24,31 @@ uint32_t ts_language_state_count(const TSLanguage *self) {
   return self->state_count;
 }
 
+const TSSymbol *ts_language_supertypes(const TSLanguage *self, uint32_t *length) {
+  if (self->version >= LANGUAGE_VERSION_WITH_RESERVED_WORDS) {
+    *length = self->supertype_count;
+    return self->supertype_symbols;
+  } else {
+    *length = 0;
+    return NULL;
+  }
+}
+
+const TSSymbol *ts_language_subtypes(
+  const TSLanguage *self,
+  TSSymbol supertype,
+  uint32_t *length
+) {
+  if (self->version < LANGUAGE_VERSION_WITH_RESERVED_WORDS || !ts_language_symbol_metadata(self, supertype).supertype) {
+    *length = 0;
+    return NULL;
+  }
+
+  TSMapSlice slice = self->supertype_map_slices[supertype];
+  *length = slice.length;
+  return &self->supertype_map_entries[slice.index];
+}
+
 uint32_t ts_language_version(const TSLanguage *self) {
   return self->version;
 }

--- a/lib/src/language.h
+++ b/lib/src/language.h
@@ -236,7 +236,7 @@ static inline void ts_language_field_map(
     return;
   }
 
-  TSFieldMapSlice slice = self->field_map_slices[production_id];
+  TSMapSlice slice = self->field_map_slices[production_id];
   *start = &self->field_map_entries[slice.index];
   *end = &self->field_map_entries[slice.index] + slice.length;
 }

--- a/lib/src/parser.h
+++ b/lib/src/parser.h
@@ -26,10 +26,11 @@ typedef struct {
   bool inherited;
 } TSFieldMapEntry;
 
+// Used to index the field and supertype maps.
 typedef struct {
   uint16_t index;
   uint16_t length;
-} TSFieldMapSlice;
+} TSMapSlice;
 
 typedef struct {
   bool visible;
@@ -115,7 +116,7 @@ struct TSLanguage {
   const TSParseActionEntry *parse_actions;
   const char * const *symbol_names;
   const char * const *field_names;
-  const TSFieldMapSlice *field_map_slices;
+  const TSMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
   const TSSymbol *public_symbol_map;
@@ -138,6 +139,10 @@ struct TSLanguage {
   const char *name;
   const TSSymbol *reserved_words;
   uint16_t max_reserved_word_set_size;
+  uint32_t supertype_count;
+  const TSSymbol *supertype_symbols;
+  const TSMapSlice *supertype_map_slices;
+  const TSSymbol *supertype_map_entries;
 };
 
 static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {


### PR DESCRIPTION
Introduces a new function that takes in a supertype symbol and returns all associated subtypes. Can be used by query.c to give better errors for invalid subtypes, as well as downstream applications like the query LSP to give better diagnostics.

Fixes #2081