### PR TITLE
feat(bindings): update swift bindings

### DIFF
--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -652,7 +652,7 @@ pub fn generate_grammar_files(
     // Generate Swift bindings
     if tree_sitter_config.bindings.swift {
         missing_path(bindings_dir.join("swift"), create_dir)?.apply(|path| {
-            let lang_path = path.join(format!("TreeSitter{camel_name}",));
+            let lang_path = path.join(format!("TreeSitter{camel_name}"));
             missing_path(&lang_path, create_dir)?;
 
             missing_path(lang_path.join(format!("{language_name}.h")), |path| {
@@ -660,21 +660,41 @@ pub fn generate_grammar_files(
             })?;
 
             missing_path(
-                path.join(format!("TreeSitter{camel_name}Tests",)),
+                path.join(format!("TreeSitter{camel_name}Tests")),
                 create_dir,
             )?
             .apply(|path| {
-                missing_path(
+                missing_path_else(
                     path.join(format!("TreeSitter{camel_name}Tests.swift")),
+                    allow_update,
                     |path| generate_file(path, TESTS_SWIFT_TEMPLATE, language_name, &generate_opts),
+                    |path| {
+                        let mut contents = fs::read_to_string(path)?;
+                        contents = contents.replace("import SwiftTreeSitter", "import TreeSitter");
+                        write_file(path, contents)?;
+                        Ok(())
+                    },
                 )?;
 
                 Ok(())
             })?;
 
-            missing_path(repo_path.join("Package.swift"), |path| {
-                generate_file(path, PACKAGE_SWIFT_TEMPLATE, language_name, &generate_opts)
-            })?;
+            missing_path_else(
+                repo_path.join("Package.swift"),
+                allow_update,
+                |path| generate_file(path, PACKAGE_SWIFT_TEMPLATE, language_name, &generate_opts),
+                |path| {
+                    let mut contents = fs::read_to_string(path)?;
+                    contents = contents
+                        .replace("\"SwiftTreeSitter\"", "\"TreeSitter\"")
+                        .replace(
+                            r#"url: "https://github.com/ChimeHQ/SwiftTreeSitter", from: "0.8.0""#,
+                            r#"url: "https://github.com/tree-sitter/swift-tree-sitter", from: "0.25.0""#
+                        );
+                    write_file(path, contents)?;
+                    Ok(())
+                },
+            )?;
 
             Ok(())
         })?;

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -664,16 +664,9 @@ pub fn generate_grammar_files(
                 create_dir,
             )?
             .apply(|path| {
-                missing_path_else(
+                missing_path(
                     path.join(format!("TreeSitter{camel_name}Tests.swift")),
-                    allow_update,
                     |path| generate_file(path, TESTS_SWIFT_TEMPLATE, language_name, &generate_opts),
-                    |path| {
-                        let mut contents = fs::read_to_string(path)?;
-                        contents = contents.replace("import SwiftTreeSitter", "import TreeSitter");
-                        write_file(path, contents)?;
-                        Ok(())
-                    },
                 )?;
 
                 Ok(())
@@ -685,12 +678,10 @@ pub fn generate_grammar_files(
                 |path| generate_file(path, PACKAGE_SWIFT_TEMPLATE, language_name, &generate_opts),
                 |path| {
                     let mut contents = fs::read_to_string(path)?;
-                    contents = contents
-                        .replace("\"SwiftTreeSitter\"", "\"TreeSitter\"")
-                        .replace(
-                            r#"url: "https://github.com/ChimeHQ/SwiftTreeSitter", from: "0.8.0""#,
-                            r#"url: "https://github.com/tree-sitter/swift-tree-sitter", from: "0.25.0""#
-                        );
+                    contents = contents.replace(
+                        "https://github.com/ChimeHQ/SwiftTreeSitter",
+                        "https://github.com/tree-sitter/swift-tree-sitter",
+                    );
                     write_file(path, contents)?;
                     Ok(())
                 },

--- a/cli/src/templates/package.swift
+++ b/cli/src/templates/package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "PARSER_CLASS_NAME", targets: ["PARSER_CLASS_NAME"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tree-sitter/swift-tree-sitter", from: "0.25.0"),
+        .package(url: "https://github.com/tree-sitter/swift-tree-sitter", from: "0.8.0"),
     ],
     targets: [
         .target(
@@ -31,7 +31,7 @@ let package = Package(
         .testTarget(
             name: "PARSER_CLASS_NAMETests",
             dependencies: [
-                "TreeSitter",
+                "SwiftTreeSitter",
                 "PARSER_CLASS_NAME",
             ],
             path: "bindings/swift/PARSER_CLASS_NAMETests"

--- a/cli/src/templates/package.swift
+++ b/cli/src/templates/package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "PARSER_CLASS_NAME", targets: ["PARSER_CLASS_NAME"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ChimeHQ/SwiftTreeSitter", from: "0.8.0"),
+        .package(url: "https://github.com/tree-sitter/swift-tree-sitter", from: "0.25.0"),
     ],
     targets: [
         .target(
@@ -31,7 +31,7 @@ let package = Package(
         .testTarget(
             name: "PARSER_CLASS_NAMETests",
             dependencies: [
-                "SwiftTreeSitter",
+                "TreeSitter",
                 "PARSER_CLASS_NAME",
             ],
             path: "bindings/swift/PARSER_CLASS_NAMETests"

--- a/cli/src/templates/tests.swift
+++ b/cli/src/templates/tests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import SwiftTreeSitter
+import TreeSitter
 import PARSER_CLASS_NAME
 
 final class PARSER_CLASS_NAMETests: XCTestCase {

--- a/cli/src/templates/tests.swift
+++ b/cli/src/templates/tests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import TreeSitter
+import SwiftTreeSitter
 import PARSER_CLASS_NAME
 
 final class PARSER_CLASS_NAMETests: XCTestCase {


### PR DESCRIPTION
Assuming the module is renamed, swift-tree-sitter **must** be updated soon after 0.25 is released or projects *will* break.
If it *isn't* renamed, then this is not a breaking change.