### PR TITLE
Fix typing for Parser.init

### DIFF
--- a/lib/binding_web/lib/web-tree-sitter.d.ts
+++ b/lib/binding_web/lib/web-tree-sitter.d.ts
@@ -217,4 +217,4 @@ interface WasmModule {
 }
 
 export type MainModule = WasmModule & typeof RuntimeExports;
-export default function MainModuleFactory (options?: EmscriptenModule): Promise<MainModule>;
+export default function MainModuleFactory(options?: Partial<EmscriptenModule>): Promise<MainModule>;

--- a/lib/binding_web/src/bindings.ts
+++ b/lib/binding_web/src/bindings.ts
@@ -9,7 +9,7 @@ export let Module: MainModule | null = null;
  *
  * Initialize the Tree-sitter WASM module. This should only be called by the {@link Parser} class via {@link Parser.init}.
  */
-export async function initializeBinding(moduleOptions?: EmscriptenModule): Promise<MainModule> {
+export async function initializeBinding(moduleOptions?: Partial<EmscriptenModule>): Promise<MainModule> {
   if (!Module) {
     Module = await createModule(moduleOptions);
   }

--- a/lib/binding_web/src/parser.ts
+++ b/lib/binding_web/src/parser.ts
@@ -105,7 +105,7 @@ export class Parser {
    * You can optionally pass in options to configure the WASM module, the most common
    * one being `locateFile` to help the module find the `.wasm` file.
    */
-  static async init(moduleOptions?: EmscriptenModule) {
+  static async init(moduleOptions?: Partial<EmscriptenModule>) {
     setModule(await initializeBinding(moduleOptions));
     TRANSFER_BUFFER = C._ts_init();
     LANGUAGE_VERSION = C.getValue(TRANSFER_BUFFER, 'i32');


### PR DESCRIPTION
## The Change

Since we're usually only providing `locateFile`, we need the type to be
`Partial<>` to allow it.

This also matches the typing in `@types/emscripten`'s
`EmscriptenModuleFactory` type signature.


## Motivation

Over the last few days I spent several hours debugging a relatively silly bug.
I returned a `vscode.Uri` from `locateFile` instead of a `string`.
Since `tsc` did not complain, I didn't even think to check that one function.

With this PR, I hope to help others avoid the same bug.

With this PR, and installing `@types/emscripten`, users will get type errors when returning the wrong type from `locateFile`.

## Implementation

I modified the `d.ts` file for the WASM part.
Before I did that, I used the `--emit-tsd` flag to generate the file.
At least on my machine, it came out different from the committed one, so I assumed it is OK to add changes to it.