### PR TITLE
fix(lib): prevent finished_tree assertion failure

### DIFF
--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -2080,6 +2080,7 @@ void ts_parser_reset(TSParser *self) {
   self->accept_count = 0;
   self->has_scanner_error = false;
   self->has_error = false;
+  self->canceled_balancing = false;
   self->parse_options = (TSParseOptions) {0};
   self->parse_state = (TSParseState) {0};
 }


### PR DESCRIPTION
**Problem:** When resetting the parser during subtree balancing, an error is thrown:

```
parser.c:2198: ts_parser_parse: Assertion `self->finished_tree.ptr' failed.
```

**Solution:** Reset `canceled_balancing` to false in `ts_parser_reset()`.