### PR TITLE
[playground] - Include jquery in the playground.md HTML

### DIFF
--- a/docs/src/7-playground.md
+++ b/docs/src/7-playground.md
@@ -98,6 +98,9 @@ you must use at least one capture, like <code>(node_name) @capture-name</code></
 
 </div>
 
+<script src="https://code.jquery.com/jquery-3.3.1.min.js" crossorigin="anonymous">
+</script>
+
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.js"></script>
 
 <script>LANGUAGE_BASE_URL = "https://tree-sitter.github.io";</script>


### PR DESCRIPTION
Fixes #4397

I've only tested this locally, but I can reproduce the linked issue on `master`, but it functions correctly with this change.

I noticed there is `playground.md`, and `playground.html` with a very similar structure, but maintained separately which I suppose led to this error. It would be cool to unify them but I'm not yet sure how much work that would involve.

Once I got this working, clicking on syntax in the Code editor _kind of_ jumps to the right node in the Tree viewer, though it doesn't highlight the actual node I'm on. That's for another day I guess.