### PR TITLE
fix(docs): don't show mdbook help popup when using code editor

### DIFF
--- a/docs/src/assets/js/playground.js
+++ b/docs/src/assets/js/playground.js
@@ -134,8 +134,9 @@ window.initializePlayground = async (opts) => {
   });
 
   codeEditor.on('keydown', (_, event) => {
-    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
-      event.stopPropagation(); // Prevent mdBook from going back/forward
+    const key = event.key;
+    if (key === 'ArrowLeft' || key === 'ArrowRight' || key === '?') {
+      event.stopPropagation(); // Prevent mdBook from going back/forward, or showing help
     }
   });
 


### PR DESCRIPTION
- Closes #4549

This fix can be verified locally by following the contribution instructions in the [docs](https://github.com/tree-sitter/tree-sitter/blob/master/docs/src/6-contributing.md#developing-documentation).