### PR TITLE
JSON test report

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -278,6 +278,8 @@ struct Test {
     pub rebuild: bool,
     #[arg(long, help = "Show only the pass-fail overview tree")]
     pub overview_only: bool,
+    #[arg(long, help = "Generate a JSON report of the test results")]
+    pub report: bool,
 }
 
 #[derive(Args)]
@@ -972,6 +974,7 @@ impl Test {
                 test_num: 1,
                 show_fields: self.show_fields,
                 overview_only: self.overview_only,
+                generate_report: self.report,
             };
 
             test::run_tests_at_path(&mut parser, &mut opts)?;
@@ -981,18 +984,20 @@ impl Test {
         test::check_queries_at_path(language, &current_dir.join("queries"))?;
 
         // Run the syntax highlighting tests.
-        let test_highlight_dir = test_dir.join("highlight");
-        if test_highlight_dir.is_dir() {
-            let mut highlighter = Highlighter::new();
-            highlighter.parser = parser;
-            test_highlight::test_highlights(
-                &loader,
-                &config.get()?,
-                &mut highlighter,
-                &test_highlight_dir,
-                color,
-            )?;
-            parser = highlighter.parser;
+        if !self.report {
+            let test_highlight_dir = test_dir.join("highlight");
+            if test_highlight_dir.is_dir() {
+                let mut highlighter = Highlighter::new();
+                highlighter.parser = parser;
+                test_highlight::test_highlights(
+                    &loader,
+                    &config.get()?,
+                    &mut highlighter,
+                    &test_highlight_dir,
+                    color,
+                )?;
+                parser = highlighter.parser;
+            }
         }
 
         let test_tag_dir = test_dir.join("tags");

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -533,7 +533,7 @@ fn run_tests(
             attributes_str,
             attributes,
         } => {
-            // print!("{}", "  ".repeat(indent_level as usize));
+            print!("{}", "  ".repeat(indent_level as usize));
 
             if attributes.skip {
                 println!(
@@ -544,14 +544,14 @@ fn run_tests(
                 return Ok(true);
             }
 
-            // if !attributes.platform {
-            //     println!(
-            //         "{:>3}.  {}",
-            //         opts.test_num,
-            //         paint(opts.color.then_some(AnsiColor::Magenta), &name),
-            //     );
-            //     return Ok(true);
-            // }
+            if !attributes.platform {
+                println!(
+                    "{:>3}.  {}",
+                    opts.test_num,
+                    paint(opts.color.then_some(AnsiColor::Magenta), &name),
+                );
+                return Ok(true);
+            }
 
             for (i, language_name) in attributes.languages.iter().enumerate() {
                 if !language_name.is_empty() {


### PR DESCRIPTION
Addresses #3891

More can be done. But I wanted to start the PR and get feedback.

With this PR, if one executes `git test --report` it will dump a JSON of test results to stdout instead of the default stdout formatting.

It only does corpus tests right now. The output is akin to this format:

```typescript
type TestResults = {
  "name": "corpus",
  "file_path": null,
  "children": (Group|Example)[]
}

type Group = {
  "name": string,
  "file_path": string,
  "children": (Group|Example)[]
}

type Example = {
  "name": string,
  "results": Result[],
}

type Result = {
  "name": string,
  "status": "fail",
  "actual_output" string,
  "diff": DiffLine[]
} | {
  "name": string,
  "status": "pass",
  "actual": string,
} | {
  "name": string,
  "status": "skipped"
}

type DiffLine = {
  tag: 'delete' | 'insert' | 'equal',
  value: string,
}
```

One can generate HTML from this that includes the ability to click on a test name and get directed to the file (in browser) with the name of the test centered and highlighted (but this code is currently not included in the PR; it's a Node project I haven't packed for NPM yet. It is a single HTML file that could be templated and included in TS as something like `tree-sitter test --html-report` that would take the JSON and dump it into the template and then log the template's HTML to screen.

A few screenshots, one of the JSON output, and one of a simple HTML report that could be built-in if desired:

<img width="716" alt="Screenshot 2024-11-13 at 2 44 39 PM" src="https://github.com/user-attachments/assets/ba32fdfd-f3a5-4398-9add-2b5f4eba20e9">
<img width="500" alt="Screenshot 2024-11-13 at 2 44 47 PM" src="https://github.com/user-attachments/assets/2def43bb-9276-4d4f-961a-cf47f367f497">
<img width="764" alt="Screenshot 2024-11-13 at 2 46 13 PM" src="https://github.com/user-attachments/assets/680461cc-0f04-4699-82f9-10d015b9f349">
