### PR TITLE
ci: add arm ubuntu runner, & use latest runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,16 +36,16 @@ jobs:
           # When adding a new `target`:
           # 1. Define a new platform alias above
           # 2. Add a new record to the matrix map in `cli/npm/install.js`
-          - { platform: linux-arm64       , target: aarch64-unknown-linux-gnu   , os: ubuntu-latest  , use-cross: true }
-          - { platform: linux-arm         , target: arm-unknown-linux-gnueabi   , os: ubuntu-latest  , use-cross: true }
-          - { platform: linux-x64         , target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04   , features: wasm  } # See #2272
-          - { platform: linux-x86         , target: i686-unknown-linux-gnu      , os: ubuntu-latest  , use-cross: true }
-          - { platform: linux-powerpc64   , target: powerpc64-unknown-linux-gnu , os: ubuntu-latest  , use-cross: true }
-          - { platform: windows-arm64     , target: aarch64-pc-windows-msvc     , os: windows-latest                   }
-          - { platform: windows-x64       , target: x86_64-pc-windows-msvc      , os: windows-latest , features: wasm  }
-          - { platform: windows-x86       , target: i686-pc-windows-msvc        , os: windows-latest                   }
-          - { platform: macos-arm64       , target: aarch64-apple-darwin        , os: macos-14       , features: wasm  }
-          - { platform: macos-x64         , target: x86_64-apple-darwin         , os: macos-13       , features: wasm  }
+          - { platform: linux-arm64       , target: aarch64-unknown-linux-gnu   , os: ubuntu-24.04-arm , features: wasm  }
+          - { platform: linux-arm         , target: arm-unknown-linux-gnueabi   , os: ubuntu-latest    , use-cross: true }
+          - { platform: linux-x64         , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest    , features: wasm  }
+          - { platform: linux-x86         , target: i686-unknown-linux-gnu      , os: ubuntu-latest    , use-cross: true }
+          - { platform: linux-powerpc64   , target: powerpc64-unknown-linux-gnu , os: ubuntu-latest    , use-cross: true }
+          - { platform: windows-arm64     , target: aarch64-pc-windows-msvc     , os: windows-latest                     }
+          - { platform: windows-x64       , target: x86_64-pc-windows-msvc      , os: windows-latest   , features: wasm  }
+          - { platform: windows-x86       , target: i686-pc-windows-msvc        , os: windows-latest                     }
+          - { platform: macos-arm64       , target: aarch64-apple-darwin        , os: macos-latest     , features: wasm  }
+          - { platform: macos-x64         , target: x86_64-apple-darwin         , os: macos-13         , features: wasm  }
 
           # Cross compilers for C library
           - { platform: linux-arm64       , cc: aarch64-linux-gnu-gcc           , ar: aarch64-linux-gnu-ar   }


### PR DESCRIPTION
Arm64 runners are in preview, so this will be nice to leverage for build time, but for some reason, the suffix is arm, not arm64 or aarch64 :laughing: [link](https://github.com/orgs/community/discussions/148648#discussion-7793082)

Ok, so even just checking out the repo [fails](https://github.com/tree-sitter/tree-sitter/actions/runs/12839301758/job/35806355649?pr=4123)....I'll keep this as draft for now