### PR TITLE
perf: More efficient computation of used symbols

### DIFF
--- a/crates/generate/src/prepare_grammar/flatten_grammar.rs
+++ b/crates/generate/src/prepare_grammar/flatten_grammar.rs
@@ -262,9 +262,10 @@ pub(super) fn flatten_grammar(
 
     for (i, variable) in variables.iter().enumerate() {
         let symbol = Symbol::non_terminal(i);
+        let used = symbol_is_used(&variables, symbol);
 
         for production in &variable.productions {
-            if production.steps.is_empty() && symbol_is_used(&variables, symbol) {
+            if production.steps.is_empty() && used {
                 Err(FlattenGrammarError::EmptyString(variable.name.clone()))?;
             }
 


### PR DESCRIPTION
As the call to `symbol_is_used` does not depend on the production, it is more efficient to call it only once outside the loop over productions.

More broadly, the reachable symbols are currently computed at three stages of parser generation (listed here from upstream to downstream):
* When parsing the grammar (in `parse_grammar.rs`, where I added the warning in #4567)
* When flattening the grammar (this location, `flatten_grammar.rs`)
* When generating the parse table (in `build_tables.rs`)

I'm not clear on whether all those stages are useful - can the reachability of some symbols change because of some intermediate transformations?