### PR TITLE
fix(generate): re-enable default url features

### DIFF
--- a/cli/generate/Cargo.toml
+++ b/cli/generate/Cargo.toml
@@ -33,4 +33,4 @@ thiserror.workspace = true
 tree-sitter.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-url = { version = "2.5.4", default-features = false }
+url.workspace = true


### PR DESCRIPTION
Fixes #4453 

### Problem
Disabling default features for the `url` crate causes tree_sitter_generate build to fail.

### Solution
Re-enable default features for the `url` crate.