### PR TITLE
cli: Adapt default Makefile/CMakeLists for repos not storing grammar.json

### DIFF
--- a/crates/cli/src/templates/cmakelists.cmake
+++ b/crates/cli/src/templates/cmakelists.cmake
@@ -19,10 +19,17 @@ include(GNUInstallDirs)
 
 find_program(TREE_SITTER_CLI tree-sitter DOC "Tree-sitter CLI")
 
+add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
+                   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/grammar.js"
+                   COMMAND "${TREE_SITTER_CLI}" generate grammar.js
+                            --stage=json
+                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                   COMMENT "Generating grammar.json")
+
 add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
                    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
                    COMMAND "${TREE_SITTER_CLI}" generate src/grammar.json
-                            --abi=${TREE_SITTER_ABI_VERSION}
+                            --stage=parser --abi=${TREE_SITTER_ABI_VERSION}
                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                    COMMENT "Generating parser.c")
 

--- a/crates/cli/src/templates/makefile
+++ b/crates/cli/src/templates/makefile
@@ -72,8 +72,11 @@ $(LANGUAGE_NAME).pc: bindings/c/$(LANGUAGE_NAME).pc.in
 		-e 's|@PROJECT_HOMEPAGE_URL@|$(HOMEPAGE_URL)|' \
 		-e 's|@CMAKE_INSTALL_PREFIX@|$(PREFIX)|' $< > $@
 
+$(SRC_DIR)/grammar.json: grammar.js
+	$(TS) generate --stage=json $^
+
 $(PARSER): $(SRC_DIR)/grammar.json
-	$(TS) generate $^
+	$(TS) generate --stage=parser $^
 
 install: all
 	install -d '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/KEBAB_PARSER_NAME '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter '$(DESTDIR)$(PCLIBDIR)' '$(DESTDIR)$(LIBDIR)'


### PR DESCRIPTION
This is a new version of #4580, to make it easier not to include tree-sitter generated files in grammar repos, as outlined in #930.

This makes it possible to run `make` or `cmake --build .` in grammar repos where `grammar.json` hasn't been included, and still get the parser compilation to work. The build scripts still work if `grammar.json` is included.

When `grammar.json` is present, this gives:
```sh
$ make
tree-sitter generate --stage=parser src/grammar.json
cc -Isrc -std=c11 -fPIC   -c -o src/parser.o src/parser.c
…
```

When only `grammar.js` is present, this gives:
```sh
$ make
tree-sitter generate --stage=json grammar.js
tree-sitter generate --stage=parser src/grammar.json
cc -Isrc -std=c11 -fPIC   -c -o src/parser.o src/parser.c
…
```
(and similarly for `cmake --build .`)

I don't know if it's possible to encourage `make` to just run `tree-sitter generate grammar.js` in this case, generating all files in one go. The [rules with grouped targets](https://www.gnu.org/software/make/manual/html_node/Multiple-Targets.html) seem to be theoretically designed for that, but I couldn't get it to work without overriding the more granular rules. I think it could also work without this feature, as the overhead of starting two processes shouldn't be significant compared to the complexity of the generation work.