### PR TITLE
Refine the documentation and command line help for "parse --edits"

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -206,7 +206,7 @@ struct Parse {
     #[arg(long, short)]
     pub quiet: bool,
     #[allow(clippy::doc_markdown)]
-    /// Apply edits in the format: \"row, col delcount insert_text\"
+    /// Apply edits in the format: \"row,col|position delcount insert_text\", can be supplied multiple times
     #[arg(
         long,
         num_args = 1..,

--- a/docs/src/cli/parse.md
+++ b/docs/src/cli/parse.md
@@ -66,7 +66,7 @@ Suppress main output.
 
 ### `--edits <EDITS>...`
 
-Apply edits after parsing the file. Edits are in the form of `row, col delcount insert_text` where row and col are 0-indexed.
+Apply edits after parsing the file. Edits are in the form of `row,col|position delcount insert_text` where row and col, or position are 0-indexed.
 
 ### `--encoding <ENCODING>`
 


### PR DESCRIPTION
Previously the format described the position as 'row, col' which would not work with a space between the comma and the col, and I didn't know about the option to pass an integer offset until I went scavenging through the project.