### PR TITLE
export wasm files to better support bundling use cases

### DIFF
--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -22,11 +22,13 @@
       "require": "./web-tree-sitter.cjs",
       "types": "./web-tree-sitter.d.ts"
     },
+    "./web-tree-sitter.wasm": "./web-tree-sitter.wasm",
     "./debug": {
       "import": "./debug/web-tree-sitter.js",
       "require": "./debug/web-tree-sitter.cjs",
       "types": "./web-tree-sitter.d.ts"
-    }
+    },
+    "./debug/web-tree-sitter.wasm": "./debug/web-tree-sitter.wasm"
   },
   "types": "web-tree-sitter.d.ts",
   "keywords": [


### PR DESCRIPTION
When using a bundler, calling `Parser.init()` without options may not work because the file won't be where it expects it.

With esbuild for example a better way is to import the `wasm` file with the `file` loader and provide it on `Parser.init`:

- index.js
```javascript
import path from "node:path";
import { Parser } from "web-tree-sitter";
import TreeSitterWasmUrl from "web-tree-sitter/tree-sitter.wasm";

await Parser.init({
    locateFile: (url, scriptDir) => {
        if (url === "tree-sitter.wasm") {
            return path.join(scriptDir, TreeSitterWasmUrl);
        }
    },
});

```


- build.js
```javascript
import esbuild from "esbuild";

await esbuild.build({
    entryPoints: ["index.js"],
    outdir: "dist",
    bundle: true,
    platform: "node",
    format: "esm",
    loader: {
        ".wasm": "file",
    },
});

```

This will copy the wasm file to the output directory and replace `TreeSitterWasmUrl` with the relative path to it.

Unfortunately at the moment it fails with:
```
✘ [ERROR] Could not resolve "web-tree-sitter/tree-sitter.wasm"

    index.js:3:30:
      3 │ import TreeSitterWasmUrl from "web-tree-sitter/tree-sitter.wasm";
        ╵                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  The path "./tree-sitter.wasm" is not exported by package "web-tree-sitter":

    node_modules/web-tree-sitter/package.json:19:13:
      19 │   "exports": {
         ╵              ^

  You can mark the path "web-tree-sitter/tree-sitter.wasm" as external to exclude it from the
  bundle, which will remove this error and leave the unresolved path in the bundle.
```

This PR fixes it.