### PR TITLE
Fix test_flatten_grammar_with_recursive_inline_variable

### DIFF
--- a/cli/generate/src/prepare_grammar/flatten_grammar.rs
+++ b/cli/generate/src/prepare_grammar/flatten_grammar.rs
@@ -533,7 +533,7 @@ mod tests {
 
         assert_eq!(
             result.unwrap_err().to_string(),
-            "Rule `test` cannot be inlined because it contains a reference to itself.",
+            "Rule `test` cannot be inlined because it contains a reference to itself",
         );
     }
 }


### PR DESCRIPTION
The `thiserror` refactor in #4048 dropped the period in the message for `FlattenGrammar::RecursiveInline`.

Due to this, the `test_flatten_grammar_with_recursive_inline_variable` has been failing since.

Restore the period to the error message to fix the test and add testing of tree-sitter-grammar to CI to avoid future regressions. This adds at most 15s to each platform that runs the tests.

I wasn't sure if there was a reason why the "test" xtask wasn't being used to test, so I took the conservative approach of just adding explicit testing for tree-sitter-grammar.