### PR TITLE
rust bindings: Add information about using WASM grammar files to README

### DIFF
--- a/lib/binding_rust/README.md
+++ b/lib/binding_rust/README.md
@@ -105,6 +105,49 @@ assert_eq!(
 );
 ```
 
+## Using WASM Grammar Files
+
+> Requires the feature **wasm** to be enabled.
+
+First, create a parser with a WASM store:
+
+```rust
+use tree_sitter::{wasmtime::Engine, Parser, WasmStore};
+
+let engine = Engine::default();
+let store = WasmStore::new(&engine).unwrap();
+
+let mut parser = Parser::new();
+parser.set_wasm_store(store).unwrap();
+```
+
+Then, load the language from a WASM file:
+
+```rust
+const JAVASCRIPT_GRAMMAR: &[u8] = include_bytes!("path/to/tree-sitter-javascript.wasm");
+
+let mut store = WasmStore::new(&engine).unwrap();
+let javascript = store
+    .load_language("javascript", JAVASCRIPT_GRAMMAR)
+    .unwrap();
+
+// The language may be loaded from a different WasmStore than the one set on
+// the parser but it must use the same underlying WasmEngine.
+parser.set_language(&javascript).unwrap();
+```
+
+Now you can parse source code:
+
+```rust
+let source_code = "let x = 1;";
+let tree = parser.parse(source_code, None).unwrap();
+
+assert_eq!(
+    tree.root_node().to_sexp(),
+    "(program (lexical_declaration (variable_declarator name: (identifier) value: (number))))"
+);
+```
+
 [tree-sitter]: https://github.com/tree-sitter/tree-sitter
 
 ## Features


### PR DESCRIPTION
Hi, I recently needed to load languages from WASM files with the rust bindings, and I had a bit of a hard time figuring out some of the details/intricacies from the documentation that I could find. 

This PR adds a basic example of how to load a WASM language with the rust bindings to the `README` so it is easier to find for new users of the library.

I did my best to follow the writing style of the existing `README`s in `bindings_rust` and `bindings_web`, but in case I am missing any important context and/or there are issues here that I am not aware of, please let me know.