### PR TITLE
feat: Windows support using MinGW-w64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,6 +163,14 @@ jobs:
       env:
         CFLAGS: -g -Werror -Wall -Wextra -Wshadow -Wpedantic -Werror=incompatible-pointer-types
 
+    - name: Build C library on Windows (make)
+      if: ${{ runner.os == 'Windows' }}
+      run: make.sh -j CC="$CC" CFLAGS="$CFLAGS" AR="$AR"
+      env:
+        CC: x86_64-w64-mingw32-gcc
+        AR: x86_64-w64-mingw32-ar
+        CFLAGS: -g -Werror -Wall -Wextra -Wshadow -Wpedantic -Werror=incompatible-pointer-types
+
     - name: Build C library (CMake)
       if: ${{ !matrix.use-cross }}
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ docs/assets/js/tree-sitter.js
 *.dylib
 *.so
 *.so.[0-9]*
+*.dll
 *.o
 *.obj
 *.exp

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,3 @@
-ifeq ($(OS),Windows_NT)
-$(error Windows is not supported)
-endif
-
 VERSION := 0.25.1
 DESCRIPTION := An incremental parsing system for programming tools
 HOMEPAGE_URL := https://tree-sitter.github.io/tree-sitter/
@@ -40,6 +36,10 @@ ifneq ($(findstring darwin,$(shell $(CC) -dumpmachine)),)
 	SOEXTVER_MAJOR = $(SONAME_MAJOR).$(SOEXT)
 	SOEXTVER = $(SONAME_MAJOR).$(SONAME_MINOR).$(SOEXT)
 	LINKSHARED += -dynamiclib -Wl,-install_name,$(LIBDIR)/libtree-sitter.$(SOEXTVER)
+else ifneq ($(findstring mingw32,$(shell $(CC) -dumpmachine)),)
+	SOEXT = dll
+	LINKSHARED += -s -shared -Wl,--out-implib,$(@:dll=lib)
+libtree-sitter.lib: libtree-sitter.$(SOEXT)
 else
 	SOEXT = so
 	SOEXTVER_MAJOR = $(SOEXT).$(SONAME_MAJOR)
@@ -70,7 +70,7 @@ tree-sitter.pc: lib/tree-sitter.pc.in
 		-e 's|@CMAKE_INSTALL_PREFIX@|$(PREFIX)|' $< > $@
 
 clean:
-	$(RM) $(OBJ) tree-sitter.pc libtree-sitter.a libtree-sitter.$(SOEXT)
+	$(RM) $(OBJ) tree-sitter.pc libtree-sitter.a libtree-sitter.$(SOEXT) libtree-stitter.lib
 
 install: all
 	install -d '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter '$(DESTDIR)$(PCLIBDIR)' '$(DESTDIR)$(LIBDIR)'

--- a/cli/src/templates/makefile
+++ b/cli/src/templates/makefile
@@ -1,7 +1,3 @@
-ifeq ($(OS),Windows_NT)
-$(error Windows is not supported)
-endif
-
 LANGUAGE_NAME := tree-sitter-KEBAB_PARSER_NAME
 HOMEPAGE_URL := PARSER_URL
 VERSION := PARSER_VERSION
@@ -37,6 +33,10 @@ ifeq ($(shell uname),Darwin)
 	SOEXTVER_MAJOR = $(SONAME_MAJOR).$(SOEXT)
 	SOEXTVER = $(SONAME_MAJOR).$(SONAME_MINOR).$(SOEXT)
 	LINKSHARED = -dynamiclib -Wl,-install_name,$(LIBDIR)/lib$(LANGUAGE_NAME).$(SOEXTVER),-rpath,@executable_path/../Frameworks
+else ifneq ($(findstring mingw32,$(shell $(CC) -dumpmachine)),)
+	SOEXT = dll
+	LINKSHARED += -s -shared -Wl,--out-implib,$(@:dll=lib)
+lib$(LANGUAGE_NAME).lib: lib$(LANGUAGE_NAME).$(SOEXT)
 else
 	SOEXT = so
 	SOEXTVER_MAJOR = $(SOEXT).$(SONAME_MAJOR)
@@ -89,7 +89,7 @@ uninstall:
 	$(RM) -r '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/KEBAB_PARSER_NAME
 
 clean:
-	$(RM) $(OBJS) $(LANGUAGE_NAME).pc lib$(LANGUAGE_NAME).a lib$(LANGUAGE_NAME).$(SOEXT)
+	$(RM) $(OBJS) $(LANGUAGE_NAME).pc lib$(LANGUAGE_NAME).a lib$(LANGUAGE_NAME).$(SOEXT) lib$(LANGUAGE_NAME).lib
 
 test:
 	$(TS) test


### PR DESCRIPTION
Building tree-sitter on Windows within a Cygwin or MSYS2 environment for MinGW-w64 targets should work. As there's no configure-like step, the tools have to be specified with:

```sh
make CC=x86_64-w64-mingw32-gcc \
     AR=x86_64-w64-mingw32-ar \
     STRIP=x86_64-w64-mingw32-strip
```

Exported symbols should be tagged.
Useful reference: [How to build and use DLLs on Windows](https://nullprogram.com/blog/2021/05/31/).

This PR doesn't include support to build libtree-sitter with MSVC or clang-cl, but generates a `libtree-sitter.lib` file for MSVC/clang-cl consumers.

Cf #3418 #3417
cc @ObserverOfTime 