### PR TITLE
fix(lib): allow error nodes to match when they are child nodes

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -5738,3 +5738,25 @@ fn test_query_with_anonymous_error_node() {
         vec![(1, vec![("error", "ERROR")]), (0, vec![("error", "ERROR")])]
     );
 }
+
+#[test]
+fn test_query_allows_error_nodes_with_children() {
+    allocations::record(|| {
+        let language = get_language("cpp");
+
+        let code = "SomeStruct foo{.bar{}};";
+
+        let mut parser = Parser::new();
+        parser.set_language(&language).unwrap();
+
+        let tree = parser.parse(code, None).unwrap();
+        let root = tree.root_node();
+
+        let query = Query::new(&language, "(initializer_list (ERROR) @error)").unwrap();
+        let mut cursor = QueryCursor::new();
+
+        let matches = cursor.matches(&query, root, code.as_bytes());
+        let matches = collect_matches(matches, &query, code);
+        assert_eq!(matches, &[(0, vec![("error", ".bar")])]);
+    });
+}

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -1338,7 +1338,12 @@ static void ts_query__perform_analysis(
           // Determine if this hypothetical child node would match the current step
           // of the query pattern.
           bool does_match = false;
-          if (visible_symbol) {
+
+          // ERROR nodes can appear anywhere, so if the step is 
+          // looking for an ERROR node, consider it potentially matchable.
+          if (step->symbol == ts_builtin_sym_error) {
+            does_match = true;
+          } else if (visible_symbol) {
             does_match = true;
             if (step->symbol == WILDCARD_SYMBOL) {
               if (


### PR DESCRIPTION
- Closes #4656

### Problem

`ERROR` nodes in a query are considered invalid if they have a non-wildcard non-ERROR parent. This is problematic for users trying to query `ERROR` nodes in specific instances.

### Solution

During query execution (specifically, during analysis when validating a query), if the current step's symbol is the builtin ERROR node, then we assume the query is valid and that the `ERROR` node is a possible child.