### PR TITLE
add generate crate to workspace & adjust to new clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ default-members = ["cli"]
 members = [
   "cli",
   "cli/config",
+  "cli/generate",
   "cli/loader",
   "lib",
   "lib/language",

--- a/cli/generate/src/render.rs
+++ b/cli/generate/src/render.rs
@@ -1847,11 +1847,11 @@ impl Generator {
                         '\u{007F}' => "DEL",
                         '\u{FEFF}' => "BOM",
                         '\u{0080}'..='\u{FFFF}' => {
-                            result.push_str(&format!("u{:04x}", c as u32));
+                            write!(result, "u{:04x}", c as u32).unwrap();
                             break 'special_chars;
                         }
                         '\u{10000}'..='\u{10FFFF}' => {
-                            result.push_str(&format!("U{:08x}", c as u32));
+                            write!(result, "U{:08x}", c as u32).unwrap();
                             break 'special_chars;
                         }
                         '0'..='9' | 'a'..='z' | 'A'..='Z' | '_' => unreachable!(),
@@ -1882,11 +1882,9 @@ impl Generator {
                 '\r' => result += "\\r",
                 '\t' => result += "\\t",
                 '\0' => result += "\\0",
-                '\u{0001}'..='\u{001f}' => result += &format!("\\x{:02x}", c as u32),
-                '\u{007F}'..='\u{FFFF}' => result += &format!("\\u{:04x}", c as u32),
-                '\u{10000}'..='\u{10FFFF}' => {
-                    result.push_str(&format!("\\U{:08x}", c as u32));
-                }
+                '\u{0001}'..='\u{001f}' => write!(result, "\\x{:02x}", c as u32).unwrap(),
+                '\u{007F}'..='\u{FFFF}' => write!(result, "\\u{:04x}", c as u32).unwrap(),
+                '\u{10000}'..='\u{10FFFF}' => write!(result, "\\U{:08x}", c as u32).unwrap(),
                 _ => result.push(c),
             }
         }


### PR DESCRIPTION
CI is failing because of the new clippy lint, which suggests to use write! over appending a string with format, to avoid an extra allocation. Additionally, the generate crate was missing in the workspace members list.