### PR TITLE
Fully fix field underflow in go_to_previous_sibling

### DIFF
--- a/cli/src/tests/tree_test.rs
+++ b/cli/src/tests/tree_test.rs
@@ -388,7 +388,7 @@ fn test_tree_cursor_previous_sibling_with_aliases() {
         .set_language(&get_test_fixture_language("aliases_in_root"))
         .unwrap();
 
-    let text = "# comment\nfoo foo";
+    let text = "# comment\n# \nfoo foo";
     let tree = parser.parse(text, None).unwrap();
     let mut cursor = tree.walk();
     assert_eq!(cursor.node().kind(), "document");
@@ -397,9 +397,18 @@ fn test_tree_cursor_previous_sibling_with_aliases() {
     assert_eq!(cursor.node().kind(), "comment");
 
     assert!(cursor.goto_next_sibling());
+    assert_eq!(cursor.node().kind(), "comment");
+
+    assert!(cursor.goto_next_sibling());
     assert_eq!(cursor.node().kind(), "bar");
 
     assert!(cursor.goto_previous_sibling());
+    assert_eq!(cursor.node().kind(), "comment");
+
+    assert!(cursor.goto_previous_sibling());
+    assert_eq!(cursor.node().kind(), "comment");
+
+    assert!(cursor.goto_next_sibling());
     assert_eq!(cursor.node().kind(), "comment");
 
     assert!(cursor.goto_next_sibling());

--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -135,11 +135,10 @@ static inline bool ts_tree_cursor_child_iterator_previous(
 
   if (!extra && self->alias_sequence) {
     *visible |= self->alias_sequence[self->structural_child_index];
-    if (self->child_index > 0) {
+    if (self->structural_child_index > 0) {
       self->structural_child_index--;
     }
   }
-
 
   // unsigned can underflow so compare it to child_count
   if (self->child_index < self->parent.ptr->child_count) {


### PR DESCRIPTION
Follow-up to https://github.com/tree-sitter/tree-sitter/pull/4472

That PR didn't fully fix the problem