### PR TITLE
chore(generate): remove unused fields

### DIFF
--- a/cli/generate/src/rules.rs
+++ b/cli/generate/src/rules.rs
@@ -41,8 +41,6 @@ pub struct MetadataParams {
     pub dynamic_precedence: i32,
     pub associativity: Option<Associativity>,
     pub is_token: bool,
-    pub is_string: bool,
-    pub is_active: bool,
     pub is_main_token: bool,
     pub alias: Option<Alias>,
     pub field_name: Option<String>,


### PR DESCRIPTION
As far as I can tell, these aren't used.
The real question is, why isn't dead code reported as a warning? I took a look, and couldn't figure it out.