### PR TITLE
fix(bindings): correct Zig bindings to expose a `language` function

### DIFF
--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -97,6 +97,7 @@ const TESTS_SWIFT_TEMPLATE: &str = include_str!("./templates/tests.swift");
 
 const BUILD_ZIG_TEMPLATE: &str = include_str!("./templates/build.zig");
 const BUILD_ZIG_ZON_TEMPLATE: &str = include_str!("./templates/build.zig.zon");
+const ROOT_ZIG_TEMPLATE: &str = include_str!("./templates/root.zig");
 
 const TREE_SITTER_JSON_SCHEMA: &str =
     "https://tree-sitter.github.io/tree-sitter/assets/schemas/config.schema.json";
@@ -699,6 +700,14 @@ pub fn generate_grammar_files(
 
         missing_path(repo_path.join("build.zig.zon"), |path| {
             generate_file(path, BUILD_ZIG_ZON_TEMPLATE, language_name, &generate_opts)
+        })?;
+
+        missing_path(bindings_dir.join("zig"), create_dir)?.apply(|path| {
+            missing_path(path.join("root.zig"), |path| {
+                generate_file(path, ROOT_ZIG_TEMPLATE, language_name, &generate_opts)
+            })?;
+
+            Ok(())
         })?;
     }
 

--- a/cli/src/templates/build.zig.zon
+++ b/cli/src/templates/build.zig.zon
@@ -1,11 +1,14 @@
 .{
     .name = "tree_sitter_PARSER_NAME",
     .version = "PARSER_VERSION",
-    .dependencies = .{},
+    .dependencies = .{ .@"tree-sitter" = .{
+        .url = "https://github.com/tree-sitter/zig-tree-sitter/archive/refs/tags/v0.25.0.tar.gz",
+        .hash = "122091f08e006d54efe4a2e1ea2899a70a7698a966416458f3f22c01e983d0e635c4",
+    } },
     .paths = .{
         "build.zig",
         "build.zig.zon",
-        "bindings/c",
+        "bindings/zig",
         "src",
         "queries",
         "LICENSE",

--- a/cli/src/templates/root.zig
+++ b/cli/src/templates/root.zig
@@ -1,0 +1,19 @@
+const testing = @import("std").testing;
+
+const ts = @import("tree-sitter");
+const Language = ts.Language;
+const Parser = ts.Parser;
+
+pub extern fn tree_sitter_PARSER_NAME() callconv(.C) *const Language;
+
+pub export fn language() *const Language {
+    return tree_sitter_PARSER_NAME();
+}
+
+test "can load grammar" {
+    const parser = Parser.create();
+    defer parser.destroy();
+    try testing.expectEqual(parser.setLanguage(language()), void{});
+    try testing.expectEqual(parser.getLanguage(), tree_sitter_PARSER_NAME());
+}
+


### PR DESCRIPTION
Instead of having users declare the extern function themselves, they can pass in the language to `Language.create` in the zig bindings. If they really want, they can always opt into the `extern fn tree_sitter_LANG() *const ts.Language` approach.

Additionally, this declares a module to make it easier for consumers to bring in the `tree-sitter-LANG` module in their project(s).