### PR TITLE
fix(cli): transform repository field to object

### DIFF
--- a/crates/cli/src/templates/package.json
+++ b/crates/cli/src/templates/package.json
@@ -2,7 +2,10 @@
   "name": "tree-sitter-PARSER_NAME",
   "version": "PARSER_VERSION",
   "description": "PARSER_DESCRIPTION",
-  "repository": "PARSER_URL",
+  "repository": {
+    "type": "git",
+    "url": "git+PARSER_URL.git"
+  },
   "funding": "FUNDING_URL",
   "license": "PARSER_LICENSE",
   "author": {


### PR DESCRIPTION
Addresses  #4547.

A `repository` field inside `package.json` transformed to an object according to [the docs](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository).