### PR TITLE
feat: Only evaluate `grammar.js` to `grammar.json`

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -133,6 +133,9 @@ struct Generate {
         default_value = "node"
     )]
     pub js_runtime: Option<String>,
+    /// Only generate `grammar.json` by evaluating `grammar.js`, but do not generate `parser.c` and related files afterwards
+    #[arg(long)]
+    pub evaluate_only: bool,
 }
 
 #[derive(Args)]
@@ -807,6 +810,7 @@ impl Generate {
             abi_version,
             self.report_states_for_rule.as_deref(),
             self.js_runtime.as_deref(),
+            self.evaluate_only,
         ) {
             if self.json {
                 eprintln!("{}", serde_json::to_string_pretty(&err)?);

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -152,6 +152,7 @@ pub fn generate_parser_in_directory<T, U, V>(
     mut abi_version: usize,
     report_symbol_name: Option<&str>,
     js_runtime: Option<&str>,
+    generate_parser: bool,
 ) -> GenerateResult<()>
 where
     T: Into<PathBuf>,
@@ -194,6 +195,11 @@ where
                 src_path.display()
             ))
         })?;
+    }
+
+    // If our job is only to generate `grammar.json` and not `parser.c`, stop here.
+    if !generate_parser {
+        return Ok(());
     }
 
     // Parse and preprocess the grammar.


### PR DESCRIPTION
This adds an `--evaluate-only` option to `tree-sitter generate` so that it only does the evaluation of `grammar.js` to `src/grammar.json`, without continuing on with the generation of `src/parser.c` and related files.

It's a follow-up to #4580.