### PR TITLE
fix(lib): add saturation subtraction to prevent integer underflow

### DIFF
--- a/lib/src/length.h
+++ b/lib/src/length.h
@@ -31,7 +31,7 @@ static inline Length length_add(Length len1, Length len2) {
 
 static inline Length length_sub(Length len1, Length len2) {
   Length result;
-  result.bytes = len1.bytes - len2.bytes;
+  result.bytes = (len1.bytes >= len2.bytes) ? len1.bytes - len2.bytes : 0;
   result.extent = point_sub(len1.extent, len2.extent);
   return result;
 }

--- a/lib/src/lexer.c
+++ b/lib/src/lexer.c
@@ -424,10 +424,7 @@ void ts_lexer_finish(Lexer *self, uint32_t *lookahead_end_byte) {
   // If the token ended at an included range boundary, then its end position
   // will have been reset to the end of the preceding range. Reset the start
   // position to match.
-  if (
-    self->token_end_position.bytes < self->token_start_position.bytes ||
-    point_lt(self->token_end_position.extent, self->token_start_position.extent)
-  ) {
+  if (self->token_end_position.bytes < self->token_start_position.bytes) {
     self->token_start_position = self->token_end_position;
   }
 

--- a/lib/src/point.h
+++ b/lib/src/point.h
@@ -22,7 +22,7 @@ static inline TSPoint point_sub(TSPoint a, TSPoint b) {
   if (a.row > b.row)
     return point__new(a.row - b.row, a.column);
   else
-    return point__new(0, a.column - b.column);
+    return point__new(0, (a.column >= b.column) ? a.column - b.column : 0);
 }
 
 static inline bool point_lte(TSPoint a, TSPoint b) {

--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -157,6 +157,7 @@ static inline bool ts_subtree_can_inline(Length padding, Length size, uint32_t l
     padding.bytes < TS_MAX_INLINE_TREE_LENGTH &&
     padding.extent.row < 16 &&
     padding.extent.column < TS_MAX_INLINE_TREE_LENGTH &&
+    size.bytes < TS_MAX_INLINE_TREE_LENGTH &&
     size.extent.row == 0 &&
     size.extent.column < TS_MAX_INLINE_TREE_LENGTH &&
     lookahead_bytes < 16;


### PR DESCRIPTION
Closes #3962

### Problem

The [`length_sub`](https://github.com/tree-sitter/tree-sitter/blob/7ba0f297e5b71dcc3c8e961447151387c8b0f797/lib/src/length.h#L32) and [`point_sub`](https://github.com/tree-sitter/tree-sitter/blob/7ba0f297e5b71dcc3c8e961447151387c8b0f797/lib/src/point.h#L21) functions are not saturating and thus can suffer from underflow in theory. 

This is what's happening with the reproducer in the linked issue, because only valid byte offsets are passed in, and not point offsets, and because of that, when we reparse a tree with an edit, the `Length` created [here](https://github.com/tree-sitter/tree-sitter/blob/7ba0f297e5b71dcc3c8e961447151387c8b0f797/lib/src/parser.c#L645) actually has a negative column value. The reason it's negative is because the start_position is `{0, 15}` whereas the lexer's token start position is `{0, 0}`, and `length_sub` will return us `{0, -15}`. This negative value is then passed into `ts_subtree_can_inline`, where the function returns false when it *should* be returning true, thus breaking a lot of code down the line that eventually causes the query weirdness to surface.

### Solution

In the two aforementioned functions, I've made their subtraction operations saturating, which prevents the column from underflowing. Additionally, a test was added that used to fail before, which is a more trimmed-down version of the reproducer in the linked issue.

### Additional notes

While writing this fix, I decided to add another fix that was on my mind - in https://github.com/tree-sitter/tree-sitter/pull/3770 I fixed an issue with parser hanging when invalid points were passed in, but I realized there was a "more correct" fix for this. Instead of also checking the points to reset the lexer position, it's more correct to use the bytes of the `size` when determining if a subtree can be inlined or not. This is a minor implementation change that does not impact or regress on the bug that was actually fixed.