### PR TITLE
illumos has endian.h

### DIFF
--- a/lib/src/portable/endian.h
+++ b/lib/src/portable/endian.h
@@ -18,6 +18,7 @@
 #if defined(HAVE_ENDIAN_H) || \
     defined(__linux__) || \
     defined(__GNU__) || \
+    defined(__illumos__) || \
     defined(__NetBSD__) || \
     defined(__OpenBSD__) || \
     defined(__CYGWIN__) || \


### PR DESCRIPTION
It looks like when this code was added illumos was missed in the header file which breaks downstream projects like Helix.

```
test result: ok. 258 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.35s

     Running unittests src/main.rs (target/debug/deps/tree_sitter-f09c53668a180e2c)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests tree_sitter_cli

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```