### PR TITLE
fix(lib): add bounds check for `alias_sequence` access in `ts_subtree_summarize_children()`

### DIFF
--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -407,7 +407,11 @@ void ts_subtree_summarize_children(
     self.ptr->dynamic_precedence += ts_subtree_dynamic_precedence(child);
     self.ptr->visible_descendant_count += ts_subtree_visible_descendant_count(child);
 
-    if (alias_sequence && alias_sequence[structural_index] != 0 && !ts_subtree_extra(child)) {
+    if (alias_sequence &&
+        structural_index < language->max_alias_sequence_length &&
+        alias_sequence[structural_index] != 0 &&
+        !ts_subtree_extra(child)
+    ) {
       self.ptr->visible_descendant_count++;
       self.ptr->visible_child_count++;
       if (ts_language_symbol_metadata(language, alias_sequence[structural_index]).named) {


### PR DESCRIPTION
Running the project's test suite with a sanitizer currently fails on `test_node_is_named_but_aliased_as_anonymous`. To reproduce, run them with:

```sh
CFLAGS="-fsanitize=address" RUSTFLAGS="-lasan --cfg sanitizing" ASAN_OPTIONS="verify_asan_link_order=0" cargo test
```

<Details>

<Summary>Asan Output</Summary>

```sh
=================================================================
==2096572==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7e3ade1184cc at pc 0x58cdb20f4a2e bp 0x7e3adc6f22f0 sp 0x7e3adc6f22e0
READ of size 2 at 0x7e3ade1184cc thread T73
    #0 0x58cdb20f4a2d in ts_subtree_summarize_children /home/lillis/projects/tree-sitter/lib/src/./subtree.c:410
    #1 0x58cdb20f5ddb in ts_subtree_new_node /home/lillis/projects/tree-sitter/lib/src/./subtree.c:510
    #2 0x58cdb20b8bf1 in ts_parser__accept /home/lillis/projects/tree-sitter/lib/src/./parser.c:1073
    #3 0x58cdb20bdaae in ts_parser__advance /home/lillis/projects/tree-sitter/lib/src/./parser.c:1670
    #4 0x58cdb20c1bae in ts_parser_parse /home/lillis/projects/tree-sitter/lib/src/./parser.c:2171
    #5 0x58cdb20c2725 in ts_parser_parse_with_options /home/lillis/projects/tree-sitter/lib/src/./parser.c:2240
    #6 0x58cdb193791f in tree_sitter::Parser::parse_with_options::hbc136d6008656929 lib/binding_rust/lib.rs:926
    #7 0x58cdb19425c9 in tree_sitter::Parser::parse::h08b9c90ca3f3cac5 lib/binding_rust/lib.rs:799
    #8 0x58cdb1a1a157 in tree_sitter_cli::tests::node_test::test_node_named_child_with_aliases_and_extras::hed583bb484a76eef cli/src/tests/node_test.rs:573
    #9 0x58cdb1979236 in tree_sitter_cli::tests::node_test::test_node_named_child_with_aliases_and_extras::_$u7b$$u7b$closure$u7d$$u7d$::h3d498d925fa47c4a cli/src/tests/node_test.rs:565
    #10 0x58cdb1a85405 in core::ops::function::FnOnce::call_once::hb8b9f74611b0496e /home/lillis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250
    #11 0x58cdb1b80cba in core::ops::function::FnOnce::call_once::h1dfa20b1ec1f6e08 library/core/src/ops/function.rs:250
    #12 0x58cdb1b80cba in test::__rust_begin_short_backtrace::h7b10906492afc420 library/test/src/lib.rs:637
    #13 0x58cdb1b7fba7 in test::run_test_in_process::_$u7b$$u7b$closure$u7d$$u7d$::h51c1c0d319f72c0a library/test/src/lib.rs:660
    #14 0x58cdb1b7fba7 in _$LT$core..panic..unwind_safe..AssertUnwindSafe$LT$F$GT$$u20$as$u20$core..ops..function..FnOnce$LT$$LP$$RP$$GT$$GT$::call_once::h5fadb750f3dbe714 library/core/src/panic/unwind_safe.rs:272
    #15 0x58cdb1b7fba7 in std::panicking::try::do_call::h1ca5071cef82bb40 library/std/src/panicking.rs:587
    #16 0x58cdb1b7fba7 in std::panicking::try::h6931de76fb9a61b1 library/std/src/panicking.rs:550
    #17 0x58cdb1b7fba7 in std::panic::catch_unwind::h67fc9dccf413f4e5 library/std/src/panic.rs:358
    #18 0x58cdb1b7fba7 in test::run_test_in_process::ha966dfbb1d048be5 library/test/src/lib.rs:660
    #19 0x58cdb1b7fba7 in test::run_test::_$u7b$$u7b$closure$u7d$$u7d$::he209928ac5e8a3b8 library/test/src/lib.rs:581
    #20 0x58cdb1b43b34 in test::run_test::_$u7b$$u7b$closure$u7d$$u7d$::h34c6289e0b5ed5a5 library/test/src/lib.rs:611
    #21 0x58cdb1b43b34 in std::sys::backtrace::__rust_begin_short_backtrace::h365aabf21799e6fc library/std/src/sys/backtrace.rs:152
    #22 0x58cdb1b475a9 in std::thread::Builder::spawn_unchecked_::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h3d5e582cba74b1c3 library/std/src/thread/mod.rs:559
    #23 0x58cdb1b475a9 in _$LT$core..panic..unwind_safe..AssertUnwindSafe$LT$F$GT$$u20$as$u20$core..ops..function..FnOnce$LT$$LP$$RP$$GT$$GT$::call_once::h1214c75c3f73f94f library/core/src/panic/unwind_safe.rs:272
    #24 0x58cdb1b475a9 in std::panicking::try::do_call::h73540336a45c0cec library/std/src/panicking.rs:587
    #25 0x58cdb1b475a9 in std::panicking::try::h428956564307af63 library/std/src/panicking.rs:550
    #26 0x58cdb1b475a9 in std::panic::catch_unwind::h1a53a6ea2f2041e3 library/std/src/panic.rs:358
    #27 0x58cdb1b475a9 in std::thread::Builder::spawn_unchecked_::_$u7b$$u7b$closure$u7d$$u7d$::hac66cbb88d807e14 library/std/src/thread/mod.rs:557
    #28 0x58cdb1b475a9 in core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::had7e2d02878d3212 library/core/src/ops/function.rs:250
    #29 0x58cdb241423a in _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::h292d1663b0785fda library/alloc/src/boxed.rs:1976
    #30 0x58cdb241423a in _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::h9d4af7b531852d72 library/alloc/src/boxed.rs:1976
    #31 0x58cdb241423a in std::sys::pal::unix::thread::Thread::new::thread_start::hcc5ed016d554f327 library/std/src/sys/pal/unix/thread.rs:106
    #32 0x7e3ae0e63241 in asan_thread_start /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:234
    #33 0x7e3ae0bdaf88 in start_thread /usr/src/debug/glibc/glibc/nptl/pthread_create.c:448
    #34 0x7e3ae0c5d1fb in __GI___clone3 (/usr/lib/libc.so.6+0x1231fb) (BuildId: dd8c4d57aacaf90b52dd44c7c555cdd687ed58f8)

0x7e3ade1184cc is located 52 bytes before global variable 'ts_symbol_metadata' defined in '/home/lillis/projects/tree-sitter/target/scratch/x86_64-linux-unknown-gnu-little/src/aliases_and_extras/parser.c:51:31' (0x7e3ade118500) of size 21
0x7e3ade1184cc is located 0 bytes after global variable 'ts_alias_sequences' defined in '/home/lillis/projects/tree-sitter/target/scratch/x86_64-linux-unknown-gnu-little/src/aliases_and_extras/parser.c:82:23' (0x7e3ade1184c0) of size 12
SUMMARY: AddressSanitizer: global-buffer-overflow /home/lillis/projects/tree-sitter/lib/src/./subtree.c:410 in ts_subtree_summarize_children
Shadow bytes around the buggy address:
  0x7e3ade118200: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 00 00
  0x7e3ade118280: 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 00 00 04 f9
  0x7e3ade118300: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 04 f9 f9
  0x7e3ade118380: f9 f9 f9 f9 00 00 00 f9 f9 f9 f9 f9 00 00 00 00
  0x7e3ade118400: 00 02 f9 f9 f9 f9 f9 f9 00 06 f9 f9 f9 f9 f9 f9
=>0x7e3ade118480: 02 f9 f9 f9 f9 f9 f9 f9 00[04]f9 f9 f9 f9 f9 f9
  0x7e3ade118500: 00 00 05 f9 f9 f9 f9 f9 00 06 f9 f9 f9 f9 f9 f9
  0x7e3ade118580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7e3ade118600: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7e3ade118680: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7e3ade118700: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
Thread T73 created by T0 here:
    #0 0x7e3ae0f39947 in pthread_create /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:245
    #1 0x58cdb2414070 in std::sys::pal::unix::thread::Thread::new::h14599304eded2348 library/std/src/sys/pal/unix/thread.rs:85
    #2 0x58cdb1b7d8d0 in std::thread::Builder::spawn_unchecked_::hb3c89b2920de5811 library/std/src/thread/mod.rs:598
    #3 0x58cdb1b7d8d0 in std::thread::Builder::spawn_unchecked::h59222b600a32227c library/std/src/thread/mod.rs:467
    #4 0x58cdb1b7d8d0 in std::thread::Builder::spawn::haaa7eb34dd380c9d library/std/src/thread/mod.rs:399
    #5 0x58cdb1b7d8d0 in test::run_test::hce2f6dc18fbf2207 library/test/src/lib.rs:611
    #6 0x58cdb1b5dfa7 in test::run_tests::he497ceba3c700087 library/test/src/lib.rs:421
    #7 0x58cdb1b5dfa7 in test::console::run_tests_console::h66d7631ce2a8b405 library/test/src/console.rs:323
    #8 0x58cdb1b7ae36 in test::test_main::hf3220c03cfb0aab4 library/test/src/lib.rs:150
    #9 0x58cdb1b7b7ba in test::test_main_static::h2f392f537f23ba0d library/test/src/lib.rs:172
    #10 0x58cdb18f9e72 in tree_sitter_cli::main::h1389acf414452597 cli/src/lib.rs
    #11 0x58cdb18f3ec6 in std::rt::lang_start::h2ba1f08531e0c503 /home/lillis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/rt.rs:198

==2096572==ABORTING
error: test failed, to rerun pass `--lib`
```

</Details>

Adding a check for `structural_index` against the language's `max_alias_sequence_length` prevents the OOB access.