### PR TITLE
perf: reorder expensive conditional operand

### DIFF
--- a/crates/generate/src/parse_grammar.rs
+++ b/crates/generate/src/parse_grammar.rs
@@ -238,13 +238,14 @@ pub(crate) fn parse_grammar(input: &str) -> ParseGrammarResult<InputGrammar> {
     let mut in_progress = HashSet::new();
 
     for (name, rule) in &rules {
-        if !variable_is_used(
-            &rules,
-            &extra_symbols,
-            &external_tokens,
-            name,
-            &mut in_progress,
-        ) && grammar_json.word.as_ref().is_none_or(|w| w != name)
+        if grammar_json.word.as_ref().is_none_or(|w| w != name)
+            && !variable_is_used(
+                &rules,
+                &extra_symbols,
+                &external_tokens,
+                name,
+                &mut in_progress,
+            )
         {
             grammar_json.conflicts.retain(|r| !r.contains(name));
             grammar_json.supertypes.retain(|r| r != name);


### PR DESCRIPTION
Another tiny performance win I found while trying to learn more about the generate code. In this case, `variable_is_used` is recursive and can be fairly expensive. By just reordering with the much cheaper `grammar_json.word.as_ref().is_none_or(|w| w != name)`, we get some small wins. This typically hovers around a 1% boost for "simpler" grammars (like tree-sitter-c), while it has no measurable affect on more "complicated" ones (i.e. tree-sitter-systemverilog or tree-sitter-ocaml).

