### PR TITLE
docs: Fix link to named-vs-anonymous-nodes section

### DIFF
--- a/docs/src/creating-parsers/5-writing-tests.md
+++ b/docs/src/creating-parsers/5-writing-tests.md
@@ -165,3 +165,4 @@ file is changed.
 [external-scanners]: ./4-external-scanners.md
 [node-field-names]: ../using-parsers/2-basic-parsing.md#node-field-names
 [s-exp]: https://en.wikipedia.org/wiki/S-expression
+[named-vs-anonymous-nodes]: ../using-parsers/2-basic-parsing.md#named-vs-anonymous-nodes


### PR DESCRIPTION
Link in this admonition is broken: https://tree-sitter.github.io/tree-sitter/creating-parsers/5-writing-tests.html#admonition-tip

> The S-expression does not show syntax nodes like func, ( and ;, which are expressed as strings and regexes in the grammar. It only shows the named nodes, as described in [this section][named-vs-anonymous-nodes] of the page on parser usage.