### PR TITLE
fix(build): bump version to 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "bindgen",
  "cc",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-cli"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "ansi_colours",
  "anstyle",
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-config"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "etcetera",
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-generate"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "heck",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-highlight"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "regex",
  "streaming-iterator",
@@ -2155,7 +2155,7 @@ version = "0.1.4"
 
 [[package]]
 name = "tree-sitter-loader"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "cc",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-tags"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "memchr",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.25.1"
+version = "0.26.0"
 authors = [
   "Max Brunsfeld <maxbrunsfeld@gmail.com>",
   "Amaan Qureshi <amaanq12@gmail.com>",

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.25.1
+VERSION := 0.26.0
 DESCRIPTION := An incremental parsing system for programming tools
 HOMEPAGE_URL := https://tree-sitter.github.io/tree-sitter/
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
   .name = "tree-sitter",
-  .version = "0.25.1",
+  .version = "0.26.0",
   .paths = .{
     "build.zig",
     "build.zig.zon",

--- a/cli/npm/package.json
+++ b/cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-cli",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "author": {
     "name": "Max Brunsfeld",
     "email": "maxbrunsfeld@gmail.com"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(tree-sitter
-        VERSION "0.25.1"
+        VERSION "0.26.0"
         DESCRIPTION "An incremental parsing system for programming tools"
         HOMEPAGE_URL "https://tree-sitter.github.io/tree-sitter/"
         LANGUAGES C)

--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-tree-sitter",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "description": "Tree-sitter bindings for the web",
   "repository": "https://github.com/tree-sitter/tree-sitter",
   "homepage": "https://github.com/tree-sitter/tree-sitter/tree/master/lib/binding_web",


### PR DESCRIPTION
After a release, `master` branch should be bumped to the next _minor_ version.

(`cargo xtask bump-version` seems broken since it doesn't respect the `-v` flag for the `Workspace` entry in `Cargo.toml`.)
