### PR TITLE
Update gitignore for .exp/.lib

### DIFF
--- a/cli/src/templates/gitignore
+++ b/cli/src/templates/gitignore
@@ -25,6 +25,8 @@ dist/
 *.dylib
 *.dll
 *.pc
+*.exp
+*.lib
 
 # Example dirs
 /examples/*/


### PR DESCRIPTION
On Windows tree-sitter-cli creates parser.exp and parser.lib so ideally we'd exclude those automatically.