### PR TITLE
chore(xtask): add success message for wasm watchers

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -305,6 +305,8 @@ macro_rules! watch_wasm {
     ($watch_fn:expr) => {
         if let Err(e) = $watch_fn() {
             eprintln!("{e}");
+        } else {
+            println!("Build succeeded");
         }
 
         let watch_files = [
@@ -335,6 +337,8 @@ macro_rules! watch_wasm {
                         {
                             if let Err(e) = $watch_fn() {
                                 eprintln!("{e}");
+                            } else {
+                                println!("Build succeeded");
                             }
                         }
                     }


### PR DESCRIPTION
Quick followup to #4082.

When using the `--watch` flag with xtask's `check-wasm-exports` and `build-wasm` commands, it's sometimes unclear whether a build has completed and was successful, or if it's still running. This just adds a simple "Build succeeded" message on success to help clear things up.