### PR TITLE
fix(generate): mark url as a Windows-only dependency

### DIFF
--- a/cli/generate/Cargo.toml
+++ b/cli/generate/Cargo.toml
@@ -29,6 +29,8 @@ serde.workspace = true
 serde_json.workspace = true
 smallbitvec.workspace = true
 thiserror.workspace = true
-url.workspace = true
 
 tree-sitter.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+url = { version = "2.5.4", default-features = false }


### PR DESCRIPTION
- Closes #4389

### Problem

Using the `url` crate brings in unnecessary dependencies in the generate crate, especially since it's only needed for Windows consumers

### Solution

Gate the `url` dependency in the generate crate to only be used when the build target is windows, and turn off default features.