### PR TITLE
fix: wasi has endian.h

### DIFF
--- a/lib/src/portable/endian.h
+++ b/lib/src/portable/endian.h
@@ -23,7 +23,8 @@
     defined(__OpenBSD__) || \
     defined(__CYGWIN__) || \
     defined(__MSYS__) || \
-    defined(__EMSCRIPTEN__)
+    defined(__EMSCRIPTEN__) || \
+    defined(__wasi__)
 
 #if defined(__NetBSD__)
 #define _NETBSD_SOURCE 1


### PR DESCRIPTION
This PR adds __wasi__ to the list of platform that has <endian.h>

I was trying to build the tree-sitter library using [WASI-SDK](https://github.com/WebAssembly/wasi-sdk), but encountered a compilation error saying this platform is not supported. I tried to add __wasi__ to the list of platform that has <endian.h> and it works.

Test on wasi-sdk-25 with amalgamation build.