### PR TITLE
Zig-build broken when importing tree-sitter as a package

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -99,7 +99,7 @@ fn wasmtimeDep(target: std.Target) []const u8 {
 fn findSourceFiles(b: *std.Build) ![]const []const u8 {
   var sources = std.ArrayList([]const u8).init(b.allocator);
 
-  var dir = try std.fs.cwd().openDir("lib/src", .{ .iterate = true });
+  var dir = try std.fs.cwd().openDir(b.path("lib/src").getPath(b), .{ .iterate = true });
   var iter = dir.iterate();
   defer dir.close();
 

--- a/build.zig
+++ b/build.zig
@@ -99,7 +99,7 @@ fn wasmtimeDep(target: std.Target) []const u8 {
 fn findSourceFiles(b: *std.Build) ![]const []const u8 {
   var sources = std.ArrayList([]const u8).init(b.allocator);
 
-  var dir = try std.fs.cwd().openDir(b.path("lib/src").getPath(b), .{ .iterate = true });
+  var dir = try b.build_root.handle.openDir("lib/src", .{ .iterate = true });
   var iter = dir.iterate();
   defer dir.close();
 


### PR DESCRIPTION
When importing the library though build.zig.zon
```zig
.dependencies = .{
        .@"tree-sitter" = .{
              .url = "https://github.com/tree-sitter/tree-sitter/archive/HASH.tar.gz",
             .hash = "1220937a628d9e5fe95b8f934d60486471730a0f661912c1f0e16542ae2151262146",
        },
  },
  ```
  
 I get this error:
  ```
  zig build
thread 534748 panic: unhandled error
/usr/bin/zig/lib/std/posix.zig:1768:23: 0x1174170 in openatZ (build)
            .NOENT => return error.FileNotFound,
                      ^
/usr/bin/zig/lib/std/fs/Dir.zig:1564:21: 0x114b996 in openDirFlagsZ (build)
        else => |e| return e,
                    ^
/usr/bin/zig/lib/std/fs/Dir.zig:1528:5: 0x1102762 in openDirZ (build)
    return self.openDirFlagsZ(sub_path_c, symlink_flags);
    ^
/usr/bin/zig/lib/std/fs/Dir.zig:1472:5: 0x10f753e in openDir (build)
    return self.openDirZ(&sub_path_c, args);
    ^
/home/alex/editor/../tree-sitter/build.zig:102:13: 0x12125b6 in findSourceFiles (build)
  var dir = try std.fs.cwd().openDir("lib/src", .{ .iterate = true });
            ^
/home/alex/editor/../tree-sitter/build.zig:32:16: 0x12133ac in build (build)
      .files = try findSourceFiles(b),
               ^
/usr/bin/zig/lib/std/Build.zig:2117:24: 0x11bae17 in runBuild__anon_16344 (build)
        .ErrorUnion => try build_zig.build(b),
                       ^
/usr/bin/zig/lib/std/Build.zig:2097:40: 0x1189e9c in dependencyInner__anon_15180 (build)
        sub_builder.runBuild(bz) catch @panic("unhandled error");
                                       ^
/usr/bin/zig/lib/std/Build.zig:1954:35: 0x115ce2e in dependency__anon_14237 (build)
            return dependencyInner(b, name, pkg.build_root, if (@hasDecl(pkg, "build_zig")) pkg.build_zig else null, pkg_hash, pkg.deps, args);
                                  ^
/home/alex/editor/build.zig:48:33: 0x1116229 in build (build)
    exe.linkLibrary(b.dependency("tree-sitter", .{
                                ^
/usr/bin/zig/lib/std/Build.zig:2116:33: 0x10fae63 in runBuild__anon_8818 (build)
        .Void => build_zig.build(b),
                                ^
/usr/bin/zig/lib/compiler/build_runner.zig:301:29: 0x10f606e in main (build)
        try builder.runBuild(root);
                            ^
/usr/bin/zig/lib/std/start.zig:524:37: 0x10dd9c5 in posixCallMainAndExit (build)
            const result = root.main() catch |err| {
                                    ^
/usr/bin/zig/lib/std/start.zig:266:5: 0x10dd4e1 in _start (build)
    asm volatile (switch (native_arch) {
    ^
```


This is due to the wasm changes in https://github.com/tree-sitter/tree-sitter/commit/9d2196cdbd4ac4e00654278fbdfb0dbbefd970dc, in particular:
```zig
  var dir = try std.fs.cwd().openDir("lib/src", .{ .iterate = true });
  var iter = dir.iterate(); 
```

`std.fs.cwd` refers to the cwd of the build process, which is not the root of tree-sitter when tree-sitter is used as a sub-module. 