### PR TITLE
`Makefile` fixes (general and for MinGW-w64)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,14 +163,6 @@ jobs:
       env:
         CFLAGS: -g -Werror -Wall -Wextra -Wshadow -Wpedantic -Werror=incompatible-pointer-types
 
-    - name: Build C library on Windows (make)
-      if: ${{ runner.os == 'Windows' }}
-      run: make.sh -j CC="$CC" CFLAGS="$CFLAGS" AR="$AR"
-      env:
-        CC: x86_64-w64-mingw32-gcc
-        AR: x86_64-w64-mingw32-ar
-        CFLAGS: -g -Werror -Wall -Wextra -Wshadow -Wpedantic -Werror=incompatible-pointer-types
-
     - name: Build C library (CMake)
       if: ${{ !matrix.use-cross }}
       run: |

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ ifneq ($(findstring darwin,$(shell $(CC) -dumpmachine)),)
 	LINKSHARED += -dynamiclib -Wl,-install_name,$(LIBDIR)/libtree-sitter.$(SOEXTVER)
 else ifneq ($(findstring mingw32,$(shell $(CC) -dumpmachine)),)
 	SOEXT = dll
-	LINKSHARED += -s -shared -Wl,--out-implib,$(@:dll=lib)
-libtree-sitter.lib: libtree-sitter.$(SOEXT)
+	LINKSHARED += -s -shared -Wl,--out-implib,$@.a
+libtree-sitter.dll.a: libtree-sitter.$(SOEXT)
 else
 	SOEXT = so
 	SOEXTVER_MAJOR = $(SOEXT).$(SONAME_MAJOR)
@@ -70,7 +70,7 @@ tree-sitter.pc: lib/tree-sitter.pc.in
 		-e 's|@CMAKE_INSTALL_PREFIX@|$(PREFIX)|' $< > $@
 
 clean:
-	$(RM) $(OBJ) tree-sitter.pc libtree-sitter.a libtree-sitter.$(SOEXT) libtree-stitter.lib
+	$(RM) $(OBJ) tree-sitter.pc libtree-sitter.a libtree-sitter.$(SOEXT) libtree-stitter.dll.a
 
 install: all
 	install -d '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter '$(DESTDIR)$(PCLIBDIR)' '$(DESTDIR)$(LIBDIR)'

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ ifneq ($(findstring darwin,$(shell $(CC) -dumpmachine)),)
 else ifneq ($(findstring mingw32,$(shell $(CC) -dumpmachine)),)
 	SOEXT = dll
 	LINKSHARED += -s -shared -Wl,--out-implib,$@.a
-libtree-sitter.dll.a: libtree-sitter.$(SOEXT)
 else
 	SOEXT = so
 	SOEXTVER_MAJOR = $(SOEXT).$(SONAME_MAJOR)
@@ -60,6 +59,9 @@ libtree-sitter.$(SOEXT): $(OBJ)
 ifneq ($(STRIP),)
 	$(STRIP) $@
 endif
+
+# For MinGW-w64 targets
+libtree-sitter.dll.a: libtree-sitter.$(SOEXT)
 
 tree-sitter.pc: lib/tree-sitter.pc.in
 	sed -e 's|@PROJECT_VERSION@|$(VERSION)|' \

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ HOMEPAGE_URL := https://tree-sitter.github.io/tree-sitter/
 PREFIX ?= /usr/local
 INCLUDEDIR ?= $(PREFIX)/include
 LIBDIR ?= $(PREFIX)/lib
+BINDIR ?= $(PREFIX)/bin
 PCLIBDIR ?= $(LIBDIR)/pkgconfig
 
 # collect sources
@@ -79,9 +80,15 @@ install: all
 	install -m644 lib/include/tree_sitter/api.h '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/api.h
 	install -m644 tree-sitter.pc '$(DESTDIR)$(PCLIBDIR)'/tree-sitter.pc
 	install -m644 libtree-sitter.a '$(DESTDIR)$(LIBDIR)'/libtree-sitter.a
+ifneq ($(findstring mingw32,$(shell $(CC) -dumpmachine)),)
+	install -d '$(DESTDIR)$(BINDIR)'
+	install -m755 libtree-sitter.dll '$(DESTDIR)$(BINDIR)'/libtree-sitter.dll
+	install -m755 libtree-sitter.dll.a '$(DESTDIR)$(LIBDIR)'/libtree-sitter.dll.a
+else
 	install -m755 libtree-sitter.$(SOEXT) '$(DESTDIR)$(LIBDIR)'/libtree-sitter.$(SOEXTVER)
 	ln -sf libtree-sitter.$(SOEXTVER) '$(DESTDIR)$(LIBDIR)'/libtree-sitter.$(SOEXTVER_MAJOR)
 	ln -sf libtree-sitter.$(SOEXTVER_MAJOR) '$(DESTDIR)$(LIBDIR)'/libtree-sitter.$(SOEXT)
+endif
 
 uninstall:
 	$(RM) '$(DESTDIR)$(LIBDIR)'/libtree-sitter.a \

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ OBJ := $(SRC:.c=.o)
 ARFLAGS := rcs
 CFLAGS ?= -O3 -Wall -Wextra -Wshadow -Wpedantic -Werror=incompatible-pointer-types
 override CFLAGS += -std=c11 -fPIC -fvisibility=hidden
-override CFLAGS += -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE
-override CFLAGS += -Ilib/src -Ilib/src/wasm -Ilib/include
+override CPPFLAGS += -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE
+override CPPFLAGS += -Ilib/src -Ilib/src/wasm -Ilib/include
 
 # ABI versioning
 SONAME_MAJOR := $(word 1,$(subst ., ,$(VERSION)))

--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,8 @@ ifneq ($(findstring mingw32,$(shell $(CC) -dumpmachine)),)
 	install -m755 libtree-sitter.dll.a '$(DESTDIR)$(LIBDIR)'/libtree-sitter.dll.a
 else
 	install -m755 libtree-sitter.$(SOEXT) '$(DESTDIR)$(LIBDIR)'/libtree-sitter.$(SOEXTVER)
-	ln -sf libtree-sitter.$(SOEXTVER) '$(DESTDIR)$(LIBDIR)'/libtree-sitter.$(SOEXTVER_MAJOR)
-	ln -sf libtree-sitter.$(SOEXTVER_MAJOR) '$(DESTDIR)$(LIBDIR)'/libtree-sitter.$(SOEXT)
+	cd '$(DESTDIR)$(LIBDIR)' && ln -sf libtree-sitter.$(SOEXTVER) libtree-sitter.$(SOEXTVER_MAJOR)
+	cd '$(DESTDIR)$(LIBDIR)' && ln -sf libtree-sitter.$(SOEXTVER_MAJOR) libtree-sitter.$(SOEXT)
 endif
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ uninstall:
 		'$(DESTDIR)$(LIBDIR)'/libtree-sitter.$(SOEXT) \
 		'$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/api.h \
 		'$(DESTDIR)$(PCLIBDIR)'/tree-sitter.pc
+	rmdir '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter
 
 .PHONY: all install uninstall clean
 


### PR DESCRIPTION
Hello all,

This PR is a continuation of my #4201 from 2 days ago. I've collected a few fixes that complete my first patch, I apologize for missing them. They stem from using the MinGW-w64 build of tree-sitter in a bigger project, rather than on its own.

The first three patches fix the Makefile to build with MinGW-w64. They also add install rules for the DLLs.
I've removed the CI for MinGW-w64: it turns out that only the C compiler is available, without the binutils (so `x86_64-w64-mingw32-ar` and `x86_64-w64-mingw32-strip` are missing). The CI script would also always use MSVC, but only use MinGW-w64 to build the library. I've tried using Rust's `x86_64-pc-windows-gnu` target, but the CI keeps on using MSVC.
The final commits are general fixes to the Makefile.