### PR TITLE
fix(cli): improve error message in cases where a langauge can't be found for one of many paths

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1002,8 +1002,11 @@ impl Parse {
 
                 for path in &paths {
                     let path = Path::new(&path);
-                    let language =
-                        loader.select_language(path, current_dir, self.scope.as_deref())?;
+                    let language = loader
+                        .select_language(path, current_dir, self.scope.as_deref())
+                        .with_context(|| {
+                            anyhow!("Failed to load langauge for path \"{}\"", path.display())
+                        })?;
 
                     parse::parse_file_at_path(
                         &mut parser,


### PR DESCRIPTION
### The Problem:

When multiple input paths are provided to the `parse` command (a la `tree-sitter parse --paths [...]`), if a language can't be found for one of the paths, it can be a little unclear *which* path caused the failure. The loader *can* fail with `Failed to load language for file name <foo.bar>`, but this isn't guaranteed. 

### The Solution:

Attach some additional context in the case where multiple paths can be provided, displaying the problematic path on failure.

Before:

```
$ tree-sitter parse foo.bar
No language found
```

After:

```
$ tree-sitter parse foo.bar
Failed to load langauge for path "foo.bar"

Caused by:
    No language found
```



This use case was brought up by digitcrusher in the community chat.