### PR TITLE
fix(cli): fix error display, considering structured data returned from generate command

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -748,7 +748,8 @@ impl Generate {
                 // Exit early to prevent errors from being printed a second time in the caller
                 std::process::exit(1);
             } else {
-                return Err(err.into());
+                // Removes extra context associated with the error
+                Err(anyhow!(err.to_string()))?;
             }
         }
         if self.build {
@@ -1640,7 +1641,7 @@ fn main() {
             }
         }
         if !err.to_string().is_empty() {
-            eprintln!("{err}");
+            eprintln!("{err:?}");
         }
         std::process::exit(1);
     }


### PR DESCRIPTION
While removing the debug specifier fixes a double print for generate errors, it actually causes us to lose some "Caused by:" information for errors returned by other subcommands that utilize anyhow. The solution here is to map generate errors to its string representation earlier, and then still use the debug specifier when printing in `main`.

Followup to https://github.com/tree-sitter/tree-sitter/pull/4083