### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -255,7 +255,7 @@ struct Test {
     /// Only run corpus test cases whose name does not match the given regex
     #[arg(long, short)]
     pub exclude: Option<Regex>,
-    /// Only run corpus test cases from from a given filename
+    /// Only run corpus test cases from a given filename
     #[arg(long)]
     pub file_name: Option<String>,
     /// The path to the tree-sitter grammar directory

--- a/crates/generate/src/build_tables/item_set_builder.rs
+++ b/crates/generate/src/build_tables/item_set_builder.rs
@@ -81,7 +81,7 @@ impl<'a> ParseItemSetBuilder<'a> {
                 .insert(symbol, ReservedWordSetId::default());
         }
 
-        // The FIRST set of a non-terminal `i` is the union of the the FIRST sets
+        // The FIRST set of a non-terminal `i` is the union of the FIRST sets
         // of all the symbols that appear at the beginnings of i's productions. Some
         // of these symbols may themselves be non-terminals, so this is a recursive
         // definition.


### PR DESCRIPTION
remove redundant words in comment