### PR TITLE
Tidy up the docs in auto-generated Rust bindings

### DIFF
--- a/cli/src/templates/lib.rs
+++ b/cli/src/templates/lib.rs
@@ -1,7 +1,7 @@
-//! This crate provides CAMEL_PARSER_NAME language support for the [tree-sitter][] parsing library.
+//! This crate provides CAMEL_PARSER_NAME language support for the [tree-sitter] parsing library.
 //!
-//! Typically, you will use the [LANGUAGE][] constant to add this language to a
-//! tree-sitter [Parser][], and then use the parser to parse some code:
+//! Typically, you will use the [`LANGUAGE`] constant to add this language to a
+//! tree-sitter [`Parser`], and then use the parser to parse some code:
 //!
 //! ```
 //! let code = r#"
@@ -15,7 +15,7 @@
 //! assert!(!tree.root_node().has_error());
 //! ```
 //!
-//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [`Parser`]: https://docs.rs/tree-sitter/RUST_BINDING_VERSION/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
 use tree_sitter_language::LanguageFn;
@@ -24,12 +24,10 @@ extern "C" {
     fn tree_sitter_PARSER_NAME() -> *const ();
 }
 
-/// The tree-sitter [`LanguageFn`][LanguageFn] for this grammar.
-///
-/// [LanguageFn]: https://docs.rs/tree-sitter-language/*/tree_sitter_language/struct.LanguageFn.html
+/// The tree-sitter [`LanguageFn`] for this grammar.
 pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_PARSER_NAME) };
 
-/// The content of the [`node-types.json`][] file for this grammar.
+/// The content of the [`node-types.json`] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers/6-static-node-types
 pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");


### PR DESCRIPTION
Hi there! I was looking into tree-sitter out of curiousity, and while messing about with it, I noticed that the doc-comments in the generated Rust bindings were formatted a little oddly.

I thought to tidy up the doc-comments a little. In particular, I did the following things:

* I removed a couple useless `[]` which appear after the text portion of a link. For example, `[tree-sitter][]` became `[tree-sitter]`. Thanks to how markdown handles reference-style links, these still link to the same place.

* Where a link refers to a item (such as a struct or const), I changed the link's text to be in backticks, such that it shows up in a `in-line code block`. For example, <code>[Parser]</code> became <code>[\`Parser\`]</code>. This brings item links in line with how many Rust crates link to items.

* I changed the link to `tree_sitter::Parser` to include the exact version of the `tree_sitter` crate used by the binding crate, rather than version `*`. This ensures that the linked documentation links to the relevant version of the crate (whether the relevant version is the latest version or not).

* I removed the reference link definition for `tree_sitter_language::LanguageFn`. This causes rustdoc to link to the `LanguageFn` item that's already in scope - which incidentally also ensures that the link will go to the exact version of `tree_sitter_language` used by the binding crate.

This should not result in any functional or visual differences to the doc (aside from the `LANGUAGE` and `Parser` links now looking like in-line code blocks).
