### PR TITLE
Add types to exports in binding_web

### DIFF
--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -19,11 +19,13 @@
   "exports": {
     ".": {
       "import": "./tree-sitter.js",
-      "require": "./tree-sitter.cjs"
+      "require": "./tree-sitter.cjs",
+      "types": "./web-tree-sitter.d.ts"
     },
     "./debug": {
       "import": "./debug/tree-sitter.js",
-      "require": "./debug/tree-sitter.cjs"
+      "require": "./debug/tree-sitter.cjs",
+      "types": "./web-tree-sitter.d.ts"
     }
   },
   "types": "web-tree-sitter.d.ts",


### PR DESCRIPTION
A quick update to `package.json` in `binding_web` to include the types on `exports`. Fixes issue #4187
