### PR TITLE
fix(cli): use xdg config directory on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,27 +488,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +545,17 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1203,12 +1193,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,17 +1338,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1830,7 +1803,6 @@ dependencies = [
  "ctor",
  "ctrlc",
  "dialoguer",
- "dirs",
  "encoding_rs",
  "filetime",
  "glob",
@@ -1875,7 +1847,7 @@ name = "tree-sitter-config"
 version = "0.25.0"
 dependencies = [
  "anyhow",
- "dirs",
+ "etcetera",
  "serde",
  "serde_json",
 ]
@@ -1922,7 +1894,7 @@ version = "0.25.0"
 dependencies = [
  "anyhow",
  "cc",
- "dirs",
+ "etcetera",
  "fs4",
  "indoc",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ clap_complete_nushell = "4.5.4"
 ctor = "0.2.9"
 ctrlc = { version = "3.4.5", features = ["termination"] }
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
-dirs = "5.0.1"
+etcetera = "0.8.0"
 filetime = "0.2.25"
 fs4 = "0.12.0"
 git2 = "0.19.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -37,7 +37,6 @@ clap_complete_nushell.workspace = true
 ctor.workspace = true
 ctrlc.workspace = true
 dialoguer.workspace = true
-dirs.workspace = true
 filetime.workspace = true
 glob.workspace = true
 heck.workspace = true

--- a/cli/config/Cargo.toml
+++ b/cli/config/Cargo.toml
@@ -17,6 +17,6 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-dirs.workspace = true
+etcetera.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/cli/config/src/lib.rs
+++ b/cli/config/src/lib.rs
@@ -2,7 +2,8 @@
 
 use std::{env, fs, path::PathBuf};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
+use etcetera::BaseStrategy as _;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -38,8 +39,24 @@ impl Config {
             return Ok(Some(xdg_path));
         }
 
-        let legacy_path = dirs::home_dir()
-            .ok_or_else(|| anyhow!("Cannot determine home directory"))?
+        if cfg!(target_os = "macos") {
+            let legacy_apple_path = etcetera::base_strategy::Apple::new()?
+                .data_dir() // `$HOME/Library/Application Support/`
+                .join("tree-sitter")
+                .join("config.json");
+            if legacy_apple_path.is_file() {
+                fs::create_dir_all(xdg_path.parent().unwrap())?;
+                fs::rename(&legacy_apple_path, &xdg_path)?;
+                println!(
+                    "Warning: your config.json file has been automatically migrated from \"{}\" to \"{}\"",
+                    legacy_apple_path.display(),
+                    xdg_path.display()
+                );
+                return Ok(Some(xdg_path));
+            }
+        }
+
+        let legacy_path = etcetera::home_dir()?
             .join(".tree-sitter")
             .join("config.json");
         if legacy_path.is_file() {
@@ -50,8 +67,8 @@ impl Config {
     }
 
     fn xdg_config_file() -> Result<PathBuf> {
-        let xdg_path = dirs::config_dir()
-            .ok_or_else(|| anyhow!("Cannot determine config directory"))?
+        let xdg_path = etcetera::choose_base_strategy()?
+            .config_dir()
             .join("tree-sitter")
             .join("config.json");
         Ok(xdg_path)
@@ -63,7 +80,7 @@ impl Config {
     ///   - Location specified by the path parameter if provided
     ///   - `$TREE_SITTER_DIR/config.json`, if the `TREE_SITTER_DIR` environment variable is set
     ///   - `tree-sitter/config.json` in your default user configuration directory, as determined by
-    ///     [`dirs::config_dir`](https://docs.rs/dirs/*/dirs/fn.config_dir.html)
+    ///     [`etcetera::choose_base_strategy`](https://docs.rs/etcetera/*/etcetera/#basestrategy)
     ///   - `$HOME/.tree-sitter/config.json` as a fallback from where tree-sitter _used_ to store
     ///     its configuration
     pub fn load(path: Option<PathBuf>) -> Result<Self> {

--- a/cli/loader/Cargo.toml
+++ b/cli/loader/Cargo.toml
@@ -26,7 +26,7 @@ default = ["tree-sitter-highlight", "tree-sitter-tags"]
 [dependencies]
 anyhow.workspace = true
 cc.workspace = true
-dirs.workspace = true
+etcetera.workspace = true
 fs4.workspace = true
 indoc.workspace = true
 lazy_static.workspace = true


### PR DESCRIPTION
Currently on macOS, the tree-sitter cli program will look inside `$HOME/Library/Application Support/tree-sitter` for a `config.json` file rather than the XDG `$HOME/.config/tree-sitter` location. This is due to our usage of the [`dirs` crate](https://crates.io/crates/dirs), which [doesn't plan on](https://github.com/dirs-dev/directories-rs/issues/47) changing this behavior or adding any additional APIs to access the XDG location. As suggested in #4023, the [`etcetera` crate](https://docs.rs/etcetera/latest/etcetera) provides this functionality as a reasonable drop-in replacement. 

This PR uses `etcetera` to point to `$HOME/.config/tree-sitter` on macOS as the default config location. If a config file is found in the old `$HOME/Library/Application Support/tree-sitter` location, it is moved to the new location and a warning message is printed (similar to the package.json's `tree-sitter` field in https://github.com/tree-sitter/tree-sitter/pull/3700.

Unfortunately I don't have access to an apple computer, so I'll have to wait for someone who does (cc @amaanq maybe?) to confirm that this actually implements the intended behavior on macOS. 

Closes https://github.com/tree-sitter/tree-sitter/issues/4023