### PR TITLE
build(bindings): move header to tree_sitter subdirectory 

### DIFF
--- a/cli/src/templates/cmakelists.cmake
+++ b/cli/src/templates/cmakelists.cmake
@@ -28,7 +28,10 @@ add_library(tree-sitter-PARSER_NAME src/parser.c)
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/scanner.c)
   target_sources(tree-sitter-PARSER_NAME PRIVATE src/scanner.c)
 endif()
-target_include_directories(tree-sitter-PARSER_NAME PRIVATE src)
+target_include_directories(tree-sitter-PARSER_NAME
+                           PRIVATE src
+                           INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/bindings/c>
+                                     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 target_compile_definitions(tree-sitter-PARSER_NAME PRIVATE
                            $<$<BOOL:${TREE_SITTER_REUSE_ALLOCATOR}>:TREE_SITTER_REUSE_ALLOCATOR>
@@ -46,8 +49,9 @@ configure_file(bindings/c/tree-sitter-PARSER_NAME.pc.in
 
 include(GNUInstallDirs)
 
-install(FILES bindings/c/tree-sitter-PARSER_NAME.h
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tree_sitter")
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/bindings/c/tree_sitter"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+        FILES_MATCHING PATTERN "*.h")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-PARSER_NAME.pc"
         DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig")
 install(TARGETS tree-sitter-PARSER_NAME

--- a/cli/src/templates/gitattributes
+++ b/cli/src/templates/gitattributes
@@ -6,7 +6,7 @@ src/parser.c linguist-generated
 src/tree_sitter/* linguist-generated
 
 # C bindings
-bindings/c/* linguist-generated
+bindings/c/** linguist-generated
 CMakeLists.txt linguist-generated
 Makefile linguist-generated
 

--- a/cli/src/templates/makefile
+++ b/cli/src/templates/makefile
@@ -71,7 +71,7 @@ $(PARSER): $(SRC_DIR)/grammar.json
 
 install: all
 	install -d '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/PARSER_NAME '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter '$(DESTDIR)$(PCLIBDIR)' '$(DESTDIR)$(LIBDIR)'
-	install -m644 bindings/c/$(LANGUAGE_NAME).h '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/$(LANGUAGE_NAME).h
+	install -m644 bindings/c/tree_sitter/$(LANGUAGE_NAME).h '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/$(LANGUAGE_NAME).h
 	install -m644 $(LANGUAGE_NAME).pc '$(DESTDIR)$(PCLIBDIR)'/$(LANGUAGE_NAME).pc
 	install -m644 lib$(LANGUAGE_NAME).a '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).a
 	install -m755 lib$(LANGUAGE_NAME).$(SOEXT) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXTVER)

--- a/docs/src/cli/init.md
+++ b/docs/src/cli/init.md
@@ -126,7 +126,7 @@ to be used from different language. Here is a list of these bindings files that 
 
 - `Makefile` — This file tells [`make`][make] how to compile your language.
 - `CMakeLists.txt` — This file tells [`cmake`][cmake] how to compile your language.
-- `bindings/c/tree-sitter-language.h` — This file provides the C interface of your language.
+- `bindings/c/tree_sitter/tree-sitter-language.h` — This file provides the C interface of your language.
 - `bindings/c/tree-sitter-language.pc` — This file provides [pkg-config][pkg-config] metadata about your language's C library.
 - `src/tree_sitter/parser.h` — This file provides some basic C definitions that are used in your generated `parser.c` file.
 - `src/tree_sitter/alloc.h` — This file provides some memory allocation macros that are to be used in your external scanner,


### PR DESCRIPTION
This patch allows users to include the parser by the same path from local build as well as installed location. Previously it was not possible to include the header prior to installing the built parser.

EDIT: typo.