### PR TITLE
Fix WASI build by not calling a non-existent function.

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1433,6 +1433,7 @@ impl Parser {
 impl Drop for Parser {
     fn drop(&mut self) {
         #[cfg(feature = "std")]
+        #[cfg(not(target_os = "wasi"))]
         {
             self.stop_printing_dot_graphs();
         }


### PR DESCRIPTION
Not sure how other people are building for WASM/WASI, but I'm using the wasi-sdk to build a binary which can be built to run natively or with wasm in wasmtime, etc.
It fails to compile for wasi because the `stop_printing_dot_graphs` function is not defined for wasi targets.