### PR TITLE
fix: smarter escape detection for invalid anonymous nodes

### DIFF
--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -202,6 +202,36 @@ fn test_query_errors_on_invalid_symbols() {
         let language = get_language("javascript");
 
         assert_eq!(
+            Query::new(&language, "\">>>>\"").unwrap_err(),
+            QueryError {
+                row: 0,
+                offset: 1,
+                column: 1,
+                kind: QueryErrorKind::NodeType,
+                message: ">>>>".to_string()
+            }
+        );
+        assert_eq!(
+            Query::new(&language, "\"te\\\"st\"").unwrap_err(),
+            QueryError {
+                row: 0,
+                offset: 1,
+                column: 1,
+                kind: QueryErrorKind::NodeType,
+                message: "te\\\"st".to_string()
+            }
+        );
+        assert_eq!(
+            Query::new(&language, "\"\\\\\" @cap").unwrap_err(),
+            QueryError {
+                row: 0,
+                offset: 1,
+                column: 1,
+                kind: QueryErrorKind::NodeType,
+                message: "\\\\".to_string()
+            }
+        );
+        assert_eq!(
             Query::new(&language, "(clas)").unwrap_err(),
             QueryError {
                 row: 0,


### PR DESCRIPTION
Right now, the current quotation escape checker fails in the case that there is an anonymous node that is just an escaped backslash (it thinks the backslash escapes the quote, when really it is just an escaped backslash itself. See the added test case for an example of this).

This commit ensures the node identification logic keeps track of the number of backslashes seen so it can accurately determine if the quotation is escaped or not.

See https://github.com/neovim/neovim/pull/31127/files