### PR TITLE
feat(cli): support selecting bindings in init cmd

### DIFF
--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -139,6 +139,7 @@ pub struct JsonConfigOpts {
     pub email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<Url>,
+    pub bindings: Bindings,
 }
 
 impl JsonConfigOpts {
@@ -185,7 +186,7 @@ impl JsonConfigOpts {
                 }),
                 namespace: None,
             },
-            bindings: Bindings::default(),
+            bindings: self.bindings,
         }
     }
 }
@@ -206,6 +207,7 @@ impl Default for JsonConfigOpts {
             author: String::new(),
             email: None,
             url: None,
+            bindings: Bindings::default(),
         }
     }
 }

--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -222,7 +222,7 @@ pub struct Links {
     pub homepage: Option<String>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(default)]
 pub struct Bindings {
     pub c: bool,
@@ -236,6 +236,61 @@ pub struct Bindings {
     pub rust: bool,
     pub swift: bool,
     pub zig: bool,
+}
+
+impl Bindings {
+    /// return available languages and its default enabled state.
+    #[must_use]
+    pub const fn languages(&self) -> [(&'static str, bool); 7] {
+        [
+            ("c", true),
+            ("go", true),
+            // Comment out Java and Kotlin until the bindings are actually available.
+            // ("java", false),
+            // ("kotlin", false),
+            ("node", true),
+            ("python", true),
+            ("rust", true),
+            ("swift", true),
+            ("zig", false),
+        ]
+    }
+
+    /// construct Bindings from a language list. If a language isn't supported, its name will be put on the error part.
+    pub fn with_enabled_languages<'a, I>(languages: I) -> Result<Self, &'a str>
+    where
+        I: Iterator<Item = &'a str>,
+    {
+        let mut out = Self {
+            c: false,
+            go: false,
+            java: false,
+            kotlin: false,
+            node: false,
+            python: false,
+            rust: false,
+            swift: false,
+            zig: false,
+        };
+
+        for v in languages {
+            match v {
+                "c" => out.c = true,
+                "go" => out.go = true,
+                // Comment out Java and Kotlin until the bindings are actually available.
+                // "java" => out.java = true,
+                // "kotlin" => out.kotlin = true,
+                "node" => out.node = true,
+                "python" => out.python = true,
+                "rust" => out.rust = true,
+                "swift" => out.swift = true,
+                "zig" => out.zig = true,
+                unsupported => return Err(unsupported),
+            }
+        }
+
+        Ok(out)
+    }
 }
 
 impl Default for Bindings {


### PR DESCRIPTION
This PR supports selecting bindings when `tree-sitter init` find no tree-stter.json during setup.
It will prompt user to select bindings to generate as follows
![image](https://github.com/user-attachments/assets/56f21040-fdfd-480a-bf0c-d5232d83eaa3)


The default enabled bindings is consistent with `tree_sitter_loader::Bindings::default()`.

