### PR TITLE
feat(cli): allow users to specify dynamic libraries directly

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1791,6 +1791,7 @@ impl DumpLanguages {
         for (configuration, language_path) in loader.get_all_language_configurations() {
             println!(
                 concat!(
+                    "name: {}\n",
                     "scope: {}\n",
                     "parser: {:?}\n",
                     "highlights: {:?}\n",
@@ -1798,6 +1799,7 @@ impl DumpLanguages {
                     "content_regex: {:?}\n",
                     "injection_regex: {:?}\n",
                 ),
+                configuration.language_name,
                 configuration.scope.as_ref().unwrap_or(&String::new()),
                 language_path,
                 configuration.highlights_filenames,

--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -723,10 +723,7 @@ impl Loader {
 
     pub fn load_language_at_path_with_name(&self, mut config: CompileConfig) -> Result<Language> {
         let mut lib_name = config.name.to_string();
-        let language_fn_name = format!(
-            "tree_sitter_{}",
-            replace_dashes_with_underscores(&config.name)
-        );
+        let language_fn_name = format!("tree_sitter_{}", config.name.replace('-', "_"));
         if self.debug_build {
             lib_name.push_str(".debug._");
         }
@@ -1713,16 +1710,4 @@ fn needs_recompile(lib_path: &Path, paths_to_check: &[PathBuf]) -> Result<bool> 
 
 fn mtime(path: &Path) -> Result<SystemTime> {
     Ok(fs::metadata(path)?.modified()?)
-}
-
-fn replace_dashes_with_underscores(name: &str) -> String {
-    let mut result = String::with_capacity(name.len());
-    for c in name.chars() {
-        if c == '-' {
-            result.push('_');
-        } else {
-            result.push(c);
-        }
-    }
-    result
 }

--- a/docs/src/cli/generate.md
+++ b/docs/src/cli/generate.md
@@ -56,6 +56,10 @@ Print the overview of states from the given rule. This is useful for debugging a
 item sets for all given states in a given rule. To solely view state count numbers for rules, pass in `-` for the rule argument.
 To view the overview of states for every rule, pass in `*` for the rule argument.
 
+### `json`
+
+Report conflicts in a JSON format.
+
 ### `--js-runtime <EXECUTABLE>`
 
 The path to the JavaScript runtime executable to use when generating the parser. The default is `node`.

--- a/docs/src/cli/highlight.md
+++ b/docs/src/cli/highlight.md
@@ -46,6 +46,10 @@ Suppress main output.
 
 The path to a file that contains paths to source files to highlight
 
+### `-p/--grammar-path <PATH>`
+
+The path to the directory containing the grammar.
+
 ### `--config-path <CONFIG_PATH>`
 
 The path to an alternative configuration (`config.json`) file. See [the init-config command](./init-config.md) for more information.

--- a/docs/src/cli/init.md
+++ b/docs/src/cli/init.md
@@ -14,6 +14,10 @@ tree-sitter init [OPTIONS] # Aliases: i
 
 Update outdated generated files, if needed.
 
+### `-p/--grammar-path <PATH>`
+
+The path to the directory containing the grammar.
+
 ## Structure of `tree-sitter.json`
 
 The main file of interest for users to configure is `tree-sitter.json`, which tells the CLI information about your grammar,

--- a/docs/src/cli/parse.md
+++ b/docs/src/cli/parse.md
@@ -14,6 +14,10 @@ tree-sitter parse [OPTIONS] [PATHS]... # Aliases: p
 
 The path to a file that contains paths to source files to parse.
 
+### `-p/--grammar-path <PATH>`
+
+The path to the directory containing the grammar.
+
 ### `--scope <SCOPE>`
 
 The language scope to use for parsing. This is useful when the language is ambiguous.
@@ -76,6 +80,10 @@ in `UTF-16BE` or `UTF-16LE`. If no `BOM` is present, `UTF-8` is the default. One
 ### `--open-log`
 
 When using the `--debug-graph` option, open the log file in the default browser.
+
+### `-j/--json`
+
+Output parsing results in a JSON format.
 
 ### `--config-path <CONFIG_PATH>`
 

--- a/docs/src/cli/query.md
+++ b/docs/src/cli/query.md
@@ -8,6 +8,10 @@ tree-sitter query [OPTIONS] <QUERY_PATH> [PATHS]... # Aliases: q
 
 ## Options
 
+### `-p/--grammar-path <PATH>`
+
+The path to the directory containing the grammar.
+
 ### `-t/--time`
 
 Print the time taken to execute the query on the file.

--- a/docs/src/cli/tags.md
+++ b/docs/src/cli/tags.md
@@ -25,6 +25,10 @@ Suppress main output.
 
 The path to a file that contains paths to source files to tag.
 
+### `-p/--grammar-path <PATH>`
+
+The path to the directory containing the grammar.
+
 ### `--config-path <CONFIG_PATH>`
 
 The path to an alternative configuration (`config.json`) file. See [the init-config command](./init-config.md) for more information.

--- a/docs/src/cli/test.md
+++ b/docs/src/cli/test.md
@@ -16,6 +16,14 @@ Only run tests whose names match this regex.
 
 Skip tests whose names match this regex.
 
+### `--file-name <NAME>`
+
+Only run tests from the given filename in the corpus.
+
+### `-p/--grammar-path <PATH>`
+
+The path to the directory containing the grammar.
+
 ### `-u/--update`
 
 Update the expected output of tests.

--- a/docs/src/cli/version.md
+++ b/docs/src/cli/version.md
@@ -22,3 +22,9 @@ different bindings. However, doing so manually is error-prone and tedious, so
 this command takes care of the burden. If you are using a version control system,
 it is recommended to commit the changes made by this command, and to tag the
 commit with the new version.
+
+## Options
+
+### `-p/--grammar-path <PATH>`
+
+The path to the directory containing the grammar.


### PR DESCRIPTION
### The Problem

The tree-sitter CLI does a lot of "magic" behind the scenes to find and load the correct dynamic library when various subcommands are used (i.e. `parse`, `query`, etc.). For some more advances use cases (i.e. testing two different commits for the same grammar), this auto-magical selection isn't desired.

### The Solution

This PR adds the ability to specify the path to a shared library directly via `--lib_path`. Internally, once the library has been loaded, the next step is to extract the language function symbol (i.e. `tree_sitter_c` from `c.so`). In my current implementation, we attempt to derive this symbol from the name of the shared library. If this doesn't work, users can pass `--language_name`.

Sample usage:

```
$ tree-sitter parse sample.c --lib-path /path/to/first/shared/lib/c.so
...
$ tree-sitter parse sample.c --lib-path /path/to/another/shared/lib/other_c.so --lang-name c
```

#### Other considerations

I'm opening this as a draft for now, until the following items can be settled agreed upon:

- [x] Ergonomics of the new arguments. Naming, documentation, etc.
- [x] Should a warning be displayed if `--lang_name` is specified when `--lib_path` isn't?
- [x] Further testing once I have some more time

Once we've settled on these changes, I'd like to:

- [x] Update the docs
- [x] *Potentially* extend this functionality to other subcommands (i.e. `fuzz`). Language loading works a bit differently for other subcommands, so we'll have to be careful not to introduce subtle regressions.

CC @sogaiu and @clason since you've both expressed interest in something like this.

Related: https://github.com/tree-sitter/tree-sitter/pull/4498