### PR TITLE
perf(generate): reserve more `Vec` capacities

### DIFF
--- a/crates/generate/src/build_tables/build_parse_table.rs
+++ b/crates/generate/src/build_tables/build_parse_table.rs
@@ -312,6 +312,12 @@ impl<'a> ParseTableBuilder<'a> {
             }
         }
 
+        let non_terminal_sets_len = non_terminal_extra_item_sets_by_first_terminal.len();
+        self.non_terminal_extra_states
+            .reserve(non_terminal_sets_len);
+        self.parse_state_info_by_id.reserve(non_terminal_sets_len);
+        self.parse_table.states.reserve(non_terminal_sets_len);
+        self.parse_state_queue.reserve(non_terminal_sets_len);
         // Add a state for each starting terminal of a non-terminal extra rule.
         for (terminal, item_set) in non_terminal_extra_item_sets_by_first_terminal {
             if terminal.is_non_terminal() {


### PR DESCRIPTION
Some more small perf wins, this just reserves a few more `Vec` capacities up front before they're `push`ed to.

**tree-sitter-c** (3.3%):
<img width="1592" height="458" alt="image" src="https://github.com/user-attachments/assets/81b41982-06b6-4bd1-b476-129dca91adf5" />

**tree-sitter-ocaml** (4.2%):
<img width="1582" height="469" alt="image" src="https://github.com/user-attachments/assets/03f118d7-dfde-4561-a612-8eef08642515" />