### PR TITLE
Feat/json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +589,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fs4"
@@ -1061,6 +1073,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "mockall"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1251,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1570,6 +1634,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "thiserror"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,6 +1792,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memchr",
+ "mockall",
  "pretty_assertions",
  "rand",
  "regex",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -72,6 +72,7 @@ tree-sitter-tags.workspace = true
 
 [dev-dependencies]
 encoding_rs = "0.8.35"
+mockall = "0.13.0"
 widestring = "1.1.0"
 tree_sitter_proc_macro = { path = "src/tests/proc_macro", package = "tree-sitter-tests-proc-macro" }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -11,6 +11,7 @@ pub mod query_testing;
 pub mod tags;
 pub mod test;
 pub mod test_highlight;
+pub mod test_result;
 pub mod test_tags;
 pub mod util;
 pub mod version;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -278,6 +278,8 @@ struct Test {
     pub rebuild: bool,
     #[arg(long, help = "Show only the pass-fail overview tree")]
     pub overview_only: bool,
+    #[arg(long, help = "Generate a JSON report of the test results")]
+    pub report: bool,
 }
 
 #[derive(Args)]
@@ -972,6 +974,7 @@ impl Test {
                 test_num: 1,
                 show_fields: self.show_fields,
                 overview_only: self.overview_only,
+                generate_report: self.report,
             };
 
             test::run_tests_at_path(&mut parser, &mut opts)?;
@@ -981,18 +984,20 @@ impl Test {
         test::check_queries_at_path(language, &current_dir.join("queries"))?;
 
         // Run the syntax highlighting tests.
-        let test_highlight_dir = test_dir.join("highlight");
-        if test_highlight_dir.is_dir() {
-            let mut highlighter = Highlighter::new();
-            highlighter.parser = parser;
-            test_highlight::test_highlights(
-                &loader,
-                &config.get()?,
-                &mut highlighter,
-                &test_highlight_dir,
-                color,
-            )?;
-            parser = highlighter.parser;
+        if !self.report {
+            let test_highlight_dir = test_dir.join("highlight");
+            if test_highlight_dir.is_dir() {
+                let mut highlighter = Highlighter::new();
+                highlighter.parser = parser;
+                test_highlight::test_highlights(
+                    &loader,
+                    &config.get()?,
+                    &mut highlighter,
+                    &test_highlight_dir,
+                    color,
+                )?;
+                parser = highlighter.parser;
+            }
         }
 
         let test_tag_dir = test_dir.join("tags");

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -140,14 +140,12 @@ pub fn run_tests_at_path(parser: &mut Parser, opts: &mut TestOptions) -> Result<
     parser.stop_printing_dot_graphs();
     let failures = results.get_failures();
     let mut has_parse_errors = results.has_parse_errors();
-    println!("Has parse errors: {}", has_parse_errors);
-    
-    if !failures.is_empty() {
+    if failures.is_empty() {
         Ok(())
     } else {
         println!();
 
-        if opts.update && has_parse_errors {
+        if opts.update && !has_parse_errors {
             if failures.len() == 1 {
                 println!("1 update:\n");
             } else {
@@ -354,11 +352,11 @@ fn tests_to_json(
             attributes_str,
             attributes,
         } => {
-            let pretty_output = format_sexp(&output, 0);
+            // let pretty_output = format_sexp(&output, 0);
             if attributes.skip {
                 let update = opts.update.then_some((
                     String::from_utf8(input.clone()).unwrap(),
-                    pretty_output,
+                    output,
                     attributes_str.clone(),
                     header_delim_len,
                     divider_delim_len));
@@ -390,14 +388,14 @@ fn tests_to_json(
                             LanguageResult::expected_fail(
                                 opts.test_num,
                                 name.clone(), 
-                                pretty_output.clone(),
+                                output.clone(),
                                 update.clone(),
                             )
                         } else { // unwanted success
                             let f = LanguageResult::unexpected_pass(
                                 opts.test_num,
                                 name.clone(), 
-                                pretty_output.clone(), 
+                                output.clone(), 
                                 update.clone(),
                             );
                             f
@@ -408,10 +406,10 @@ fn tests_to_json(
                             actual = strip_sexp_fields(&actual);
                         }
                         if actual == output.clone() {
-                            LanguageResult::pass(opts.test_num, name.clone(), pretty_output.clone(), update.clone())
+                            LanguageResult::pass(opts.test_num, name.clone(), output.clone(), update.clone())
                         } else {
                             let actual = tree.root_node().to_sexp();
-                            LanguageResult::fail(opts.test_num, name.clone(), pretty_output.clone(), actual, update.clone())
+                            LanguageResult::fail(opts.test_num, name.clone(), output.clone(), actual, update.clone())
                         }
                     };
                     opts.test_num += 1;
@@ -465,6 +463,7 @@ fn tests_to_json(
                             opts.test_num += 1;
                             Ok(TestResult::Skipped { idx: opts.test_num, name: name.clone(), update })
                         } else {
+                            opts.test_num += count_subtests(&el);
                             tests_to_json(parser, el, opts)
                         }
                     }

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -533,7 +533,7 @@ fn run_tests(
             attributes_str,
             attributes,
         } => {
-            // print!("{}", "  ".repeat(indent_level as usize));
+            print!("{}", "  ".repeat(indent_level as usize));
 
             if attributes.skip {
                 println!(
@@ -544,14 +544,14 @@ fn run_tests(
                 return Ok(true);
             }
 
-            // if !attributes.platform {
-            //     println!(
-            //         "{:>3}.  {}",
-            //         opts.test_num,
-            //         paint(opts.color.then_some(AnsiColor::Magenta), &name),
-            //     );
-            //     return Ok(true);
-            // }
+            if !attributes.platform {
+                println!(
+                    "{:>3}.  {}",
+                    opts.test_num,
+                    paint(opts.color.then_some(AnsiColor::Magenta), &name),
+                );
+                return Ok(true);
+            }
 
             for (i, language_name) in attributes.languages.iter().enumerate() {
                 if !language_name.is_empty() {

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -106,7 +106,7 @@ pub struct TestOptions<'a> {
     pub test_num: usize,
     pub show_fields: bool,
     pub overview_only: bool,
-    pub generate_report: bool,
+    pub generate_report: Option<String>,
 }
 
 pub fn run_tests_at_path(parser: &mut Parser, opts: &mut TestOptions) -> Result<TestResult> {
@@ -129,7 +129,7 @@ pub fn run_tests_at_path(parser: &mut Parser, opts: &mut TestOptions) -> Result<
         do_updates(&results)?;
     }
 
-    if opts.generate_report {
+    if opts.generate_report.is_some() {
         return Ok(results);
     }
 
@@ -1475,7 +1475,7 @@ a
             test_num: 0,
             show_fields: false,
             overview_only: false,
-            generate_report: false,
+            generate_report: None,
         }
     }
 

--- a/cli/src/test.rs
+++ b/cli/src/test.rs
@@ -1714,4 +1714,9 @@ a
         );
         dbg!("results", results);
     }
+
+    #[test]
+    fn create_parser_test() {
+        let p = Parser::new();
+    }
 }

--- a/cli/src/test_highlight.rs
+++ b/cli/src/test_highlight.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::Path};
 
-use anstyle::AnsiColor;
+// use anstyle::AnsiColor;
 use anyhow::{anyhow, Result};
 use tree_sitter::Point;
 use tree_sitter_highlight::{Highlight, HighlightConfiguration, HighlightEvent, Highlighter};
@@ -11,7 +11,7 @@ use tree_sitter_loader::{Config, Loader};
 use super::{
     query_testing::{parse_position_comments, to_utf8_point, Assertion, Utf8Point},
     test_result::HighlightTestResult,
-    test::paint,
+    // test::paint,
     util,
 };
 
@@ -51,100 +51,98 @@ pub fn test_highlights(
     loader_config: &Config,
     highlighter: &mut Highlighter,
     directory: &Path,
-    use_color: bool,
-) -> Result<()> {
-    println!("syntax highlighting:");
-    // test_highlights_indented(loader, loader_config, highlighter, directory, use_color, 2)
-    let results = do_tests(directory, loader, loader_config, highlighter)?;
-    print!("{}", results.to_string(use_color, 0));
-    Ok(())
+) -> Result<HighlightTestResult> {
+    // println!("syntax highlighting:");
+    do_tests(directory, loader, loader_config, highlighter)
+    // print!("{}", results.to_string(use_color, 0));
+    // Ok(results)
 }
 
-fn test_highlights_indented(
-    loader: &Loader,
-    loader_config: &Config,
-    highlighter: &mut Highlighter,
-    directory: &Path,
-    use_color: bool,
-    indent_level: usize,
-) -> Result<()> {
-    let mut failed = false;
+// fn test_highlights_indented(
+//     loader: &Loader,
+//     loader_config: &Config,
+//     highlighter: &mut Highlighter,
+//     directory: &Path,
+//     use_color: bool,
+//     indent_level: usize,
+// ) -> Result<()> {
+//     let mut failed = false;
 
-    for highlight_test_file in fs::read_dir(directory)? {
-        let highlight_test_file = highlight_test_file?;
-        let test_file_path = highlight_test_file.path();
-        let test_file_name = highlight_test_file.file_name();
-        print!(
-            "{indent:indent_level$}",
-            indent = "",
-            indent_level = indent_level * 2
-        );
-        if test_file_path.is_dir() && test_file_path.read_dir()?.next().is_some() {
-            println!("{}:", test_file_name.into_string().unwrap());
-            if test_highlights_indented(
-                loader,
-                loader_config,
-                highlighter,
-                &test_file_path,
-                use_color,
-                indent_level + 1,
-            )
-            .is_err()
-            {
-                failed = true;
-            }
-        } else {
-            let (language, language_config) = loader
-                .language_configuration_for_file_name(&test_file_path)?
-                .ok_or_else(|| {
-                    anyhow!(
-                        "{}",
-                        util::lang_not_found_for_path(test_file_path.as_path(), loader_config)
-                    )
-                })?;
-            let highlight_config = language_config
-                .highlight_config(language, None)?
-                .ok_or_else(|| anyhow!("No highlighting config found for {test_file_path:?}"))?;
-            match test_highlight(
-                loader,
-                highlighter,
-                highlight_config,
-                fs::read(&test_file_path)?.as_slice(),
-            ) {
-                Ok(assertion_count) => {
-                    println!(
-                        "✓ {} ({assertion_count} assertions)",
-                        paint(
-                            use_color.then_some(AnsiColor::Green),
-                            test_file_name.to_string_lossy().as_ref()
-                        ),
-                    );
-                }
-                Err(e) => {
-                    println!(
-                        "✗ {}",
-                        paint(
-                            use_color.then_some(AnsiColor::Red),
-                            test_file_name.to_string_lossy().as_ref()
-                        )
-                    );
-                    println!(
-                        "{indent:indent_level$}  {e}",
-                        indent = "",
-                        indent_level = indent_level * 2
-                    );
-                    failed = true;
-                }
-            }
-        }
-    }
+//     for highlight_test_file in fs::read_dir(directory)? {
+//         let highlight_test_file = highlight_test_file?;
+//         let test_file_path = highlight_test_file.path();
+//         let test_file_name = highlight_test_file.file_name();
+//         print!(
+//             "{indent:indent_level$}",
+//             indent = "",
+//             indent_level = indent_level * 2
+//         );
+//         if test_file_path.is_dir() && test_file_path.read_dir()?.next().is_some() {
+//             println!("{}:", test_file_name.into_string().unwrap());
+//             if test_highlights_indented(
+//                 loader,
+//                 loader_config,
+//                 highlighter,
+//                 &test_file_path,
+//                 use_color,
+//                 indent_level + 1,
+//             )
+//             .is_err()
+//             {
+//                 failed = true;
+//             }
+//         } else {
+//             let (language, language_config) = loader
+//                 .language_configuration_for_file_name(&test_file_path)?
+//                 .ok_or_else(|| {
+//                     anyhow!(
+//                         "{}",
+//                         util::lang_not_found_for_path(test_file_path.as_path(), loader_config)
+//                     )
+//                 })?;
+//             let highlight_config = language_config
+//                 .highlight_config(language, None)?
+//                 .ok_or_else(|| anyhow!("No highlighting config found for {test_file_path:?}"))?;
+//             match test_highlight(
+//                 loader,
+//                 highlighter,
+//                 highlight_config,
+//                 fs::read(&test_file_path)?.as_slice(),
+//             ) {
+//                 Ok(assertion_count) => {
+//                     println!(
+//                         "✓ {} ({assertion_count} assertions)",
+//                         paint(
+//                             use_color.then_some(AnsiColor::Green),
+//                             test_file_name.to_string_lossy().as_ref()
+//                         ),
+//                     );
+//                 }
+//                 Err(e) => {
+//                     println!(
+//                         "✗ {}",
+//                         paint(
+//                             use_color.then_some(AnsiColor::Red),
+//                             test_file_name.to_string_lossy().as_ref()
+//                         )
+//                     );
+//                     println!(
+//                         "{indent:indent_level$}  {e}",
+//                         indent = "",
+//                         indent_level = indent_level * 2
+//                     );
+//                     failed = true;
+//                 }
+//             }
+//         }
+//     }
 
-    if failed {
-        Err(anyhow!(""))
-    } else {
-        Ok(())
-    }
-}
+//     if failed {
+//         Err(anyhow!(""))
+//     } else {
+//         Ok(())
+//     }
+// }
 
 fn do_tests(
     directory: &Path,

--- a/cli/src/test_result.rs
+++ b/cli/src/test_result.rs
@@ -55,9 +55,9 @@ impl TestResult {
         match self {
             TestResult::Executed { name, results, .. } => {
                 results.iter().filter_map(|(_, result)| {
-                    dbg!("[get_failures] result: {:?}", result);
                     match result {
                         LanguageResult::Fail { expected, result, .. } => Some((name.clone(), result.clone(), expected.clone())),
+                        LanguageResult::Pass { intended: false, .. } => Some((name.clone(), "".to_string(), "NO ERROR".to_string())),
                         _ => None,
                     }
                 }).collect()

--- a/cli/src/test_result.rs
+++ b/cli/src/test_result.rs
@@ -1,0 +1,204 @@
+use serde::{ser::SerializeStruct, Serialize, Serializer};
+use std::path::PathBuf;
+use similar::{TextDiff, ChangeTag};
+
+#[derive(Clone, Serialize)]
+#[serde(untagged)]
+pub enum TestResult {
+    Executed {
+        name: String,
+        results: Vec<(String, LanguageResult)>,
+    },
+    NoPlatform {
+        name: String,
+    },
+    Skipped {
+        name: String,
+        update: Option<(String, String, String, usize, usize)>,
+    },
+    Group {
+        name: String,
+        file_path: Option<PathBuf>,
+        children: Vec<TestResult>,
+    }
+}
+
+// pub impl Iter for TestResult {
+//     type Item = TestResult;
+
+//     fn next(&mut self) -> Option(Self::Item) {
+//         let current = self.curr;
+
+//         self.curr = self.next;
+//         self.next = 
+//     }
+// }
+
+impl TestResult {
+    pub fn get_all_tests(self) -> Vec<TestResult> {
+        match self {
+            TestResult::Group { children, .. } => {
+                children.iter().flat_map(|child| child.clone().get_all_tests()).collect()
+            }
+            // TestResult::Executed { results } => {
+
+            // }
+            _ => vec![self],
+        }
+    }
+    pub fn has_failures(&self) -> bool {
+        match self {
+            TestResult::Executed { results, .. } => {
+                results.iter().any(|(_, result)| match result {
+                    LanguageResult::Fail { .. } => true,
+                    _ => false,
+                })
+            }
+            TestResult::Group { children, .. } => {
+                children.iter().any(|child| child.has_failures())
+            }
+            _ => false,
+        }
+    }
+    pub fn get_failures(&self) -> Vec<(String, String, String)> {
+        match self {
+            TestResult::Executed { name, results, .. } => {
+                results.iter().filter_map(|(_, result)| {
+                    match result {
+                        LanguageResult::Fail { expected, result, .. } => Some((name.clone(), result.clone(), expected.clone())),
+                        _ => None,
+                    }
+                }).collect()
+            }
+            TestResult::Group { children, .. } => {
+                children.iter().flat_map(|child| child.get_failures()).collect()
+            }
+            _ => vec![],
+        }
+    }
+}
+#[derive(Clone)]
+pub enum LanguageResult {
+    Pass {
+        name: String,
+        expected: String,
+        intended: bool,
+        update: Option<(String, usize, usize)>
+    },
+    Fail {
+        name: String,
+        expected: String,
+        result: String,
+        diff: Vec<DiffResult>,
+        update: Option<(String, usize, usize)>,
+    },
+    ExpectedFailure {
+        name: String,
+        expected: String,
+        update: Option<(String, usize, usize)>,
+    },
+}
+impl Serialize for LanguageResult {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: Serializer, 
+    {
+        // let mut state = serializer.serialize_struct("LanguageResult")
+        match self {
+            LanguageResult::Pass { name, expected, intended, .. } => {
+                let mut state = serializer.serialize_struct("Pass", 4)?;
+                state.serialize_field("status", "passed")?;
+                state.serialize_field("name", &name)?;
+                state.serialize_field("expected", &expected)?;
+                state.serialize_field("intended", intended)?;
+                state.end()
+            }
+            LanguageResult::Fail { name, expected, result, diff, .. } => {
+                let mut state = serializer.serialize_struct("Fail", 5)?;
+                state.serialize_field("status", "failed")?;
+                state.serialize_field("name", &name)?;
+                state.serialize_field("expected", &expected)?;
+                state.serialize_field("result", &result)?;
+                state.serialize_field("diff", diff)?;
+                state.end()
+            }
+            LanguageResult::ExpectedFailure { name, expected, .. } => {
+                let mut state = serializer.serialize_struct("ExpectedFailure", 3)?;
+                state.serialize_field("status", "expected failure")?;
+                state.serialize_field("name", &name)?;
+                state.serialize_field("expected", &expected)?;
+                state.end()
+            }
+        }
+    }
+}
+impl LanguageResult {
+    pub fn pass(name: String, expected: String, update: Option<(String, usize, usize)>) -> Self {
+        LanguageResult::Pass {
+            name: name,
+            expected,
+            update,
+            intended: true,
+        }
+    }
+    pub fn unexpected_pass(name: String, expected: String, update: Option<(String, usize, usize)>) -> Self {
+        LanguageResult::Pass {
+            name: name,
+            expected,
+            update,
+            intended: false,
+        }
+    }
+    pub fn expected_fail(name: String, expected: String, update: Option<(String, usize, usize)>) -> Self {
+        LanguageResult::ExpectedFailure {
+            name,
+            expected,
+            update,
+        }
+    }
+    pub fn fail(name: String, expected: String, result: String, update: Option<(String, usize, usize)>) -> Self {
+        let diff = TextDiff::from_lines(&expected, &result);
+        let mut diff_vec = vec![];
+        for d in diff.iter_all_changes() {
+            let line = match d.tag() {
+                ChangeTag::Equal => DiffResult::Equal { value: d.as_str().unwrap().to_string()},
+                ChangeTag::Delete => DiffResult::Delete { value: d.as_str().unwrap().to_string()},
+                ChangeTag::Insert => DiffResult::Insert { value: d.as_str().unwrap().to_string()}
+            };
+            diff_vec.push(line);
+        }
+        LanguageResult::Fail {
+            name,
+            expected,
+            result,
+            diff: diff_vec,
+            update,
+        }
+    }
+}
+
+#[derive(Clone)]
+enum DiffResult {
+    Equal { value: String },
+    Insert { value: String },
+    Delete { value: String },
+}
+impl Serialize for DiffResult {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        let mut state = serializer.serialize_struct("DiffResult", 2)?;
+        match self {
+            DiffResult::Equal { value } => {
+                state.serialize_field("value", &value)?;
+                state.serialize_field("tag", "equal")?
+            }
+            DiffResult::Delete { value } => {
+                state.serialize_field("value", &value)?;
+                state.serialize_field("tag", "delete")?
+            }
+            DiffResult::Insert { value } => {
+                state.serialize_field("value", &value)?;
+                state.serialize_field("tag", "insert")?
+            }
+        }
+        state.end()
+    }
+}

--- a/cli/src/test_result.rs
+++ b/cli/src/test_result.rs
@@ -430,25 +430,6 @@ impl TagTestResult {
     }
 }
 
-// impl Serialize for TagTestResult {
-//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-//         match self {
-//             TagTestResult::Success { name, assertion_count } => {
-//                 let mut state = serializer.serialize_struct("Success", 2)?;
-//                 state.serialize_field("name", name)?;
-//                 state.serialize_field("assertion_count", assertion_count)?;
-//                 state.end()
-//             },
-//             TagTestResult::Failure { name, error } => {
-//                 let mut state = serializer.serialize_struct("Failure", 2)?;
-//                 state.serialize_field("name", name)?;
-//                 state.serialize_field("error", &error.to_string())?;
-//                 state.end()
-//             },
-//         }
-//     }
-// }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cli/src/test_result.rs
+++ b/cli/src/test_result.rs
@@ -10,9 +10,11 @@ pub enum TestResult {
         results: Vec<(String, LanguageResult)>,
     },
     NoPlatform {
+        idx: usize,
         name: String,
     },
     Skipped {
+        idx: usize,
         name: String,
         update: Option<(String, String, String, usize, usize)>,
     },
@@ -80,12 +82,14 @@ impl TestResult {
 #[derive(Clone)]
 pub enum LanguageResult {
     Pass {
+        idx: usize,
         name: String,
         expected: String,
         intended: bool,
         update: Option<(String, usize, usize)>
     },
     Fail {
+        idx: usize,
         name: String,
         expected: String,
         result: String,
@@ -93,6 +97,7 @@ pub enum LanguageResult {
         update: Option<(String, usize, usize)>,
     },
     ExpectedFailure {
+        idx: usize,
         name: String,
         expected: String,
         update: Option<(String, usize, usize)>,
@@ -132,30 +137,33 @@ impl Serialize for LanguageResult {
     }
 }
 impl LanguageResult {
-    pub fn pass(name: String, expected: String, update: Option<(String, usize, usize)>) -> Self {
+    pub fn pass(idx: usize, name: String, expected: String, update: Option<(String, usize, usize)>) -> Self {
         LanguageResult::Pass {
-            name: name,
+            idx,
+            name,
             expected,
             update,
             intended: true,
         }
     }
-    pub fn unexpected_pass(name: String, expected: String, update: Option<(String, usize, usize)>) -> Self {
+    pub fn unexpected_pass(idx: usize, name: String, expected: String, update: Option<(String, usize, usize)>) -> Self {
         LanguageResult::Pass {
-            name: name,
+            idx,
+            name,
             expected,
             update,
             intended: false,
         }
     }
-    pub fn expected_fail(name: String, expected: String, update: Option<(String, usize, usize)>) -> Self {
+    pub fn expected_fail(idx: usize, name: String, expected: String, update: Option<(String, usize, usize)>) -> Self {
         LanguageResult::ExpectedFailure {
+            idx,
             name,
             expected,
             update,
         }
     }
-    pub fn fail(name: String, expected: String, result: String, update: Option<(String, usize, usize)>) -> Self {
+    pub fn fail(idx: usize, name: String, expected: String, result: String, update: Option<(String, usize, usize)>) -> Self {
         let diff = TextDiff::from_lines(&expected, &result);
         let mut diff_vec = vec![];
         for d in diff.iter_all_changes() {
@@ -167,6 +175,7 @@ impl LanguageResult {
             diff_vec.push(line);
         }
         LanguageResult::Fail {
+            idx,
             name,
             expected,
             result,

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -3665,6 +3665,7 @@ impl fmt::Display for QueryError {
 
 #[doc(hidden)]
 #[must_use]
+/// sexp must be a single line
 pub fn format_sexp(sexp: &str, initial_indent_level: usize) -> String {
     let mut indent_level = initial_indent_level;
     let mut formatted = String::new();


### PR DESCRIPTION
Addresses #3891 

introduces two flags to `tree-sitter test`:

`--report <REPORT>` which allows a user to create a JSON report stored in a given file. If the user types `:stdout:` as the filename, it will dump the JSON to stdout, which enables a user to pipe the output to the receiving application of their choice (like a test report generator that converts JSON to an HTML report of their choice)

`--open-report`, which opens the JSON report in a browser. Some browsers have fancy JSON display abilities that can be useful here. Though it would be nice to have an idea of a JSON program that could be configured to open instead of it going to the browser. Could be in a future PR.

The JSON report includes results for corpus, highlighting, and tag tests.

This is an improvement over a previous (closed by me) PR that had suggestions from @amaanq. We now have the ability to open the output in an application (although right now it opens in browser)

The JSON is also typed now, which is safer than spamming the serve `json!` macro everywhere.

I could see there being an --html-report flag, too, that is essentially a pre-ordained HTML template with the JSON results dumped into it, and then auto-open that in browser, but I think it'd be better as a future feature so this PR doesn't become even larger. As it is, there were a lot of necessary changes in order to create JSON *or* "standard" test results.