### PR TITLE
fix(query): ensure immediate matches for any node when an anchor follows a wildcard node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,8 +88,11 @@ jobs:
 
     - name: Install cross
       if: ${{ matrix.use-cross }}
-      # TODO: Remove 'RUSTFLAGS=""' onc https://github.com/cross-rs/cross/issues/1561 is resolved
-      run: RUSTFLAGS="" cargo install cross --git https://github.com/cross-rs/cross
+      run: |
+        if [ ! -x "$(command -v cross)" ]; then
+          # TODO: Remove 'RUSTFLAGS=""' once https://github.com/cross-rs/cross/issues/1561 is resolved
+          RUSTFLAGS="" cargo install cross --git https://github.com/cross-rs/cross
+        fi
 
     - name: Configure cross
       if: ${{ matrix.use-cross }}

--- a/cli/src/tests/helpers/query_helpers.rs
+++ b/cli/src/tests/helpers/query_helpers.rs
@@ -320,8 +320,8 @@ pub fn assert_query_matches(
     let tree = parser.parse(source, None).unwrap();
     let mut cursor = QueryCursor::new();
     let matches = cursor.matches(query, tree.root_node(), source.as_bytes());
-    pretty_assertions::assert_eq!(collect_matches(matches, query, source), expected);
-    pretty_assertions::assert_eq!(cursor.did_exceed_match_limit(), false);
+    pretty_assertions::assert_eq!(expected, collect_matches(matches, query, source));
+    pretty_assertions::assert_eq!(false, cursor.did_exceed_match_limit());
 }
 
 pub fn collect_matches<'a>(


### PR DESCRIPTION
- Closes #1461

### Problem

As described in the linked issue, anonymous wildcard nodes have seemingly bizarre behavior when paired together with an anchor. These queries will consider anonymous nodes right before the following immediate node, but they will also consider named nodes and skip any anonymous nodes in the way before the following immediate node. So for the given python example:

```py
(c, d,)
```

and given a query that captures *any* node (named or anonymous) before the closing parenthesis, such as:
```scm
(tuple _ @last . ")" . )
```

The expected behavior would be that the comma following `d` is captured, as that's the last node before the parenthesis. However, both the comma and the identifier `d` are captured, which is unexpected. I think it makes sense that when we're dealing with anonymous wildcard nodes, we should consider immediate matches that are anonymous or named, not just named and "skipping" anonymous nodes.

### Solution

In the query code, I've added another purpose for the field `seeking_immediate_match` for query states. Before, this was only used for quantified captures to indicate that the next match must be immediate, but now, we're also using it in the event that a wildcard node preceding an anchor can allow for *any* node, anonymous or named. 

This fixes the incorrect behavior observed in the issue, where both the named node before the comma and the comma itself were matching, due to the semantics of the anchor operator when it comes to nodes other than the wildcard node.