### PR TITLE
fix(wasm): delete `var_i32_type` after initializing global stack pointer value

### DIFF
--- a/lib/src/wasm_store.c
+++ b/lib/src/wasm_store.c
@@ -754,6 +754,7 @@ TSWasmStore *ts_wasm_store_new(TSWasmEngine *engine, TSWasmError *wasm_error) {
   wasmtime_val_t stack_pointer_value = WASM_I32_VAL(0);
   wasmtime_global_t stack_pointer_global;
   error = wasmtime_global_new(context, var_i32_type, &stack_pointer_value, &stack_pointer_global);
+  wasm_globaltype_delete(var_i32_type);
   ts_assert(!error);
 
   *self = (TSWasmStore) {


### PR DESCRIPTION
<Details>

<Summary>Valgrind before:</Summary>

```
valgrind --tool=memcheck --leak-check=full --track-origins=yes target/debug/ts_leaky
==681391== Memcheck, a memory error detector
==681391== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==681391== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==681391== Command: target/debug/ts_leaky
==681391==
==681391== Warning: set address range perms: large range [0x59c87000, 0x15dc87000) (noaccess)
successfully loaded language
==681391== Warning: set address range perms: large range [0x59c87000, 0x15dc87000) (noaccess)
==681391==
==681391== HEAP SUMMARY:
==681391==     in use at exit: 993 bytes in 7 blocks
==681391==   total heap usage: 33,993 allocs, 33,986 frees, 47,206,639 bytes allocated
==681391==
==681391== 224 bytes in 1 blocks are definitely lost in loss record 5 of 7
==681391==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==681391==    by 0x28904F: alloc (alloc.rs:94)
==681391==    by 0x28904F: alloc::alloc::Global::alloc_impl (alloc.rs:189)
==681391==    by 0x288E74: alloc::alloc::exchange_malloc (alloc.rs:250)
==681391==    by 0x27C390: wasm_globaltype_new (boxed.rs:261)
==681391==    by 0x2680F9: ts_wasm_store_new (wasm_store.c:752)
==681391==    by 0x265407: tree_sitter::wasm_language::WasmStore::new (wasm_language.rs:50)
==681391==    by 0x264FC7: ts_leaky::main (main.rs:8)
==681391==    by 0x264EEA: core::ops::function::FnOnce::call_once (function.rs:250)
==681391==    by 0x264E6D: std::sys::backtrace::__rust_begin_short_backtrace (backtrace.rs:152)
==681391==    by 0x264E40: std::rt::lang_start::{{closure}} (rt.rs:206)
==681391==    by 0xFA8BBF: std::rt::lang_start_internal (function.rs:284)
==681391==    by 0x264E26: std::rt::lang_start (rt.rs:205)
==681391==
==681391== LEAK SUMMARY:
==681391==    definitely lost: 224 bytes in 1 blocks
==681391==    indirectly lost: 0 bytes in 0 blocks
==681391==      possibly lost: 0 bytes in 0 blocks
==681391==    still reachable: 769 bytes in 6 blocks
==681391==         suppressed: 0 bytes in 0 blocks
==681391== Reachable blocks (those to which a pointer was found) are not shown.
==681391== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==681391==
==681391== For lists of detected and suppressed errors, rerun with: -s
==681391== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
</Details>

<Details>

<Summary>Valgrind after:</Summary>

```
valgrind --tool=memcheck --leak-check=full --track-origins=yes target/debug/ts_leaky
==688530== Memcheck, a memory error detector
==688530== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==688530== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==688530== Command: target/debug/ts_leaky
==688530==
==688530== Warning: set address range perms: large range [0x59c87000, 0x15dc87000) (noaccess)
successfully loaded language
==688530== Warning: set address range perms: large range [0x59c87000, 0x15dc87000) (noaccess)
==688530==
==688530== HEAP SUMMARY:
==688530==     in use at exit: 769 bytes in 6 blocks
==688530==   total heap usage: 33,993 allocs, 33,987 frees, 47,206,639 bytes allocated
==688530==
==688530== LEAK SUMMARY:
==688530==    definitely lost: 0 bytes in 0 blocks
==688530==    indirectly lost: 0 bytes in 0 blocks
==688530==      possibly lost: 0 bytes in 0 blocks
==688530==    still reachable: 769 bytes in 6 blocks
==688530==         suppressed: 0 bytes in 0 blocks
==688530== Reachable blocks (those to which a pointer was found) are not shown.
==688530== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==688530==
==688530== For lists of detected and suppressed errors, rerun with: -s
==688530== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

</Details>

- Closes 4513