### PR TITLE
docs: mention ~ and $HOME for parser-directories

### DIFF
--- a/docs/src/cli/init-config.md
+++ b/docs/src/cli/init-config.md
@@ -30,7 +30,8 @@ on your filesystem. You can control this using the `"parser-directories"` key in
 {
   "parser-directories": [
     "/Users/my-name/code",
-    "/Users/my-name/other-code"
+    "~/other-code",
+    "$HOME/another-code"
   ]
 }
 ```


### PR DESCRIPTION
I noticed that `~` and `$HOME` could be used when configuring `parser-directories` in `config.json` but I didn't manage to find it in the docs.  I guess it was added [here](https://github.com/tree-sitter/tree-sitter/pull/1220).

I've only tried it on a Linux box...may be it works on other supported platforms as well?

This PR contains a suggestion to add some appropriate text to the `parser-directories` portion of the `init-config` page.