### PR TITLE
build: do not define _POSIX_C_SOURCE on NetBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 ifeq ($(OS),Windows_NT)
 $(error Windows is not supported)
-else
-	detected_OS := $(shell uname -s)
 endif
 
 VERSION := 0.25.1
@@ -29,10 +27,7 @@ OBJ := $(SRC:.c=.o)
 ARFLAGS := rcs
 CFLAGS ?= -O3 -Wall -Wextra -Wshadow -Wpedantic -Werror=incompatible-pointer-types
 override CFLAGS += -std=c11 -fPIC -fvisibility=hidden
-ifneq ($(detected_OS),NetBSD)
-override CFLAGS += -D_POSIX_C_SOURCE=200112L
-endif
-override CFLAGS += -D_DEFAULT_SOURCE
+override CFLAGS += -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE
 override CFLAGS += -Ilib/src -Ilib/src/wasm -Ilib/include
 
 # ABI versioning

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 ifeq ($(OS),Windows_NT)
 $(error Windows is not supported)
+else
+	detected_OS := $(shell uname -s)
 endif
 
 VERSION := 0.25.1
@@ -27,7 +29,10 @@ OBJ := $(SRC:.c=.o)
 ARFLAGS := rcs
 CFLAGS ?= -O3 -Wall -Wextra -Wshadow -Wpedantic -Werror=incompatible-pointer-types
 override CFLAGS += -std=c11 -fPIC -fvisibility=hidden
-override CFLAGS += -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE
+ifneq ($(detected_OS),NetBSD)
+override CFLAGS += -D_POSIX_C_SOURCE=200112L
+endif
+override CFLAGS += -D_DEFAULT_SOURCE
 override CFLAGS += -Ilib/src -Ilib/src/wasm -Ilib/include
 
 # ABI versioning

--- a/lib/src/portable/endian.h
+++ b/lib/src/portable/endian.h
@@ -18,16 +18,20 @@
 #if defined(HAVE_ENDIAN_H) || \
     defined(__linux__) || \
     defined(__GNU__) || \
+    defined(__NetBSD__) || \
     defined(__OpenBSD__) || \
     defined(__CYGWIN__) || \
     defined(__MSYS__) || \
     defined(__EMSCRIPTEN__)
 
+#if defined(__NetBSD__)
+#define _NETBSD_SOURCE 1
+#endif
+
 # include <endian.h>
 
 #elif defined(HAVE_SYS_ENDIAN_H) || \
     defined(__FreeBSD__) || \
-    defined(__NetBSD__) || \
     defined(__DragonFly__)
 
 # include <sys/endian.h>

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -1,3 +1,7 @@
+#if defined(__NetBSD__) && defined(_POSIX_C_SOURCE)
+#undef _POSIX_C_SOURCE
+#endif
+
 #include "tree_sitter/api.h"
 #include "./alloc.h"
 #include "./array.h"

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -1,3 +1,8 @@
+/*
+ * On NetBSD, defining standard requirements like this removes symbols
+ * from the namespace; however, we need non-standard symbols for
+ * endian.h.
+ */
 #if defined(__NetBSD__) && defined(_POSIX_C_SOURCE)
 #undef _POSIX_C_SOURCE
 #endif


### PR DESCRIPTION
It leads to missing symbols, see #4180.