### PR TITLE
3991/word token

### DIFF
--- a/cli/generate/src/build_tables/mod.rs
+++ b/cli/generate/src/build_tables/mod.rs
@@ -202,10 +202,10 @@ fn populate_used_symbols(
     parse_table.symbols.push(Symbol::end());
     for (i, value) in terminal_usages.into_iter().enumerate() {
         if value {
-            // Assign the grammar's word token a low numerical index. This ensures that
+            // Assign the grammar's "word" token a low numerical index. This ensures that
             // it can be stored in a subtree with no heap allocations, even for grammars with
             // very large numbers of tokens. This is an optimization, but it's also important to
-            // ensure that a subtree's symbol can be successfully reassigned to the word token
+            // ensure that a subtree's symbol can be successfully reassigned to the "word" token
             // without having to move the subtree to the heap.
             // See https://github.com/tree-sitter/tree-sitter/issues/258
             if syntax_grammar.word_token.map_or(false, |t| t.index == i) {
@@ -279,7 +279,7 @@ fn identify_keywords(
     let mut cursor = NfaCursor::new(&lexical_grammar.nfa, Vec::new());
 
     // First find all of the candidate keyword tokens: tokens that start with
-    // letters or underscore and can match the same string as a word token.
+    // letters or underscore and can match the same string as a "word" token.
     let keyword_candidates = lexical_grammar
         .variables
         .iter()
@@ -331,8 +331,8 @@ fn identify_keywords(
                     continue;
                 }
 
-                // If the word token was already valid in every state containing
-                // this keyword candidate, then substituting the word token won't
+                // If the "word" token was already valid in every state containing
+                // this keyword candidate, then substituting the "word" token won't
                 // introduce any new lexical conflicts.
                 if coincident_token_index
                     .states_with(*token, Symbol::terminal(other_index))

--- a/cli/generate/src/prepare_grammar/extract_tokens.rs
+++ b/cli/generate/src/prepare_grammar/extract_tokens.rs
@@ -141,7 +141,7 @@ pub(super) fn extract_tokens(
         let token = symbol_replacer.replace_symbol(token);
         if token.is_non_terminal() {
             return Err(anyhow!(
-                "Non-terminal symbol '{}' cannot be used as the word token",
+                "Non-terminal symbol '{}' cannot be used as the \"word\" token",
                 &variables[token.index].name
             ));
         }

--- a/cli/generate/src/prepare_grammar/intern_symbols.rs
+++ b/cli/generate/src/prepare_grammar/intern_symbols.rs
@@ -68,7 +68,7 @@ pub(super) fn intern_symbols(grammar: &InputGrammar) -> Result<InternedGrammar> 
         word_token = Some(
             interner
                 .intern_name(name)
-                .ok_or_else(|| anyhow!("Undefined symbol `{name}` as grammar's word token"))?,
+                .ok_or_else(|| anyhow!("Undefined symbol `{name}` as grammar's \"word\" token"))?,
         );
     }
 

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -1686,7 +1686,7 @@ static bool ts_parser__advance(
 
     // If there were no parse actions for the current lookahead token, then
     // it is not valid in this state. If the current lookahead token is a
-    // keyword, then switch to treating it as the normal word token if that
+    // keyword, then switch to treating it as the normal "word" token if that
     // token is valid in this state.
     if (
       ts_subtree_is_keyword(lookahead) &&


### PR DESCRIPTION
I added quotation marks around `word` in every occurrence of `"word token"` that was about the token called `word`, including in comments. This should avoid confusion for people creating grammars who run into this bug and are using `token(...)` in their code.

See discussion [here](https://discord.com/channels/1063097320771698699/1063097321648312354/1315715723502555206) for an example

**Edit** Oh this would close #3991 