### PR TITLE
feat(generate): defer to ABI 14 if tree-sitter.json doesn't exist, rather than hard failing

### DIFF
--- a/cli/generate/src/render.rs
+++ b/cli/generate/src/render.rs
@@ -20,8 +20,8 @@ use super::{
 };
 
 const SMALL_STATE_THRESHOLD: usize = 64;
-const ABI_VERSION_MIN: usize = 14;
-const ABI_VERSION_MAX: usize = tree_sitter::LANGUAGE_VERSION;
+pub const ABI_VERSION_MIN: usize = 14;
+pub const ABI_VERSION_MAX: usize = tree_sitter::LANGUAGE_VERSION;
 const ABI_VERSION_WITH_RESERVED_WORDS: usize = 15;
 const BUILD_VERSION: &str = env!("CARGO_PKG_VERSION");
 const BUILD_SHA: Option<&'static str> = option_env!("BUILD_SHA");

--- a/cli/src/templates/_cargo.toml
+++ b/cli/src/templates/_cargo.toml
@@ -12,7 +12,13 @@ edition = "2021"
 autoexamples = false
 
 build = "bindings/rust/build.rs"
-include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*", "tree-sitter.json"]
+include = [
+  "bindings/rust/*",
+  "grammar.js",
+  "queries/*",
+  "src/*",
+  "tree-sitter.json",
+]
 
 [lib]
 path = "bindings/rust/lib.rs"
@@ -21,7 +27,7 @@ path = "bindings/rust/lib.rs"
 tree-sitter-language = "0.1"
 
 [build-dependencies]
-cc = "1.1.22"
+cc = "1.2"
 
 [dev-dependencies]
 tree-sitter = "RUST_BINDING_VERSION"


### PR DESCRIPTION
- Followup to #4135

As noted in this [comment](https://github.com/tree-sitter/tree-sitter/pull/4135#issuecomment-2614290692), we should not hard fail generating if the `tree-sitter.json` file doesn't exist. Instead, we should print a warning mentioning that this file *is* a requirement for ABI 15, and default to ABI 14.