### PR TITLE
enhancement: do not validate e-mail address during grammar init

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -586,11 +586,11 @@ impl Init {
             };
 
             let email = || {
-                Input::with_theme(&ColorfulTheme::default())
+                Input::<String>::with_theme(&ColorfulTheme::default())
                     .with_prompt("Author email")
                     .allow_empty(true)
                     .interact_text()
-                    .map(|e: String| (!e.trim().is_empty()).then_some(e))
+                    .map(|e| (!e.trim().is_empty()).then_some(e))
             };
 
             let url = || {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -588,20 +588,9 @@ impl Init {
             let email = || {
                 Input::with_theme(&ColorfulTheme::default())
                     .with_prompt("Author email")
-                    .validate_with({
-                        move |input: &String| -> Result<(), &str> {
-                            if (input.contains('@') && input.contains('.'))
-                                || input.trim().is_empty()
-                            {
-                                Ok(())
-                            } else {
-                                Err("This is not a valid email address")
-                            }
-                        }
-                    })
                     .allow_empty(true)
                     .interact_text()
-                    .map(|e| (!e.trim().is_empty()).then_some(e))
+                    .map(|e: String| (!e.trim().is_empty()).then_some(e))
             };
 
             let url = || {


### PR DESCRIPTION
fixes and will close #3994

Removed email validation and added explicit type parameter (`: String`) a few lines down because linter recommended it.