### PR TITLE
fix(xtask): properly trim emscripten version at the source

### DIFF
--- a/cli/loader/build.rs
+++ b/cli/loader/build.rs
@@ -9,5 +9,8 @@ fn main() {
     );
 
     let emscripten_version = std::fs::read_to_string("emscripten-version").unwrap();
-    println!("cargo:rustc-env=EMSCRIPTEN_VERSION={emscripten_version}");
+    println!(
+        "cargo:rustc-env=EMSCRIPTEN_VERSION={}",
+        emscripten_version.trim()
+    );
 }

--- a/xtask/src/build_wasm.rs
+++ b/xtask/src/build_wasm.rs
@@ -107,7 +107,7 @@ pub fn run_wasm(args: &BuildWasm) -> Result<()> {
             };
 
             // Run `emcc` in a container using the `emscripten-slim` image
-            command.args([EMSCRIPTEN_TAG.trim(), "emcc"]);
+            command.args([EMSCRIPTEN_TAG, "emcc"]);
             command
         }
     };

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -170,11 +170,12 @@ struct UpgradeWasmtime {
 
 const BUILD_VERSION: &str = env!("CARGO_PKG_VERSION");
 const BUILD_SHA: Option<&str> = option_env!("BUILD_SHA");
-const EMSCRIPTEN_VERSION: &str = include_str!("../../cli/loader/emscripten-version");
+const EMSCRIPTEN_VERSION: &str = include_str!("../../cli/loader/emscripten-version").trim_ascii();
 const EMSCRIPTEN_TAG: &str = concat!(
     "docker.io/emscripten/emsdk:",
     include_str!("../../cli/loader/emscripten-version")
-);
+)
+.trim_ascii();
 
 fn main() {
     let result = run();


### PR DESCRIPTION
I noticed that `cargo xtask fetch-emscripten` was failing because of the same newline issue I fixed in https://github.com/tree-sitter/tree-sitter/pull/4365. `trim_ascii` is available in `const` contexts, so it makes more sense to just fix this at the source rather than hoping we catch all current (and future) uses of this string.

Edit: Marking this as a draft for now until the lint/wasm issue are resolved.