### PR TITLE
feat!: remove `ts_node_child_containing_descendant` and migration code for `tree-sitter.json`

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -19,7 +19,7 @@ use tree_sitter_cli::{
         LOG_GRAPH_ENABLED, START_SEED,
     },
     highlight::{self, HighlightOptions},
-    init::{generate_grammar_files, get_root_path, migrate_package_json, JsonConfigOpts},
+    init::{generate_grammar_files, get_root_path, JsonConfigOpts},
     input::{get_input, get_tmp_source_file, CliInput},
     logger,
     parse::{self, ParseFileOptions, ParseOutput, ParseTheme},
@@ -497,9 +497,8 @@ impl InitConfig {
 }
 
 impl Init {
-    fn run(self, current_dir: &Path, migrated: bool) -> Result<()> {
-        let configure_json = !current_dir.join("tree-sitter.json").exists()
-            && (!current_dir.join("package.json").exists() || !migrated);
+    fn run(self, current_dir: &Path) -> Result<()> {
+        let configure_json = !current_dir.join("tree-sitter.json").exists();
 
         let (language_name, json_config_opts) = if configure_json {
             let mut opts = JsonConfigOpts::default();
@@ -1640,7 +1639,7 @@ fn main() {
             }
         }
         if !err.to_string().is_empty() {
-            eprintln!("{err}");
+            eprintln!("{err:?}");
         }
         std::process::exit(1);
     }
@@ -1675,17 +1674,9 @@ fn run() -> Result<()> {
     let current_dir = env::current_dir().unwrap();
     let loader = loader::Loader::new()?;
 
-    let migrated = if !current_dir.join("tree-sitter.json").exists()
-        && current_dir.join("package.json").exists()
-    {
-        migrate_package_json(&current_dir).unwrap_or(false)
-    } else {
-        false
-    };
-
     match command {
         Commands::InitConfig(_) => InitConfig::run()?,
-        Commands::Init(init_options) => init_options.run(&current_dir, migrated)?,
+        Commands::Init(init_options) => init_options.run(&current_dir)?,
         Commands::Generate(generate_options) => generate_options.run(loader, &current_dir)?,
         Commands::Build(build_options) => build_options.run(loader, &current_dir)?,
         Commands::Parse(parse_options) => parse_options.run(loader, &current_dir)?,

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -397,15 +397,11 @@ extern "C" {
     pub fn ts_node_next_parse_state(self_: TSNode) -> TSStateId;
 }
 extern "C" {
-    #[doc = " Get the node's immediate parent.\n Prefer [`ts_node_child_containing_descendant`] for\n iterating over the node's ancestors."]
+    #[doc = " Get the node's immediate parent.\n Prefer [`ts_node_child_with_descendant`] for\n iterating over the node's ancestors."]
     pub fn ts_node_parent(self_: TSNode) -> TSNode;
 }
 extern "C" {
-    #[doc = " @deprecated use [`ts_node_contains_descendant`] instead, this will be removed in 0.25\n\n Get the node's child containing `descendant`. This will not return\n the descendant if it is a direct child of `self`, for that use\n `ts_node_contains_descendant`."]
-    pub fn ts_node_child_containing_descendant(self_: TSNode, descendant: TSNode) -> TSNode;
-}
-extern "C" {
-    #[doc = " Get the node that contains `descendant`.\n\n Note that this can return `descendant` itself, unlike the deprecated function\n [`ts_node_child_containing_descendant`]."]
+    #[doc = " Get the node that contains `descendant`.\n\n Note that this can return `descendant` itself."]
     pub fn ts_node_child_with_descendant(self_: TSNode, descendant: TSNode) -> TSNode;
 }
 extern "C" {

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1886,7 +1886,7 @@ impl<'tree> Node<'tree> {
     }
 
     /// Get this node's immediate parent.
-    /// Prefer [`child_containing_descendant`](Node::child_containing_descendant)
+    /// Prefer [`child_with_descendant`](Node::child_with_descendant)
     /// for iterating over this node's ancestors.
     #[doc(alias = "ts_node_parent")]
     #[must_use]
@@ -1894,20 +1894,9 @@ impl<'tree> Node<'tree> {
         Self::new(unsafe { ffi::ts_node_parent(self.0) })
     }
 
-    /// Get this node's child containing `descendant`. This will not return
-    /// the descendant if it is a direct child of `self`, for that use
-    /// [`Node::child_with_descendant`].
-    #[doc(alias = "ts_node_child_containing_descendant")]
-    #[must_use]
-    #[deprecated(since = "0.24.0", note = "Prefer child_with_descendant instead")]
-    pub fn child_containing_descendant(&self, descendant: Self) -> Option<Self> {
-        Self::new(unsafe { ffi::ts_node_child_containing_descendant(self.0, descendant.0) })
-    }
-
     /// Get the node that contains `descendant`.
     ///
-    /// Note that this can return `descendant` itself, unlike the deprecated function
-    /// [`Node::child_containing_descendant`].
+    /// Note that this can return `descendant` itself.
     #[doc(alias = "ts_node_child_with_descendant")]
     #[must_use]
     pub fn child_with_descendant(&self, descendant: Self) -> Option<Self> {

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -605,25 +605,15 @@ TSStateId ts_node_next_parse_state(TSNode self);
 
 /**
  * Get the node's immediate parent.
- * Prefer [`ts_node_child_containing_descendant`] for
+ * Prefer [`ts_node_child_with_descendant`] for
  * iterating over the node's ancestors.
  */
 TSNode ts_node_parent(TSNode self);
 
 /**
- * @deprecated use [`ts_node_contains_descendant`] instead, this will be removed in 0.25
- *
- * Get the node's child containing `descendant`. This will not return
- * the descendant if it is a direct child of `self`, for that use
- * `ts_node_contains_descendant`.
- */
-TSNode ts_node_child_containing_descendant(TSNode self, TSNode descendant);
-
-/**
  * Get the node that contains `descendant`.
  *
- * Note that this can return `descendant` itself, unlike the deprecated function
- * [`ts_node_child_containing_descendant`].
+ * Note that this can return `descendant` itself.
  */
 TSNode ts_node_child_with_descendant(TSNode self, TSNode descendant);
 

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -557,37 +557,6 @@ TSNode ts_node_parent(TSNode self) {
   return node;
 }
 
-TSNode ts_node_child_containing_descendant(TSNode self, TSNode descendant) {
-  uint32_t start_byte = ts_node_start_byte(descendant);
-  uint32_t end_byte = ts_node_end_byte(descendant);
-  bool is_empty = start_byte == end_byte;
-
-  do {
-    NodeChildIterator iter = ts_node_iterate_children(&self);
-    do {
-      if (
-        !ts_node_child_iterator_next(&iter, &self)
-        || ts_node_start_byte(self) > start_byte
-        || self.id == descendant.id
-      ) {
-        return ts_node__null();
-      }
-
-      // If the descendant is empty, and the end byte is within `self`,
-      // we check whether `self` contains it or not.
-      if (is_empty && iter.position.bytes >= end_byte && ts_node_child_count(self) > 0) {
-        TSNode child = ts_node_child_with_descendant(self, descendant);
-        // If the child is not null, return self if it's relevant, else return the child
-        if (!ts_node_is_null(child)) {
-          return ts_node__is_relevant(self, true) ? self : child;
-        }
-      }
-    } while ((is_empty ? iter.position.bytes <= end_byte : iter.position.bytes < end_byte) || ts_node_child_count(self) == 0);
-  } while (!ts_node__is_relevant(self, true));
-
-  return self;
-}
-
 TSNode ts_node_child_with_descendant(TSNode self, TSNode descendant) {
   uint32_t start_byte = ts_node_start_byte(descendant);
   uint32_t end_byte = ts_node_end_byte(descendant);

--- a/xtask/src/check_wasm_exports.rs
+++ b/xtask/src/check_wasm_exports.rs
@@ -15,7 +15,7 @@ use notify_debouncer_full::new_debouncer;
 
 use crate::{bail_on_err, build_wasm::run_wasm, watch_wasm, BuildWasm, CheckWasmExports};
 
-const EXCLUDES: [&str; 28] = [
+const EXCLUDES: [&str; 27] = [
     // Unneeded because the JS side has its own way of implementing it
     "ts_node_child_by_field_name",
     "ts_node_edit",
@@ -25,8 +25,6 @@ const EXCLUDES: [&str; 28] = [
     "ts_node_eq",
     "ts_tree_cursor_current_field_name",
     "ts_lookahead_iterator_current_symbol_name",
-    // Deprecated
-    "ts_node_child_containing_descendant",
     // Not used in wasm
     "ts_init",
     "ts_set_allocator",


### PR DESCRIPTION
Just some cleanup before 0.25