### PR TITLE
cli: Adapt default Makefile/CMakeLists to work without `grammar.json`

### DIFF
--- a/crates/cli/src/templates/cmakelists.cmake
+++ b/crates/cli/src/templates/cmakelists.cmake
@@ -19,6 +19,13 @@ include(GNUInstallDirs)
 
 find_program(TREE_SITTER_CLI tree-sitter DOC "Tree-sitter CLI")
 
+add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
+                   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/grammar.js"
+                   COMMAND "${TREE_SITTER_CLI}" generate grammar.js
+                            --abi=${TREE_SITTER_ABI_VERSION}
+                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                   COMMENT "Generating grammar.json")
+
 add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
                    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
                    COMMAND "${TREE_SITTER_CLI}" generate src/grammar.json

--- a/crates/cli/src/templates/makefile
+++ b/crates/cli/src/templates/makefile
@@ -67,6 +67,8 @@ $(LANGUAGE_NAME).pc: bindings/c/$(LANGUAGE_NAME).pc.in
 		-e 's|@CMAKE_INSTALL_PREFIX@|$(PREFIX)|' $< > $@
 
 $(PARSER): $(SRC_DIR)/grammar.json
+$(SRC_DIR)/grammar.json: grammar.js
+$(PARSER) $(SRC_DIR)/grammar.json:
 	$(TS) generate $^
 
 install: all


### PR DESCRIPTION
This is a step towards making it easier for folks not to include tree-sitter generated files in grammar repos, as outlined in #930.

This makes it possible to run `make` or `cmake` in grammar repos where `grammar.json` hasn't been included, and still get the parser compilation to work. The build scripts still work if `grammar.json` is included.

One problem that if `grammar.json` isn't included, the generation process will run twice:
* once as `tree-sitter generate grammar.js`
* a second time as `tree-sitter generate src/grammar.json` But that's not actually necessary as the first invokation already generates both `src/grammar.json` and `src/parser.c` (plus other files).

If that's an issue, one could introduce a parameter to `tree-sitter generate` so that it only does the evaluation from `grammar.js` to `src/grammar.json` and stops there. This would avoid work getting done twice.

This change was suggested to me by @mavit in [a grammar I maintain](https://codeberg.org/grammar-orchard/tree-sitter-gomod-orchard) which doesn't track generated files. I'm far from a `make` expert so I hope this makes sense.