### PR TITLE
fix(xtask): trim `EMSCRIPTEN_TAG` arg to docker command in `build-wasm` command

### DIFF
--- a/.github/workflows/wasm_exports.yml
+++ b/.github/workflows/wasm_exports.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - lib/include/tree_sitter/api.h
       - lib/binding_web/**
+      - xtask/src/**
   push:
     branches: [master]
     paths:

--- a/xtask/src/build_wasm.rs
+++ b/xtask/src/build_wasm.rs
@@ -107,7 +107,7 @@ pub fn run_wasm(args: &BuildWasm) -> Result<()> {
             };
 
             // Run `emcc` in a container using the `emscripten-slim` image
-            command.args([EMSCRIPTEN_TAG, "emcc"]);
+            command.args([EMSCRIPTEN_TAG.trim(), "emcc"]);
             command
         }
     };


### PR DESCRIPTION
This should fix the CI issues in #4363 and #4364