### PR TITLE
Place APIs for generating grammars from a file behind a feature flag

### DIFF
--- a/crates/generate/Cargo.toml
+++ b/crates/generate/Cargo.toml
@@ -19,6 +19,10 @@ path = "src/generate.rs"
 [lints]
 workspace = true
 
+[features]
+default = ["load"]
+load = ["dep:semver", "dep:url"]
+
 [dependencies]
 anyhow.workspace = true
 heck.workspace = true
@@ -28,7 +32,7 @@ log.workspace = true
 regex.workspace = true
 regex-syntax.workspace = true
 rustc-hash.workspace = true
-semver.workspace = true
+semver = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 smallbitvec.workspace = true
@@ -38,4 +42,4 @@ topological-sort.workspace = true
 tree-sitter.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-url.workspace = true
+url = { workspace = true, optional = true }

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -30,6 +30,7 @@ pub struct VariableInfo {
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq, Default, PartialOrd, Ord)]
+#[cfg(feature = "load")]
 pub struct NodeInfoJSON {
     #[serde(rename = "type")]
     kind: String,
@@ -47,6 +48,7 @@ pub struct NodeInfoJSON {
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg(feature = "load")]
 pub struct NodeTypeJSON {
     #[serde(rename = "type")]
     kind: String,
@@ -54,6 +56,7 @@ pub struct NodeTypeJSON {
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg(feature = "load")]
 pub struct FieldInfoJSON {
     multiple: bool,
     required: bool,
@@ -67,6 +70,7 @@ pub struct ChildQuantity {
     multiple: bool,
 }
 
+#[cfg(feature = "load")]
 impl Default for FieldInfoJSON {
     fn default() -> Self {
         Self {
@@ -441,6 +445,7 @@ pub fn get_supertype_symbol_map(
     supertype_symbol_map
 }
 
+#[cfg(feature = "load")]
 pub type SuperTypeCycleResult<T> = Result<T, SuperTypeCycleError>;
 
 #[derive(Debug, Error, Serialize)]
@@ -462,6 +467,7 @@ impl std::fmt::Display for SuperTypeCycleError {
     }
 }
 
+#[cfg(feature = "load")]
 pub fn generate_node_types_json(
     syntax_grammar: &SyntaxGrammar,
     lexical_grammar: &LexicalGrammar,
@@ -783,6 +789,7 @@ pub fn generate_node_types_json(
     Ok(result)
 }
 
+#[cfg(feature = "load")]
 fn process_supertypes(info: &mut FieldInfoJSON, subtype_map: &[(NodeTypeJSON, Vec<NodeTypeJSON>)]) {
     for (supertype, subtypes) in subtype_map {
         if info.types.contains(supertype) {
@@ -829,7 +836,7 @@ where
     })
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "load"))]
 mod tests {
     use super::*;
     use crate::{


### PR DESCRIPTION
The `url` dependency pulls in a lot of transitive ICU crates, which impacts compile times when `tree-sitter-generate` is being used from a crate like `rust-sitter` which passes in the grammar definition in-memory. This shifts the APIs that depend on `url` behind a feature flag for loading grammars from a file. Furthermore, `url` is only needed on Windows, so we avoid the dependency altogether on non-Windows platforms.