### PR TITLE
test(python): improve bindings test to detect ABI incompatibilities

### DIFF
--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -599,14 +599,32 @@ pub fn generate_grammar_files(
             })?;
 
             missing_path(path.join("tests"), create_dir)?.apply(|path| {
-                missing_path(path.join("test_binding.py"), |path| {
-                    generate_file(
-                        path,
-                        TEST_BINDING_PY_TEMPLATE,
-                        language_name,
-                        &generate_opts,
-                    )
-                })?;
+                missing_path_else(
+                    path.join("test_binding.py"),
+                    allow_update,
+                    |path| {
+                        generate_file(
+                            path,
+                            TEST_BINDING_PY_TEMPLATE,
+                            language_name,
+                            &generate_opts,
+                        )
+                    },
+                    |path| {
+                        let mut contents = fs::read_to_string(path)?;
+                        if !contents.contains("Parser(Language(") {
+                            contents = contents
+                                .replace("tree_sitter.Language(", "Parser(Language(")
+                                .replace(".language())\n", ".language()))\n")
+                                .replace(
+                                    "import tree_sitter\n",
+                                    "from tree_sitter import Language, Parser\n",
+                                );
+                            write_file(path, contents)?;
+                        }
+                        Ok(())
+                    },
+                )?;
                 Ok(())
             })?;
 

--- a/crates/cli/src/templates/test_binding.py
+++ b/crates/cli/src/templates/test_binding.py
@@ -1,12 +1,12 @@
 from unittest import TestCase
 
-import tree_sitter
+from tree_sitter import Language, Parser
 import tree_sitter_LOWER_PARSER_NAME
 
 
 class TestLanguage(TestCase):
     def test_can_load_grammar(self):
         try:
-            tree_sitter.Language(tree_sitter_LOWER_PARSER_NAME.language())
+            Parser(Language(tree_sitter_LOWER_PARSER_NAME.language()))
         except Exception:
             self.fail("Error loading TITLE_PARSER_NAME grammar")


### PR DESCRIPTION
Previously, python bindings test would not detect ABI incompatibilities. At this time, the latest pypi release of py-tree-sitter does not support 15, which is the default, and it creates the problem.

Improve the test to create a Parser, which will detect it:
```
======================================================================
ERROR: test_can_load_grammar
----------------------------------------------------------------------
Traceback (most recent call last):
  File "../tests/test_binding.py", line 10, in test_can_load_grammar
    _ = Parser(language)
ValueError: Incompatible Language version 15. Must be between 13 and 14

----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (errors=1)
```
