### PR TITLE
fix(test): unwrap result of `get_node_types` in `test_node_types_deeper_extras` test

### DIFF
--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -1078,7 +1078,8 @@ mod tests {
                 },
             ],
             ..Default::default()
-        });
+        })
+        .unwrap();
 
         assert_eq!(node_types.len(), 6);
 


### PR DESCRIPTION
The test added in https://github.com/tree-sitter/tree-sitter/pull/4557 calls into `get_node_types`, which had its return type changed in #4280 from `Vec<NodeInfoJSON>` to `SuperTypeCycleResult<Vec<NodeInfoJSON>>`. The fix here is to just unwrap the `Result` in the test case.