### PR TITLE
fix(lib): prevent wildcards from incorrectly marking child patterns as infallible

### DIFF
--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -5520,3 +5520,33 @@ fn f() {
     );
     assert_eq!(matches, flipped_matches);
 }
+
+#[test]
+fn test_wildcard_parent_allows_fallible_child_patterns() {
+    let language = get_language("javascript");
+    let mut parser = Parser::new();
+    parser.set_language(&language).unwrap();
+
+    let source_code = r#"
+function foo() {
+    "bar"
+}
+    "#;
+
+    let query = Query::new(
+        &language,
+        "(function_declaration
+          (_
+            (expression_statement)
+          )
+        ) @part",
+    )
+    .unwrap();
+
+    assert_query_matches(
+        &language,
+        &query,
+        source_code,
+        &[(0, vec![("part", "function foo() {\n    \"bar\"\n}")])],
+    );
+}

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -3004,7 +3004,7 @@ bool ts_query__step_is_fallible(
   return (
     next_step->depth != PATTERN_DONE_MARKER &&
     next_step->depth > step->depth &&
-    !next_step->parent_pattern_guaranteed
+    (!next_step->parent_pattern_guaranteed || step->symbol == WILDCARD_SYMBOL)
   );
 }
 


### PR DESCRIPTION
- Closes #2483

### Problem

When a query pattern had a wildcard parent followed by a specific child pattern  (like `(_ (expression_statement))`), we incorrectly treated the child pattern as guaranteed to match based on its `parent_pattern_guaranteed` flag in `ts_query__step_is_fallible`. However, this flag only indicates that the pattern is guaranteed *after* we've successfully matched a wildcard node that contains the required child - it doesn't mean the child pattern will match under any wildcard parent.

For example, in the following JavaScript snippet, `function foo() { "bar" }`, the pattern `(function_declaration (_ (expression_statement)))` should be treated as fallible when we're at the wildcard query step since the wildcard could match nodes that don't contain an expression_statement.

### Solution

In `ts_query__step_is_fallible`, we change the condition to treat any step that is not done and has a depth larger than the current step as fallible if it has a wildcard parent.