### PR TITLE
fix(lib): use inclusive range check for non-empty nodes in next sibling computation

### DIFF
--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -264,7 +264,15 @@ static inline TSNode ts_node__next_sibling(TSNode self, bool include_anonymous) 
     NodeChildIterator iterator = ts_node_iterate_children(&node);
     while (ts_node_child_iterator_next(&iterator, &child)) {
       if (iterator.position.bytes <= target_end_byte) continue;
-      if (ts_node_start_byte(child) < ts_node_start_byte(self)) {
+      uint32_t start_byte = ts_node_start_byte(self);
+      uint32_t child_start_byte = ts_node_start_byte(child);
+
+      bool is_empty = start_byte == target_end_byte;
+      bool contains_target = is_empty ?
+        child_start_byte < start_byte :
+        child_start_byte <= start_byte;
+
+      if (contains_target) {
         if (ts_node__subtree(child).ptr != ts_node__subtree(self).ptr) {
           child_containing_target = child;
         }


### PR DESCRIPTION
- Closes #4062