### PR TITLE
Fix broken link

### DIFF
--- a/docs/src/7-playground.md
+++ b/docs/src/7-playground.md
@@ -89,7 +89,7 @@ Logging (if enabled) can be viewed in the browser's console.
 <p>The syntax tree should update as you type in the code. As you move around the
 code, the current node should be highlighted in the tree; you can also click any
 node in the tree to select the corresponding part of the code.</p>
-<p>You can enter one or more <a href="/using-parsers/queries/index.html">patterns</a>
+<p>You can enter one or more <a href="/tree-sitter/using-parsers/queries/index.html">patterns</a>
 into the Query panel. If the query is valid, its captures will be
 highlighted both in the Code and in the Query panels. Otherwise
 the problematic parts of the query will be underlined, and detailed


### PR DESCRIPTION
The url to the tree-sitter query patterns was broken.