### PR TITLE
binding_web: replace dynamic require with import

### DIFF
--- a/lib/binding_web/src/language.ts
+++ b/lib/binding_web/src/language.ts
@@ -261,8 +261,7 @@ export class Language {
     } else {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (globalThis.process?.versions.node) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-require-imports
-        const fs: typeof import('fs/promises') = require('fs/promises');
+        const fs: typeof import('fs/promises') = await import('fs/promises');
         bytes = fs.readFile(input);
       } else {
         bytes = fetch(input)


### PR DESCRIPTION
Dynamic `require` is not allowed inside ES modules.
As a result, loading `web-tree-sitter` was partially broken when loaded
using `import`, causing calls to `Language.load(...)` to fail.

The `require` call was replaced with `import`, making it work both
as a ES module and as a CJS module.

This seems to be most easily demonstrated by trying to run `web-tree-sitter` under `vitest` when installing it from npm.
It fails when using `import { Parser, Language } from "web-tree-sitter"`, but succeeds with  `const { Language, Parser } = require("web-tree-sitter")`.
My test to reproduce this was minimal - just `Language.load(...)`.

After after making the change in this PR, I ran the tree-sitter tests, as well as trying to run my minimal test with both import methods (ESM and CJS), and it worked ok.
That said, this is my first foray into the JS/TS build-pipeline shenanigans, and I don't feel confident enough to say it doesn't break other usecases.