### PR TITLE
fix(rust): adapt to a few new nightly lints

### DIFF
--- a/cli/generate/src/build_tables/build_lex_table.rs
+++ b/cli/generate/src/build_tables/build_lex_table.rs
@@ -359,9 +359,7 @@ fn minimize_lex_table(table: &mut LexTable, parse_table: &mut ParseTable) {
         &mut group_ids_by_state_id,
         1,
         lex_states_differ,
-    ) {
-        continue;
-    }
+    ) {}
 
     let mut new_states = Vec::with_capacity(state_ids_by_group_id.len());
     for state_ids in &state_ids_by_group_id {

--- a/cli/generate/src/build_tables/minimize_parse_table.rs
+++ b/cli/generate/src/build_tables/minimize_parse_table.rs
@@ -151,9 +151,7 @@ impl Minimizer<'_> {
             &mut group_ids_by_state_id,
             0,
             |left, right, groups| self.state_successors_differ(left, right, groups),
-        ) {
-            continue;
-        }
+        ) {}
 
         let error_group_index = state_ids_by_group_id
             .iter()
@@ -262,7 +260,7 @@ impl Minimizer<'_> {
         for (symbol, s1) in &state1.nonterminal_entries {
             if let Some(s2) = state2.nonterminal_entries.get(symbol) {
                 match (s1, s2) {
-                    (GotoAction::ShiftExtra, GotoAction::ShiftExtra) => continue,
+                    (GotoAction::ShiftExtra, GotoAction::ShiftExtra) => {}
                     (GotoAction::Goto(s1), GotoAction::Goto(s2)) => {
                         let group1 = group_ids_by_state_id[*s1];
                         let group2 = group_ids_by_state_id[*s2];

--- a/cli/generate/src/render.rs
+++ b/cli/generate/src/render.rs
@@ -1056,7 +1056,6 @@ impl Generator {
                     }
                     self.add_character(end);
                     add!(self, ")");
-                    continue;
                 } else if end == start {
                     add!(self, "lookahead == ");
                     self.add_character(start);

--- a/cli/src/tests/corpus_test.rs
+++ b/cli/src/tests/corpus_test.rs
@@ -425,7 +425,6 @@ fn test_feature_corpus_files() {
 
                 if !passed {
                     failure_count += 1;
-                    continue;
                 }
             }
         }

--- a/tags/src/lib.rs
+++ b/tags/src/lib.rs
@@ -149,7 +149,7 @@ impl TagsConfiguration {
                 "doc" => doc_capture_index = Some(i as u32),
                 "local.scope" => local_scope_capture_index = Some(i as u32),
                 "local.definition" => local_definition_capture_index = Some(i as u32),
-                "local.reference" | "" => continue,
+                "local.reference" | "" => {}
                 _ => {
                     let mut is_definition = false;
 


### PR DESCRIPTION
Looks like redundant `continue`'s are on the chopping block now. 