### PR TITLE
feat(c): rename DecodeFunction to TSDecodeFunction

### DIFF
--- a/docs/src/using-parsers/2-basic-parsing.md
+++ b/docs/src/using-parsers/2-basic-parsing.md
@@ -38,15 +38,15 @@ typedef struct {
     uint32_t *bytes_read
   );
   TSInputEncoding encoding;
-  DecodeFunction decode;
+  TSDecodeFunction decode;
 } TSInput;
 ```
 
 If you want to decode text that is not encoded in UTF-8 or UTF-16, you can set the `decode` field of the input to your function
-that will decode text. The signature of the `DecodeFunction` is as follows:
+that will decode text. The signature of the `TSDecodeFunction` is as follows:
 
 ```c
-typedef uint32_t (*DecodeFunction)(
+typedef uint32_t (*TSDecodeFunction)(
   const uint8_t *string,
   uint32_t length,
   int32_t *code_point

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -35,7 +35,7 @@ pub struct TSQueryCursor {
 pub struct TSLookaheadIterator {
     _unused: [u8; 0],
 }
-pub type DecodeFunction = ::core::option::Option<
+pub type TSDecodeFunction = ::core::option::Option<
     unsafe extern "C" fn(string: *const u8, length: u32, code_point: *mut i32) -> u32,
 >;
 pub const TSInputEncodingUTF8: TSInputEncoding = 0;
@@ -75,7 +75,7 @@ pub struct TSInput {
         ) -> *const ::core::ffi::c_char,
     >,
     pub encoding: TSInputEncoding,
-    pub decode: DecodeFunction,
+    pub decode: TSDecodeFunction,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -51,11 +51,14 @@ typedef struct TSLookaheadIterator TSLookaheadIterator;
 // This function signature reads one code point from the given string,
 // returning the number of bytes consumed. It should write the code point
 // to the `code_point` pointer, or write -1 if the input is invalid.
-typedef uint32_t (*DecodeFunction)(
+typedef uint32_t (*TSDecodeFunction)(
   const uint8_t *string,
   uint32_t length,
   int32_t *code_point
 );
+
+// Deprecated alias to be removed in ABI 16
+typedef TSDecodeFunction DecodeFunction;
 
 typedef enum TSInputEncoding {
   TSInputEncodingUTF8,
@@ -87,7 +90,7 @@ typedef struct TSInput {
   void *payload;
   const char *(*read)(void *payload, uint32_t byte_index, TSPoint position, uint32_t *bytes_read);
   TSInputEncoding encoding;
-  DecodeFunction decode;
+  TSDecodeFunction decode;
 } TSInput;
 
 typedef struct TSParseState {

--- a/lib/src/lexer.c
+++ b/lib/src/lexer.c
@@ -114,7 +114,7 @@ static void ts_lexer__get_lookahead(Lexer *self) {
   }
 
   const uint8_t *chunk = (const uint8_t *)self->chunk + position_in_chunk;
-  DecodeFunction decode =
+  TSDecodeFunction decode =
     self->input.encoding == TSInputEncodingUTF8    ? ts_decode_utf8     :
     self->input.encoding == TSInputEncodingUTF16LE ? ts_decode_utf16_le :
     self->input.encoding == TSInputEncodingUTF16BE ? ts_decode_utf16_be : self->input.decode;


### PR DESCRIPTION
Keep a typedef for backwards compatibility until ABI 16.

Ref: #4721