### PR TITLE
fix: re-export `StreamingIterator` and `StreamingIteratorMut`

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -28,7 +28,7 @@ use std::os::fd::AsRawFd;
 #[cfg(all(windows, feature = "std"))]
 use std::os::windows::io::AsRawHandle;
 
-use streaming_iterator::{StreamingIterator, StreamingIteratorMut};
+pub use streaming_iterator::{StreamingIterator, StreamingIteratorMut};
 use tree_sitter_language::LanguageFn;
 
 #[cfg(feature = "wasm")]
@@ -2962,6 +2962,10 @@ impl QueryCursor {
     /// captures. Because multiple patterns can match the same set of nodes,
     /// one match may contain captures that appear *before* some of the
     /// captures from a previous match.
+    ///
+    /// Iterating over a `QueryMatches` object requires the `StreamingIterator`
+    /// or `StreamingIteratorMut` trait to be in scope. This can be done via
+    /// `use tree_sitter::StreamingIterator` or `use tree_sitter::StreamingIteratorMut`
     #[doc(alias = "ts_query_cursor_exec")]
     pub fn matches<'query, 'cursor: 'query, 'tree, T: TextProvider<I>, I: AsRef<[u8]>>(
         &'cursor mut self,
@@ -3045,6 +3049,10 @@ impl QueryCursor {
     ///
     /// This is useful if you don't care about which pattern matched, and just
     /// want a single, ordered sequence of captures.
+    ///
+    /// Iterating over a `QueryCaptures` object requires the `StreamingIterator`
+    /// or `StreamingIteratorMut` trait to be in scope. This can be done via
+    /// `use tree_sitter::StreamingIterator` or `use tree_sitter::StreamingIteratorMut`
     #[doc(alias = "ts_query_cursor_exec")]
     pub fn captures<'query, 'cursor: 'query, 'tree, T: TextProvider<I>, I: AsRef<[u8]>>(
         &'cursor mut self,


### PR DESCRIPTION
This PR aims to address the issues brought up in the followup discussion from #3504. Namely, our use of [`streaming_iterator`](https://crates.io/crates/streaming-iterator) leads to some confusion, as users of the rust lib have to import the `streaming_iterator` crate in order to use things like query captures and matches. This change simply re-exports `StreamingIterator` and `StreamingIteratorMut` for the Rust binding. A user can then import them directly from tree-sitter. 

I tested this locally with the following program (note the import of `tree_sitter::StreamingIterator`):

```rust
use anyhow::Result;
use tree_sitter::{Parser, Query, QueryCursor, StreamingIterator};

fn main() -> Result<()> {
    let mut parser = Parser::new();
    parser.set_language(&tree_sitter_c::LANGUAGE.into())?;
    let src = "int x = 0;";
    let tree = parser.parse(src, None).unwrap();
    let querytext = "(identifier)";
    let query = Query::new(&tree_sitter_c::LANGUAGE.into(), querytext).unwrap();
    let mut query_cursor = QueryCursor::new();

    let mut matches = query_cursor.matches(&query, tree.root_node(), src.as_bytes());
    while let Some(m) = matches.next() {
        println!("{m:#?}");
    }
    Ok(())
}
```

This compiles and gives the expected output:

```sh
» cargo run
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/stream_test`
QueryMatch { id: 0, pattern_index: 0, captures: [] }
```