### PR TITLE
feat: Warn about unreachable variables

### DIFF
--- a/crates/generate/src/parse_grammar.rs
+++ b/crates/generate/src/parse_grammar.rs
@@ -246,6 +246,7 @@ pub(crate) fn parse_grammar(input: &str) -> ParseGrammarResult<InputGrammar> {
             &mut in_progress,
         ) && grammar_json.word.as_ref().is_none_or(|w| w != name)
         {
+            println!("Warning: unused variable {name:?}");
             grammar_json.conflicts.retain(|r| !r.contains(name));
             grammar_json.supertypes.retain(|r| r != name);
             grammar_json.inline.retain(|r| r != name);

--- a/crates/generate/src/parse_grammar.rs
+++ b/crates/generate/src/parse_grammar.rs
@@ -246,7 +246,7 @@ pub(crate) fn parse_grammar(input: &str) -> ParseGrammarResult<InputGrammar> {
             &mut in_progress,
         ) && grammar_json.word.as_ref().is_none_or(|w| w != name)
         {
-            println!("Warning: unused variable {name:?}");
+            eprintln!("Warning: unused variable {name:?}");
             grammar_json.conflicts.retain(|r| !r.contains(name));
             grammar_json.supertypes.retain(|r| r != name);
             grammar_json.inline.retain(|r| r != name);


### PR DESCRIPTION
Closes #4565.

I added this warning as a `println!`, similarly to the existing warnings for unnecessary conflict declarations. Ideally, those should be using `log::warn`, but the logging system is only initialized when the user has passed `-l` / `--log` on the CLI.

Turning such warnings into logging statements would also make them easier to unit test, for instance via the [`testing_logger`](https://crates.io/crates/testing_logger) crate.