### PR TITLE
Expose members of `TSHighlighter`.

### DIFF
--- a/highlight/src/c_lib.rs
+++ b/highlight/src/c_lib.rs
@@ -9,10 +9,10 @@ use tree_sitter::Language;
 use super::{Error, Highlight, HighlightConfiguration, Highlighter, HtmlRenderer};
 
 pub struct TSHighlighter {
-    languages: HashMap<String, (Option<Regex>, HighlightConfiguration)>,
-    attribute_strings: Vec<&'static [u8]>,
-    highlight_names: Vec<String>,
-    carriage_return_index: Option<usize>,
+    pub languages: HashMap<String, (Option<Regex>, HighlightConfiguration)>,
+    pub attribute_strings: Vec<&'static [u8]>,
+    pub highlight_names: Vec<String>,
+    pub carriage_return_index: Option<usize>,
 }
 
 pub struct TSHighlightBuffer {


### PR DESCRIPTION
We at GitHub need this as part of our syntax highlighting pipeline, so as to provide fluent support for highlighting via CSS syntax directives rather than pure-HTML ones. We’re currently hacking around this by keeping a copy of the `TSHighlighter` struct in our source code and doing unsafe casts to it, which is pretty fragile. It would be great to expose these fields (or provide accessor functions, which I’m happy to do).