### PR TITLE
feat: improve the init command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           # When adding a new `target`:
           # 1. Define a new platform alias above
           # 2. Add a new record to the matrix map in `cli/npm/install.js`
-          - { platform: linux-arm64       , target: aarch64-unknown-linux-gnu   , os: ubuntu-24.04-arm , features: wasm  }
+          - { platform: linux-arm64       , target: aarch64-unknown-linux-gnu   , os: ubuntu-latest    , use-cross: true }
           - { platform: linux-arm         , target: arm-unknown-linux-gnueabi   , os: ubuntu-latest    , use-cross: true }
           - { platform: linux-x64         , target: x86_64-unknown-linux-gnu    , os: ubuntu-latest    , features: wasm  }
           - { platform: linux-x86         , target: i686-unknown-linux-gnu      , os: ubuntu-latest    , use-cross: true }

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -217,6 +217,8 @@ pub struct Author {
 pub struct Links {
     pub repository: Url,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub funding: Option<Url>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub homepage: Option<String>,
 }
 

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -167,6 +167,8 @@ pub struct Grammar {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub camelcase: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     pub scope: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<PathBuf>,

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -187,6 +187,8 @@ pub struct Grammar {
     pub first_line_regex: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content_regex: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub class_name: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -22,6 +22,7 @@ const ABI_VERSION_MAX_PLACEHOLDER: &str = "ABI_VERSION_MAX";
 
 const PARSER_NAME_PLACEHOLDER: &str = "PARSER_NAME";
 const CAMEL_PARSER_NAME_PLACEHOLDER: &str = "CAMEL_PARSER_NAME";
+const TITLE_PARSER_NAME_PLACEHOLDER: &str = "TITLE_PARSER_NAME";
 const UPPER_PARSER_NAME_PLACEHOLDER: &str = "UPPER_PARSER_NAME";
 const LOWER_PARSER_NAME_PLACEHOLDER: &str = "LOWER_PARSER_NAME";
 const KEBAB_PARSER_NAME_PLACEHOLDER: &str = "KEBAB_PARSER_NAME";
@@ -119,6 +120,7 @@ pub fn path_in_ignore(repo_path: &Path) -> bool {
 pub struct JsonConfigOpts {
     pub name: String,
     pub camelcase: String,
+    pub title: String,
     pub description: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repository: Option<Url>,
@@ -143,6 +145,7 @@ impl JsonConfigOpts {
             grammars: vec![Grammar {
                 name: self.name.clone(),
                 camelcase: Some(self.camelcase),
+                title: Some(self.title),
                 scope: self.scope,
                 path: None,
                 external_files: PathsJSON::Empty,
@@ -188,6 +191,7 @@ impl Default for JsonConfigOpts {
         Self {
             name: String::new(),
             camelcase: String::new(),
+            title: String::new(),
             description: String::new(),
             repository: None,
             funding: None,
@@ -212,6 +216,7 @@ struct GenerateOpts<'a> {
     funding: Option<&'a str>,
     version: &'a Version,
     camel_parser_name: &'a str,
+    title_parser_name: &'a str,
     class_name: &'a str,
 }
 
@@ -254,6 +259,10 @@ pub fn generate_grammar_files(
         .camelcase
         .clone()
         .unwrap_or_else(|| language_name.to_upper_camel_case());
+    let title_name = tree_sitter_config.grammars[0]
+        .title
+        .clone()
+        .unwrap_or_else(|| language_name.to_upper_camel_case());
     let class_name = tree_sitter_config.grammars[0]
         .class_name
         .clone()
@@ -283,6 +292,7 @@ pub fn generate_grammar_files(
             .and_then(|l| l.funding.as_ref().map(|f| f.as_str())),
         version: &tree_sitter_config.metadata.version,
         camel_parser_name: &camel_name,
+        title_parser_name: &title_name,
         class_name: &class_name,
     };
 
@@ -701,6 +711,10 @@ fn generate_file(
         .replace(
             CAMEL_PARSER_NAME_PLACEHOLDER,
             generate_opts.camel_parser_name,
+        )
+        .replace(
+            TITLE_PARSER_NAME_PLACEHOLDER,
+            generate_opts.title_parser_name,
         )
         .replace(
             UPPER_PARSER_NAME_PLACEHOLDER,

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -24,6 +24,7 @@ const PARSER_NAME_PLACEHOLDER: &str = "PARSER_NAME";
 const CAMEL_PARSER_NAME_PLACEHOLDER: &str = "CAMEL_PARSER_NAME";
 const UPPER_PARSER_NAME_PLACEHOLDER: &str = "UPPER_PARSER_NAME";
 const LOWER_PARSER_NAME_PLACEHOLDER: &str = "LOWER_PARSER_NAME";
+const KEBAB_PARSER_NAME_PLACEHOLDER: &str = "KEBAB_PARSER_NAME";
 const PARSER_CLASS_NAME_PLACEHOLDER: &str = "PARSER_CLASS_NAME";
 
 const PARSER_DESCRIPTION_PLACEHOLDER: &str = "PARSER_DESCRIPTION";
@@ -403,13 +404,13 @@ pub fn generate_grammar_files(
     // Generate C bindings
     if tree_sitter_config.bindings.c {
         missing_path(bindings_dir.join("c"), create_dir)?.apply(|path| {
-            let old_file = &path.join(format!("tree-sitter-{language_name}.h"));
+            let old_file = &path.join(format!("tree-sitter-{}.h", language_name.to_kebab_case()));
             if allow_update && fs::exists(old_file).unwrap_or(false) {
                 fs::remove_file(old_file)?;
             }
             missing_path(path.join("tree_sitter"), create_dir)?.apply(|include_path| {
                 missing_path(
-                    include_path.join(format!("tree-sitter-{language_name}.h")),
+                    include_path.join(format!("tree-sitter-{}.h", language_name.to_kebab_case())),
                     |path| {
                         generate_file(path, PARSER_NAME_H_TEMPLATE, language_name, &generate_opts)
                     },
@@ -418,7 +419,7 @@ pub fn generate_grammar_files(
             })?;
 
             missing_path(
-                path.join(format!("tree-sitter-{language_name}.pc.in")),
+                path.join(format!("tree-sitter-{}.pc.in", language_name.to_kebab_case())),
                 |path| {
                     generate_file(
                         path,
@@ -708,6 +709,10 @@ fn generate_file(
         .replace(
             LOWER_PARSER_NAME_PLACEHOLDER,
             &language_name.to_snake_case(),
+        )
+        .replace(
+            KEBAB_PARSER_NAME_PLACEHOLDER,
+            &language_name.to_kebab_case(),
         )
         .replace(PARSER_NAME_PLACEHOLDER, language_name)
         .replace(CLI_VERSION_PLACEHOLDER, CLI_VERSION)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -534,6 +534,13 @@ impl Init {
                     .interact_text()
             };
 
+            let title = |name: &str| {
+                Input::<String>::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Title (human-readable name)")
+                    .default(name.to_upper_camel_case())
+                    .interact_text()
+            };
+
             let description = |name: &str| {
                 Input::<String>::with_theme(&ColorfulTheme::default())
                     .with_prompt("Description")
@@ -656,6 +663,7 @@ impl Init {
             let choices = [
                 "name",
                 "camelcase",
+                "title",
                 "description",
                 "repository",
                 "funding",
@@ -674,6 +682,7 @@ impl Init {
                     match $choice {
                         "name" => opts.name = name()?,
                         "camelcase" => opts.camelcase = camelcase_name(&opts.name)?,
+                        "title" => opts.title = title(&opts.name)?,
                         "description" => opts.description = description(&opts.name)?,
                         "repository" => opts.repository = Some(repository(&opts.name)?),
                         "funding" => opts.funding = funding()?,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -577,7 +577,7 @@ impl Init {
             let file_types = |name: &str| {
                 Input::<String>::with_theme(&ColorfulTheme::default())
                     .with_prompt("File types (space-separated)")
-                    .default(format!(".{name}"))
+                    .default(name.to_string())
                     .interact_text()
                     .map(|ft| {
                         let mut set = HashSet::new();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -560,6 +560,24 @@ impl Init {
                     .interact_text()
             };
 
+            let funding = || {
+                Input::<String>::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Funding URL")
+                    .allow_empty(true)
+                    .validate_with(|input: &String| {
+                        if input.trim().is_empty()
+                            || Url::parse(input)
+                                .is_ok_and(|u| u.scheme() == "http" || u.scheme() == "https")
+                        {
+                            Ok(())
+                        } else {
+                            Err("The URL must start with 'http://' or 'https://'")
+                        }
+                    })
+                    .interact_text()
+                    .map(|e| (!e.trim().is_empty()).then(|| Url::parse(&e).unwrap()))
+            };
+
             let scope = |name: &str| {
                 Input::<String>::with_theme(&ColorfulTheme::default())
                     .with_prompt("TextMate scope")
@@ -640,6 +658,7 @@ impl Init {
                 "camelcase",
                 "description",
                 "repository",
+                "funding",
                 "scope",
                 "file_types",
                 "version",
@@ -657,6 +676,7 @@ impl Init {
                         "camelcase" => opts.camelcase = camelcase_name(&opts.name)?,
                         "description" => opts.description = description(&opts.name)?,
                         "repository" => opts.repository = Some(repository(&opts.name)?),
+                        "funding" => opts.funding = funding()?,
                         "scope" => opts.scope = scope(&opts.name)?,
                         "file_types" => opts.file_types = file_types(&opts.name)?,
                         "version" => opts.version = initial_version()?,

--- a/cli/src/templates/binding_test.go
+++ b/cli/src/templates/binding_test.go
@@ -10,6 +10,6 @@ import (
 func TestCanLoadGrammar(t *testing.T) {
 	language := tree_sitter.NewLanguage(tree_sitter_LOWER_PARSER_NAME.Language())
 	if language == nil {
-		t.Errorf("Error loading CAMEL_PARSER_NAME grammar")
+		t.Errorf("Error loading TITLE_PARSER_NAME grammar")
 	}
 }

--- a/cli/src/templates/build.rs
+++ b/cli/src/templates/build.rs
@@ -17,5 +17,5 @@ fn main() {
         println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
     }
 
-    c_config.compile("tree-sitter-PARSER_NAME");
+    c_config.compile("tree-sitter-KEBAB_PARSER_NAME");
 }

--- a/cli/src/templates/cmakelists.cmake
+++ b/cli/src/templates/cmakelists.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 
-project(tree-sitter-PARSER_NAME
+project(tree-sitter-KEBAB_PARSER_NAME
         VERSION "PARSER_VERSION"
         DESCRIPTION "PARSER_DESCRIPTION"
         HOMEPAGE_URL "PARSER_URL"
@@ -24,42 +24,42 @@ add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                    COMMENT "Generating parser.c")
 
-add_library(tree-sitter-PARSER_NAME src/parser.c)
+add_library(tree-sitter-KEBAB_PARSER_NAME src/parser.c)
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/scanner.c)
-  target_sources(tree-sitter-PARSER_NAME PRIVATE src/scanner.c)
+  target_sources(tree-sitter-KEBAB_PARSER_NAME PRIVATE src/scanner.c)
 endif()
-target_include_directories(tree-sitter-PARSER_NAME
+target_include_directories(tree-sitter-KEBAB_PARSER_NAME
                            PRIVATE src
                            INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/bindings/c>
                                      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-target_compile_definitions(tree-sitter-PARSER_NAME PRIVATE
+target_compile_definitions(tree-sitter-KEBAB_PARSER_NAME PRIVATE
                            $<$<BOOL:${TREE_SITTER_REUSE_ALLOCATOR}>:TREE_SITTER_REUSE_ALLOCATOR>
                            $<$<CONFIG:Debug>:TREE_SITTER_DEBUG>)
 
-set_target_properties(tree-sitter-PARSER_NAME
+set_target_properties(tree-sitter-KEBAB_PARSER_NAME
                       PROPERTIES
                       C_STANDARD 11
                       POSITION_INDEPENDENT_CODE ON
                       SOVERSION "${TREE_SITTER_ABI_VERSION}.${PROJECT_VERSION_MAJOR}"
                       DEFINE_SYMBOL "")
 
-configure_file(bindings/c/tree-sitter-PARSER_NAME.pc.in
-               "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-PARSER_NAME.pc" @ONLY)
+configure_file(bindings/c/tree-sitter-KEBAB_PARSER_NAME.pc.in
+               "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-KEBAB_PARSER_NAME.pc" @ONLY)
 
 include(GNUInstallDirs)
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/bindings/c/tree_sitter"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
         FILES_MATCHING PATTERN "*.h")
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-PARSER_NAME.pc"
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-KEBAB_PARSER_NAME.pc"
         DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig")
-install(TARGETS tree-sitter-PARSER_NAME
+install(TARGETS tree-sitter-KEBAB_PARSER_NAME
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
 file(GLOB QUERIES queries/*.scm)
 install(FILES ${QUERIES}
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/tree-sitter/queries/PARSER_NAME")
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/tree-sitter/queries/KEBAB_PARSER_NAME")
 
 add_custom_target(ts-test "${TREE_SITTER_CLI}" test
                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/cli/src/templates/index.js
+++ b/cli/src/templates/index.js
@@ -3,7 +3,7 @@ const root = require("path").join(__dirname, "..", "..");
 module.exports =
   typeof process.versions.bun === "string"
     // Support `bun build --compile` by being statically analyzable enough to find the .node file at build-time
-    ? require(`../../prebuilds/${process.platform}-${process.arch}/tree-sitter-PARSER_NAME.node`)
+    ? require(`../../prebuilds/${process.platform}-${process.arch}/tree-sitter-KEBAB_PARSER_NAME.node`)
     : require("node-gyp-build")(root);
 
 try {

--- a/cli/src/templates/lib.rs
+++ b/cli/src/templates/lib.rs
@@ -10,7 +10,7 @@
 //! let language = tree_sitter_PARSER_NAME::LANGUAGE;
 //! parser
 //!     .set_language(&language.into())
-//!     .expect("Error loading CAMEL_PARSER_NAME parser");
+//!     .expect("Error loading TITLE_PARSER_NAME parser");
 //! let tree = parser.parse(code, None).unwrap();
 //! assert!(!tree.root_node().has_error());
 //! ```
@@ -48,6 +48,6 @@ mod tests {
         let mut parser = tree_sitter::Parser::new();
         parser
             .set_language(&super::LANGUAGE.into())
-            .expect("Error loading CAMEL_PARSER_NAME parser");
+            .expect("Error loading TITLE_PARSER_NAME parser");
     }
 }

--- a/cli/src/templates/makefile
+++ b/cli/src/templates/makefile
@@ -2,7 +2,7 @@ ifeq ($(OS),Windows_NT)
 $(error Windows is not supported)
 endif
 
-LANGUAGE_NAME := tree-sitter-PARSER_NAME
+LANGUAGE_NAME := tree-sitter-KEBAB_PARSER_NAME
 HOMEPAGE_URL := PARSER_URL
 VERSION := PARSER_VERSION
 
@@ -70,14 +70,14 @@ $(PARSER): $(SRC_DIR)/grammar.json
 	$(TS) generate $^
 
 install: all
-	install -d '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/PARSER_NAME '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter '$(DESTDIR)$(PCLIBDIR)' '$(DESTDIR)$(LIBDIR)'
+	install -d '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/KEBAB_PARSER_NAME '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter '$(DESTDIR)$(PCLIBDIR)' '$(DESTDIR)$(LIBDIR)'
 	install -m644 bindings/c/tree_sitter/$(LANGUAGE_NAME).h '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/$(LANGUAGE_NAME).h
 	install -m644 $(LANGUAGE_NAME).pc '$(DESTDIR)$(PCLIBDIR)'/$(LANGUAGE_NAME).pc
 	install -m644 lib$(LANGUAGE_NAME).a '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).a
 	install -m755 lib$(LANGUAGE_NAME).$(SOEXT) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXTVER)
 	ln -sf lib$(LANGUAGE_NAME).$(SOEXTVER) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXTVER_MAJOR)
 	ln -sf lib$(LANGUAGE_NAME).$(SOEXTVER_MAJOR) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXT)
-	install -m644 queries/*.scm '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/PARSER_NAME
+	install -m644 queries/*.scm '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/KEBAB_PARSER_NAME
 
 uninstall:
 	$(RM) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).a \
@@ -86,7 +86,7 @@ uninstall:
 		'$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXT) \
 		'$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/$(LANGUAGE_NAME).h \
 		'$(DESTDIR)$(PCLIBDIR)'/$(LANGUAGE_NAME).pc
-	$(RM) -r '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/PARSER_NAME
+	$(RM) -r '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/KEBAB_PARSER_NAME
 
 clean:
 	$(RM) $(OBJS) $(LANGUAGE_NAME).pc lib$(LANGUAGE_NAME).a lib$(LANGUAGE_NAME).$(SOEXT)

--- a/cli/src/templates/package.json
+++ b/cli/src/templates/package.json
@@ -3,6 +3,7 @@
   "version": "PARSER_VERSION",
   "description": "PARSER_DESCRIPTION",
   "repository": "PARSER_URL",
+  "funding": "FUNDING_URL",
   "license": "PARSER_LICENSE",
   "author": {
     "name": "PARSER_AUTHOR_NAME",

--- a/cli/src/templates/package.swift
+++ b/cli/src/templates/package.swift
@@ -9,16 +9,16 @@ if FileManager.default.fileExists(atPath: "src/scanner.c") {
 }
 
 let package = Package(
-    name: "TreeSitterCAMEL_PARSER_NAME",
+    name: "PARSER_CLASS_NAME",
     products: [
-        .library(name: "TreeSitterCAMEL_PARSER_NAME", targets: ["TreeSitterCAMEL_PARSER_NAME"]),
+        .library(name: "PARSER_CLASS_NAME", targets: ["PARSER_CLASS_NAME"]),
     ],
     dependencies: [
         .package(url: "https://github.com/ChimeHQ/SwiftTreeSitter", from: "0.8.0"),
     ],
     targets: [
         .target(
-            name: "TreeSitterCAMEL_PARSER_NAME",
+            name: "PARSER_CLASS_NAME",
             dependencies: [],
             path: ".",
             sources: sources,
@@ -29,12 +29,12 @@ let package = Package(
             cSettings: [.headerSearchPath("src")]
         ),
         .testTarget(
-            name: "TreeSitterCAMEL_PARSER_NAMETests",
+            name: "PARSER_CLASS_NAMETests",
             dependencies: [
                 "SwiftTreeSitter",
-                "TreeSitterCAMEL_PARSER_NAME",
+                "PARSER_CLASS_NAME",
             ],
-            path: "bindings/swift/TreeSitterCAMEL_PARSER_NAMETests"
+            path: "bindings/swift/PARSER_CLASS_NAMETests"
         )
     ],
     cLanguageStandard: .c11

--- a/cli/src/templates/pyproject.toml
+++ b/cli/src/templates/pyproject.toml
@@ -20,6 +20,7 @@ readme = "README.md"
 
 [project.urls]
 Homepage = "PARSER_URL"
+Funding = "FUNDING_URL"
 
 [project.optional-dependencies]
 core = ["tree-sitter~=0.24"]

--- a/cli/src/templates/test_binding.py
+++ b/cli/src/templates/test_binding.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
-import tree_sitter, tree_sitter_LOWER_PARSER_NAME
+import tree_sitter
+import tree_sitter_LOWER_PARSER_NAME
 
 
 class TestLanguage(TestCase):
@@ -8,4 +9,4 @@ class TestLanguage(TestCase):
         try:
             tree_sitter.Language(tree_sitter_LOWER_PARSER_NAME.language())
         except Exception:
-            self.fail("Error loading CAMEL_PARSER_NAME grammar")
+            self.fail("Error loading TITLE_PARSER_NAME grammar")

--- a/cli/src/templates/tests.swift
+++ b/cli/src/templates/tests.swift
@@ -1,8 +1,8 @@
 import XCTest
 import SwiftTreeSitter
-import TreeSitterCAMEL_PARSER_NAME
+import PARSER_CLASS_NAME
 
-final class TreeSitterCAMEL_PARSER_NAMETests: XCTestCase {
+final class PARSER_CLASS_NAMETests: XCTestCase {
     func testCanLoadGrammar() throws {
         let parser = Parser()
         let language = Language(language: tree_sitter_LOWER_PARSER_NAME())

--- a/cli/src/templates/tests.swift
+++ b/cli/src/templates/tests.swift
@@ -7,6 +7,6 @@ final class PARSER_CLASS_NAMETests: XCTestCase {
         let parser = Parser()
         let language = Language(language: tree_sitter_LOWER_PARSER_NAME())
         XCTAssertNoThrow(try parser.setLanguage(language),
-                         "Error loading CAMEL_PARSER_NAME grammar")
+                         "Error loading TITLE_PARSER_NAME grammar")
     }
 }

--- a/docs/src/assets/schemas/config.schema.json
+++ b/docs/src/assets/schemas/config.schema.json
@@ -172,6 +172,11 @@
               "format": "uri",
               "description": "The project's repository."
             },
+            "funding": {
+              "type": "string",
+              "format": "uri",
+              "description": "The project's funding link."
+            },
             "homepage": {
               "type": "string",
               "format": "uri",

--- a/docs/src/assets/schemas/config.schema.json
+++ b/docs/src/assets/schemas/config.schema.json
@@ -133,6 +133,11 @@
             "type": "string",
             "format": "regex",
             "description": "A regex pattern that will be tested against the contents of the file in order to break ties in cases where multiple grammars matched the file."
+          },
+          "class-name": {
+            "type": "string",
+            "pattern": "^TreeSitter\\w+$",
+            "description": "The class name for the Swift, Java & Kotlin bindings"
           }
         },
         "additionalProperties": false,

--- a/docs/src/assets/schemas/config.schema.json
+++ b/docs/src/assets/schemas/config.schema.json
@@ -28,7 +28,7 @@
           "scope": {
             "type": "string",
             "description": "The TextMate scope that represents this language.",
-            "pattern": "^(source|text)(\\.\\w+)+$",
+            "pattern": "^(source|text)(\\.[\\w\\-]+)+$",
             "examples": [
               "source.rust",
               "text.html"


### PR DESCRIPTION
- Closes #3960

### Problem

The init command is lacking some features that could be beneficial to users.

### Solution

Changes:
- allow dashes in scopes (only changes the schema)
- don't prepend default filetype with a period, as that's incorrect
- add an optional funding field
- add a class-name field for high level languages

What I didn't address in the linked issue for reasons explained below:

-  Don't write the default bindings object
    I don't get the point of this, it's a handful of extra lines and clearly lets users know they can configure bindings, without having to dig into the init command's docs
    
- Take file types into account in injection-regex
   Not a fan of this, because we'd have to do some "regex building" of multiple alternations - plus, the language name lowercased should suffice for a lot of these cases.
       
- Add a verbose `name` for the `description` and error messages
   I don't even get this, especially the error messages part
   
- Comma-separated file-types do not get separated
   We had agreed on using space as the separator, using two separators makes no sense. 
   
- The grammar name is in snake_case but some files expect kebab-case
   I don't know of a language that has this problem (uses underscores in its name).