### PR TITLE
fix(docs): update test command flag from -f to -i

### DIFF
--- a/docs/src/creating-parsers/5-writing-tests.md
+++ b/docs/src/creating-parsers/5-writing-tests.md
@@ -80,7 +80,7 @@ By default, the `tree-sitter test` command runs all the tests in your `test/corp
 can use the `-f` flag:
 
 ```sh
-tree-sitter test -f 'Return statements'
+tree-sitter test -i 'Return statements'
 ```
 
 The recommendation is to be comprehensive in adding tests. If it's a visible node, add it to a test file in your `test/corpus`


### PR DESCRIPTION
The `-f` flag on `tree-sitter test` seems to have been removed or replaced with a `-i, --include` flag. This PR updates the "Writing Tests" page to reflect this change.