### PR TITLE
fix(lib): return early for empty predicate step slice

### DIFF
--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -2978,9 +2978,7 @@ const TSQueryPredicateStep *ts_query_predicates_for_pattern(
 ) {
   Slice slice = self->patterns.contents[pattern_index].predicate_steps;
   *step_count = slice.length;
-  if (self->predicate_steps.contents == NULL) {
-    return NULL;
-  }
+  if (slice.length == 0) return NULL;
   return &self->predicate_steps.contents[slice.offset];
 }
 


### PR DESCRIPTION
This PR pulls the bug fix out of #4430 so that it can be included in our upcoming release.

cc @clason 