### PR TITLE
fix(bindings): ignore go.sum

### DIFF
--- a/crates/cli/src/templates/gitignore
+++ b/crates/cli/src/templates/gitignore
@@ -14,6 +14,7 @@ Package.resolved
 
 # Go artifacts
 _obj/
+go.sum
 
 # Python artifacts
 .venv/


### PR DESCRIPTION
Alternatively we can unignore all lockfiles, or just `package-lock.json` (required for child grammars).