### PR TITLE
fix(templates): Generate from grammar.js.

### DIFF
--- a/crates/cli/src/templates/cmakelists.cmake
+++ b/crates/cli/src/templates/cmakelists.cmake
@@ -20,8 +20,8 @@ include(GNUInstallDirs)
 find_program(TREE_SITTER_CLI tree-sitter DOC "Tree-sitter CLI")
 
 add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
-                   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
-                   COMMAND "${TREE_SITTER_CLI}" generate src/grammar.json
+                   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/grammar.js"
+                   COMMAND "${TREE_SITTER_CLI}" generate grammer.js
                             --abi=${TREE_SITTER_ABI_VERSION}
                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                    COMMENT "Generating parser.c")

--- a/crates/cli/src/templates/makefile
+++ b/crates/cli/src/templates/makefile
@@ -72,7 +72,7 @@ $(LANGUAGE_NAME).pc: bindings/c/$(LANGUAGE_NAME).pc.in
 		-e 's|@PROJECT_HOMEPAGE_URL@|$(HOMEPAGE_URL)|' \
 		-e 's|@CMAKE_INSTALL_PREFIX@|$(PREFIX)|' $< > $@
 
-$(PARSER): $(SRC_DIR)/grammar.json
+$(PARSER): grammar.js
 	$(TS) generate $^
 
 install: all


### PR DESCRIPTION
Switch both the template Makefile and CMakeLists.txt to default to generating from grammar.js instead of grammar.json.

The template does not include a grammar.json, so trying to use the Makefile or CMake will fail. The docs do suggest running tree-sitter generate after tree-sitter init, but this shouldn't be necessary for the build system to work.

Since the documentation focuses on editing the grammar.js file, the build system should rebuild when changes are made to grammar.js instead of src/grammar.json