### PR TITLE
fix(lib): use `clock_gettime` on macOS again

### DIFF
--- a/lib/src/clock.h
+++ b/lib/src/clock.h
@@ -49,9 +49,9 @@ static inline bool clock_is_gt(TSClock self, TSClock other) {
   return self > other;
 }
 
-#elif defined(CLOCK_MONOTONIC) && !defined(__APPLE__)
+#elif defined(CLOCK_MONOTONIC)
 
-// POSIX with monotonic clock support (Linux)
+// POSIX with monotonic clock support (Linux, macOS)
 // * Represent a time as a monotonic (seconds, nanoseconds) pair.
 // * Represent a duration as a number of microseconds.
 //
@@ -102,7 +102,7 @@ static inline bool clock_is_gt(TSClock self, TSClock other) {
 
 #else
 
-// macOS or POSIX without monotonic clock support
+// POSIX without monotonic clock support
 // * Represent a time as a process clock value.
 // * Represent a duration as a number of process clock ticks.
 //


### PR DESCRIPTION
### Problem

The computation for timeouts can be seemingly inaccurate when there is no monotonic clock support - expectations that assume it can be used to measure wall time is inaccurate, as it measures CPU (processor) time on POSIX systems ([see here](https://linux.die.net/man/3/clock)).

This restriction was made in https://github.com/tree-sitter/tree-sitter/commit/25b0fbd6, which was due to the fact that macOS 10.12 was only 3 years old at the time, and users with older macs would suffer from crashes when using the core library built with a newer mac. However, today, macOS 10.12 is over 8 years old, and the version below that, OS X 10.11 El Capitan, is over 9 years old and hasn't received security updates since 2018, so there should be next to zero people using this version. 

### Solution

This PR trivially reverts that change, as practically every modern mac used today has monotonic clock support, and there's no need to force an entire OS off of `clock_gettime()` now.