### PR TITLE
Use native TLS for ureq when fetching wasi-sdk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,13 +98,13 @@ jobs:
       if: ${{ matrix.use-cross }}
       run: |
         printf '%s\n' > Cross.toml \
-          '[target.${{ matrix.target }}]'                                   \
-          'image = "ghcr.io/cross-rs/${{ matrix.target }}:edge"'            \
-          '[build]'                                                         \
-          'pre-build = ['                                                   \
-          '  "dpkg --add-architecture $CROSS_DEB_ARCH",'                    \
-          '  "curl -fsSL https://deb.nodesource.com/setup_22.x | bash -",'  \
-          '  "apt-get update && apt-get -y install libssl-dev nodejs"'      \
+          '[target.${{ matrix.target }}]'                                         \
+          'image = "ghcr.io/cross-rs/${{ matrix.target }}:edge"'                  \
+          '[build]'                                                               \
+          'pre-build = ['                                                         \
+          '  "dpkg --add-architecture $CROSS_DEB_ARCH",'                          \
+          '  "curl -fsSL https://deb.nodesource.com/setup_22.x | bash -",'        \
+          '  "apt-get update && apt-get -y install pkg-config libssl-dev nodejs"' \
           ']'
         cat - Cross.toml <<< 'Cross.toml:'
         printf '%s\n' >> $GITHUB_ENV \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           # 1. Define a new platform alias above
           # 2. Add a new record to the matrix map in `cli/npm/install.js`
           - { platform: linux-arm64       , target: aarch64-unknown-linux-gnu   , os: ubuntu-latest    , use-cross: true }
-          - { platform: linux-arm         , target: arm-unknown-linux-gnueabi   , os: ubuntu-latest    , use-cross: true }
+          - { platform: linux-arm         , target: arm-unknown-linux-gnueabihf , os: ubuntu-latest    , use-cross: true }
           - { platform: linux-x64         , target: x86_64-unknown-linux-gnu    , os: ubuntu-22.04     , features: wasm  }
           - { platform: linux-x86         , target: i686-unknown-linux-gnu      , os: ubuntu-latest    , use-cross: true }
           - { platform: linux-powerpc64   , target: powerpc64-unknown-linux-gnu , os: ubuntu-latest    , use-cross: true }
@@ -48,10 +48,10 @@ jobs:
           - { platform: macos-x64         , target: x86_64-apple-darwin         , os: macos-13         , features: wasm  }
 
           # Cross compilers for C library
-          - { platform: linux-arm64       , cc: aarch64-linux-gnu-gcc           , ar: aarch64-linux-gnu-ar   }
-          - { platform: linux-arm         , cc: arm-linux-gnueabi-gcc           , ar: arm-linux-gnueabi-ar   }
-          - { platform: linux-x86         , cc: i686-linux-gnu-gcc              , ar: i686-linux-gnu-ar      }
-          - { platform: linux-powerpc64   , cc: powerpc64-linux-gnu-gcc         , ar: powerpc64-linux-gnu-ar }
+          - { platform: linux-arm64       , cc: aarch64-linux-gnu-gcc           , ar: aarch64-linux-gnu-ar           }
+          - { platform: linux-arm         , cc: arm-unknown-linux-gnueabihf-gcc , ar: arm-unknown-linux-gnueabihf-ar }
+          - { platform: linux-x86         , cc: i686-linux-gnu-gcc              , ar: i686-linux-gnu-ar              }
+          - { platform: linux-powerpc64   , cc: powerpc64-linux-gnu-gcc         , ar: powerpc64-linux-gnu-ar         }
 
           # Prevent race condition (see #2041)
           - { platform: windows-x64   , rust-test-threads: 1 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,13 +98,13 @@ jobs:
       if: ${{ matrix.use-cross }}
       run: |
         printf '%s\n' > Cross.toml \
-          '[target.${{ matrix.target }}]'                                         \
-          'image = "ghcr.io/cross-rs/${{ matrix.target }}:edge"'                  \
-          '[build]'                                                               \
-          'pre-build = ['                                                         \
-          '  "dpkg --add-architecture $CROSS_DEB_ARCH",'                          \
-          '  "curl -fsSL https://deb.nodesource.com/setup_22.x | bash -",'        \
-          '  "apt-get update && apt-get -y install pkg-config libssl-dev nodejs"' \
+          '[target.${{ matrix.target }}]'                                                         \
+          'image = "ghcr.io/cross-rs/${{ matrix.target }}:edge"'                                  \
+          '[build]'                                                                               \
+          'pre-build = ['                                                                         \
+          '  "dpkg --add-architecture $CROSS_DEB_ARCH",'                                          \
+          '  "curl -fsSL https://deb.nodesource.com/setup_22.x | bash -",'                        \
+          '  "apt-get update && apt-get -y install pkg-config libssl-dev:$CROSS_DEB_ARCH nodejs"' \
           ']'
         cat - Cross.toml <<< 'Cross.toml:'
         printf '%s\n' >> $GITHUB_ENV \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,13 +98,15 @@ jobs:
       if: ${{ matrix.use-cross }}
       run: |
         printf '%s\n' > Cross.toml \
-          '[target.${{ matrix.target }}]'                                                         \
-          'image = "ghcr.io/cross-rs/${{ matrix.target }}:edge"'                                  \
-          '[build]'                                                                               \
-          'pre-build = ['                                                                         \
-          '  "dpkg --add-architecture $CROSS_DEB_ARCH",'                                          \
-          '  "curl -fsSL https://deb.nodesource.com/setup_22.x | bash -",'                        \
-          '  "apt-get update && apt-get -y install pkg-config libssl-dev:$CROSS_DEB_ARCH nodejs"' \
+          '[target.${{ matrix.target }}]'                                  \
+          'image = "ghcr.io/cross-rs/${{ matrix.target }}:edge"'           \
+          '[build]'                                                        \
+          'pre-build = ['                                                  \
+          '  "dpkg --add-architecture $CROSS_DEB_ARCH && if [ \"$CROSS_DEB_ARCH\" = \"ppc64\" ]; then dpkg --add-architecture ppc64el; fi",' \
+          '  "curl -fsSL https://deb.nodesource.com/setup_22.x | bash -",' \
+          '  "apt-get update",'                                            \
+          '  "apt-get -y install pkg-config nodejs",'                      \
+          '  "case $CROSS_DEB_ARCH in ppc64) apt-get -y install libssl-dev:ppc64el;; *) apt-get -y install libssl-dev:$CROSS_DEB_ARCH;; esac"' \
           ']'
         cat - Cross.toml <<< 'Cross.toml:'
         printf '%s\n' >> $GITHUB_ENV \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+
+[[package]]
 name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +345,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
@@ -490,6 +506,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +660,21 @@ name = "foldhash"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1221,6 +1262,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,6 +1388,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "openssl"
+version = "0.10.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e"
+dependencies = [
+ "bitflags 2.8.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,6 +1442,15 @@ name = "path-slash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1648,6 +1741,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.8.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2157,14 +2282,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7a3e9af6113ecd57b8c63d3cd76a385b2e3881365f1f489e54f49801d0c83ea"
 dependencies = [
  "base64",
+ "der",
  "flate2",
  "log",
+ "native-tls",
  "percent-encoding",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
  "ureq-proto",
  "utf-8",
+ "webpki-root-certs",
  "webpki-roots",
 ]
 
@@ -2605,7 +2733,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5df295f8451142f1856b1bd86a606dfe9587d439bc036e319c827700dbd555e"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.0",
  "home",
  "jni",
  "log",
@@ -2614,6 +2742,15 @@ dependencies = [
  "objc2-foundation",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "0.26.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180d2741b6115c3d906577e6533ad89472d48d96df00270fccb78233073d77f7"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ thiserror = "2.0.12"
 tiny_http = "0.12.0"
 toml = "0.8.20"
 unindent = "0.2.4"
+ureq = { version = "3.0.11", features = ["native-tls"] }
 url = { version = "2.5.4", features = ["serde"] }
 walkdir = "2.5.0"
 wasmparser = "0.224.1"

--- a/cli/loader/Cargo.toml
+++ b/cli/loader/Cargo.toml
@@ -39,8 +39,8 @@ serde.workspace = true
 serde_json.workspace = true
 tar.workspace = true
 tempfile.workspace = true
+ureq.workspace = true
 url.workspace = true
-ureq = "3.0.11"
 
 tree-sitter = { workspace = true }
 tree-sitter-highlight = { workspace = true, optional = true }

--- a/cli/loader/src/lib.rs
+++ b/cli/loader/src/lib.rs
@@ -1096,13 +1096,21 @@ impl Loader {
             )
         })?;
 
-        let response = ureq::get(&sdk_url)
+        let config = ureq::config::Config::builder()
+            .tls_config(
+                ureq::tls::TlsConfig::builder()
+                    .provider(ureq::tls::TlsProvider::NativeTls)
+                    .build(),
+            )
+            .build();
+        let response = config
+            .new_agent()
+            .get(&sdk_url)
             .call()
             .with_context(|| format!("Failed to download wasi-sdk from {sdk_url}"))?;
         if !response.status().is_success() {
             return Err(anyhow::anyhow!(
-                "Failed to download wasi-sdk from {}",
-                sdk_url
+                "Failed to download wasi-sdk from {sdk_url}",
             ));
         }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -27,6 +27,6 @@ regex.workspace = true
 semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-ureq = "3.0.11"
+ureq.workspace = true
 notify = "8.0.0"
 notify-debouncer-full = "0.5.0"


### PR DESCRIPTION
Closes #4295

### Problem

ureq uses `rustls` by default - some consumers would prefer if it used the OS-native TLS libraries (e.g. OpenSSL)

### Solution

In the ureq dependency, I've enabled the `native-tls` feature, and configure it to use native TLS as the TLS provider.