### PR TITLE
fix(cli): require correct setuptools version

### DIFF
--- a/crates/cli/src/templates/pyproject.toml
+++ b/crates/cli/src/templates/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=62.4.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
The build process uses the module `setuptools.command.build` which was added in 62.4.0 as
per https://github.com/pypa/setuptools/blob/main/NEWS.rst#v6240

also ref https://github.com/tree-sitter-perl/tree-sitter-perl/issues/214
