### PR TITLE
fix(rust)!: take `u32` for index parameter to `Node::{child, named_child}`

### DIFF
--- a/crates/cli/src/fuzz/corpus_test.rs
+++ b/crates/cli/src/fuzz/corpus_test.rs
@@ -23,7 +23,7 @@ pub fn check_consistent_sizes(tree: &Tree, input: &[u8]) {
         let mut some_child_has_changes = false;
         let mut actual_named_child_count = 0;
         for i in 0..node.child_count() {
-            let child = node.child(i).unwrap();
+            let child = node.child(i as u32).unwrap();
             assert!(child.start_byte() >= last_child_end_byte);
             assert!(child.start_position() >= last_child_end_point);
             check(child, line_offsets);

--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -572,7 +572,7 @@ pub fn parse_file_at_path(
                         write!(&mut stdout, "</{}>", tag.expect("there is a tag"))?;
                         // we only write a line in the case where it's the last sibling
                         if let Some(parent) = node.parent() {
-                            if parent.child(parent.child_count() - 1).unwrap() == node {
+                            if parent.child(parent.child_count() as u32 - 1).unwrap() == node {
                                 stdout.write_all(b"\n")?;
                             }
                         }

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1765,8 +1765,8 @@ impl<'tree> Node<'tree> {
     /// [`Node::children`] instead.
     #[doc(alias = "ts_node_child")]
     #[must_use]
-    pub fn child(&self, i: usize) -> Option<Self> {
-        Self::new(unsafe { ffi::ts_node_child(self.0, i as u32) })
+    pub fn child(&self, i: u32) -> Option<Self> {
+        Self::new(unsafe { ffi::ts_node_child(self.0, i) })
     }
 
     /// Get this node's number of children.
@@ -1784,8 +1784,8 @@ impl<'tree> Node<'tree> {
     /// [`Node::named_children`] instead.
     #[doc(alias = "ts_node_named_child")]
     #[must_use]
-    pub fn named_child(&self, i: usize) -> Option<Self> {
-        Self::new(unsafe { ffi::ts_node_named_child(self.0, i as u32) })
+    pub fn named_child(&self, i: u32) -> Option<Self> {
+        Self::new(unsafe { ffi::ts_node_named_child(self.0, i) })
     }
 
     /// Get this node's number of *named* children.


### PR DESCRIPTION
Rework of #4652.

@junnplus I've added you as a co-author to this commit, thanks for taking an initial pass!

- Closes #4515 