### PR TITLE
fix(highlight): account for multiple rows in highlight testing assertions

### DIFF
--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -29,18 +29,28 @@ pub struct Stats {
 impl fmt::Display for Stats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let duration_us = self.total_duration.as_micros();
+        let success_rate = if self.total_parses > 0 {
+            format!(
+                "{:.2}%",
+                ((self.successful_parses as f64) / (self.total_parses as f64)) * 100.0,
+            )
+        } else {
+            "N/A".to_string()
+        };
+        let duration_str = match (self.total_parses, duration_us) {
+            (0, _) => "N/A".to_string(),
+            (_, 0) => "0 bytes/ms".to_string(),
+            (_, _) => format!(
+                "{} bytes/ms",
+                ((self.total_bytes as u128) * 1_000) / duration_us
+            ),
+        };
         writeln!(
             f,
-            "Total parses: {}; successful parses: {}; failed parses: {}; success percentage: {:.2}%; average speed: {} bytes/ms",
+            "Total parses: {}; successful parses: {}; failed parses: {}; success percentage: {success_rate}; average speed: {duration_str}",
             self.total_parses,
             self.successful_parses,
             self.total_parses - self.successful_parses,
-            ((self.successful_parses as f64) / (self.total_parses as f64)) * 100.0,
-            if duration_us != 0 {
-                ((self.total_bytes as u128) * 1_000) / duration_us
-            } else {
-                0
-            }
         )
     }
 }

--- a/cli/src/test_highlight.rs
+++ b/cli/src/test_highlight.rs
@@ -172,7 +172,7 @@ pub fn iterate_assertions(
             let mut j = i;
             while let (false, Some(highlight)) = (passed, highlights.get(j)) {
                 end_column = position.column + length - 1;
-                if highlight.0.column > end_column {
+                if highlight.0.row >= position.row && highlight.0.column > end_column {
                     break 'highlight_loop;
                 }
 


### PR DESCRIPTION
This highlight test case is currently broken:

```vim
echo
"\ lorem ipsum
" <- @comment
```

I believe the issue is that the `line_continuation_comment` node starts at position [0,4], rather than [1,0]. This starting position causes [this](https://github.com/tree-sitter/tree-sitter/blob/521da2b0a7e8815efbcf1e4b98e5ac16113c5763/cli/src/test_highlight.rs#L175) if block to incorrectly enter. Even though the highlight's *column* is past the position's end column, the highlight starts a row earlier. The fix is to just make sure the highlight's row is considered in addition to the column.

Bonus commit: Noticed this while debugging this issue. When zero test cases are parsed, "NaN%" is displayed for the  success percentage and "0 bytes/ms" is shown for the parse rate. When no (measured) parsing took place, we don't have a valid success or parse rates to display. N/A seems more correct in this case.

cc @clason 

- Closes #4330