### PR TITLE
docs: add documentation for TSPoint coordinates

### DIFF
--- a/docs/section-2-using-parsers.md
+++ b/docs/section-2-using-parsers.md
@@ -173,15 +173,17 @@ Tree-sitter provides a [DOM](https://en.wikipedia.org/wiki/Document_Object_Model
 const char *ts_node_type(TSNode);
 ```
 
-Syntax nodes store their position in the source code both in terms of raw bytes and row/column coordinates:
+Syntax nodes store their position in the source code both in terms of raw bytes and row/column coordinates.
+In a point, rows and columns are zero-based. The `row` field represents the number of newlines before a given 
+position, while `column` represents the number of bytes between the position and beginning of the line.
 
 ```c
 uint32_t ts_node_start_byte(TSNode);
 uint32_t ts_node_end_byte(TSNode);
 
 typedef struct {
-  uint32_t row;    // zero-based
-  uint32_t column; // zero-based, measured in bytes
+  uint32_t row;
+  uint32_t column;
 } TSPoint;
 
 TSPoint ts_node_start_point(TSNode);

--- a/docs/section-2-using-parsers.md
+++ b/docs/section-2-using-parsers.md
@@ -180,8 +180,8 @@ uint32_t ts_node_start_byte(TSNode);
 uint32_t ts_node_end_byte(TSNode);
 
 typedef struct {
-  uint32_t row;
-  uint32_t column;
+  uint32_t row;    // zero-based
+  uint32_t column; // zero-based, measured in bytes
 } TSPoint;
 
 TSPoint ts_node_start_point(TSNode);


### PR DESCRIPTION
Added documentation on how TSPoint coordinates are to be interpreted; basically just copied over an explanation from Max in [this discussion thread](https://github.com/tree-sitter/tree-sitter/discussions/1286).