### PR TITLE
fix(lib): check if an `ERROR` node is named before assuming it's the builtin error node

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -17,7 +17,10 @@ use super::helpers::{
 };
 use crate::tests::{
     generate_parser,
-    helpers::query_helpers::{collect_captures, collect_matches},
+    helpers::{
+        fixtures::get_test_fixture_language,
+        query_helpers::{collect_captures, collect_matches},
+    },
     ITERATION_COUNT,
 };
 
@@ -5707,4 +5710,31 @@ fn test_query_with_predicate_causing_oob_access() {
        path: (scoped_identifier (identifier) @_regex (#any-of? @_regex \"Regex\" \"RegexBuilder\") .))
      (#set! injection.language \"regex\"))";
     Query::new(&language, query).unwrap();
+}
+
+#[test]
+fn test_query_with_anonymous_error_node() {
+    let language = get_test_fixture_language("anonymous_error");
+    let mut parser = Parser::new();
+    parser.set_language(&language).unwrap();
+
+    let source = "ERROR";
+
+    let tree = parser.parse(source, None).unwrap();
+    let query = Query::new(
+        &language,
+        r#"
+          "ERROR" @error
+          (document "ERROR" @error)
+        "#,
+    )
+    .unwrap();
+    let mut cursor = QueryCursor::new();
+    let matches = cursor.matches(&query, tree.root_node(), source.as_bytes());
+    let matches = collect_matches(matches, &query, source);
+
+    assert_eq!(
+        matches,
+        vec![(1, vec![("error", "ERROR")]), (0, vec![("error", "ERROR")])]
+    );
 }

--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -186,7 +186,7 @@ TSSymbol ts_language_symbol_for_name(
   uint32_t length,
   bool is_named
 ) {
-  if (!strncmp(string, "ERROR", length)) return ts_builtin_sym_error;
+  if (is_named && !strncmp(string, "ERROR", length)) return ts_builtin_sym_error;
   uint16_t count = (uint16_t)ts_language_symbol_count(self);
   for (TSSymbol i = 0; i < count; i++) {
     TSSymbolMetadata metadata = ts_language_symbol_metadata(self, i);

--- a/test/fixtures/test_grammars/anonymous_error/corpus.txt
+++ b/test/fixtures/test_grammars/anonymous_error/corpus.txt
@@ -1,0 +1,9 @@
+======================
+A simple error literal
+======================
+
+ERROR
+
+---
+
+(document)

--- a/test/fixtures/test_grammars/anonymous_error/grammar.js
+++ b/test/fixtures/test_grammars/anonymous_error/grammar.js
@@ -1,0 +1,6 @@
+module.exports = grammar({
+  name: 'anonymous_error',
+  rules: {
+    document: $ => repeat(choice('ok', 'ERROR')),
+  }
+});


### PR DESCRIPTION
- Closes #4687

### Problem

Any node that is named "ERROR" will be assumed to be the built-in error node. This does not make sense for anonymous nodes, and causes issues when trying to query this node as seen in the [cst grammar](https://github.com/tree-sitter-grammars/tree-sitter-cst).

### Solution

Only assume the "ERROR" node is the builtin error node if it is named and not anonymous