### PR TITLE
fix(cli): remove double print of generate errors

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1636,7 +1636,7 @@ fn main() {
             }
         }
         if !err.to_string().is_empty() {
-            eprintln!("{err:?}");
+            eprintln!("{err}");
         }
         std::process::exit(1);
     }


### PR DESCRIPTION
Followup to #4048. 

Since we're returning errors as structured data (rather than anyhow's error type) from `tree_sitter_generate::generate_parser_in_directory`, our usage of the debug print specifier with said error causes the contents to be printed twice:

![image](https://github.com/user-attachments/assets/3383f912-85dd-468c-9b75-546d147df970)

Since `Error` implements `Display`, it should be fine to just print them without the debug specifier:

![image](https://github.com/user-attachments/assets/6cefccf1-0887-4ad4-98d8-4b812a2105a3)