### PR TITLE
fix(web): wasm export paths

### DIFF
--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -22,13 +22,13 @@
       "require": "./tree-sitter.cjs",
       "types": "./web-tree-sitter.d.ts"
     },
-    "./web-tree-sitter.wasm": "./web-tree-sitter.wasm",
+    "./tree-sitter.wasm": "./tree-sitter.wasm",
     "./debug": {
       "import": "./debug/tree-sitter.js",
       "require": "./debug/tree-sitter.cjs",
       "types": "./web-tree-sitter.d.ts"
     },
-    "./debug/web-tree-sitter.wasm": "./debug/web-tree-sitter.wasm"
+    "./debug/tree-sitter.wasm": "./debug/tree-sitter.wasm"
   },
   "types": "web-tree-sitter.d.ts",
   "keywords": [


### PR DESCRIPTION
This commit https://github.com/tree-sitter/tree-sitter/commit/69e857b3877f9b06b7a6474f227904b496f6ebf5 was cherry picked from a commit that had the changes from https://github.com/tree-sitter/tree-sitter/commit/a40265cbebfd6401d21eb095e250937915c9c3f7 so the paths ended up wrong.

Fixes #4576