### PR TITLE
Mark all format-like macros for Clippy

### DIFF
--- a/cli/generate/src/render.rs
+++ b/cli/generate/src/render.rs
@@ -26,6 +26,7 @@ const ABI_VERSION_WITH_RESERVED_WORDS: usize = 15;
 const BUILD_VERSION: &str = env!("CARGO_PKG_VERSION");
 const BUILD_SHA: Option<&'static str> = option_env!("BUILD_SHA");
 
+#[clippy::format_args]
 macro_rules! add {
     ($this: tt, $($arg: tt)*) => {{
         $this.buffer.write_fmt(format_args!($($arg)*)).unwrap();
@@ -40,6 +41,7 @@ macro_rules! add_whitespace {
     }};
 }
 
+#[clippy::format_args]
 macro_rules! add_line {
     ($this: tt, $($arg: tt)*) => {
         add_whitespace!($this);


### PR DESCRIPTION
See https://doc.rust-lang.org/nightly/clippy/attribs.html#clippyformat_args

Ensure that usage of the macros with `format!`-like parameters will be validated by Clippy