### PR TITLE
Make --wasm --debug add DWARF info to language Wasm

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -908,6 +908,8 @@ impl Build {
             eprintln!("Warning: --docker flag is no longer used, and will be removed in a future release.");
         }
 
+        loader.debug_build(self.debug);
+
         if self.wasm {
             let output_path = self.output.map(|path| current_dir.join(path));
             let root_path = get_root_path(&grammar_path.join("tree-sitter.json"))?;
@@ -946,7 +948,6 @@ impl Build {
                 (false, false) => &[],
             };
 
-            loader.debug_build(self.debug);
             loader.force_rebuild(true);
 
             let config = Config::load(None)?;

--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -1042,7 +1042,7 @@ impl Loader {
             output_name,
             "-fPIC",
             "-shared",
-            "-Os",
+            if self.debug_build { "-g" } else { "-Os" },
             format!("-Wl,--export=tree_sitter_{language_name}").as_str(),
             "-Wl,--allow-undefined",
             "-Wl,--no-entry",


### PR DESCRIPTION
So that error stack traces contain the source code instead of raw Wasm error traces, if you have the [DWARF extension](https://chromewebstore.google.com/detail/pdcpmagijalfljmkmjngeonclgbbannb?utm_source=item-share-cb) installed.