### PR TITLE
fix(bindings): improve zig dependency fetching logic

### DIFF
--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -389,6 +389,7 @@ pub fn generate_grammar_files(
                 |path| {
                     let contents = fs::read_to_string(path)?;
                     if !contents.contains("bun") {
+                        eprintln!("Replacing index.js");
                         generate_file(path, INDEX_JS_TEMPLATE, language_name, &generate_opts)?;
                     }
                     Ok(())
@@ -755,8 +756,13 @@ pub fn generate_grammar_files(
             allow_update,
             |path| generate_file(path, BUILD_ZIG_TEMPLATE, language_name, &generate_opts),
             |path| {
-                eprintln!("Replacing build.zig");
-                generate_file(path, BUILD_ZIG_TEMPLATE, language_name, &generate_opts)
+                let contents = fs::read_to_string(path)?;
+                if !contents.contains("b.pkg_hash.len") {
+                    eprintln!("Replacing build.zig");
+                    generate_file(path, BUILD_ZIG_TEMPLATE, language_name, &generate_opts)
+                } else {
+                    Ok(())
+                }
             },
         )?;
 
@@ -765,8 +771,13 @@ pub fn generate_grammar_files(
             allow_update,
             |path| generate_file(path, BUILD_ZIG_ZON_TEMPLATE, language_name, &generate_opts),
             |path| {
-                eprintln!("Replacing build.zig.zon");
-                generate_file(path, BUILD_ZIG_ZON_TEMPLATE, language_name, &generate_opts)
+                let contents = fs::read_to_string(path)?;
+                if !contents.contains(".name = .tree_sitter_") {
+                    eprintln!("Replacing build.zig.zon");
+                    generate_file(path, BUILD_ZIG_ZON_TEMPLATE, language_name, &generate_opts)
+                } else {
+                    Ok(())
+                }
             },
         )?;
 
@@ -776,8 +787,13 @@ pub fn generate_grammar_files(
                 allow_update,
                 |path| generate_file(path, ROOT_ZIG_TEMPLATE, language_name, &generate_opts),
                 |path| {
-                    eprintln!("Replacing root.zig");
-                    generate_file(path, ROOT_ZIG_TEMPLATE, language_name, &generate_opts)
+                    let contents = fs::read_to_string(path)?;
+                    if contents.contains("ts.Language") {
+                        eprintln!("Replacing root.zig");
+                        generate_file(path, ROOT_ZIG_TEMPLATE, language_name, &generate_opts)
+                    } else {
+                        Ok(())
+                    }
                 },
             )?;
 

--- a/crates/cli/src/templates/build.zig
+++ b/crates/cli/src/templates/build.zig
@@ -68,13 +68,16 @@ pub fn build(b: *std.Build) !void {
     });
     tests.root_module.addImport(library_name, module);
 
-    var args = try std.process.argsWithAllocator(b.allocator);
-    defer args.deinit();
-    while (args.next()) |a| {
-        if (std.mem.eql(u8, a, "test")) {
-            const ts_dep = b.lazyDependency("tree_sitter", .{}) orelse continue;
-            tests.root_module.addImport("tree-sitter", ts_dep.module("tree-sitter"));
-            break;
+    // HACK: fetch tree-sitter dependency only when testing this module
+    if (b.pkg_hash.len == 0) {
+        var args = try std.process.argsWithAllocator(b.allocator);
+        defer args.deinit();
+        while (args.next()) |a| {
+            if (std.mem.eql(u8, a, "test")) {
+                const ts_dep = b.lazyDependency("tree_sitter", .{}) orelse continue;
+                tests.root_module.addImport("tree-sitter", ts_dep.module("tree-sitter"));
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Currently, including a tree-sitter parser as a dependency in a zig project and running `zig build test` on the project will fetch the zig-tree-sitter dependency declared by the parser. This is a problem because (a) consumers may not want this dependency for whatever reason and (b) due to how often Zig breaks everything and how scarcely most tree-sitter parsers are updated, the zig-tree-sitter version pinned by the parser module will often be outdated and broken.

The workaround I used was taken from https://ziggit.dev/t/11234.

I also noticed that we were unconditionally replacing the files and fixed that while I was at it.

---

/cc @nvlled