### PR TITLE
fix(docs): indicate CJS env var export is different on Windows platforms

### DIFF
--- a/lib/binding_web/CONTRIBUTING.md
+++ b/lib/binding_web/CONTRIBUTING.md
@@ -41,7 +41,7 @@ by visiting the [Rust website][rust] and following the instructions there.
 
 > [!NOTE]
 > By default, the build process will emit an ES6 module. If you need a CommonJS module, export `CJS` to `true`, or just
-> run `CJS=true npm run build`.
+> run `CJS=true npm run build` (or the equivalent command for Windows).
 
 > [!TIP]
 > To build the library with debug information, you can run `npm run build:debug`. The `CJS` environment variable is still


### PR DESCRIPTION
It's not in scope for tree-sitter to document the various ways that different platforms use/interact with environment variables. I think it's fine to note that a given invocation is different in this case, though. 

- Closes #4599