### PR TITLE
fix(docs): replace `TSInput` by `TSInputEdit` in "Advanced Parsing"

### DIFF
--- a/docs/src/using-parsers/3-advanced-parsing.md
+++ b/docs/src/using-parsers/3-advanced-parsing.md
@@ -23,7 +23,7 @@ Then, you can call `ts_parser_parse` again, passing in the old tree. This will c
 with the old tree.
 
 When you edit a syntax tree, the positions of its nodes will change. If you have stored any `TSNode` instances outside of
-the `TSTree`, you must update their positions separately, using the same `TSInput` value, in order to update their
+the `TSTree`, you must update their positions separately, using the same `TSInputEdit` value, in order to update their
 cached positions.
 
 ```c


### PR DESCRIPTION
In the [Advanced Parsing](https://tree-sitter.github.io/tree-sitter/using-parsers/3-advanced-parsing.html) documentation, there's a sentence that says:

> *"If you have stored any `TSNode` instances outside of the `TSTree`, you must update their positions separately, using the same `TSInput` value, in order to update their cached positions."*

I think this might be a typo — it should probably say `TSInputEdit`, not `TSInput`, since that's what's used to update positions after edits.

Let me know if I misunderstood!
