### PR TITLE
fix(bindings): only include top level LICENSE file

### DIFF
--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -373,14 +373,25 @@ pub fn generate_grammar_files(
                 generate_file(path, BUILD_RS_TEMPLATE, language_name, &generate_opts)
             })?;
 
-            missing_path(repo_path.join("Cargo.toml"), |path| {
-                generate_file(
-                    path,
-                    CARGO_TOML_TEMPLATE,
-                    dashed_language_name.as_str(),
-                    &generate_opts,
-                )
-            })?;
+            missing_path_else(
+                repo_path.join("Cargo.toml"),
+                allow_update,
+                |path| {
+                    generate_file(
+                        path,
+                        CARGO_TOML_TEMPLATE,
+                        dashed_language_name.as_str(),
+                        &generate_opts,
+                    )
+                },
+                |path| {
+                    let contents = fs::read_to_string(path)?;
+                    if contents.contains("\"LICENSE\"") {
+                        write_file(path, contents.replace("\"LICENSE\"", "\"/LICENSE\""))?;
+                    }
+                    Ok(())
+                },
+            )?;
 
             Ok(())
         })?;

--- a/crates/cli/src/templates/_cargo.toml
+++ b/crates/cli/src/templates/_cargo.toml
@@ -18,7 +18,7 @@ include = [
   "queries/*",
   "src/*",
   "tree-sitter.json",
-  "LICENSE",
+  "/LICENSE",
 ]
 
 [lib]


### PR DESCRIPTION
Ref: tree-sitter/workflows#33