### PR TITLE
feat(playground): provide colored highlight for captures in code editor

### DIFF
--- a/cli/src/playground.html
+++ b/cli/src/playground.html
@@ -32,6 +32,11 @@
       </div>
 
       <div class="header-item">
+        <input id="accessibility-checkbox" type="checkbox">
+        <label for="accessibility-checkbox">accessibility</label>
+      </div>
+
+      <div class="header-item">
         <label for="update-time">parse time: </label>
         <span id="update-time"></span>
       </div>

--- a/docs/src/7-playground.md
+++ b/docs/src/7-playground.md
@@ -59,6 +59,9 @@
 <input id="query-checkbox" type="checkbox"></input>
 <label for="query-checkbox">Query</label>
 
+<input id="accessibility-checkbox" type="checkbox"></input>
+<label for="accessibility-checkbox">Accessibility</label>
+
 <textarea id="code-input">
 </textarea>
 

--- a/docs/src/assets/js/playground.js
+++ b/docs/src/assets/js/playground.js
@@ -114,6 +114,7 @@ window.initializePlayground = async function initializePlayground(opts) {
   const queryCheckbox = document.getElementById("query-checkbox");
   const queryContainer = document.getElementById("query-container");
   const queryInput = document.getElementById("query-input");
+  const accessibilityCheckbox = document.getElementById("accessibility-checkbox");
   const updateTimeSpan = document.getElementById("update-time");
   const languagesByName = {};
 
@@ -172,6 +173,7 @@ window.initializePlayground = async function initializePlayground(opts) {
   loggingCheckbox.addEventListener("change", handleLoggingChange);
   anonymousNodes.addEventListener('change', renderTree);
   queryCheckbox.addEventListener("change", handleQueryEnableChange);
+  accessibilityCheckbox.addEventListener("change",handleQueryChange);
   languageSelect.addEventListener("change", handleLanguageChange);
   outputContainer.addEventListener("click", handleTreeClick);
 
@@ -321,6 +323,14 @@ window.initializePlayground = async function initializePlayground(opts) {
     handleCursorMovement();
   }
 
+  function getCaptureCSS(name) {
+    if (accessibilityCheckbox.checked) {
+      return `color: white; background-color: ${colorForCaptureName(name)}`;
+    } else {
+      return `color: ${colorForCaptureName(name)}`;
+    }
+  }
+
   function runTreeQuery(_, startRow, endRow) {
     if (endRow == null) {
       const viewport = codeEditor.getViewport();
@@ -349,7 +359,7 @@ window.initializePlayground = async function initializePlayground(opts) {
             {
               inclusiveLeft: true,
               inclusiveRight: true,
-              css: `color: ${colorForCaptureName(name)}`,
+              css: getCaptureCSS(name),
             },
           );
         }


### PR DESCRIPTION
This slightly alters how captures how captures are differentiated in the playground's editor, making it more accessible to those with color blindness as described in #1714. 

Quick demo:

![accessibility_captures](https://github.com/user-attachments/assets/78580624-a3ff-4fae-9cfa-f93444924712)

While the original issue just mentioned captures in the code editor, should this change also be applied to the captures in the query editor as well?

Closes #1714