### PR TITLE
fix(cli): correct range in cst pretty printer

### DIFF
--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -679,7 +679,12 @@ fn write_node_text(
             // and adjust the column by setting it to the length of *this* line.
             node_range.start_point.row += i;
             node_range.end_point.row = node_range.start_point.row;
-            node_range.end_point.column = line.len();
+            node_range.end_point.column = line.len()
+                + if i == 0 {
+                    node_range.start_point.column
+                } else {
+                    0
+                };
             let formatted_line = render_line_feed(line, opts);
             if !opts.no_ranges {
                 write!(


### PR DESCRIPTION
Noticed this while testing out #4054. There's a small logic error in the range rendering logic for named nodes. We currently manually set the end column to the length of the node's text. This is incorrect for a node's first line of text if it isn't the first node on that line. 

Before (note the incorrect `1` column value for several of the node range's end points):

![image](https://github.com/user-attachments/assets/5887f1d8-f597-42c7-abcd-9736fbcefb47)

After:

![image](https://github.com/user-attachments/assets/8fce60f7-ba03-4bc5-8091-f894ae058cbe)