### PR TITLE
feat(bindings): support building Rust package for Wasm

### DIFF
--- a/crates/cli/src/templates/build.rs
+++ b/crates/cli/src/templates/build.rs
@@ -7,6 +7,11 @@ fn main() {
     #[cfg(target_env = "msvc")]
     c_config.flag("-utf-8");
 
+    if std::env::var("TARGET").unwrap() == "wasm32-unknown-unknown" {
+        let sysroot_dir = std::path::Path::new("bindings/rust/wasm-sysroot");
+        c_config.include(sysroot_dir);
+    }
+
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());

--- a/crates/cli/src/templates/stdint.h
+++ b/crates/cli/src/templates/stdint.h
@@ -1,0 +1,21 @@
+#pragma once
+
+typedef signed char int8_t;
+typedef short int16_t;
+typedef long int32_t;
+typedef long long int64_t;
+
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned long uint32_t;
+typedef unsigned long long uint64_t;
+
+typedef unsigned long size_t;
+
+typedef unsigned int uintptr_t;
+
+typedef unsigned int wint_t;
+
+#define UINT8_MAX 0xff
+#define UINT16_MAX 0xffff
+#define UINT32_MAX 0xffffffff

--- a/crates/cli/src/templates/stdlib.h
+++ b/crates/cli/src/templates/stdlib.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <stdint.h>
+
+#define NULL ((void*)0)
+
+void* malloc(size_t);
+void* calloc(size_t, size_t);
+void free(void*);
+void* realloc(void*, size_t);
+
+void abort(void);

--- a/crates/cli/src/templates/string.h
+++ b/crates/cli/src/templates/string.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <stdint.h>
+
+void* memchr(const void*, int, size_t);
+int memcmp(const void*, const void*, size_t);
+void* memcpy(void*, const void*, size_t);
+void *memmove(void*, const void*, size_t);
+void *memset(void*, int, size_t);
+int strcmp(const char*, const char*);
+size_t strlen(const char*);
+char* strncat(char*, const char*, size_t);
+int strncmp(const char*, const char*, size_t);
+char* strncpy(char*, const char*, size_t);

--- a/crates/cli/src/templates/wctype.h
+++ b/crates/cli/src/templates/wctype.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <stdint.h>
+
+int iswalnum(wint_t);
+int iswalpha(wint_t);
+int iswblank(wint_t);
+int iswdigit(wint_t);
+int iswlower(wint_t);
+int iswspace(wint_t);
+int iswupper(wint_t);
+int iswxdigit(wint_t);
+
+wint_t towlower(wint_t);
+wint_t towupper(wint_t);


### PR DESCRIPTION
Tree-sitter claims to support building for WebAssembly and yet on every step of the way there are road blocks if you want something more than download a pre-built WASM binary blob. That people struggle with it is obvious from the various discussions surrounding the matter, e.g.:
- https://github.com/tree-sitter/tree-sitter/discussions/1550
- https://github.com/tree-sitter/tree-sitter/discussions/2010
- https://github.com/tree-sitter/tree-sitter/discussions/1024

It's not just the core library: even languages fail to build for the target (certainly their Rust bindings). As it turns out it's actually not that hard to get going and this change boils down the various recommendations from some of the discussions into making generated language grammars build for the `wasm32-unknown-unknown` target out of the box. All that has to be done is to add and make known a minimal sysroot with header files that make certain types known and stub out core C allocation functions.
Note that the sized type definitions are 32 bit specific and will likely need adjustment once 64 bit WebAssembly is being used more broadly. Given the `wasm32-unknown-unknown` check this should be obvious and can be postponed until `wasm64-unknown-unknown` [0] is more widely used, I think.

[0] https://doc.rust-lang.org/nightly/rustc/platform-support/wasm64-unknown-unknown.html