### PR TITLE
Remove src files from npm package

### DIFF
--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -2,7 +2,10 @@
   "name": "web-tree-sitter",
   "version": "0.26.0",
   "description": "Tree-sitter bindings for the web",
-  "repository": "https://github.com/tree-sitter/tree-sitter",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tree-sitter/tree-sitter.git"
+  },
   "homepage": "https://github.com/tree-sitter/tree-sitter/tree/master/lib/binding_web",
   "license": "MIT",
   "author": {

--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -23,7 +23,7 @@
         "default": "./web-tree-sitter.js"
       },
       "require": {
-        "types": "./web-tree-sitter.d.cts",
+        "types": "./web-tree-sitter.d.ts",
         "default": "./web-tree-sitter.cjs"
       }
     },
@@ -34,7 +34,7 @@
         "default": "./debug/web-tree-sitter.js"
       },
       "require": {
-        "types": "./web-tree-sitter.d.cts",
+        "types": "./web-tree-sitter.d.ts",
         "default": "./debug/web-tree-sitter.cjs"
       }
     },
@@ -50,11 +50,8 @@
   "files": [
     "README.md",
     "web-tree-sitter.cjs",
-    "web-tree-sitter.cjs.map",
     "web-tree-sitter.js",
-    "web-tree-sitter.js.map",
     "web-tree-sitter.wasm",
-    "web-tree-sitter.wasm.map",
     "debug/web-tree-sitter.cjs",
     "debug/web-tree-sitter.cjs.map",
     "debug/web-tree-sitter.js",
@@ -62,12 +59,7 @@
     "debug/web-tree-sitter.wasm",
     "debug/web-tree-sitter.wasm.map",
     "web-tree-sitter.d.ts",
-    "web-tree-sitter.d.ts.map",
-    "web-tree-sitter.d.cts",
-    "web-tree-sitter.d.cts.map",
-    "src/**/*.ts",
-    "lib/*.c",
-    "lib/*.h"
+    "web-tree-sitter.d.ts.map"
   ],
   "devDependencies": {
     "@eslint/js": "^9.20.0",


### PR DESCRIPTION
Fixes #4596

* removed all `.c` and `.h` files
* removed most of the useless `.map` files (that is what `/debug` is for)
* merged `web-tree-sitter.d.ts` and `web-tree-sitter.d.cts` (as they are the same)
* normalized the `repository` string to an `object`
```sh
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "repository" was changed from a string to an object
npm warn publish "repository.url" was normalized to "git+https://github.com/tree-sitter/tree-sitter.git"
```