### PR TITLE
fix(web): provide type in the exports

### DIFF
--- a/lib/binding_web/package-lock.json
+++ b/lib/binding_web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-tree-sitter",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-tree-sitter",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.19.0",

--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -19,11 +19,13 @@
   "exports": {
     ".": {
       "import": "./tree-sitter.js",
-      "require": "./tree-sitter.cjs"
+      "require": "./tree-sitter.cjs",
+      "types": "./web-tree-sitter.d.ts"
     },
     "./debug": {
       "import": "./debug/tree-sitter.js",
-      "require": "./debug/tree-sitter.cjs"
+      "require": "./debug/tree-sitter.cjs",
+      "types": "./web-tree-sitter.d.ts"
     }
   },
   "types": "web-tree-sitter.d.ts",


### PR DESCRIPTION
When using TypeScript projects using other module settings than CommonJs, the types were not correctly exposed, and the compilation failed.

This adds the types path to the exports so compilation works for `module: NodeNext` and other variants.

I've tested this with a test project using TypeScript and several `module` and `moduleResolution` combinations.