### PR TITLE
Revert "feat(generate): warn about unreachable variables (#4567)"

### DIFF
--- a/crates/generate/src/parse_grammar.rs
+++ b/crates/generate/src/parse_grammar.rs
@@ -247,7 +247,6 @@ pub(crate) fn parse_grammar(input: &str) -> ParseGrammarResult<InputGrammar> {
                 &mut in_progress,
             )
         {
-            eprintln!("Warning: unused variable {name:?}");
             grammar_json.conflicts.retain(|r| !r.contains(name));
             grammar_json.supertypes.retain(|r| r != name);
             grammar_json.inline.retain(|r| r != name);


### PR DESCRIPTION
This reverts commit 25c601bd2fd4b7bd6c4f575d6ea5867cfff7c008.

Reason: Too many false positives (especially for split parsers).

That information is useful, but unresolvable warnings for a significant class of parsers are not acceptable. We need to (re)think carefully how we report this (and similar) "lints".
