### PR TITLE
fix(xtask): error if new version supplied to xtask is less than or equal to current version

### DIFF
--- a/xtask/src/bump.rs
+++ b/xtask/src/bump.rs
@@ -127,6 +127,11 @@ pub fn run(args: BumpVersion) -> Result<()> {
         }
         next_version
     };
+    if next_version <= current_version {
+        return Err(anyhow!(format!(
+            "Next version {next_version} must be greater than current version {current_version}"
+        )));
+    }
 
     println!("Bumping from {current_version} to {next_version}");
     update_crates(&current_version, &next_version)?;


### PR DESCRIPTION
Currently, if you do the following:

`cargo xtask bump-version -v <current crate version>`

the crate version will instead be bumped to the next minor version:

![image](https://github.com/user-attachments/assets/f032832c-e5d2-4c41-bcf1-c6be13d18ee1)
