### PR TITLE
docs(rust): remove adding `cc` as a build dependency for consumers

### DIFF
--- a/lib/binding_rust/README.md
+++ b/lib/binding_rust/README.md
@@ -17,13 +17,6 @@ use tree_sitter::{InputEdit, Language, Parser, Point};
 let mut parser = Parser::new();
 ```
 
-Add the `cc` crate to your `Cargo.toml` under `[build-dependencies]`:
-
-```toml
-[build-dependencies]
-cc="*"
-```
-
 Then, add a language as a dependency:
 
 ```toml
@@ -32,7 +25,7 @@ tree-sitter = "0.24"
 tree-sitter-rust = "0.23"
 ```
 
-To then use a language, you assign them to the parser.
+To use a language, you assign them to the parser.
 
 ```rust
 parser.set_language(&tree_sitter_rust::LANGUAGE.into()).expect("Error loading Rust grammar");


### PR DESCRIPTION
- Closes #4387

### Problem

The docs tell consumers of the Rust library to add `cc` as a build dependency. This is not needed, as downstream grammars compile the parser for you

### Solution

Remove the step telling users to add `cc` as a build dependency in the docs