### PR TITLE
fix(build): bump version to 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-cli"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "ansi_colours",
  "anstyle",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-config"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "etcetera",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-generate"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "heck",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-highlight"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "regex",
  "streaming-iterator",
@@ -2148,7 +2148,7 @@ version = "0.1.4"
 
 [[package]]
 name = "tree-sitter-loader"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-tags"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "memchr",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.25.1"
+version = "0.26.0"
 authors = [
   "Max Brunsfeld <maxbrunsfeld@gmail.com>",
   "Amaan Qureshi <amaanq12@gmail.com>",
@@ -150,9 +150,9 @@ walkdir = "2.5.0"
 wasmparser = "0.224.0"
 webbrowser = "1.0.3"
 
-tree-sitter = { version = "0.25.1", path = "./lib" }
-tree-sitter-generate = { version = "0.25.1", path = "./cli/generate" }
-tree-sitter-loader = { version = "0.25.1", path = "./cli/loader" }
-tree-sitter-config = { version = "0.25.1", path = "./cli/config" }
-tree-sitter-highlight = { version = "0.25.1", path = "./highlight" }
-tree-sitter-tags = { version = "0.25.1", path = "./tags" }
+tree-sitter = { version = "0.26.0", path = "./lib" }
+tree-sitter-generate = { version = "0.26.0", path = "./cli/generate" }
+tree-sitter-loader = { version = "0.26.0", path = "./cli/loader" }
+tree-sitter-config = { version = "0.26.0", path = "./cli/config" }
+tree-sitter-highlight = { version = "0.26.0", path = "./highlight" }
+tree-sitter-tags = { version = "0.26.0", path = "./tags" }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.25.1
+VERSION := 0.26.0
 DESCRIPTION := An incremental parsing system for programming tools
 HOMEPAGE_URL := https://tree-sitter.github.io/tree-sitter/
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
   .name = .tree_sitter,
   .fingerprint = 0x841224b447ac0d4f,
-  .version = "0.25.1",
+  .version = "0.26.0",
   .paths = .{
     "build.zig",
     "build.zig.zon",

--- a/cli/npm/package.json
+++ b/cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-cli",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "author": {
     "name": "Max Brunsfeld",
     "email": "maxbrunsfeld@gmail.com"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(tree-sitter
-        VERSION "0.25.1"
+        VERSION "0.26.0"
         DESCRIPTION "An incremental parsing system for programming tools"
         HOMEPAGE_URL "https://tree-sitter.github.io/tree-sitter/"
         LANGUAGES C)

--- a/lib/binding_web/package-lock.json
+++ b/lib/binding_web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-tree-sitter",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-tree-sitter",
-      "version": "0.25.1",
+      "version": "0.26.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.20.0",

--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-tree-sitter",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "description": "Tree-sitter bindings for the web",
   "repository": "https://github.com/tree-sitter/tree-sitter",
   "homepage": "https://github.com/tree-sitter/tree-sitter/tree/master/lib/binding_web",


### PR DESCRIPTION
After a release, `master` branch should be bumped to the next _minor_ version `0.x+1.0` since all point releases come from the backport `release-0.x` branch.


(Second try, this time manually since `cargo xtask` didn't work.)