### PR TITLE
feat(rust)!: use `ops::ControlFlow` as parse and query progress return value

### DIFF
--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt, fs,
     io::{self, Write},
+    ops::ControlFlow,
     path::{Path, PathBuf},
     sync::atomic::{AtomicUsize, Ordering},
     time::{Duration, Instant},
@@ -357,15 +358,15 @@ pub fn parse_file_at_path(
     let progress_callback = &mut |_: &ParseState| {
         if let Some(cancellation_flag) = opts.cancellation_flag {
             if cancellation_flag.load(Ordering::SeqCst) != 0 {
-                return true;
+                return ControlFlow::Break(());
             }
         }
 
         if opts.timeout > 0 && start_time.elapsed().as_micros() > opts.timeout as u128 {
-            return true;
+            return ControlFlow::Break(());
         }
 
-        false
+        ControlFlow::Continue(())
     };
 
     let parse_opts = ParseOptions::new().progress_callback(progress_callback);

--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -1,4 +1,4 @@
-use std::{env, fmt::Write, sync::LazyLock};
+use std::{env, fmt::Write, ops::ControlFlow, sync::LazyLock};
 
 use indoc::indoc;
 use rand::{prelude::StdRng, SeedableRng};
@@ -5446,8 +5446,13 @@ fn test_query_execution_with_timeout() {
             &query,
             tree.root_node(),
             source_code.as_bytes(),
-            QueryCursorOptions::new()
-                .progress_callback(&mut |_| start_time.elapsed().as_micros() > 1000),
+            QueryCursorOptions::new().progress_callback(&mut |_| {
+                if start_time.elapsed().as_micros() > 1000 {
+                    ControlFlow::Break(())
+                } else {
+                    ControlFlow::Continue(())
+                }
+            }),
         )
         .count();
     assert!(matches < 1000);

--- a/crates/highlight/src/highlight.rs
+++ b/crates/highlight/src/highlight.rs
@@ -7,7 +7,8 @@ use std::{
     iter,
     marker::PhantomData,
     mem::{self, MaybeUninit},
-    ops, str,
+    ops::{self, ControlFlow},
+    str,
     sync::{
         atomic::{AtomicUsize, Ordering},
         LazyLock,
@@ -538,9 +539,13 @@ impl<'a> HighlightIterLayer<'a> {
                         None,
                         Some(ParseOptions::new().progress_callback(&mut |_| {
                             if let Some(cancellation_flag) = cancellation_flag {
-                                cancellation_flag.load(Ordering::SeqCst) != 0
+                                if cancellation_flag.load(Ordering::SeqCst) != 0 {
+                                    ControlFlow::Break(())
+                                } else {
+                                    ControlFlow::Continue(())
+                                }
                             } else {
-                                false
+                                ControlFlow::Continue(())
                             }
                         })),
                     )

--- a/crates/tags/src/tags.rs
+++ b/crates/tags/src/tags.rs
@@ -7,7 +7,7 @@ use std::{
     collections::HashMap,
     ffi::{CStr, CString},
     mem,
-    ops::Range,
+    ops::{ControlFlow, Range},
     os::raw::c_char,
     str,
     sync::atomic::{AtomicUsize, Ordering},
@@ -301,9 +301,13 @@ impl TagsContext {
                 None,
                 Some(ParseOptions::new().progress_callback(&mut |_| {
                     if let Some(cancellation_flag) = cancellation_flag {
-                        cancellation_flag.load(Ordering::SeqCst) != 0
+                        if cancellation_flag.load(Ordering::SeqCst) != 0 {
+                            ControlFlow::Break(())
+                        } else {
+                            ControlFlow::Continue(())
+                        }
                     } else {
-                        false
+                        ControlFlow::Continue(())
                     }
                 })),
             )


### PR DESCRIPTION
Instead of returning an undocumented boolean flag, use a `core::ops::ControlFlow` object. At the expense of being a bit more verbose, this is a type that should be self-explanatory in the context of a callback, as an indication of whether to continue processing or stop.