### PR TITLE
build(zig)!: upgrade build.zig to zig 0.15

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -95,7 +95,7 @@ fn wasmtimeDep(target: std.Target) []const u8 {
 }
 
 fn findSourceFiles(b: *std.Build) ![]const []const u8 {
-  var sources = std.ArrayList([]const u8).init(b.allocator);
+  var sources : std.ArrayList([]const u8) = .empty;
 
   var dir = try b.build_root.handle.openDir("lib/src", .{ .iterate = true });
   var iter = dir.iterate();
@@ -106,7 +106,7 @@ fn findSourceFiles(b: *std.Build) ![]const []const u8 {
     const file = entry.name;
     const ext = std.fs.path.extension(file);
     if (std.mem.eql(u8, ext, ".c") and !std.mem.eql(u8, file, "lib.c")) {
-      try sources.append(b.dupe(file));
+      try sources.append(b.allocator, b.dupe(file));
     }
   }
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,6 +2,7 @@
   .name = .tree_sitter,
   .fingerprint = 0x841224b447ac0d4f,
   .version = "0.26.0",
+  .minimum_zig_version = "0.15.0",
   .paths = .{
     "build.zig",
     "build.zig.zon",


### PR DESCRIPTION
This no longer supports zig 0.14.

As an alternative, with some tomfoolery (`initWithCapacity`) it would be possible to support both versions at once. However zig 0.14 is considered end-of-life with the release of zig 0.15 