### PR TITLE
fix(lib): do not access the alias sequence for the `end` subtree in `ts_subtree_summarize_children`

### DIFF
--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -407,7 +407,12 @@ void ts_subtree_summarize_children(
     self.ptr->dynamic_precedence += ts_subtree_dynamic_precedence(child);
     self.ptr->visible_descendant_count += ts_subtree_visible_descendant_count(child);
 
-    if (alias_sequence && alias_sequence[structural_index] != 0 && !ts_subtree_extra(child)) {
+    if (
+      !ts_subtree_extra(child) &&
+      ts_subtree_symbol(child) != 0 &&
+      alias_sequence &&
+      alias_sequence[structural_index] != 0
+    ) {
       self.ptr->visible_descendant_count++;
       self.ptr->visible_child_count++;
       if (ts_language_symbol_metadata(language, alias_sequence[structural_index]).named) {


### PR DESCRIPTION
- Supersedes #4412

### Problem

As mentioned in #4412, running the test `test_node_is_named_but_aliased_as_anonymous` will fail, and ASAN will report an OOB array access. During iteration inside `summarize_children`, the last child that is summarized is the `end` node. At this point, the structural index of this child is "3", which is the same as the max number of aliases per sequence. As such, when the alias for this `end` node is looked up, an OOB occurs.

### Solution

The `end` node will never have an alias, so a check is added to ensure the end node's alias is never looked up. I also moved the condition of the child not being an extra to the beginning of the condition.