### PR TITLE
fix(generate): propagate node types error

### DIFF
--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -257,7 +257,7 @@ fn generate_parser_for_grammar_with_opts(
         &lexical_grammar,
         &simple_aliases,
         &variable_info,
-    );
+    )?;
     let supertype_symbol_map =
         node_types::get_supertype_symbol_map(&syntax_grammar, &simple_aliases, &variable_info);
     let tables = build_tables(

--- a/crates/generate/src/prepare_grammar/flatten_grammar.rs
+++ b/crates/generate/src/prepare_grammar/flatten_grammar.rs
@@ -266,7 +266,7 @@ pub(super) fn flatten_grammar(
         let used = symbol_is_used(&variables, symbol);
 
         for production in &variable.productions {
-            if production.steps.is_empty() && used {
+            if used && production.steps.is_empty() {
                 Err(FlattenGrammarError::EmptyString(variable.name.clone()))?;
             }
 


### PR DESCRIPTION
I introduced this bug in #4280 by not propagating the `SuperTypeCycleError` up at the call site.

- Closes #4598 