### PR TITLE
docs(cli): Updated with the new `version` features (pre-#4205)

### DIFF
--- a/docs/src/cli/version.md
+++ b/docs/src/cli/version.md
@@ -17,11 +17,25 @@ This will update the version in several files, if they exist:
 * CMakeLists.txt
 * pyproject.toml
 
+Alternative forms can use the version in `tree-sitter.json` to bump automatically:
+
+```bash
+tree-sitter version --bump patch # patch bump
+tree-sitter version --bump minor # minor bump
+tree-sitter version --bump major # major bump
+```
+
 As a grammar author, you should keep the version of your grammar in sync across
 different bindings. However, doing so manually is error-prone and tedious, so
 this command takes care of the burden. If you are using a version control system,
 it is recommended to commit the changes made by this command, and to tag the
 commit with the new version.
+
+To print the current version without bumping it, use:
+
+```bash
+tree-sitter version
+```
 
 ## Options
 


### PR DESCRIPTION
As requested by [ObserverOfTime](https://github.com/tree-sitter/tree-sitter/pull/4205#pullrequestreview-3145178698), this is the separate PR for the docs update to be released before #4205