### PR TITLE
update ci paths

### DIFF
--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -2,8 +2,14 @@ name: Check Bindgen Output
 
 on:
   pull_request:
+    paths:
+      - lib/include/tree_sitter/api.h
+      - lib/binding_rust/bindings.rs
   push:
     branches: [master]
+    paths:
+      - lib/include/tree_sitter/api.h
+      - lib/binding_rust/bindings.rs
 
 jobs:
   check-bindgen:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,20 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - docs/**
+      - "**/README.md"
+      - CONTRIBUTING.md
+      - LICENSE
+      - cli/src/templates
   push:
     branches: [master]
+    paths-ignore:
+      - docs/**
+      - "**/README.md"
+      - CONTRIBUTING.md
+      - LICENSE
+      - cli/src/templates
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,8 @@
 name: Deploy Docs
 on:
   push:
-    branches:
-      - "master"
+    branches: [master]
+    paths: [docs/**]
 
 jobs:
   deploy-docs:


### PR DESCRIPTION
### Problem

When the docs are updated, or files like the README or LICENSE, the full CI workflow is run no matter what, which is totally unnecessary.

### Solution

For the main CI, we exclude files in `docs/`, `LICENSE`, any `README.md`, `CONTRIBUTING.md`, and any of the template files.

For the docs CI, we only run a deployment if any file in `docs/` has changed.

For the bindgen CI, we only check the output of bindgen when `api.h` has changed