### PR TITLE
Replace deprecated function on build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,17 +8,22 @@ pub fn build(b: *std.Build) !void {
   const shared = b.option(bool, "build-shared", "Build a shared library") orelse false;
   const amalgamated = b.option(bool, "amalgamated", "Build using an amalgamated source") orelse false;
 
-  const lib: *std.Build.Step.Compile = if (!shared) b.addStaticLibrary(.{
+  const lib: *std.Build.Step.Compile = if (!shared) b.addLibrary(.{
     .name = "tree-sitter",
-    .target = target,
-    .optimize = optimize,
-    .link_libc = true,
-  }) else b.addSharedLibrary(.{
+    .root_module = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    }),
+  }) else b.addLibrary(.{
     .name = "tree-sitter",
-    .pic = true,
-    .target = target,
-    .optimize = optimize,
-    .link_libc = true,
+    .linkage = .dynamic,
+    .root_module = b.createModule(.{
+        .pic = true,
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    }),
   });
 
   if (amalgamated) {

--- a/build.zig
+++ b/build.zig
@@ -8,21 +8,14 @@ pub fn build(b: *std.Build) !void {
   const shared = b.option(bool, "build-shared", "Build a shared library") orelse false;
   const amalgamated = b.option(bool, "amalgamated", "Build using an amalgamated source") orelse false;
 
-  const lib: *std.Build.Step.Compile = if (!shared) b.addLibrary(.{
+  const lib: *std.Build.Step.Compile = b.addLibrary(.{
     .name = "tree-sitter",
+    .linkage = if (shared) .dynamic else .static,
     .root_module = b.createModule(.{
-        .target = target,
-        .optimize = optimize,
-        .link_libc = true,
-    }),
-  }) else b.addLibrary(.{
-    .name = "tree-sitter",
-    .linkage = .dynamic,
-    .root_module = b.createModule(.{
-        .pic = true,
-        .target = target,
-        .optimize = optimize,
-        .link_libc = true,
+      .target = target,
+      .optimize = optimize,
+      .link_libc = true,
+      .pic = if (shared) true else null,
     }),
   });
 


### PR DESCRIPTION
The deprecated function addStaticLibrary() has been removed entirely so it no longer builds on recent dev versions of zig.

~~Also the build.zig weirdly uses two-space indentation, but I didn't format the whole file to avoid cluttering the diff.~~ 
Edit: Well actually the whole codebase uses two-space so never mind.