### PR TITLE
fix(wasm): restore passing in ERROR to `descendantsOfType`

### DIFF
--- a/lib/binding_web/src/node.ts
+++ b/lib/binding_web/src/node.ts
@@ -416,6 +416,11 @@ export class Node {
     // Convert the type strings to numeric type symbols
     const symbols: number[] = [];
     const typesBySymbol = this.tree.language.types;
+    for (const node_type of types) {
+      if (node_type == "ERROR") {
+        symbols.push(65535); // Internally, ts_builtin_sym_error is -1, which is UINT_16MAX
+      }
+    }
     for (let i = 0, n = typesBySymbol.length; i < n; i++) {
       if (types.includes(typesBySymbol[i])) {
         symbols.push(i);

--- a/lib/binding_web/test/node.test.ts
+++ b/lib/binding_web/test/node.test.ts
@@ -63,7 +63,7 @@ describe('Node', () => {
       tree = parser.parse('x10 + 1000')!;
       expect(tree.rootNode.children).toHaveLength(1);
       const sumNode = tree.rootNode.firstChild!.firstChild!;
-      expect(sumNode.children.map(child => child!.type)).toEqual(['identifier', '+', 'number' ]);
+      expect(sumNode.children.map(child => child!.type)).toEqual(['identifier', '+', 'number']);
     });
   });
 
@@ -446,6 +446,24 @@ describe('Node', () => {
       quotientNode.children.forEach((node) => {
         expect(node!.nextParseState).toBe(JavaScript.nextState(node!.parseState, node!.grammarId));
       });
+    });
+  });
+
+  describe('.descendantsOfType("ERROR")', () => {
+    it('finds all of the descendants of an ERROR node', () => {
+      tree = parser.parse(
+        `if ({a: 'b'} {c: 'd'}) {
+          // ^ ERROR
+          x = function(a) { b; } function(c) { d; }
+        }`
+      )!;
+      const errorNode = tree.rootNode;
+      const descendants = errorNode.descendantsOfType('ERROR');
+      expect(
+        descendants.map((node) => node!.startIndex)
+      ).toEqual(
+        [4]
+      );
     });
   });
 


### PR DESCRIPTION
It looks like the fix in https://github.com/tree-sitter/tree-sitter/pull/4103 got missed in https://github.com/tree-sitter/tree-sitter/pull/4121.

- Closes #4214