### PR TITLE
feat: add nushell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete_nushell"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "315902e790cc6e5ddd20cbd313c1d0d49db77f191e149f96397230fb82a17677"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1718,7 @@ dependencies = [
  "bstr",
  "clap",
  "clap_complete",
+ "clap_complete_nushell",
  "ctor",
  "ctrlc",
  "dialoguer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ clap = { version = "4.5.21", features = [
   "unstable-styles",
 ] }
 clap_complete = "4.5.38"
+clap_complete_nushell = "4.5.4"
 ctor = "0.2.9"
 ctrlc = { version = "3.4.5", features = ["termination"] }
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,6 +33,7 @@ anyhow.workspace = true
 bstr.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
+clap_complete_nushell.workspace = true
 ctor.workspace = true
 ctrlc.workspace = true
 dialoguer.workspace = true

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 use anstyle::{AnsiColor, Color, Style};
 use anyhow::{anyhow, Context, Result};
 use clap::{crate_authors, Args, Command, FromArgMatches as _, Subcommand, ValueEnum};
-use clap_complete::{generate, Shell};
+use clap_complete::generate;
 use dialoguer::{theme::ColorfulTheme, Confirm, FuzzySelect, Input};
 use glob::glob;
 use heck::ToUpperCamelCase;
@@ -447,6 +447,16 @@ struct Complete {
         help = "The shell to generate completions for"
     )]
     pub shell: Shell,
+}
+
+#[derive(ValueEnum, Clone)]
+pub enum Shell {
+    Bash,
+    Elvish,
+    Fish,
+    PowerShell,
+    Zsh,
+    Nushell,
 }
 
 impl InitConfig {
@@ -1293,12 +1303,19 @@ impl DumpLanguages {
 
 impl Complete {
     fn run(self, cli: &mut Command) {
-        generate(
-            self.shell,
-            cli,
-            cli.get_name().to_string(),
-            &mut std::io::stdout(),
-        );
+        let name = cli.get_name().to_string();
+        let mut stdout = std::io::stdout();
+
+        match self.shell {
+            Shell::Bash => generate(clap_complete::shells::Bash, cli, &name, &mut stdout),
+            Shell::Elvish => generate(clap_complete::shells::Elvish, cli, &name, &mut stdout),
+            Shell::Fish => generate(clap_complete::shells::Fish, cli, &name, &mut stdout),
+            Shell::PowerShell => {
+                generate(clap_complete::shells::PowerShell, cli, &name, &mut stdout);
+            }
+            Shell::Zsh => generate(clap_complete::shells::Zsh, cli, &name, &mut stdout),
+            Shell::Nushell => generate(clap_complete_nushell::Nushell, cli, &name, &mut stdout),
+        }
     }
 }
 


### PR DESCRIPTION
### Problem

Unfortunately, clap doesn't include `nushell` completions in the `clap_complete` crate, and it'd be nice if we could add nushell completions for consume.

### Solution

Luckily, clap does have a `clap_complete_nushell` crate, but this does involve bringing in another dependency. This is the model they're adopting for the future, so this is not unreasonable to do now.