### PR TITLE
fix(wasm): check docker presence without arguments

### DIFF
--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -986,7 +986,6 @@ impl Loader {
         let source = if !force_docker && Command::new(emcc_name).output().is_ok() {
             EmccSource::Native
         } else if Command::new("docker")
-            .arg("info")
             .output()
             .is_ok_and(|out| out.status.success())
         {

--- a/xtask/src/build_wasm.rs
+++ b/xtask/src/build_wasm.rs
@@ -33,7 +33,6 @@ pub fn run_wasm(args: &BuildWasm) -> Result<()> {
     let source = if !args.docker && Command::new(emcc_name).output().is_ok() {
         EmccSource::Native
     } else if Command::new("docker")
-        .arg("info")
         .output()
         .is_ok_and(|out| out.status.success())
     {


### PR DESCRIPTION
Problem:
When the Docker daemon is not running, the wasm build process
incorrectly reports that Docker is not found in PATH. This happens
because the `docker info` command fails when the daemon is not active,
even though the `docker` executable is present.

Solution:
Replace the use of `docker info` with a simple execution of `docker`
(without arguments) to reliably check for its presence, regardless of
the daemon's state.