### PR TITLE
Web bindings cleanup

### DIFF
--- a/crates/xtask/src/embed_sources.rs
+++ b/crates/xtask/src/embed_sources.rs
@@ -1,0 +1,61 @@
+use anyhow::Result;
+use std::fs;
+use std::path::Path;
+
+/// Restores sourcesContent if it was stripped by Binaryen.
+///
+/// This is a workaround for Binaryen where `wasm-opt -O2` and higher
+/// optimization levels strip the `sourcesContent` field from source maps,
+/// even when the source map was generated with `--sources` flag.
+///
+/// This is fixed upstream in Binaryen as of Apr 9, 2025, but there hasn't been a release with the fix yet.
+/// See: <https://github.com/WebAssembly/binaryen/issues/6805>
+///
+/// This reads the original source files and embeds them in the
+/// source map's `sourcesContent` field, making debugging possible even
+/// with optimized builds.
+///
+/// TODO: Once Binaryen releases a version with the fix, and emscripten updates to that
+/// version, and we update our emscripten version, this function can be removed.
+pub fn embed_sources_in_map(map_path: &Path) -> Result<()> {
+    let map_content = fs::read_to_string(map_path)?;
+    let mut map: serde_json::Value = serde_json::from_str(&map_content)?;
+
+    if let Some(sources_content) = map.get("sourcesContent") {
+        if let Some(arr) = sources_content.as_array() {
+            if !arr.is_empty() && arr.iter().any(|v| !v.is_null()) {
+                return Ok(());
+            }
+        }
+    }
+
+    let sources = map["sources"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("No sources array in source map"))?;
+
+    let map_dir = map_path.parent().unwrap_or(Path::new("."));
+    let mut sources_content = Vec::new();
+
+    for source in sources {
+        let source_path = source.as_str().unwrap_or("");
+        let full_path = map_dir.join(source_path);
+
+        let content = if full_path.exists() {
+            match fs::read_to_string(&full_path) {
+                Ok(content) => serde_json::Value::String(content),
+                Err(_) => serde_json::Value::Null,
+            }
+        } else {
+            serde_json::Value::Null
+        };
+
+        sources_content.push(content);
+    }
+
+    map["sourcesContent"] = serde_json::Value::Array(sources_content);
+
+    let output = serde_json::to_string(&map)?;
+    fs::write(map_path, output)?;
+
+    Ok(())
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -3,6 +3,7 @@ mod build_wasm;
 mod bump;
 mod check_wasm_exports;
 mod clippy;
+mod embed_sources;
 mod fetch;
 mod generate;
 mod test;

--- a/lib/binding_web/package-lock.json
+++ b/lib/binding_web/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.20.0",
+        "@types/emscripten": "^1.40.0",
         "@types/node": "^24.3.0",
         "@vitest/coverage-v8": "^3.0.5",
         "dts-buddy": "^0.6.2",
@@ -20,14 +21,6 @@
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.23.0",
         "vitest": "^3.0.5"
-      },
-      "peerDependencies": {
-        "@types/emscripten": "^1.40.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/emscripten": {
-          "optional": true
-        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1195,9 +1188,8 @@
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.40.0.tgz",
       "integrity": "sha512-MD2JJ25S4tnjnhjWyalMS6K6p0h+zQV6+Ylm+aGbiS8tSn/aHLSGNzBgduj6FB4zH0ax2GRMGYi/8G1uOxhXWA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",

--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -70,6 +70,7 @@
   ],
   "devDependencies": {
     "@eslint/js": "^9.20.0",
+    "@types/emscripten": "^1.40.0",
     "@types/node": "^24.3.0",
     "@vitest/coverage-v8": "^3.0.5",
     "dts-buddy": "^0.6.2",
@@ -80,14 +81,6 @@
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.23.0",
     "vitest": "^3.0.5"
-  },
-  "peerDependencies": {
-    "@types/emscripten": "^1.40.0"
-  },
-  "peerDependenciesMeta": {
-    "@types/emscripten": {
-      "optional": true
-    }
   },
   "scripts": {
     "build:ts": "tsc -b . && node script/build.js",

--- a/lib/binding_web/script/build.js
+++ b/lib/binding_web/script/build.js
@@ -1,48 +1,36 @@
 import esbuild from 'esbuild';
 import fs from 'fs/promises';
-import path from 'path';
 
 const format = process.env.CJS ? 'cjs' : 'esm';
 const debug = process.argv.includes('--debug');
 const outfile = `${debug ? 'debug/' : ''}web-tree-sitter.${format === 'esm' ? 'js' : 'cjs'}`;
 
-// Copy source files to lib directory - we'll map the Wasm's sourcemap to these files.
-async function copySourceFiles() {
-  const sourceDir = '../src';
-  const files = await fs.readdir(sourceDir);
-
-  for (const file of files) {
-    if (file.endsWith('.c') || file.endsWith('.h')) {
-      await fs.copyFile(
-        path.join(sourceDir, file),
-        path.join('lib', file)
-      );
-    }
-  }
-}
-
 async function processWasmSourceMap(inputPath, outputPath) {
   const mapContent = await fs.readFile(inputPath, 'utf8');
   const sourceMap = JSON.parse(mapContent);
 
-  // Filter out emscripten files and normalize paths
-  sourceMap.sources = sourceMap.sources
-    .filter(source => {
-      // Keep only tree-sitter source files
-      return source.includes('../../src/') || source === 'tree-sitter.c';
-    })
-    .map(source => {
-      if (source.includes('../../src/')) {
-        return source.replace('../../src/', debug ? '../lib/' : 'lib/');
-      } else if (source === 'tree-sitter.c') {
-        return debug ? '../lib/tree-sitter.c' : 'lib/tree-sitter.c';
-      } else {
-        return source;
-      }
-    });
+  const isTreeSitterSource = (source) => 
+    source.includes('../../src/') || source === 'tree-sitter.c';
+
+  const normalizePath = (source) => {
+    if (source.includes('../../src/')) {
+      return source.replace('../../src/', debug ? '../lib/' : 'lib/');
+    } else if (source === 'tree-sitter.c') {
+      return debug ? '../lib/tree-sitter.c' : 'lib/tree-sitter.c';
+    }
+    return source;
+  };
+
+  const filtered = sourceMap.sources
+    .map((source, index) => ({ source, content: sourceMap.sourcesContent?.[index] }))
+    .filter(item => isTreeSitterSource(item.source))
+    .map(item => ({ source: normalizePath(item.source), content: item.content }));
+
+  sourceMap.sources = filtered.map(item => item.source);
+  sourceMap.sourcesContent = filtered.map(item => item.content);
+
   await fs.writeFile(outputPath, JSON.stringify(sourceMap, null, 2));
 }
-
 
 async function build() {
   await esbuild.build({
@@ -62,7 +50,6 @@ async function build() {
   const outputWasmName = `${debug ? 'debug/' : ''}web-tree-sitter.wasm`;
   await fs.copyFile('lib/web-tree-sitter.wasm', outputWasmName);
 
-  await copySourceFiles();
   await processWasmSourceMap('lib/web-tree-sitter.wasm.map', `${outputWasmName}.map`);
 }
 


### PR DESCRIPTION
This PR entails some cleanup for the web bindings.

- Move back `@types/emscripten` to dev deps, peer deps are buggy and don't seem to get installed
- Allow users to manually specify the WASI SDK path, which makes it easier for packaging and/or isolated builds.
- Restore `sourcesContent` when building the web bindings, currently building with any optimization level higher than `-O1` causes binaryen to strip the `sourcesContent` field of the source map. This is fixed upstream, but a release hasn't been cut with it (let alone emscripten updating their version of binaryen).…module…module