### PR TITLE
Update README.md

### DIFF
--- a/lib/binding_web/README.md
+++ b/lib/binding_web/README.md
@@ -46,7 +46,7 @@ file to your `public` directory. You can do this automatically with a `postinsta
 You can also use this module with [deno](https://deno.land/):
 
 ```js
-import Parser from "npm:web-tree-sitter";
+import { Parser } from "npm:web-tree-sitter";
 await Parser.init();
 // the library is ready
 ```


### PR DESCRIPTION
The deno demo code in the web_bindings has a typo (which manifests in https://www.npmjs.com/package/web-tree-sitter), and this PR fixes it.

```
$ deno
Deno 2.3.1
exit using ctrl+d, ctrl+c, or close()
REPL is running with all permissions allowed.
To specify permissions, run `deno repl` with allow flags.
> import Parser from "npm:web-tree-sitter";
undefined
> Parser
undefined
> ^D
$ deno
Deno 2.3.1
exit using ctrl+d, ctrl+c, or close()
REPL is running with all permissions allowed.
To specify permissions, run `deno repl` with allow flags.
> import { Parser } from "npm:web-tree-sitter";
undefined
> Parser
[class Parser]
> await Parser.init()
undefined
> ^D
```