### PR TITLE
fix(lib): don't consider unfinished captures definite when the following step is immediate

### DIFF
--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -3206,7 +3206,7 @@ static bool ts_query_cursor__first_in_progress_capture(
   uint32_t *state_index,
   uint32_t *byte_offset,
   uint32_t *pattern_index,
-  bool *root_pattern_guaranteed
+  bool *is_definite
 ) {
   bool result = false;
   *state_index = UINT32_MAX;
@@ -3241,8 +3241,11 @@ static bool ts_query_cursor__first_in_progress_capture(
       (node_start_byte == *byte_offset && state->pattern_index < *pattern_index)
     ) {
       QueryStep *step = &self->query->steps.contents[state->step_index];
-      if (root_pattern_guaranteed) {
-        *root_pattern_guaranteed = step->root_pattern_guaranteed;
+      if (is_definite) {
+        // We're being a bit conservative here by asserting that the following step
+        // is not immediate, because this capture might end up being discarded if the
+        // following symbol in the tree isn't the required symbol for this step.
+        *is_definite = step->root_pattern_guaranteed && !step->is_immediate;
       } else if (step->root_pattern_guaranteed) {
         continue;
       }


### PR DESCRIPTION
- Closes #2750

### Problem

When collecting captures with the query cursor, unfinished captures were incorrectly marked as "definite" even when they had pending immediate steps from an anchor (`.`). This caused captures to be returned prematurely before verifying if they would be discarded by the anchor constraint, leading to extra captures being returned that should have been filtered out when iterating with `ts_query_cursor_next_capture`.

Given the query `(array (_) @foo . "]")`, we would capture all elements in the array rather than just the last one before the closing bracket when iterating over *captures* (iterating over matches was unaffected).

### Solution

In `ts_query_cursor__first_in_progress_capture`, we're a little more conservative about when an unfinished capture is considered definite. A capture is now only marked as definite if its pattern is guaranteed **and** there are no pending immediate steps that could cause the capture to be discarded later.