### PR TITLE
feat: add error information in the progress callback

### DIFF
--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -82,6 +82,7 @@ pub struct TSInput {
 pub struct TSParseState {
     pub payload: *mut ::core::ffi::c_void,
     pub current_byte_offset: u32,
+    pub has_error: bool,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -147,6 +147,11 @@ impl ParseState {
     pub const fn current_byte_offset(&self) -> usize {
         unsafe { self.0.as_ref() }.current_byte_offset as usize
     }
+
+    #[must_use]
+    pub const fn has_error(&self) -> bool {
+        unsafe { self.0.as_ref() }.has_error
+    }
 }
 
 /// A stateful object that is passed into a [`QueryProgressCallback`]

--- a/lib/binding_web/lib/imports.js
+++ b/lib/binding_web/lib/imports.js
@@ -23,9 +23,9 @@ mergeInto(LibraryManager.library, {
     }
   },
 
-  tree_sitter_progress_callback(currentOffset) {
+  tree_sitter_progress_callback(currentOffset, hasError) {
     if (Module.currentProgressCallback) {
-      return Module.currentProgressCallback({ currentOffset });
+      return Module.currentProgressCallback({ currentOffset, hasError });
     }
     return false;
   },

--- a/lib/binding_web/lib/tree-sitter.c
+++ b/lib/binding_web/lib/tree-sitter.c
@@ -139,7 +139,8 @@ extern void tree_sitter_log_callback(
 );
 
 extern bool tree_sitter_progress_callback(
-  uint32_t current_offset
+  uint32_t current_offset,
+  bool has_error
 );
 
 extern bool tree_sitter_query_progress_callback(
@@ -178,7 +179,7 @@ static void call_log_callback(
 static bool progress_callback(
   TSParseState *state
 ) {
-  return tree_sitter_progress_callback(state->current_byte_offset);
+  return tree_sitter_progress_callback(state->current_byte_offset, state->has_error);
 }
 
 static bool query_progress_callback(

--- a/lib/binding_web/src/parser.ts
+++ b/lib/binding_web/src/parser.ts
@@ -53,6 +53,9 @@ export interface ParseOptions {
 export interface ParseState {
   /** The byte offset in the document that the parser is at. */
   currentOffset: number;
+
+  /** Indicates whether the parser has encountered an error during parsing. */
+  hasError: boolean;
 }
 
 /**

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -94,6 +94,7 @@ typedef struct TSInput {
 typedef struct TSParseState {
   void *payload;
   uint32_t current_byte_offset;
+  bool has_error;
 } TSParseState;
 
 typedef struct TSParseOptions {


### PR DESCRIPTION
Hi Tree-Sitter team!

Taking another stab at this since [my last PR](https://github.com/tree-sitter/tree-sitter/pull/2289#event-12066393031), leveraging the upcoming callback paradigm introduced by https://github.com/tree-sitter/tree-sitter/pull/3843

In https://github.com/tree-sitter/tree-sitter/issues/2541 my notion of exiting early didn't seem to make the cut when the issue was closed. In the PR this [thread](https://github.com/tree-sitter/tree-sitter/pull/3843#discussion_r1823579755) between @amaanq & @maxbrunsfeld briefly talked about it. I got the impression from having a brief [conversation](https://github.com/tree-sitter/tree-sitter/issues/2541#issuecomment-2502557752) with @amaanq that my prior attempt was errant from trying to infer an error too early.

This PR instead is attempting to report to the callback that an error node will be added to the tree.

To be clear that's the scenario I'm interested in. Because if there's a portion of the tree that is just an error node I'm no longer interested in the tree at all and would prefer to cancel processing rather than waste time executing further.

I also noted [this site](https://github.com/tree-sitter/tree-sitter/blob/69d977d73648010d7060001fa518f3198a41a7e5/lib/src/parser.c#L1493) as being an alternative, but wasn't sure if that'd be preferable to what I ended up pushing up.

As always happy to make changes