### PR TITLE
Update build.zig.zon for zig master/0.14

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-  .name = "tree-sitter",
+  .name = .tree_sitter,
+  .fingerprint = 0x841224b447ac0d4f,
   .version = "0.25.1",
   .paths = .{
     "build.zig",


### PR DESCRIPTION
In a recently landed change (https://github.com/ziglang/zig/pull/22994), the structure of the `build.zig.zon` file changed. This PR fixes the structure to be compatible with the newest master build and coming 0.14 release.