### PR TITLE
chore(bindings): include license file in crate

### DIFF
--- a/cli/src/templates/_cargo.toml
+++ b/cli/src/templates/_cargo.toml
@@ -18,6 +18,7 @@ include = [
   "queries/*",
   "src/*",
   "tree-sitter.json",
+  "LICENSE",
 ]
 
 [lib]


### PR DESCRIPTION
Because cargo can't behave like every sane package manager and include license files by default.