### PR TITLE
fix: patch ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,7 @@ jobs:
     - name: Build wasmtime library
       if: ${{ !matrix.use-cross && contains(matrix.features, 'wasm') }}
       run: |
+        mkdir -p target
         WASMTIME_VERSION=$(cargo metadata --format-version=1 --locked --features wasm | \
                            jq -r '.packages[] | select(.name == "wasmtime-c-api-impl") | .version')
         curl -LSs "$WASMTIME_REPO/archive/refs/tags/v${WASMTIME_VERSION}.tar.gz" | tar xzf - -C target

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,8 @@ jobs:
 
     - name: Install cross
       if: ${{ matrix.use-cross }}
-      run: cargo install cross --git https://github.com/cross-rs/cross
+      # TODO: Remove 'RUSTFLAGS=""' onc https://github.com/cross-rs/cross/issues/1561 is resolved
+      run: RUSTFLAGS="" cargo install cross --git https://github.com/cross-rs/cross
 
     - name: Configure cross
       if: ${{ matrix.use-cross }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ clap = { version = "4.5.21", features = [
   "unstable-styles",
 ] }
 clap_complete = "4.5.38"
-ctor = "0.2.8"
+ctor = "0.2.9"
 ctrlc = { version = "3.4.5", features = ["termination"] }
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 dirs = "5.0.1"

--- a/cli/src/query_testing.rs
+++ b/cli/src/query_testing.rs
@@ -223,11 +223,11 @@ pub fn assert_expected_captures(
     let contents = fs::read_to_string(path)?;
     let pairs = parse_position_comments(parser, language, contents.as_bytes())?;
     for assertion in &pairs {
-        if let Some(found) = &infos
-            .iter()
-            .find(|p| assertion.position >= p.start &&
-                 (assertion.position.row < p.end.row || assertion.position.column + assertion.length - 1 < p.end.column))
-        {
+        if let Some(found) = &infos.iter().find(|p| {
+            assertion.position >= p.start
+                && (assertion.position.row < p.end.row
+                    || assertion.position.column + assertion.length - 1 < p.end.column)
+        }) {
             if assertion.expected_capture_name != found.name && found.name != "name" {
                 return Err(anyhow!(
                     "Assertion failed: at {}, found {}, expected {}",

--- a/cli/src/test_highlight.rs
+++ b/cli/src/test_highlight.rs
@@ -171,7 +171,7 @@ pub fn iterate_assertions(
             // position, looking for one that matches the assertion.
             let mut j = i;
             while let (false, Some(highlight)) = (passed, highlights.get(j)) {
-                end_column = (*position).column + length - 1;
+                end_column = position.column + length - 1;
                 if highlight.0.column > end_column {
                     break 'highlight_loop;
                 }

--- a/cli/src/test_tags.rs
+++ b/cli/src/test_tags.rs
@@ -132,7 +132,7 @@ pub fn test_tag(
             // position, looking for one that matches the assertion
             let mut j = i;
             while let (false, Some(tag)) = (passed, tags.get(j)) {
-                end_column = (*position).column + length - 1;
+                end_column = position.column + length - 1;
                 if tag.0.column > end_column {
                     break 'tag_loop;
                 }


### PR DESCRIPTION
Spent a little time digging into some of the recent issues popping up in CI runs.  I *think* this should fix the two problems I outlined below, but  you never know until you actually do a run. 

To be specific:

- Running  `cargo +nightly test --workspace --all-targets` on nightly gives the following error:

```sh
error: unexpected `cfg` condition value: `used_linker`
Error:   --> cli/src/fuzz/allocations.rs:10:1
   |
10 | #[ctor::ctor]
   | ^^^^^^^^^^^^^
   |
   = note: expected values for `feature` are: `wasm`
   = help: consider adding `used_linker` as a feature in `Cargo.toml`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: `-D unexpected-cfgs` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unexpected_cfgs)]`
   = note: this error originates in the attribute macro `ctor::ctor` (in Nightly builds, run with -Z macro-backtrace for more info)

    Checking xtask v0.1.0 (/home/runner/work/tree-sitter/tree-sitter/xtask)
error: unexpected `cfg` condition value: `used_linker`
Error:   --> cli/src/tests/helpers/allocations.rs:10:1
   |
10 | #[ctor::ctor]
   | ^^^^^^^^^^^^^
   |
   = note: expected values for `feature` are: `wasm`
   = help: consider adding `used_linker` as a feature in `Cargo.toml`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: this error originates in the attribute macro `ctor::ctor` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `tree-sitter-cli` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `tree-sitter-cli` (lib test) due to 2 previous errors
make: *** [Makefile:108: lint] Error 101
Error: Process completed with exit code 2.
```

This shows up during the `Lint files` step of our `check` workflow. These errors were reported in the rust-ctor crate [here](https://github.com/mmastrac/rust-ctor/issues/309), and patched in the 0.2.9 release. So to fix this I just bumped the dependency version from 0.2.8 to 0.2.9.

- Running ` cargo install cross --git https://github.com/cross-rs/cross` as part of the `Install cross` step of our `build` workflow results in the following errors:

<Details>

```sh
warning: creating a shared reference to mutable static is discouraged
   --> src/docker/local.rs:168:34
    |
168 |     let is_terminated = unsafe { crate::errors::TERMINATED.load(Ordering::SeqCst) };
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[warn(static_mut_refs)]` on by default

warning: creating a shared reference to mutable static is discouraged
   --> src/docker/shared.rs:568:17
    |
568 |             if !CHILD_CONTAINER.exists.swap(true, Ordering::SeqCst) {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives

warning: creating a shared reference to mutable static is discouraged
   --> src/docker/shared.rs:592:18
    |
592 |         unsafe { CHILD_CONTAINER.exists() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives

warning: creating a mutable reference to mutable static is discouraged
   --> src/docker/shared.rs:604:13
    |
604 |             CHILD_CONTAINER.exit();
    |             ^^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives

warning: creating a mutable reference to mutable static is discouraged
   --> src/docker/shared.rs:630:13
    |
630 |             CHILD_CONTAINER.finish(is_tty, msg_info);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives

warning: creating a shared reference to mutable static is discouraged
  --> src/errors.rs:27:9
   |
27 |     if !TERMINATED.swap(true, Ordering::SeqCst) && temp::has_tempfiles() {
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ shared reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives

warning: creating a mutable reference to mutable static is discouraged
   --> src/errors.rs:105:5
    |
105 |     docker::CHILD_CONTAINER.terminate();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives

warning: creating a shared reference to mutable static is discouraged
  --> src/temp.rs:22:15
   |
22 |     unsafe { !FILES.is_empty() || !DIRS.is_empty() }
   |               ^^^^^^^^^^^^^^^^ shared reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives

warning: creating a shared reference to mutable static is discouraged
  --> src/temp.rs:22:36
   |
22 |     unsafe { !FILES.is_empty() || !DIRS.is_empty() }
   |                                    ^^^^^^^^^^^^^^^ shared reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives

warning: creating a mutable reference to mutable static is discouraged
  --> src/temp.rs:31:5
   |
31 |     FILES.clear();
   |     ^^^^^^^^^^^^^ mutable reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives

warning: creating a mutable reference to mutable static is discouraged
  --> src/temp.rs:32:5
   |
32 |     DIRS.clear();
   |     ^^^^^^^^^^^^ mutable reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives

warning: creating a mutable reference to mutable static is discouraged
  --> src/temp.rs:41:5
   |
41 |     FILES.push(file);
   |     ^^^^^^^^^^^^^^^^ mutable reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives

warning: creating a mutable reference to mutable static is discouraged
  --> src/temp.rs:42:8
   |
42 |     Ok(FILES.last_mut().expect("file list should not be empty"))
   |        ^^^^^^^^^^^^^^^^ mutable reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives

warning: creating a mutable reference to mutable static is discouraged
  --> src/temp.rs:48:5
   |
48 |     FILES.pop()
   |     ^^^^^^^^^^^ mutable reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives

warning: creating a mutable reference to mutable static is discouraged
  --> src/temp.rs:90:5
   |
90 |     DIRS.push(dir);
   |     ^^^^^^^^^^^^^^ mutable reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives

warning: creating a shared reference to mutable static is discouraged
  --> src/temp.rs:91:8
   |
91 |     Ok(DIRS.last().expect("should not be empty").path())
   |        ^^^^^^^^^^^ shared reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives

warning: creating a mutable reference to mutable static is discouraged
  --> src/temp.rs:97:5
   |
97 |     DIRS.pop()
   |     ^^^^^^^^^^ mutable reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
```
</Details>

This has been reported upstream in the cross crate [here](https://github.com/cross-rs/cross/issues/1561). Reading through the issue's discussion so far, it looks like fixing these warnings will require a non-trivial refactor. Given this, I think a reasonable (temporary) fix is just to silence the warnings by overriding the `-D warning` default.
