### PR TITLE
ci(nvim-ts): update paths to refactor

### DIFF
--- a/.github/workflows/nvim_ts.yml
+++ b/.github/workflows/nvim_ts.yml
@@ -3,7 +3,10 @@ name: nvim-treesitter parser tests
 on:
   pull_request:
     paths:
-      - 'cli/**'
+      - 'crates/cli/**'
+      - 'crates/config/**'
+      - 'crates/generate/**'
+      - 'crates/loader/**'
       - '.github/workflows/nvim_ts.yml'
   workflow_dispatch:
 
@@ -13,7 +16,7 @@ concurrency:
 
 jobs:
   check_compilation:
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -55,7 +58,7 @@ jobs:
 
       - if: matrix.type == 'build'
         name: Compile parsers
-        run: $NVIM -l ./scripts/install-parsers.lua
+        run: $NVIM -l ./scripts/install-parsers.lua --max-jobs=10
         working-directory: ${{ env.NVIM_TS_DIR }}
         shell: bash
 


### PR DESCRIPTION
Problem: After https://github.com/tree-sitter/tree-sitter/pull/4496, the crater tests from nvim-treesitter no longer run on PRs with relevant changes.

Solution: Update the paths in the workflows to the new structure.

Also throttle the build step to 10 parallel tasks (reduces flakiness on Windows) ~~and raise the limit for the generate step to 3 (reduces the chance of timeouts)~~ (macOS runners have only 7GB RAM 😭 ).

Also raise the timeout limit to 30 minutes (it's more expensive to have to restart flaky tests than to let them run).

(Actually, I would suggest just removing this timeout completely -- it's not that this workflow is unbounded or can freeze.)

