### PR TITLE
Fix: add wasm32 support to portable/endian.h

### DIFF
--- a/lib/src/portable/endian.h
+++ b/lib/src/portable/endian.h
@@ -24,7 +24,8 @@
     defined(__CYGWIN__) || \
     defined(__MSYS__) || \
     defined(__EMSCRIPTEN__) || \
-    defined(__wasi__)
+    defined(__wasi__) || \
+    defined(__wasm32__)
 
 #if defined(__NetBSD__)
 #define _NETBSD_SOURCE 1

--- a/lib/src/portable/endian.h
+++ b/lib/src/portable/endian.h
@@ -25,7 +25,6 @@
     defined(__MSYS__) || \
     defined(__EMSCRIPTEN__) || \
     defined(__wasi__) || \
-    defined(__wasm32__) || \
     defined(__wasm__)
 
 #if defined(__NetBSD__)

--- a/lib/src/portable/endian.h
+++ b/lib/src/portable/endian.h
@@ -25,7 +25,8 @@
     defined(__MSYS__) || \
     defined(__EMSCRIPTEN__) || \
     defined(__wasi__) || \
-    defined(__wasm32__)
+    defined(__wasm32__) || \
+    defined(__wasm__)
 
 #if defined(__NetBSD__)
 #define _NETBSD_SOURCE 1


### PR DESCRIPTION
When targeting wasm32-unknown-unknown, the build currently fails with:
#error platform not supported
in src/portable/endian.h, even though WebAssembly is little-endian

This PR adds support for __wasm__/ __wasm32__ by adding the two to the sequence of defined statements