### PR TITLE
fix(rust): use core crates for no_std

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,7 +238,6 @@ jobs:
       if: ${{ !matrix.no-run && !matrix.use-cross && inputs.run-test }}
       run: $BUILD_CMD run -p xtask -- test-wasm
 
-
     - name: Upload CLI artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,6 +203,13 @@ jobs:
         npm run build
         npm run build:debug
 
+    - name: Check no_std builds
+      if: ${{ !matrix.no-run && inputs.run-test }}
+      shell: bash
+      run: |
+        cd lib
+        $BUILD_CMD check --no-default-features
+
     - name: Build target
       run: $BUILD_CMD build --release --target=${{ matrix.target }} --features=${{ matrix.features }}
 
@@ -230,6 +237,7 @@ jobs:
     - name: Run wasm tests
       if: ${{ !matrix.no-run && !matrix.use-cross && inputs.run-test }}
       run: $BUILD_CMD run -p xtask -- test-wasm
+
 
     - name: Upload CLI artifact
       uses: actions/upload-artifact@v4

--- a/lib/binding_rust/ffi.rs
+++ b/lib/binding_rust/ffi.rs
@@ -16,6 +16,7 @@ extern "C" {
 }
 
 #[cfg(windows)]
+#[cfg(feature = "std")]
 extern "C" {
     pub(crate) fn _ts_dup(handle: *mut std::os::raw::c_void) -> std::os::raw::c_int;
 }

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1222,7 +1222,7 @@ impl Parser {
             len: u32,
             code_point: *mut i32,
         ) -> u32 {
-            let (c, len) = D::decode(std::slice::from_raw_parts(data, len as usize));
+            let (c, len) = D::decode(core::slice::from_raw_parts(data, len as usize));
             if let Some(code_point) = code_point.as_mut() {
                 *code_point = c;
             }
@@ -1422,7 +1422,7 @@ impl Parser {
         if let Some(flag) = flag {
             ffi::ts_parser_set_cancellation_flag(
                 self.0.as_ptr(),
-                std::ptr::from_ref::<AtomicUsize>(flag).cast::<usize>(),
+                core::ptr::from_ref::<AtomicUsize>(flag).cast::<usize>(),
             );
         } else {
             ffi::ts_parser_set_cancellation_flag(self.0.as_ptr(), ptr::null());

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1432,7 +1432,10 @@ impl Parser {
 
 impl Drop for Parser {
     fn drop(&mut self) {
-        self.stop_printing_dot_graphs();
+        #[cfg(feature = "std")]
+        {
+            self.stop_printing_dot_graphs();
+        }
         self.set_logger(None);
         unsafe { ffi::ts_parser_delete(self.0.as_ptr()) }
     }


### PR DESCRIPTION
Fixes #4302 

Adds a feature flag to the binding lib, used core where possible. Maybe worth a no_std test case?