### PR TITLE
Change `(Node | null)[]` return types to `Node[]`

### DIFF
--- a/lib/binding_web/src/node.ts
+++ b/lib/binding_web/src/node.ts
@@ -12,10 +12,10 @@ export class Node {
   private [0] = 0; // Internal handle for WASM
 
   /** @internal */
-  private _children?: (Node | null)[];
+  private _children?: Node[];
 
   /** @internal */
-  private _namedChildren?: (Node | null)[];
+  private _namedChildren?: Node[];
 
   /** @internal */
   constructor(
@@ -258,7 +258,7 @@ export class Node {
    *
    * See also {@link Node#children}.
    */
-  childrenForFieldName(fieldName: string): (Node | null)[] {
+  childrenForFieldName(fieldName: string): Node[] {
     const fieldId = this.tree.language.fields.indexOf(fieldName);
     if (fieldId !== -1 && fieldId !== 0) return this.childrenForFieldId(fieldId);
     return [];
@@ -269,17 +269,17 @@ export class Node {
     *
     * See also {@link Node#childrenForFieldName}.
     */
-  childrenForFieldId(fieldId: number): (Node | null)[] {
+  childrenForFieldId(fieldId: number): Node[] {
     marshalNode(this);
     C._ts_node_children_by_field_id_wasm(this.tree[0], fieldId);
     const count = C.getValue(TRANSFER_BUFFER, 'i32');
     const buffer = C.getValue(TRANSFER_BUFFER + SIZE_OF_INT, 'i32');
-    const result = new Array<Node | null>(count);
+    const result = new Array<Node>(count);
 
     if (count > 0) {
       let address = buffer;
       for (let i = 0; i < count; i++) {
-        result[i] = unmarshalNode(this.tree, address);
+        result[i] = unmarshalNode(this.tree, address)!;
         address += SIZE_OF_NODE;
       }
       C._free(buffer);
@@ -356,7 +356,7 @@ export class Node {
    * If you're walking the tree recursively, you may want to use the
    * {@link TreeCursor} APIs directly instead.
    */
-  get children(): (Node | null)[] {
+  get children(): Node[] {
     if (!this._children) {
       marshalNode(this);
       C._ts_node_children_wasm(this.tree[0]);
@@ -366,7 +366,7 @@ export class Node {
       if (count > 0) {
         let address = buffer;
         for (let i = 0; i < count; i++) {
-          this._children[i] = unmarshalNode(this.tree, address);
+          this._children[i] = unmarshalNode(this.tree, address)!;
           address += SIZE_OF_NODE;
         }
         C._free(buffer);
@@ -380,7 +380,7 @@ export class Node {
    *
    * See also {@link Node#children}.
    */
-  get namedChildren(): (Node | null)[] {
+  get namedChildren(): Node[] {
     if (!this._namedChildren) {
       marshalNode(this);
       C._ts_node_named_children_wasm(this.tree[0]);
@@ -390,7 +390,7 @@ export class Node {
       if (count > 0) {
         let address = buffer;
         for (let i = 0; i < count; i++) {
-          this._namedChildren[i] = unmarshalNode(this.tree, address);
+          this._namedChildren[i] = unmarshalNode(this.tree, address)!;
           address += SIZE_OF_NODE;
         }
         C._free(buffer);
@@ -410,7 +410,7 @@ export class Node {
     types: string | string[],
     startPosition: Point = ZERO_POINT,
     endPosition: Point = ZERO_POINT
-  ): (Node | null)[] {
+  ): Node[] {
     if (!Array.isArray(types)) types = [types];
 
     // Convert the type strings to numeric type symbols
@@ -448,11 +448,11 @@ export class Node {
     // Instantiate the nodes based on the data returned
     const descendantCount = C.getValue(TRANSFER_BUFFER, 'i32');
     const descendantAddress = C.getValue(TRANSFER_BUFFER + SIZE_OF_INT, 'i32');
-    const result = new Array<Node | null>(descendantCount);
+    const result = new Array<Node>(descendantCount);
     if (descendantCount > 0) {
       let address = descendantAddress;
       for (let i = 0; i < descendantCount; i++) {
-        result[i] = unmarshalNode(this.tree, address);
+        result[i] = unmarshalNode(this.tree, address)!;
         address += SIZE_OF_NODE;
       }
     }

--- a/lib/binding_web/test/node.test.ts
+++ b/lib/binding_web/test/node.test.ts
@@ -63,7 +63,7 @@ describe('Node', () => {
       tree = parser.parse('x10 + 1000')!;
       expect(tree.rootNode.children).toHaveLength(1);
       const sumNode = tree.rootNode.firstChild!.firstChild!;
-      expect(sumNode.children.map(child => child!.type)).toEqual(['identifier', '+', 'number']);
+      expect(sumNode.children.map(child => child.type)).toEqual(['identifier', '+', 'number']);
     });
   });
 
@@ -72,7 +72,7 @@ describe('Node', () => {
       tree = parser.parse('x10 + 1000')!;
       const sumNode = tree.rootNode.firstChild!.firstChild!;
       expect(tree.rootNode.namedChildren).toHaveLength(1);
-      expect(sumNode.namedChildren.map(child => child!.type)).toEqual(['identifier', 'number']);
+      expect(sumNode.namedChildren.map(child => child.type)).toEqual(['identifier', 'number']);
     });
   });
 
@@ -94,7 +94,7 @@ describe('Node', () => {
       expect(node.type).toBe('if_statement');
       const alternatives = node.childrenForFieldName('alternative');
       const alternativeTexts = alternatives.map(n => {
-        const condition = n!.childForFieldName('condition')!;
+        const condition = n.childForFieldName('condition')!;
         return source.slice(condition.startIndex, condition.endIndex);
       });
       expect(alternativeTexts).toEqual(['two', 'three', 'four']);
@@ -108,8 +108,8 @@ describe('Node', () => {
 
       expect(quotientNode.startIndex).toBe(0);
       expect(quotientNode.endIndex).toBe(15);
-      expect(quotientNode.children.map(child => child!.startIndex)).toEqual([0, 7, 9]);
-      expect(quotientNode.children.map(child => child!.endIndex)).toEqual([6, 8, 15]);
+      expect(quotientNode.children.map(child => child.startIndex)).toEqual([0, 7, 9]);
+      expect(quotientNode.children.map(child => child.endIndex)).toEqual([6, 8, 15]);
     });
   });
 
@@ -121,12 +121,12 @@ describe('Node', () => {
 
       expect(sumNode.startPosition).toEqual({ row: 0, column: 0 });
       expect(sumNode.endPosition).toEqual({ row: 0, column: 10 });
-      expect(sumNode.children.map((child) => child!.startPosition)).toEqual([
+      expect(sumNode.children.map((child) => child.startPosition)).toEqual([
         { row: 0, column: 0 },
         { row: 0, column: 4 },
         { row: 0, column: 6 },
       ]);
-      expect(sumNode.children.map((child) => child!.endPosition)).toEqual([
+      expect(sumNode.children.map((child) => child.endPosition)).toEqual([
         { row: 0, column: 3 },
         { row: 0, column: 5 },
         { row: 0, column: 10 },
@@ -136,7 +136,7 @@ describe('Node', () => {
     it('handles characters that occupy two UTF16 code units', () => {
       tree = parser.parse('a👍👎1 /\n b👎c👎')!;
       const sumNode = tree.rootNode.firstChild!.firstChild!;
-      expect(sumNode.children.map(child => [child!.startPosition, child!.endPosition])).toEqual([
+      expect(sumNode.children.map(child => [child.startPosition, child.endPosition])).toEqual([
         [{ row: 0, column: 0 }, { row: 0, column: 6 }],
         [{ row: 0, column: 7 }, { row: 0, column: 8 }],
         [{ row: 1, column: 1 }, { row: 1, column: 7 }]
@@ -193,10 +193,10 @@ describe('Node', () => {
     it('returns the node\'s next and previous sibling', () => {
       tree = parser.parse('x10 + 1000')!;
       const sumNode = tree.rootNode.firstChild!.firstChild!;
-      expect(sumNode.children[1]!.id).toBe(sumNode.children[0]!.nextSibling!.id);
-      expect(sumNode.children[2]!.id).toBe(sumNode.children[1]!.nextSibling!.id);
-      expect(sumNode.children[0]!.id).toBe(sumNode.children[1]!.previousSibling!.id);
-      expect(sumNode.children[1]!.id).toBe(sumNode.children[2]!.previousSibling!.id);
+      expect(sumNode.children[1].id).toBe(sumNode.children[0].nextSibling!.id);
+      expect(sumNode.children[2].id).toBe(sumNode.children[1].nextSibling!.id);
+      expect(sumNode.children[0].id).toBe(sumNode.children[1].previousSibling!.id);
+      expect(sumNode.children[1].id).toBe(sumNode.children[2].previousSibling!.id);
     });
   });
 
@@ -204,8 +204,8 @@ describe('Node', () => {
     it('returns the node\'s next and previous named sibling', () => {
       tree = parser.parse('x10 + 1000')!;
       const sumNode = tree.rootNode.firstChild!.firstChild!;
-      expect(sumNode.namedChildren[1]!.id).toBe(sumNode.namedChildren[0]!.nextNamedSibling!.id);
-      expect(sumNode.namedChildren[0]!.id).toBe(sumNode.namedChildren[1]!.previousNamedSibling!.id);
+      expect(sumNode.namedChildren[1].id).toBe(sumNode.namedChildren[0].nextNamedSibling!.id);
+      expect(sumNode.namedChildren[0].id).toBe(sumNode.namedChildren[1].previousNamedSibling!.id);
     });
   });
 
@@ -277,9 +277,9 @@ describe('Node', () => {
 
       const sum = node.firstChild!.firstChild!;
       expect(sum.hasError).toBe(true);
-      expect(sum.children[0]!.hasError).toBe(false);
-      expect(sum.children[1]!.hasError).toBe(false);
-      expect(sum.children[2]!.hasError).toBe(true);
+      expect(sum.children[0].hasError).toBe(false);
+      expect(sum.children[1].hasError).toBe(false);
+      expect(sum.children[2].hasError).toBe(true);
     });
   });
 
@@ -293,10 +293,10 @@ describe('Node', () => {
 
       const multi = node.firstChild!.firstChild!;
       expect(multi.hasError).toBe(true);
-      expect(multi.children[0]!.isError).toBe(false);
-      expect(multi.children[1]!.isError).toBe(false);
-      expect(multi.children[2]!.isError).toBe(true);
-      expect(multi.children[3]!.isError).toBe(false);
+      expect(multi.children[0].isError).toBe(false);
+      expect(multi.children[1].isError).toBe(false);
+      expect(multi.children[2].isError).toBe(true);
+      expect(multi.children[3].isError).toBe(false);
     });
   });
 
@@ -311,9 +311,9 @@ describe('Node', () => {
       const sum = node.firstChild!.firstChild!.firstNamedChild!;
       expect(sum.type).toBe('binary_expression');
       expect(sum.hasError).toBe(true);
-      expect(sum.children[0]!.isMissing).toBe(false);
-      expect(sum.children[1]!.isMissing).toBe(false);
-      expect(sum.children[2]!.isMissing).toBe(true);
+      expect(sum.children[0].isMissing).toBe(false);
+      expect(sum.children[1].isMissing).toBe(false);
+      expect(sum.children[2].isMissing).toBe(true);
     });
   });
 
@@ -344,10 +344,10 @@ describe('Node', () => {
         const [numerator, slash, denominator] = quotientNode.children;
 
         expect(tree.rootNode.text).toBe(text);
-        expect(denominator!.text).toBe(denominatorSrc);
+        expect(denominator.text).toBe(denominatorSrc);
         expect(quotientNode.text).toBe(text);
-        expect(numerator!.text).toBe(numeratorSrc);
-        expect(slash!.text).toBe('/');
+        expect(numerator.text).toBe(numeratorSrc);
+        expect(slash.text).toBe('/');
       });
     });
   });
@@ -435,16 +435,16 @@ describe('Node', () => {
       expect(tree.rootNode.parseState).toBe(0);
       // parse states will change on any change to the grammar so test that it
       // returns something instead
-      expect(numerator!.parseState).toBeGreaterThan(0);
-      expect(slash!.parseState).toBeGreaterThan(0);
-      expect(denominator!.parseState).toBeGreaterThan(0);
+      expect(numerator.parseState).toBeGreaterThan(0);
+      expect(slash.parseState).toBeGreaterThan(0);
+      expect(denominator.parseState).toBeGreaterThan(0);
     });
 
     it('returns next parse state equal to the language', () => {
       tree = parser.parse(text)!;
       const quotientNode = tree.rootNode.firstChild!.firstChild!;
       quotientNode.children.forEach((node) => {
-        expect(node!.nextParseState).toBe(JavaScript.nextState(node!.parseState, node!.grammarId));
+        expect(node.nextParseState).toBe(JavaScript.nextState(node.parseState, node.grammarId));
       });
     });
   });
@@ -460,7 +460,7 @@ describe('Node', () => {
       const errorNode = tree.rootNode;
       const descendants = errorNode.descendantsOfType('ERROR');
       expect(
-        descendants.map((node) => node!.startIndex)
+        descendants.map((node) => node.startIndex)
       ).toEqual(
         [4]
       );
@@ -473,8 +473,8 @@ describe('Node', () => {
       const outerSum = tree.rootNode.firstChild!.firstChild!;
 
       const descendants = outerSum.descendantsOfType('number', { row: 0, column: 2 }, { row: 0, column: 15 });
-      expect(descendants.map(node => node!.startIndex)).toEqual([4, 12]);
-      expect(descendants.map(node => node!.endPosition)).toEqual([{ row: 0, column: 5 }, { row: 0, column: 13 }]);
+      expect(descendants.map(node => node.startIndex)).toEqual([4, 12]);
+      expect(descendants.map(node => node.endPosition)).toEqual([{ row: 0, column: 5 }, { row: 0, column: 13 }]);
     });
   });
 

--- a/lib/binding_web/web-tree-sitter.d.ts
+++ b/lib/binding_web/web-tree-sitter.d.ts
@@ -490,13 +490,13 @@ declare module 'web-tree-sitter' {
 		 *
 		 * See also {@link Node#children}.
 		 */
-		childrenForFieldName(fieldName: string): (Node | null)[];
+		childrenForFieldName(fieldName: string): Node[];
 		/**
 		  * Get an array of this node's children with a given field id.
 		  *
 		  * See also {@link Node#childrenForFieldName}.
 		  */
-		childrenForFieldId(fieldId: number): (Node | null)[];
+		childrenForFieldId(fieldId: number): Node[];
 		/** Get the node's first child that contains or starts after the given byte offset. */
 		firstChildForIndex(index: number): Node | null;
 		/** Get the node's first named child that contains or starts after the given byte offset. */
@@ -531,13 +531,13 @@ declare module 'web-tree-sitter' {
 		 * If you're walking the tree recursively, you may want to use the
 		 * {@link TreeCursor} APIs directly instead.
 		 */
-		get children(): (Node | null)[];
+		get children(): Node[];
 		/**
 		 * Iterate over this node's named children.
 		 *
 		 * See also {@link Node#children}.
 		 */
-		get namedChildren(): (Node | null)[];
+		get namedChildren(): Node[];
 		/**
 		 * Get the descendants of this node that are the given type, or in the given types array.
 		 *
@@ -545,7 +545,7 @@ declare module 'web-tree-sitter' {
 		 *
 		 * Additionally, a `startPosition` and `endPosition` can be passed in to restrict the search to a byte range.
 		 */
-		descendantsOfType(types: string | string[], startPosition?: Point, endPosition?: Point): (Node | null)[];
+		descendantsOfType(types: string | string[], startPosition?: Point, endPosition?: Point): Node[];
 		/** Get this node's next sibling. */
 		get nextSibling(): Node | null;
 		/** Get this node's previous sibling. */


### PR DESCRIPTION
In the rewrite for web-tree-sitter 0.25, some functions that used to return `Node[]` were changed to `(Node | null)[]`.
This makes using them tricky, as it requires filtering out the `null` values.

But from what I gather - they don't actually return `null` values now either.

Given the way the [C part is written](https://github.com/tree-sitter/tree-sitter/blob/07a1b7fc003f8a896f74a03805498a5ca0a8d4d0/lib/binding_web/lib/tree-sitter.c#L680), if I understand correctly, those functions should always return a `Node[]`, and have no `null` elements.

This PR adds non-null assertions to change those type signatures and make using the functions the same as with previous versions.