### PR TITLE
fix(cli): drop homepage link from config

### DIFF
--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -182,7 +182,6 @@ impl JsonConfigOpts {
                         .expect("Failed to parse default repository URL")
                     }),
                     funding: self.funding,
-                    homepage: None,
                 }),
                 namespace: None,
             },

--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -218,8 +218,6 @@ pub struct Links {
     pub repository: Url,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub funding: Option<Url>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub homepage: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/docs/src/assets/schemas/config.schema.json
+++ b/docs/src/assets/schemas/config.schema.json
@@ -188,11 +188,6 @@
               "type": "string",
               "format": "uri",
               "description": "The project's funding link."
-            },
-            "homepage": {
-              "type": "string",
-              "format": "uri",
-              "description": "The project's homepage."
             }
           },
           "additionalProperties": false,

--- a/docs/src/cli/init.md
+++ b/docs/src/cli/init.md
@@ -104,7 +104,7 @@ Typically, this will all be set up when you run `tree-sitter init`, but you are 
 - `description` — The brief description of your grammar
 - `authors` (required) — An array of objects that contain a `name` field, and optionally an `email` and `url` field.
 Each field is a string
-- `links` — An object that contains a `repository` field, and optionally a `homepage` field. Each field is a string
+- `links` — An object that contains a `repository` field, and optionally a `funding` field. Each field is a string
 - `namespace` — The namespace for the `Java` and `Kotlin` bindings, defaults to `io.github.tree-sitter` if not provided
 
 ### The `bindings` field


### PR DESCRIPTION
We don't actually use this currently and the vast majority of grammars don't have a homepage other than the repository itself.