### PR TITLE
fix(xtask): add emscription version in commit msg

### DIFF
--- a/xtask/src/upgrade_emscripten.rs
+++ b/xtask/src/upgrade_emscripten.rs
@@ -32,7 +32,7 @@ pub fn run() -> Result<()> {
     let repo = Repository::open(".")?;
     create_commit(
         &repo,
-        "build(deps): bump emscripten version",
+        &format!("build(deps): bump emscripten to {version}"),
         &["cli/loader/emscripten-version"],
     )?;
 


### PR DESCRIPTION
Follow-up to https://github.com/tree-sitter/tree-sitter/pull/4015#event-15717971888