### PR TITLE
feat(cli): add json summary of parsing and generate errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,6 +1870,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallbitvec",
+ "thiserror 2.0.9",
  "tree-sitter",
  "url",
 ]

--- a/cli/generate/Cargo.toml
+++ b/cli/generate/Cargo.toml
@@ -29,6 +29,7 @@ semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 smallbitvec.workspace = true
+thiserror.workspace = true
 url.workspace = true
 
 tree-sitter.workspace = true

--- a/cli/generate/src/build_tables/mod.rs
+++ b/cli/generate/src/build_tables/mod.rs
@@ -8,8 +8,9 @@ mod token_conflicts;
 
 use std::collections::{BTreeSet, HashMap};
 
-use anyhow::Result;
 pub use build_lex_table::LARGE_CHARACTER_RANGE_COUNT;
+use build_parse_table::BuildTableResult;
+pub use build_parse_table::ParseTableBuilderError;
 use log::info;
 
 use self::{
@@ -42,7 +43,7 @@ pub fn build_tables(
     variable_info: &[VariableInfo],
     inlines: &InlinedProductionMap,
     report_symbol_name: Option<&str>,
-) -> Result<Tables> {
+) -> BuildTableResult<Tables> {
     let item_set_builder = ParseItemSetBuilder::new(syntax_grammar, lexical_grammar, inlines);
     let following_tokens =
         get_following_tokens(syntax_grammar, lexical_grammar, inlines, &item_set_builder);

--- a/cli/generate/src/rules.rs
+++ b/cli/generate/src/rules.rs
@@ -1,10 +1,11 @@
 use std::{collections::HashMap, fmt};
 
+use serde::Serialize;
 use smallbitvec::SmallBitVec;
 
 use super::grammars::VariableType;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
 pub enum SymbolType {
     External,
     End,
@@ -13,19 +14,19 @@ pub enum SymbolType {
     NonTerminal,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
 pub enum Associativity {
     Left,
     Right,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
 pub struct Alias {
     pub value: String,
     pub is_named: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default, Serialize)]
 pub enum Precedence {
     #[default]
     None,
@@ -35,7 +36,7 @@ pub enum Precedence {
 
 pub type AliasMap = HashMap<Symbol, Alias>;
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize)]
 pub struct MetadataParams {
     pub precedence: Precedence,
     pub dynamic_precedence: i32,
@@ -46,13 +47,13 @@ pub struct MetadataParams {
     pub field_name: Option<String>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
 pub struct Symbol {
     pub kind: SymbolType,
     pub index: usize,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub enum Rule {
     Blank,
     String(String),

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -381,7 +381,8 @@ pub fn generate_grammar_files(
             let Some(opts) = opts else { unreachable!() };
 
             let tree_sitter_json = opts.clone().to_tree_sitter_json();
-            write_file(path, serde_json::to_string_pretty(&tree_sitter_json)?)
+            write_file(path, serde_json::to_string_pretty(&tree_sitter_json)?)?;
+            Ok(())
         },
         |path| {
             // updating the config, if needed
@@ -523,10 +524,9 @@ pub fn generate_grammar_files(
                 |path| {
                     let contents = fs::read_to_string(path)?;
                     if contents.contains("fs.exists(") {
-                        write_file(path, contents.replace("fs.exists(", "fs.existsSync("))
-                    } else {
-                        Ok(())
+                        write_file(path, contents.replace("fs.exists(", "fs.existsSync("))?;
                     }
+                    Ok(())
                 },
             )?;
 
@@ -566,10 +566,9 @@ pub fn generate_grammar_files(
                     let contents = fs::read_to_string(path)?;
                     let old = "add_custom_target(test";
                     if contents.contains(old) {
-                        write_file(path, contents.replace(old, "add_custom_target(ts-test"))
-                    } else {
-                        Ok(())
+                        write_file(path, contents.replace(old, "add_custom_target(ts-test"))?;
                     }
+                    Ok(())
                 },
             )?;
 
@@ -671,10 +670,9 @@ pub fn generate_grammar_files(
                                         "egg_info": EggInfo,
                                 "#},
                             );
-                        write_file(path, contents)
-                    } else {
-                        Ok(())
+                        write_file(path, contents)?;
                     }
+                    Ok(())
                 },
             )?;
 
@@ -951,7 +949,8 @@ fn generate_file(
         }
     }
 
-    write_file(path, replacement)
+    write_file(path, replacement)?;
+    Ok(())
 }
 
 fn create_dir(path: &Path) -> Result<()> {


### PR DESCRIPTION
This PR serves two purposes:

1. Provide the option to output a JSON summary of parsing results. 

This change is fairly small, but a nice addition.

<Details>

<Summary>Small example with a large and small file</Summary>

```sh
» cat small.c
int main(int argc, char *argv[])
{
    int * x = NULL;
    return EXIT_SUCCESS;
}

[lillis@LaptopWill] ~/projects/tree-sitter-c (master)
» /home/lillis/projects/tree-sitter/target/debug/tree-sitter parse -j small.c src/parser.c
src/parser.c    Parse:  991.82 ms         3931 bytes/ms (MISSING identifier [5513, 17] - [5513, 17])
{
  "parse_summaries": [
    {
      "file": "small.c",
      "successful": true,
      "start": {
        "row": 0,
        "column": 0
      },
      "end": {
        "row": 5,
        "column": 0
      },
      "duration": {
        "secs": 0,
        "nanos": 123995
      },
      "bytes": 82
    },
    {
      "file": "src/parser.c",
      "successful": false,
      "start": {
        "row": 0,
        "column": 0
      },
      "end": {
        "row": 119615,
        "column": 0
      },
      "duration": {
        "secs": 0,
        "nanos": 991820360
      },
      "bytes": 3899295
    }
  ],
  "cumulative_stats": {
    "successful_parses": 1,
    "total_parses": 2,
    "total_bytes": 3899377,
    "total_duration": {
      "secs": 0,
      "nanos": 991944355
    }
  }
}
```
</Details>

2. Aggressively refactor how errors are propagated and reported in the `generate` crate

This is a much larger change. Currently, the `generate` crate heavily leans on [anyhow](https://crates.io/crates/anyhow) to create and propagate errors up, typically as a `String`. This is fine for user-facing errors when used via `tree-sitter-cli`, but less than ideal when the `generate` crate is used as a library. Additionally, this makes it difficult to report errors in a machine-readable format (such as JSON). This PR makes heavy used of [thiserror](https://crates.io/crates/thiserror) so that errors consist of structured data. This does add a bit of boilerplate-like code, but also serves to better show how the various pieces of `generate` can fail. In some places, it also serves to significantly streamline some core logic. Since our errors are returned as structured data, we can use serde to report these in JSON if a user desires.

Purposefully breaking the tree-sitter-c grammar yields the following errors:

![image](https://github.com/user-attachments/assets/d4d37ffd-2837-48a1-9c02-e4d1ec43e203)

<Details>
<Summary>Using the --json-errors flag with generate yields this</Summary>

```shell
[lillis@LaptopWill] ~/projects/tree-sitter-c (master)
» /home/lillis/projects/tree-sitter/target/debug/tree-sitter generate --json-errors
{
  "GenerateParser": {
    "BuildTables": {
      "Conflict": {
        "symbol_sequence": [
          "'('",
          "type_specifier",
          "'('",
          "_declaration_specifiers",
          "'('",
          "identifier"
        ],
        "conflicting_lookahead": "')'",
        "possible_interpretations": [
          {
            "preceding_symbols": [
              "'('",
              "type_specifier",
              "'('",
              "_declaration_specifiers",
              "'('"
            ],
            "variable_name": "_declarator",
            "production_step_symbols": [
              "identifier"
            ],
            "step_index": 1,
            "done": true,
            "conflicting_lookahead": "')'",
            "precedence": null,
            "associativity": null
          },
          {
            "preceding_symbols": [
              "'('",
              "type_specifier",
              "'('",
              "_declaration_specifiers",
              "'('"
            ],
            "variable_name": "type_specifier",
            "production_step_symbols": [
              "identifier"
            ],
            "step_index": 1,
            "done": true,
            "conflicting_lookahead": "')'",
            "precedence": null,
            "associativity": null
          }
        ],
        "possible_resolutions": [
          {
            "Precedence": {
              "symbols": [
                "_declarator"
              ]
            }
          },
          {
            "Precedence": {
              "symbols": [
                "type_specifier"
              ]
            }
          },
          {
            "AddConflict": {
              "symbols": [
                "_declarator",
                "type_specifier"
              ]
            }
          }
        ]
      }
    }
  }
}
```
</Details>

Closes #3182