### PR TITLE
fix(lib): remove duplicate TSLanguageMetadata typedef

### DIFF
--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -42,7 +42,6 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
-typedef struct TSLanguageMetadata TSLanguageMetadata;
 typedef struct TSParser TSParser;
 typedef struct TSTree TSTree;
 typedef struct TSQuery TSQuery;

--- a/lib/src/parser.h
+++ b/lib/src/parser.h
@@ -18,7 +18,6 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
-typedef struct TSLanguageMetadata TSLanguageMetadata;
 typedef struct TSLanguageMetadata {
   uint8_t major_version;
   uint8_t minor_version;


### PR DESCRIPTION
To fix the following error:
```
clang -Isubprojects/tree-sitter-0.25.3/libtree_sitter.a.p -I../subprojects/tree-sitter-0.25.3/lib/src -I../subprojects/tree-sitter-0.25.3/lib/include -fdiagnostics-color=always -fsanitize=address,undefined -fno-omit-frame-pointer -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Werror -std=c99 -O2 -g --std=gnu99 -DASAN=1 -DRZ_ASSERT_STDOUT=1 -fPIC -MD -MQ subprojects/tree-sitter-0.25.3/libtree_sitter.a.p/lib_src_lib.c.o -MF subprojects/tree-sitter-0.25.3/libtree_sitter.a.p/lib_src_lib.c.o.d -o subprojects/tree-sitter-0.25.3/libtree_sitter.a.p/lib_src_lib.c.o -c ../subprojects/tree-sitter-0.25.3/lib/src/lib.c
In file included from ../subprojects/tree-sitter-0.25.3/lib/src/lib.c:1:
In file included from ../subprojects/tree-sitter-0.25.3/lib/src/./alloc.c:2:
../subprojects/tree-sitter-0.25.3/lib/include/tree_sitter/api.h:199:3: error: redefinition of typedef 'TSLanguageMetadata' is a C11 feature [-Werror,-Wtypedef-redefinition]
} TSLanguageMetadata;
  ^
../subprojects/tree-sitter-0.25.3/lib/include/tree_sitter/api.h:45:35: note: previous definition is here
typedef struct TSLanguageMetadata TSLanguageMetadata;
                                  ^
1 error generated.
```