### PR TITLE
fix(rust): address new clippy lint for pointer comparisons

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -2087,7 +2087,7 @@ impl<'tree> Node<'tree> {
 
 impl PartialEq for Node<'_> {
     fn eq(&self, other: &Self) -> bool {
-        self.0.id == other.0.id
+        core::ptr::eq(self.0.id, other.0.id)
     }
 }
 


### PR DESCRIPTION
Uses ` core::ptr::eq` rather than the suggested  `std::ptr::eq` to maintain `no_std` compatibility.