### PR TITLE
fix(rust): prevent overflow in error message calculation

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -342,6 +342,16 @@ fn test_query_errors_on_invalid_symbols() {
                 message: "\"alternatives\"".to_string()
             }
         );
+        assert_eq!(
+            Query::new(&language, "fakefield: (identifier)").unwrap_err(),
+            QueryError {
+                row: 0,
+                offset: 0,
+                column: 0,
+                kind: QueryErrorKind::Field,
+                message: "\"fakefield\"".to_string()
+            }
+        );
     });
 }
 

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -2446,7 +2446,7 @@ impl Query {
                 // Error types that report names
                 ffi::TSQueryErrorNodeType | ffi::TSQueryErrorField | ffi::TSQueryErrorCapture => {
                     let suffix = source.split_at(offset).1;
-                    let in_quotes = source.as_bytes()[offset - 1] == b'"';
+                    let in_quotes = offset > 0 && source.as_bytes()[offset - 1] == b'"';
                     let mut backslashes = 0;
                     let end_offset = suffix
                         .find(|c| {


### PR DESCRIPTION
**Problem:** When encountering an invalid symbol at the beginning of the file, the rust bindings attempt to index the character at position -1 of the query source, which leads to an overflow and thus invalid character index which causes a panic.

**Solution:** Bounds check the offset before performing the subtraction.