### PR TITLE
fix(rust): adapt to new nightly lint

### DIFF
--- a/cli/benches/benchmark.rs
+++ b/cli/benches/benchmark.rs
@@ -112,7 +112,7 @@ fn main() {
 
             parse(path, max_path_length, |source| {
                 Query::new(&language, str::from_utf8(source).unwrap())
-                    .with_context(|| format!("Query file path: {path:?}"))
+                    .with_context(|| format!("Query file path: {}", path.display()))
                     .expect("Failed to parse query");
             });
         }
@@ -201,7 +201,7 @@ fn parse(path: &Path, max_path_length: usize, mut action: impl FnMut(&[u8])) -> 
     );
 
     let source_code = fs::read(path)
-        .with_context(|| format!("Failed to read {path:?}"))
+        .with_context(|| format!("Failed to read {}", path.display()))
         .unwrap();
     let time = Instant::now();
     for _ in 0..*REPETITION_COUNT {
@@ -221,6 +221,6 @@ fn get_language(path: &Path) -> Language {
     let src_path = GRAMMARS_DIR.join(path).join("src");
     TEST_LOADER
         .load_language_at_path(CompileConfig::new(&src_path, None, None))
-        .with_context(|| format!("Failed to load language at path {src_path:?}"))
+        .with_context(|| format!("Failed to load language at path {}", src_path.display()))
         .unwrap()
 }

--- a/cli/generate/src/lib.rs
+++ b/cli/generate/src/lib.rs
@@ -183,7 +183,8 @@ pub fn generate_parser_in_directory(
     if grammar_path.file_name().unwrap() != "grammar.json" {
         fs::write(src_path.join("grammar.json"), &grammar_json).map_err(|e| {
             GenerateError::IO(format!(
-                "Failed to write grammar.json to {src_path:?} -- {e}"
+                "Failed to write grammar.json to {} -- {e}",
+                src_path.display()
             ))
         })?;
     }

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -561,8 +561,8 @@ impl Loader {
                 // If multiple language configurations match, then determine which
                 // one to use by applying the configurations' content regexes.
                 else {
-                    let file_contents =
-                        fs::read(path).with_context(|| format!("Failed to read path {path:?}"))?;
+                    let file_contents = fs::read(path)
+                        .with_context(|| format!("Failed to read path {}", path.display()))?;
                     let file_contents = String::from_utf8_lossy(&file_contents);
                     let mut best_score = -2isize;
                     let mut best_configuration_id = None;
@@ -780,8 +780,8 @@ impl Loader {
         if recompile {
             fs::create_dir_all(lock_path.parent().unwrap()).with_context(|| {
                 format!(
-                    "Failed to create directory {:?}",
-                    lock_path.parent().unwrap()
+                    "Failed to create directory {}",
+                    lock_path.parent().unwrap().display()
                 )
             })?;
             let lock_file = fs::OpenOptions::new()
@@ -799,7 +799,7 @@ impl Loader {
         }
 
         let library = unsafe { Library::new(&output_path) }
-            .with_context(|| format!("Error opening dynamic library {output_path:?}"))?;
+            .with_context(|| format!("Error opening dynamic library {}", output_path.display()))?;
         let language = unsafe {
             let language_fn = library
                 .get::<Symbol<unsafe extern "C" fn() -> Language>>(language_fn_name.as_bytes())
@@ -1564,7 +1564,7 @@ impl LanguageConfiguration<'_> {
         error.row = source[range.start..offset_within_section]
             .matches('\n')
             .count();
-        Error::from(error).context(format!("Error in query file {path:?}"))
+        Error::from(error).context(format!("Error in query file {}", path.display()))
     }
 
     #[allow(clippy::type_complexity)]
@@ -1581,7 +1581,7 @@ impl LanguageConfiguration<'_> {
                 let abs_path = self.root_path.join(path);
                 let prev_query_len = query.len();
                 query += &fs::read_to_string(&abs_path)
-                    .with_context(|| format!("Failed to read query file {path:?}"))?;
+                    .with_context(|| format!("Failed to read query file {}", path.display()))?;
                 path_ranges.push((path.clone(), prev_query_len..query.len()));
             }
         } else {
@@ -1599,7 +1599,7 @@ impl LanguageConfiguration<'_> {
             let path = queries_path.join(default_path);
             if path.exists() {
                 query = fs::read_to_string(&path)
-                    .with_context(|| format!("Failed to read query file {path:?}"))?;
+                    .with_context(|| format!("Failed to read query file {}", path.display()))?;
                 path_ranges.push((PathBuf::from(default_path), 0..query.len()));
             }
         }
@@ -1612,8 +1612,8 @@ fn needs_recompile(lib_path: &Path, paths_to_check: &[PathBuf]) -> Result<bool> 
     if !lib_path.exists() {
         return Ok(true);
     }
-    let lib_mtime =
-        mtime(lib_path).with_context(|| format!("Failed to read mtime of {lib_path:?}"))?;
+    let lib_mtime = mtime(lib_path)
+        .with_context(|| format!("Failed to read mtime of {}", lib_path.display()))?;
     for path in paths_to_check {
         if mtime(path)? > lib_mtime {
             return Ok(true);

--- a/cli/src/input.rs
+++ b/cli/src/input.rs
@@ -89,8 +89,8 @@ pub fn get_input(
                 let Some(path_str) = path.to_str() else {
                     bail!("Invalid path: {}", path.display());
                 };
-                let paths =
-                    glob(path_str).with_context(|| format!("Invalid glob pattern {path:?}"))?;
+                let paths = glob(path_str)
+                    .with_context(|| format!("Invalid glob pattern {}", path.display()))?;
                 for path in paths {
                     incorporate_path(path?, positive);
                 }

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -34,7 +34,7 @@ pub fn query_file_at_path(
     let mut stdout = stdout.lock();
 
     let query_source = fs::read_to_string(query_path)
-        .with_context(|| format!("Error reading query file {query_path:?}"))?;
+        .with_context(|| format!("Error reading query file {}", query_path.display()))?;
     let query = Query::new(language, &query_source).with_context(|| "Query compilation failed")?;
 
     let mut query_cursor = QueryCursor::new();
@@ -55,7 +55,7 @@ pub fn query_file_at_path(
     }
 
     let source_code =
-        fs::read(path).with_context(|| format!("Error reading source file {path:?}"))?;
+        fs::read(path).with_context(|| format!("Error reading source file {}", path.display()))?;
     let tree = parser.parse(&source_code, None).unwrap();
 
     let start = Instant::now();

--- a/cli/src/wasm.rs
+++ b/cli/src/wasm.rs
@@ -23,10 +23,18 @@ pub fn load_language_wasm_file(language_dir: &Path) -> Result<(String, Vec<u8>)>
 pub fn get_grammar_name(language_dir: &Path) -> Result<String> {
     let src_dir = language_dir.join("src");
     let grammar_json_path = src_dir.join("grammar.json");
-    let grammar_json = fs::read_to_string(&grammar_json_path)
-        .with_context(|| format!("Failed to read grammar file {grammar_json_path:?}"))?;
-    let grammar: GrammarJSON = serde_json::from_str(&grammar_json)
-        .with_context(|| format!("Failed to parse grammar file {grammar_json_path:?}"))?;
+    let grammar_json = fs::read_to_string(&grammar_json_path).with_context(|| {
+        format!(
+            "Failed to read grammar file {}",
+            grammar_json_path.display()
+        )
+    })?;
+    let grammar: GrammarJSON = serde_json::from_str(&grammar_json).with_context(|| {
+        format!(
+            "Failed to parse grammar file {}",
+            grammar_json_path.display()
+        )
+    })?;
     Ok(grammar.name)
 }
 

--- a/lib/binding_rust/build.rs
+++ b/lib/binding_rust/build.rs
@@ -112,7 +112,10 @@ fn generate_bindings(out_dir: &std::path::Path) {
         .expect("Failed to generate bindings");
 
     let bindings_rs = out_dir.join("bindings.rs");
-    bindings
-        .write_to_file(&bindings_rs)
-        .unwrap_or_else(|_| panic!("Failed to write bindings into path: {bindings_rs:?}"));
+    bindings.write_to_file(&bindings_rs).unwrap_or_else(|_| {
+        panic!(
+            "Failed to write bindings into path: {}",
+            bindings_rs.display()
+        )
+    });
 }


### PR DESCRIPTION
Nightly clippy is working again, and with it a [new lint](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_debug_formatting). 