### PR TITLE
Remove `tree-sitter` dependency from `tree-sitter-generate`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,6 @@
 [alias]
 xtask = "run --package xtask --"
+
+[env]
+# See: https://github.com/rust-lang/cargo/issues/3946#issuecomment-973132993
+CARGO_WORKSPACE_DIR = { value = "", relative = true }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,7 +2014,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.16",
  "topological-sort",
- "tree-sitter",
  "url",
 ]
 

--- a/crates/generate/Cargo.toml
+++ b/crates/generate/Cargo.toml
@@ -47,8 +47,6 @@ smallbitvec.workspace = true
 thiserror.workspace = true
 topological-sort.workspace = true
 
-tree-sitter.workspace = true
-
 [target.'cfg(windows)'.dependencies]
 url = { workspace = true, optional = true }
 

--- a/crates/generate/build.rs
+++ b/crates/generate/build.rs
@@ -1,0 +1,11 @@
+use std::{env, fs, path::PathBuf};
+
+fn main() {
+    // This will always be ran in CI before publishing.
+    // We don't use a symlink for windows compatibility.
+    fs::copy(
+        concat!(env!("CARGO_WORKSPACE_DIR"), "lib/src/parser.h"),
+        PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR should be set")).join("parser.h"),
+    )
+    .expect("failed to copy parser.h template");
+}

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -65,8 +65,11 @@ struct GeneratedParser {
     node_types_json: String,
 }
 
+const LANGUAGE_VERSION: usize = 15;
+
 pub const ALLOC_HEADER: &str = include_str!("templates/alloc.h");
 pub const ARRAY_HEADER: &str = include_str!("templates/array.h");
+pub const PARSER_HEADER: &str = include_str!(concat!(env!("OUT_DIR"), "/parser.h"));
 
 pub type GenerateResult<T> = Result<T, GenerateError>;
 
@@ -271,7 +274,7 @@ where
     fs::create_dir_all(&header_path)?;
     write_file(&header_path.join("alloc.h"), ALLOC_HEADER)?;
     write_file(&header_path.join("array.h"), ARRAY_HEADER)?;
-    write_file(&header_path.join("parser.h"), tree_sitter::PARSER_HEADER)?;
+    write_file(&header_path.join("parser.h"), PARSER_HEADER)?;
 
     Ok(())
 }
@@ -284,7 +287,7 @@ pub fn generate_parser_for_grammar(
     let input_grammar = parse_grammar(&grammar_json)?;
     let parser = generate_parser_for_grammar_with_opts(
         &input_grammar,
-        tree_sitter::LANGUAGE_VERSION,
+        LANGUAGE_VERSION,
         semantic_version,
         None,
     )?;

--- a/crates/generate/src/render.rs
+++ b/crates/generate/src/render.rs
@@ -5,6 +5,7 @@ use std::{
     mem::swap,
 };
 
+use crate::LANGUAGE_VERSION;
 use indoc::indoc;
 
 use super::{
@@ -21,7 +22,7 @@ use super::{
 
 const SMALL_STATE_THRESHOLD: usize = 64;
 pub const ABI_VERSION_MIN: usize = 14;
-pub const ABI_VERSION_MAX: usize = tree_sitter::LANGUAGE_VERSION;
+pub const ABI_VERSION_MAX: usize = LANGUAGE_VERSION;
 const ABI_VERSION_WITH_RESERVED_WORDS: usize = 15;
 const BUILD_VERSION: &str = env!("CARGO_PKG_VERSION");
 


### PR DESCRIPTION
It was only used to share two constants, and balloons it's dependencies.

This also makes `generate_parser_for_grammar` work in wasm. (Tested in `wasm32-wasip2` in wasmtime with the json grammar, `wasm32-unknown-unknown` running in the same setup exited successfully so I'm pretty confident it works as well).

I wasn't sure what to do with `parser.h`, I could've `include_str!`ed it outside the crate, or symlinked it, but I didn't find a conscious if this is ok to do, and apparently `cargo publish` warns against the first one, so I ended up copying it like `alloc.h` and `array.h` (I'm aware these aren't exact copies like `parser.h`). The other constant was `LANGUAGE_VERSION`, `ABI_VERSION_MIN` and `ABI_VERSION_WITH_RESERVED_WORDS` need to be updated anyway so it's not really a problem to manually update it too.