### PR TITLE
fix(ci): increase timeouts for flaky tests

### DIFF
--- a/lib/binding_web/test/parser.test.ts
+++ b/lib/binding_web/test/parser.test.ts
@@ -256,7 +256,7 @@ describe('Parser', () => {
       expect(() => parser.parse({})).toThrow('Argument must be a string or a function');
     });
 
-    it('handles long input strings', { timeout: 5000 }, () => {
+    it('handles long input strings', { timeout: 10000 }, () => {
       const repeatCount = 10000;
       const inputString = `[${Array(repeatCount).fill('0').join(',')}]`;
 

--- a/lib/binding_web/test/query.test.ts
+++ b/lib/binding_web/test/query.test.ts
@@ -64,7 +64,7 @@ describe('Query', () => {
   });
 
   describe('.matches', () => {
-    it('returns all of the matches for the given query', () => {
+    it('returns all of the matches for the given query', { timeout: 10000 }, () => {
       tree = parser.parse('function one() { two(); function three() {} }')!;
       query = new Query(JavaScript, `
         (function_declaration name: (identifier) @fn-def)
@@ -462,7 +462,7 @@ describe('Query', () => {
   });
 
   describe('Set a timeout', () => {
-    it('returns less than the expected matches', () => {
+    it('returns less than the expected matches', { timeout: 10000 }, () => {
       tree = parser.parse('function foo() while (true) { } }\n'.repeat(1000))!;
       query = new Query(JavaScript, '(function_declaration name: (identifier) @function)');
       const matches = query.matches(tree.rootNode, { timeoutMicros: 1000 });
@@ -538,7 +538,7 @@ describe('Query', () => {
     });
   });
 
-  describe('Executes with a timeout', () => {
+  describe('Executes with a timeout', { timeout: 10000 }, () => {
     it('Returns less than the expected matches', () => {
       tree = parser.parse('function foo() while (true) { } }\n'.repeat(1000))!;
       query = new Query(JavaScript, '(function_declaration) @function');


### PR DESCRIPTION
Bumps the timeouts for flaky tests observed in a few recent CI runs, including https://github.com/tree-sitter/tree-sitter/actions/runs/14542531040/job/40803083733#step:21:135