### PR TITLE
feat(cli): show parse times in testing output

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -274,6 +274,8 @@ struct Test {
     pub config_path: Option<PathBuf>,
     #[arg(long, help = "Force showing fields in test diffs")]
     pub show_fields: bool,
+    #[arg(long, help = "Show the time each test case took to parse")]
+    pub show_times: bool,
     #[arg(short, long, help = "Force rebuild the parser")]
     pub rebuild: bool,
     #[arg(long, help = "Show only the pass-fail overview tree")]
@@ -959,6 +961,7 @@ impl Test {
         parser.set_language(language)?;
 
         let test_dir = current_dir.join("test");
+        let mut stats = parse::Stats::default();
 
         // Run the corpus tests. Look for them in `test/corpus`.
         let test_corpus_dir = test_dir.join("corpus");
@@ -974,11 +977,14 @@ impl Test {
                 languages: languages.iter().map(|(l, n)| (n.as_str(), l)).collect(),
                 color,
                 test_num: 1,
+                stats: &mut stats,
                 show_fields: self.show_fields,
+                show_times: self.show_times,
                 overview_only: self.overview_only,
             };
 
             test::run_tests_at_path(&mut parser, &mut opts)?;
+            println!("\n{stats}");
         }
 
         // Check that all of the queries are valid.


### PR DESCRIPTION
This adds timing information in two forms for the cli's `test` subcommand. By default, the CLI will now print out some timing stats at  the end of a run. For example, running `tree-sitter test` on `tree-sitter-c` now looks like:

```sh
ambiguities:
      1. ✓ pointer declarations vs expressions
      2. ✓ casts vs multiplications
      3. ✓ function-like type macros vs function calls
     ...
     83. ✓ Attributes
  types:
     84. ✓ Primitive types
     85. ✓ Type modifiers

Total parses: 85; successful parses: 85; failed parses: 0; success percentage: 100.00%; average speed: 2058 bytes/ms

syntax highlighting:
    ✓ keywords.c (3 assertions)
    ✓ names.c (20 assertions)

```

~~In addition, running `tree-sitter test --show-times` will display the parsing time for each individual test case.~~ The use case outlined in #3929 describes finding tests with slow parse rates. Simply printing the parse times isn't useful in this regard (tests vary a lot from run to run even on the same hardware). Providing the parse rate is more useful, but still leaves the user with a lot of guess work and manual checking. A solution I arrived at is to check for statistically significant slow parse rates. The process is basically as follows:

1. When `tree-sitter test` is run, parse all relevant test cases and record their adjusted (logarithmic) parse rates.
- Log parse rates are recorded in order to mitigate against the effect of outliers, which leads to a large standard deviation, making our statistical tests useless. This is just a heuristic.
2. Calculate the mean and standard deviation of all parse log parse rates.
3. Run all the tests normally. When each test is run, if its adjusted parsing rate is more than 3 standard deviations below the mean parsing rate (the "Empirical Rule"), a warning is printed alongside the test name.

By default the `--stat outliers-and-total` option is passed, meaning that running `tree-sitter test` will display a warning if any tests have a slow parse rate. If `--stat all` is passed, the parse rates for every test will be displayed as well as any outliers. Finally, passing `--stat total-only` will only display the total parsing statistics at the end.

This could look like the following for tree-sitter-c, which has one test that occasionally triggers this check:

```sh
❯ ts_dev test
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s
  ambiguities:
      1. ✓ pointer declarations vs expressions
      2. ✓ casts vs multiplications
      3. ✓ function-like type macros vs function calls
     ...
     57. ✓ Top Level Empty Expression Statement -- Warning: Slow parse rate (333.333bytes/ms)
     ...
     83. ✓ Attributes
  types:
     84. ✓ Primitive types
     85. ✓ Type modifiers

Total parses: 85; successful parses: 85; failed parses: 0; success percentage: 100.00%; average speed: 2143 bytes/ms

syntax highlighting:
    ✓ keywords.c (3 assertions)
    ✓ names.c (20 assertions)
```

And here's a screenshot of the `--stat all` flag being passed for good measure:

![image](https://github.com/user-attachments/assets/4b10de7d-cae2-4e95-a6a3-969d9935d31e)

Closes #3929 