### PR TITLE
fix(rust): change index parameter types from u32 to usize

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1827,18 +1827,18 @@ impl<'tree> Node<'tree> {
     /// Get the field name of this node's child at the given index.
     #[doc(alias = "ts_node_field_name_for_child")]
     #[must_use]
-    pub fn field_name_for_child(&self, child_index: u32) -> Option<&'static str> {
+    pub fn field_name_for_child(&self, child_index: usize) -> Option<&'static str> {
         unsafe {
-            let ptr = ffi::ts_node_field_name_for_child(self.0, child_index);
+            let ptr = ffi::ts_node_field_name_for_child(self.0, child_index as u32);
             (!ptr.is_null()).then(|| CStr::from_ptr(ptr).to_str().unwrap())
         }
     }
 
     /// Get the field name of this node's named child at the given index.
     #[must_use]
-    pub fn field_name_for_named_child(&self, named_child_index: u32) -> Option<&'static str> {
+    pub fn field_name_for_named_child(&self, named_child_index: usize) -> Option<&'static str> {
         unsafe {
-            let ptr = ffi::ts_node_field_name_for_named_child(self.0, named_child_index);
+            let ptr = ffi::ts_node_field_name_for_named_child(self.0, named_child_index as u32);
             (!ptr.is_null()).then(|| CStr::from_ptr(ptr).to_str().unwrap())
         }
     }


### PR DESCRIPTION
Fix https://github.com/tree-sitter/tree-sitter/issues/4515