### PR TITLE
refactor: Output warnings via the logger

### DIFF
--- a/crates/cli/src/logger.rs
+++ b/crates/cli/src/logger.rs
@@ -1,4 +1,4 @@
-use log::{LevelFilter, Log, Metadata, Record};
+use log::{Level, LevelFilter, Log, Metadata, Record};
 
 #[allow(dead_code)]
 struct Logger {
@@ -11,14 +11,20 @@ impl Log for Logger {
     }
 
     fn log(&self, record: &Record) {
-        eprintln!(
-            "[{}] {}",
-            record
-                .module_path()
-                .unwrap_or_default()
-                .trim_start_matches("rust_tree_sitter_cli::"),
-            record.args()
-        );
+        if record.level() == Level::Error {
+            eprintln!("Error: {}", record.args());
+        } else if record.level() == Level::Warn {
+            eprintln!("Warning: {}", record.args());
+        } else {
+            eprintln!(
+                "[{}] {}",
+                record
+                    .module_path()
+                    .unwrap_or_default()
+                    .trim_start_matches("rust_tree_sitter_cli::"),
+                record.args()
+            );
+        }
     }
 
     fn flush(&self) {}

--- a/crates/cli/src/logger.rs
+++ b/crates/cli/src/logger.rs
@@ -26,5 +26,5 @@ impl Log for Logger {
 
 pub fn init() {
     log::set_boxed_logger(Box::new(Logger { filter: None })).unwrap();
-    log::set_max_level(LevelFilter::Info);
+    log::set_max_level(LevelFilter::Warn);
 }

--- a/crates/cli/src/logger.rs
+++ b/crates/cli/src/logger.rs
@@ -11,19 +11,17 @@ impl Log for Logger {
     }
 
     fn log(&self, record: &Record) {
-        if record.level() == Level::Error {
-            eprintln!("Error: {}", record.args());
-        } else if record.level() == Level::Warn {
-            eprintln!("Warning: {}", record.args());
-        } else {
-            eprintln!(
+        match record.level() {
+            Level::Error => eprintln!("Error: {}", record.args()),
+            Level::Warn => eprintln!("Warning: {}", record.args()),
+            _ => eprintln!(
                 "[{}] {}",
                 record
                     .module_path()
                     .unwrap_or_default()
                     .trim_start_matches("rust_tree_sitter_cli::"),
                 record.args()
-            );
+            ),
         }
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -10,6 +10,7 @@ use clap::{crate_authors, Args, Command, FromArgMatches as _, Subcommand, ValueE
 use clap_complete::generate;
 use dialoguer::{theme::ColorfulTheme, Confirm, FuzzySelect, Input, MultiSelect};
 use heck::ToUpperCamelCase;
+use log::LevelFilter;
 use regex::Regex;
 use semver::Version as SemverVersion;
 use tree_sitter::{ffi, Parser, Point};
@@ -788,7 +789,7 @@ impl Init {
 impl Generate {
     fn run(self, mut loader: loader::Loader, current_dir: &Path) -> Result<()> {
         if self.log {
-            logger::init();
+            log::set_max_level(LevelFilter::Info);
         }
         let abi_version =
             self.abi_version
@@ -1705,6 +1706,7 @@ impl Complete {
 }
 
 fn main() {
+    logger::init();
     let result = run();
     if let Err(err) = &result {
         // Ignore BrokenPipe errors

--- a/crates/generate/src/build_tables/build_parse_table.rs
+++ b/crates/generate/src/build_tables/build_parse_table.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use indexmap::{map::Entry, IndexMap};
+use log::warn;
 use rustc_hash::FxHasher;
 use serde::Serialize;
 use thiserror::Error;
@@ -339,17 +340,22 @@ impl<'a> ParseTableBuilder<'a> {
         }
 
         if !self.actual_conflicts.is_empty() {
-            println!("Warning: unnecessary conflicts");
-            for conflict in &self.actual_conflicts {
-                println!(
-                    "  {}",
-                    conflict
-                        .iter()
-                        .map(|symbol| format!("`{}`", self.symbol_name(symbol)))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
-            }
+            warn!(
+                "unnecessary conflicts:\n{}",
+                &self
+                    .actual_conflicts
+                    .iter()
+                    .map(|conflict| format!(
+                        "  {}",
+                        conflict
+                            .iter()
+                            .map(|symbol| format!("`{}`", self.symbol_name(symbol)))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
         }
 
         Ok((self.parse_table, self.parse_state_info_by_id))

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use anyhow::Result;
+use log::warn;
 use regex::{Regex, RegexBuilder};
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -202,8 +203,8 @@ where
     let semantic_version = read_grammar_version(&repo_path)?;
 
     if semantic_version.is_none() && abi_version > ABI_VERSION_MIN {
-        println!("Warning: No `tree-sitter.json` file found in your grammar, this file is required to generate with ABI {abi_version}. Using ABI version {ABI_VERSION_MIN} instead.");
-        println!("This file can be set up with `tree-sitter init`. For more information, see https://tree-sitter.github.io/tree-sitter/cli/init.");
+        warn!("No `tree-sitter.json` file found in your grammar, this file is required to generate with ABI {abi_version}. Using ABI version {ABI_VERSION_MIN} instead.\n\
+               This file can be set up with `tree-sitter init`. For more information, see https://tree-sitter.github.io/tree-sitter/cli/init.");
         abi_version = ABI_VERSION_MIN;
     }
 

--- a/crates/generate/src/parse_grammar.rs
+++ b/crates/generate/src/parse_grammar.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use anyhow::Result;
+use log::warn;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use thiserror::Error;
@@ -320,7 +321,7 @@ fn parse_rule(json: RuleJSON, is_token: bool) -> ParseGrammarResult<Rule> {
                     } else {
                         // silently ignore unicode flags
                         if c != 'u' && c != 'v' {
-                            eprintln!("Warning: unsupported flag {c}");
+                            warn!("unsupported flag {c}");
                         }
                         false
                     }

--- a/crates/generate/src/prepare_grammar/intern_symbols.rs
+++ b/crates/generate/src/prepare_grammar/intern_symbols.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use log::warn;
 use serde::Serialize;
 use thiserror::Error;
 
@@ -185,8 +186,8 @@ impl Interner<'_> {
     // inconsistent behavior with queries can occur. So we should warn the user about it.
     fn check_single(&self, elements: &[Rule], name: Option<&str>) {
         if elements.len() == 1 && matches!(elements[0], Rule::String(_) | Rule::Pattern(_, _)) {
-            eprintln!(
-                "Warning: rule {} contains a `seq` or `choice` rule with a single element. This is unnecessary.",
+            warn!(
+                "rule {} contains a `seq` or `choice` rule with a single element. This is unnecessary.",
                 name.unwrap_or_default()
             );
         }


### PR DESCRIPTION
Instead of writing warnings about grammar sources files on a mixture of the standard output / standard error streams, this makes them go through the logging infrastructure, which is made available to all CLI commands (instead of just the `generate` command). I've tried to preserve the output format of the warnings.

This PR isn't meant to be comprehensive, there are many more `(e)println!` statements that could be migrated, but I imagine this can be done in follow-up changes.

Also I noticed that the existing logging statements in the `generate` crate are written with the `info` level, but in my opinion they rather belong to `debug`. Moving them to this level would make it possible to set `info` as default logging level, which would make more sense to me.

This is a follow-up to #4567. Depending on which one is merged first, I'll update the other one accordingly.