### PR TITLE
build(rust): use $CARGO_PKG_RUST_VERSION when generating bindings

### DIFF
--- a/lib/binding_rust/build.rs
+++ b/lib/binding_rust/build.rs
@@ -56,29 +56,6 @@ fn generate_bindings(out_dir: &std::path::Path) {
 
     use bindgen::RustTarget;
 
-    let output = Command::new("cargo")
-        .args(["metadata", "--format-version", "1"])
-        .output()
-        .unwrap();
-
-    let metadata = serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
-
-    let Some(rust_version) = metadata
-        .get("packages")
-        .and_then(|packages| packages.as_array())
-        .and_then(|packages| {
-            packages.iter().find_map(|package| {
-                if package["name"] == "tree-sitter" {
-                    package.get("rust_version").and_then(|v| v.as_str())
-                } else {
-                    None
-                }
-            })
-        })
-    else {
-        panic!("Failed to find tree-sitter package in cargo metadata");
-    };
-
     const HEADER_PATH: &str = "include/tree_sitter/api.h";
 
     println!("cargo:rerun-if-changed={HEADER_PATH}");
@@ -96,6 +73,8 @@ fn generate_bindings(out_dir: &std::path::Path) {
         "TSQueryMatch",
         "TSQueryPredicateStep",
     ];
+
+    let rust_version = env!("CARGO_PKG_RUST_VERSION");
 
     let bindings = bindgen::Builder::default()
         .header(HEADER_PATH)


### PR DESCRIPTION
Since [cargo 1.63], `$CARGO_PKG_RUST_VERSION` is set in the build
environment to the value of the `rust-version` Cargo.toml field.

This removes the need to manually invoke cargo from build.rs during a
build of the tree-sitter crate with the bindgen feature enabled.

Removing the cargo invocation also ensures the build doesn't write to
the current directory when the target directory has been redirected
elsewhere. "cargo metadata" will attempt to update Cargo.lock, which
will fail if the source tree is read-only.

[cargo 1.63]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-163-2022-08-11