### PR TITLE
[playground] - Initialize each tree node with a 'plain' class

### DIFF
--- a/docs/src/assets/js/playground.js
+++ b/docs/src/assets/js/playground.js
@@ -292,10 +292,10 @@ window.initializePlayground = async (opts) => {
 
           const nodeClass =
             displayName === 'ERROR' || displayName.startsWith('MISSING')
-              ? 'node-link error'
+              ? 'node-link error plain'
               : cursor.nodeIsNamed
-                ? 'node-link named'
-                : 'node-link anonymous';
+                ? 'node-link named plain'
+                : 'node-link anonymous plain';
 
           row = `<div class="tree-row">${"  ".repeat(indentLevel)}${fieldName}` +
             `<a class='${nodeClass}' href="#" data-id=${id} ` +


### PR DESCRIPTION
From what I can tell, when you click on a syntax element in the source code viewer, it highlights the appropriate node in the tree viewer. This seems to be accomplished by [toggling](https://github.com/tree-sitter/tree-sitter/blob/d4d8ed32b324a846d6bbe6078393d7b3a2975519/docs/src/assets/js/playground.js#L467-L480) the `plain` and `highlighted` CSS classes.

However, it seems like the nodes are never initialized with the `plain` class, so any string replacement done won't make a change.

String replacement to update classes probably isn't the best approach to start with, but for now I'm assuming there was a good reason it was done that way and I haven't looked further into it yet.

I think this regression was introduced with this change:

https://github.com/tree-sitter/tree-sitter/commit/043969ef18875a4b0330b7578fd2d21e7f826f63#diff-9b440dc84b2bfe4465df8515ad3b641c2e81a16cb3e4cd6e0cf1c4d51b852a65R217-R268

<img width="1399" alt="Screenshot 2025-04-26 at 13 34 47" src="https://github.com/user-attachments/assets/aadedd22-9f03-42de-b571-d377c2bf54ae" />

The `displayClass` var is introduced, but not used anywhere.

It was later removed in this commit:

https://github.com/tree-sitter/tree-sitter/commit/b70843a033a15320c0d3775bb8f50c27f300b4c7#diff-222a674a844e49782957b250c74f2af3a5fa2573673b08aba6ac019bd8e2c807L217