### PR TITLE
Expose internal error nodes as `ERROR_INTERNAL`

### DIFF
--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -129,7 +129,7 @@ TSSymbolMetadata ts_language_symbol_metadata(
   if (symbol == ts_builtin_sym_error)  {
     return (TSSymbolMetadata) {.visible = true, .named = true};
   } else if (symbol == ts_builtin_sym_error_repeat) {
-    return (TSSymbolMetadata) {.visible = false, .named = false};
+    return (TSSymbolMetadata) {.visible = true, .named = false};
   } else {
     return self->symbol_metadata[symbol];
   }
@@ -139,7 +139,7 @@ TSSymbol ts_language_public_symbol(
   const TSLanguage *self,
   TSSymbol symbol
 ) {
-  if (symbol == ts_builtin_sym_error) return symbol;
+  if (symbol == ts_builtin_sym_error || symbol == ts_builtin_sym_error_repeat) return symbol;
   return self->public_symbol_map[symbol];
 }
 
@@ -172,7 +172,7 @@ const char *ts_language_symbol_name(
   if (symbol == ts_builtin_sym_error) {
     return "ERROR";
   } else if (symbol == ts_builtin_sym_error_repeat) {
-    return "_ERROR";
+    return "ERROR_INTERNAL";
   } else if (symbol < ts_language_symbol_count(self)) {
     return self->symbol_names[symbol];
   } else {
@@ -187,6 +187,7 @@ TSSymbol ts_language_symbol_for_name(
   bool is_named
 ) {
   if (!strncmp(string, "ERROR", length)) return ts_builtin_sym_error;
+  if (!strncmp(string, "ERROR_INTERNAL", length)) return ts_builtin_sym_error_repeat;
   uint16_t count = (uint16_t)ts_language_symbol_count(self);
   for (TSSymbol i = 0; i < count; i++) {
     TSSymbolMetadata metadata = ts_language_symbol_metadata(self, i);

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -526,13 +526,6 @@ bool ts_node_is_error(TSNode self) {
   return symbol == ts_builtin_sym_error;
 }
 
-uint32_t ts_node_error_child(TSNode self) {
-  if (!ts_node_is_error(self)) {
-    return 0;
-  }
-  return self.context[3];
-}
-
 uint32_t ts_node_descendant_count(TSNode self) {
   return ts_subtree_visible_descendant_count(ts_node__subtree(self)) + 1;
 }

--- a/lib/src/node.c
+++ b/lib/src/node.c
@@ -526,6 +526,13 @@ bool ts_node_is_error(TSNode self) {
   return symbol == ts_builtin_sym_error;
 }
 
+uint32_t ts_node_error_child(TSNode self) {
+  if (!ts_node_is_error(self)) {
+    return 0;
+  }
+  return self.context[3];
+}
+
 uint32_t ts_node_descendant_count(TSNode self) {
   return ts_subtree_visible_descendant_count(ts_node__subtree(self)) + 1;
 }


### PR DESCRIPTION
This PR remaps `_ERROR` nodes as `ERROR_INTERNAL` and makes them visible (but not named). This is useful for identifying which parts of an `ERROR` node actually caused the error to occur.

I'm not sure what kind of broader implications these changes would have on the whole system, but it seems to work well. Let me know if you have any suggestions or if this would cause other problems.

Thanks