### PR TITLE
feat(rust): Add direct link to documentation

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 readme = "README.md"
 homepage.workspace = true
 repository.workspace = true
+documentation = "https://docs.rs/tree-sitter-cli"
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 readme = "README.md"
 homepage.workspace = true
 repository.workspace = true
+documentation = "https://docs.rs/tree-sitter-config"
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/generate/Cargo.toml
+++ b/crates/generate/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 readme = "README.md"
 homepage.workspace = true
 repository.workspace = true
+documentation = "https://docs.rs/tree-sitter-generate"
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/highlight/Cargo.toml
+++ b/crates/highlight/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 readme = "README.md"
 homepage.workspace = true
 repository.workspace = true
+documentation = "https://docs.rs/tree-sitter-highlight"
 license.workspace = true
 keywords = ["incremental", "parsing", "syntax", "highlighting"]
 categories = ["parsing", "text-editors"]

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.76"
 readme = "README.md"
 homepage.workspace = true
 repository.workspace = true
+documentation = "https://docs.rs/tree-sitter-language"
 license.workspace = true
 keywords.workspace = true
 categories = ["api-bindings", "development-tools::ffi", "parsing"]

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 readme = "README.md"
 homepage.workspace = true
 repository.workspace = true
+documentation = "https://docs.rs/tree-sitter-loader"
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/tags/Cargo.toml
+++ b/crates/tags/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 readme = "README.md"
 homepage.workspace = true
 repository.workspace = true
+documentation = "https://docs.rs/tree-sitter-tags"
 license.workspace = true
 keywords = ["incremental", "parsing", "syntax", "tagging"]
 categories = ["parsing", "text-editors"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.76"
 readme = "binding_rust/README.md"
 homepage.workspace = true
 repository.workspace = true
+documentation = "https://docs.rs/tree-sitter"
 license.workspace = true
 keywords.workspace = true
 categories = [


### PR DESCRIPTION
Make the URL to the documentation of the crate known so that it will be easier to click through to it from a crates.io search [0].

[0] https://doc.rust-lang.org/cargo/reference/manifest.html#the-documentation-field