### PR TITLE
fix(query): correct `last_child_step_index` in cases where a new step wasn't created.

### DIFF
--- a/cli/src/tests/query_test.rs
+++ b/cli/src/tests/query_test.rs
@@ -5621,3 +5621,14 @@ const foo = [
     assert_eq!(matches.len(), 1);
     assert_eq!(matches[0].1, captures);
 }
+
+#[test]
+fn test_query_with_predicate_causing_oob_access() {
+    let language = get_language("rust");
+
+    let query = "(call_expression
+     function: (scoped_identifier
+       path: (scoped_identifier (identifier) @_regex (#any-of? @_regex \"Regex\" \"RegexBuilder\") .))
+     (#set! injection.language \"regex\"))";
+    Query::new(&language, query).unwrap();
+}

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -2523,6 +2523,9 @@ static TSQueryError ts_query__parse_pattern(
           child_is_immediate,
           &child_capture_quantifiers
         );
+        // In the event we only parsed a predicate, meaning no new steps were added,
+        // then subtract one so we're not indexing past the end of the array
+        if (step_index == self->steps.size) step_index--;
         if (e == PARENT_DONE) {
           if (stream->next == ')') {
             if (child_is_immediate) {
@@ -2531,7 +2534,7 @@ static TSQueryError ts_query__parse_pattern(
                 return TSQueryErrorSyntax;
               }
               // Mark this step *and* its alternatives as the last child of the parent.
-              QueryStep *last_child_step = &self->steps.contents[last_child_step_index];
+              QueryStep *last_child_step = array_get(&self->steps, last_child_step_index);
               last_child_step->is_last_child = true;
               if (
                 last_child_step->alternative_index != NONE &&


### PR DESCRIPTION
## The Problem

Not 100% confident I have the root cause, but here's the basic idea:

The full query:

```scm
(call_expression
  function: (scoped_identifier
    path: (scoped_identifier (identifier) @_regex (#any-of? @_regex "Regex" "RegexBuilder") .))
  (#set! injection.language "regex"))
```

For the stack frame that causes the OOB access, we're inside the for loop here:

https://github.com/tree-sitter/tree-sitter/blob/bfc5d1180cf194fdf5cbb2db708b2abce4ea62bb/lib/src/query.c#L2477-L2487

and the start of the stream is pointing to `(#any-of? @_regex "Regex" "RegexBuilder").....`. Further down in the loop's body, `step_index` stores the value of `self-steps.size` here: 

https://github.com/tree-sitter/tree-sitter/blob/bfc5d1180cf194fdf5cbb2db708b2abce4ea62bb/lib/src/query.c#L2518-L2525

The recursive call to `ts_query__parse_pattern` immediately after parses the predicate `(#any-of? @_regex "Regex" "RegexBuilder")`. Parsing the predicate did not push new entries to `self->steps`, so when `last_child_step_index` is assigned to `step_index` following that call, it now indexes past the end of `self->steps`. The loop runs again, and this time it parses the anchor, here: 

https://github.com/tree-sitter/tree-sitter/blob/bfc5d1180cf194fdf5cbb2db708b2abce4ea62bb/lib/src/query.c#L2511-L2516

After this, another recursive call to `ts_query__parse_pattern` returns immediately with `PARENT_DONE`, since the stream now points to `)`. The first 3 `if` conditions following the recursive call are satisfied, so we then use the out of bounds `last_child_step_index` to index into `self->steps.contents`, causing the UB.

## The Solution

Add a simple check for this case, decrementing `step_index` before its assignment to `last_child_step_index` if necessary.

- Fixes #4421 