### PR TITLE
fix(cli): eliminate leak of version string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ clap = { version = "4.5.41", features = [
   "derive",
   "env",
   "help",
+  "string",
   "unstable-styles",
 ] }
 clap_complete = "4.5.55"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1746,7 +1746,6 @@ fn run() -> Result<()> {
         || BUILD_VERSION.to_string(),
         |build_sha| format!("{BUILD_VERSION} ({build_sha})"),
     );
-    let version: &'static str = Box::leak(version.into_boxed_str());
 
     let cli = Command::new("tree-sitter")
         .help_template(


### PR DESCRIPTION
This is a small (non-)issue that's bothered me for awhile now. After constructing the CLI's `version` as a `String`, we then place it into a `Box` and leak said box. This is done to appease the static lifetime requirement for the version string from clap. In practice this leak doesn't really matter (it's only a few bytes!). However, this can be annoying when debugging other issues. For example, when running the CLI under an address sanitizer, it gets (correctly) reported as a memory leak:


<Details>

<Summary>ASAN Output</Summary>

```
=================================================================
==1553361==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 6 byte(s) in 1 object(s) allocated from:
    #0 0x5624157c0524 in malloc /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:67:3
    #1 0x56241797d65b in std::sys::alloc::unix::_$LT$impl$u20$core..alloc..global..GlobalAlloc$u20$for$u20$std..alloc..System$GT$::alloc::h8693fed7123887bd /home/lillis/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/alloc/unix.rs:14:22
    #2 0x562417a5880e in __rustc::__rdl_alloc /home/lillis/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/alloc.rs:402:20
    #3 0x562417ba56c4 in alloc::alloc::Global::alloc_impl::h4d0b23df4a1ac187 /home/lillis/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:189:73
    #4 0x562417ba5f28 in _$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$::allocate::h2cf374fdac235200 /home/lillis/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:250:14
    #5 0x562417bb44ad in alloc::raw_vec::RawVecInner$LT$A$GT$::with_capacity_in::h374d23ad405c697f /home/lillis/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec/mod.rs:422:15
    #6 0x562417bb3c9c in alloc::raw_vec::RawVec$LT$T$C$A$GT$::with_capacity_in::h95535a5464cca815 /home/lillis/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec/mod.rs:190:20
    #7 0x562417bb142b in alloc::slice::_$LT$impl$u20$$u5b$T$u5d$$GT$::to_vec_in::hc2d508238f1acf55 /home/lillis/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/slice.rs:402:16
    #8 0x562416d8ef29 in _$LT$alloc..string..String$u20$as$u20$core..convert..From$LT$$RF$str$GT$$GT$::from::h1082c882d0fbf348 /home/lillis/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/string.rs:3056:11
    #9 0x5624158b4d0d in tree_sitter::main::hbdf5614a9f40903c /home/lillis/projects/tree-sitter/crates/cli/src/main.rs:1730:18
    #10 0x56241592d3ea in core::ops::function::FnOnce::call_once::h0b24b35577a5d973 /home/lillis/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:253:5
    #11 0x562417a0fb1a in std::panic::catch_unwind::hd8ea447a462a28c6 /home/lillis/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
    #12 0x562417968808 in std::panicking::catch_unwind::do_call::h997a416324e26ec4 /home/lillis/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:589:40
    #13 0x56241796f79a in __rust_try std.ebd859e7d684eb75-cgu.04
    #14 0x562417a0faed in std::panic::catch_unwind::ha9bc77828dfafe24 /home/lillis/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
    #15 0x562415996dcf in std::rt::lang_start::he4d17192ae83806b /home/lillis/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/rt.rs:205:5
    #16 0x562415910f3d in main (/home/lillis/projects/tree-sitter/target/x86_64-unknown-linux-gnu/debug/tree-sitter+0x12dff3d) (BuildId: ac80683dc06ff580e4eedbf03df4ada4ecc557c0)
    #17 0x7ffff81caa88  ([stack]+0x4aa88)

SUMMARY: AddressSanitizer: 6 byte(s) leaked in 1 allocation(s).
```

</Details>

It turns out `clap` has a feature flag (`"string"`) to address this, eliminating the need for the leaked memory.