### PR TITLE
Add failing test showing empty next named sibling

### DIFF
--- a/cli/src/tests/node_test.rs
+++ b/cli/src/tests/node_test.rs
@@ -334,6 +334,33 @@ fn test_next_sibling_of_zero_width_node() {
 }
 
 #[test]
+fn test_missing_next_named_sibling() {
+    let grammar_json = load_grammar_file(
+        &fixtures_dir()
+            .join("test_grammars")
+            .join("missing_next_named_sibling")
+            .join("grammar.js"),
+        None,
+    )
+    .unwrap();
+
+    let (parser_name, parser_code) = generate_parser_for_grammar(&grammar_json).unwrap();
+
+    let mut parser = Parser::new();
+    let language = get_test_language(&parser_name, &parser_code, None);
+    parser.set_language(&language).unwrap();
+
+    let tree = parser.parse("(a) b c", None).unwrap();
+
+    let root_node = tree.root_node();
+    let lit_lit = root_node.child(0).unwrap();
+    assert_eq!(lit_lit.kind(), "list_lit");
+
+    let sym_lit = lit_lit.next_named_sibling().map(|node| node.kind());
+    assert_eq!(sym_lit, Some("sym_lit"));
+}
+
+#[test]
 fn test_node_field_name_for_child() {
     let mut parser = Parser::new();
     parser.set_language(&get_language("c")).unwrap();

--- a/test/fixtures/test_grammars/missing_next_named_sibling/corpus.txt
+++ b/test/fixtures/test_grammars/missing_next_named_sibling/corpus.txt
@@ -1,0 +1,9 @@
+===========================
+missing next named sibling
+===========================
+
+(a) b c
+
+---
+
+(source (list_lit (sym_lit (sym_name))) (sym_lit (sym_name)) (sym_lit (sym_name)))

--- a/test/fixtures/test_grammars/missing_next_named_sibling/grammar.js
+++ b/test/fixtures/test_grammars/missing_next_named_sibling/grammar.js
@@ -1,0 +1,66 @@
+// This is a partial extraction of the clojure grammar found at
+// https://github.com/sogaiu/tree-sitter-clojure
+
+function regex(...patts) {
+  return RegExp(patts.join(""));
+}
+
+const WHITESPACE_CHAR = regex(
+  "[",
+  "\\f\\n\\r\\t, ",
+  "\\u000B\\u001C\\u001D\\u001E\\u001F",
+  "\\u2028\\u2029\\u1680",
+  "\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2008",
+  "\\u2009\\u200a\\u205f\\u3000",
+  "]",
+);
+
+const WHITESPACE = token(repeat1(WHITESPACE_CHAR));
+
+const SYMBOL_HEAD = regex(
+  "[^",
+  "\\f\\n\\r\\t ",
+  "/",
+  "()\\[\\]{}",
+  '"',
+  "@~^;`",
+  "\\\\",
+  ",:#'0-9",
+  "\\u000B\\u001C\\u001D\\u001E\\u001F",
+  "\\u2028\\u2029\\u1680",
+  "\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2008",
+  "\\u2009\\u200a\\u205f\\u3000",
+  "]",
+);
+
+const SYMBOL_BODY = choice(SYMBOL_HEAD, regex("[:#'0-9]"));
+
+const SYMBOL = token(seq(SYMBOL_HEAD, repeat(SYMBOL_BODY)));
+
+module.exports = grammar({
+  name: "missing_next_named_sibling",
+
+  extras: ($) => [],
+
+  conflicts: ($) => [],
+
+  rules: {
+    source: ($) => repeat(choice($._form, $._gap)),
+
+    _ws: ($) => WHITESPACE,
+    _gap: ($) => choice($._ws),
+
+    _form: ($) => choice($.sym_lit, $.list_lit),
+
+    _sym_unqualified: ($) => field("name", alias(choice(SYMBOL), $.sym_name)),
+    sym_lit: ($) => seq(choice($._sym_unqualified)),
+
+    _bare_list_lit: ($) =>
+      seq(
+        field("open", "("),
+        repeat(choice(field("value", $._form), $._gap)),
+        field("close", ")"),
+      ),
+    list_lit: ($) => seq($._bare_list_lit),
+  },
+});


### PR DESCRIPTION
This adds a test to reproduce the regression described in https://github.com/tree-sitter/tree-sitter/issues/4062.

This extracts the relevant parts of the clojure grammar to demonstrate the issue.

This test passes on commits prior to 5d1be54, for example this was tested on v0.24.4.