### PR TITLE
feat(cli): rebuild parsers by default when --grammar-path is passed.

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -429,6 +429,9 @@ struct Query {
     #[arg(long, short = 'n')]
     #[clap(conflicts_with = "paths", conflicts_with = "paths_file")]
     pub test_number: Option<u32>,
+    /// Force rebuild the parser
+    #[arg(short, long)]
+    pub rebuild: bool,
 }
 
 #[derive(Args)]
@@ -474,6 +477,9 @@ struct Highlight {
     #[arg(long, short = 'n')]
     #[clap(conflicts_with = "paths", conflicts_with = "paths_file")]
     pub test_number: Option<u32>,
+    /// Force rebuild the parser
+    #[arg(short, long)]
+    pub rebuild: bool,
 }
 
 #[derive(Args)]
@@ -503,6 +509,9 @@ struct Tags {
     #[arg(long, short = 'n')]
     #[clap(conflicts_with = "paths", conflicts_with = "paths_file")]
     pub test_number: Option<u32>,
+    /// Force rebuild the parser
+    #[arg(short, long)]
+    pub rebuild: bool,
 }
 
 #[derive(Args)]
@@ -1495,6 +1504,7 @@ impl Highlight {
         loader.configure_highlights(&theme_config.theme.highlight_names);
         let loader_config = config.get()?;
         loader.find_all_languages(&loader_config)?;
+        loader.force_rebuild(self.rebuild);
 
         let cancellation_flag = util::cancel_on_signal();
 
@@ -1649,6 +1659,7 @@ impl Tags {
         let config = Config::load(self.config_path)?;
         let loader_config = config.get()?;
         loader.find_all_languages(&loader_config)?;
+        loader.force_rebuild(self.rebuild);
 
         let cancellation_flag = util::cancel_on_signal();
 

--- a/crates/cli/src/tests/helpers/query_helpers.rs
+++ b/crates/cli/src/tests/helpers/query_helpers.rs
@@ -182,7 +182,9 @@ impl Pattern {
         }
 
         matches.sort_unstable();
-        matches.iter_mut().for_each(|m| m.last_node = None);
+        for m in &mut matches {
+            m.last_node = None;
+        }
         matches.dedup();
         matches
     }

--- a/crates/highlight/src/highlight.rs
+++ b/crates/highlight/src/highlight.rs
@@ -1222,12 +1222,14 @@ impl HtmlRenderer {
 
             // At line boundaries, close and re-open all of the open tags.
             if c == b'\n' {
-                highlights.iter().for_each(|_| self.end_highlight());
+                for _ in highlights {
+                    self.end_highlight();
+                }
                 self.html.push(c);
                 self.line_offsets.push(self.html.len() as u32);
-                highlights
-                    .iter()
-                    .for_each(|scope| self.start_highlight(*scope, attribute_callback));
+                for scope in highlights {
+                    self.start_highlight(*scope, attribute_callback);
+                }
             } else if let Some(escape) = html_escape(c) {
                 self.html.extend_from_slice(escape);
             } else {


### PR DESCRIPTION
@sogaiu brought up a neat use case  [here](https://github.com/tree-sitter/tree-sitter/pull/4358#issuecomment-2943845395) that #4358 didn't quite cover. The CLI tool stores built parsers in between runs, which leads to a nice start time boost for non-cold invocations to commands like `parse`, `fuzz`, etc. This clashes a bit with the `--grammar-path` option, however, as a cached build of a parser from a previous invocation will be used even if a subsequent use points to a different copy of the same grammar with `--grammar-path`. This is a nice use case if, say, you have two copies of a grammar checked out at different commits. 

The work around to this issue is to simply rebuild the parser when `--grammar-path` is supplied. This seems reasonable to me -- a user passing `--grammar-path` is indicating they want to use the grammar exactly at *that* path and that path only. Any residual global state (e.g. `.so` files left behind in `~/.cache/tree-sitter/lib`) should be ignored. The extra time spent rebuilding the parser can be a bit annoying if you aren't using two copies of the same grammar, however. ~~To mitigate this pain point, I've also added `--no-rebuild` as a `--grammar-path` only argument to circumvent this behavior.~~

Also, because the `query`, `highlight`, and `tags` commands load parsers, this PR also adds the associated `--rebuild` flag.