### PR TITLE
feat(cli): improve readability of parse debug output

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,7 +22,7 @@ use tree_sitter_cli::{
     init::{generate_grammar_files, get_root_path, migrate_package_json, JsonConfigOpts},
     input::{get_input, get_tmp_source_file, CliInput},
     logger,
-    parse::{self, ParseFileOptions, ParseOutput, ParseTheme},
+    parse::{self, ParseDebugType, ParseFileOptions, ParseOutput, ParseTheme},
     playground, query,
     tags::{self, TagsOptions},
     test::{self, TestOptions, TestStats},
@@ -171,8 +171,9 @@ struct Parse {
     #[arg(long)]
     pub scope: Option<String>,
     /// Show parsing debug log
-    #[arg(long, short = 'd')]
-    pub debug: bool,
+    #[arg(long, short = 'd')] // TODO: Rework once clap adds `default_missing_value_t`
+    #[allow(clippy::option_option)]
+    pub debug: Option<Option<ParseDebugType>>,
     /// Compile a parser in debug mode
     #[arg(long, short = '0')]
     pub debug_build: bool,
@@ -877,6 +878,11 @@ impl Parse {
 
         let should_track_stats = self.stat;
         let mut stats = parse::ParseStats::default();
+        let debug: ParseDebugType = match self.debug {
+            None => ParseDebugType::Quiet,
+            Some(None) => ParseDebugType::Normal,
+            Some(Some(specifier)) => specifier,
+        };
 
         let mut options = ParseFileOptions {
             edits: &edits
@@ -887,7 +893,7 @@ impl Parse {
             print_time: time,
             timeout,
             stats: &mut stats,
-            debug: self.debug,
+            debug,
             debug_graph: self.debug_graph,
             cancellation_flag: Some(&cancellation_flag),
             encoding,


### PR DESCRIPTION
This improves the readability of the CLI's output when the `-d` flag is passed to the `parse` subcommand. The possible values are `quiet` (no debug output), `normal` (the default, normal debug output), and `pretty` (shown in screenshot below). Each log line is colored corresponding to the log's current process version.

Before: (`parse -d`)

![image](https://github.com/user-attachments/assets/e581ccbb-8173-418e-8cf6-1331dc0f9915)

After: (`parse -d pretty`)

![image](https://github.com/user-attachments/assets/b6d5e258-f95a-4538-acda-38c3ca298c05)

- Closes #1634

Note that we had to use `Option<Option<T>>` for the `--debug` argument type. This is necessary until clap implements `default_missing_value_t` (see https://github.com/clap-rs/clap/discussions/3897#discussioncomment-11299190).