### PR TITLE
fix(generate): return error when single state transitions have indirectly recursive cycles

### DIFF
--- a/crates/cli/src/tests/corpus_test.rs
+++ b/crates/cli/src/tests/corpus_test.rs
@@ -381,7 +381,7 @@ fn test_feature_corpus_files() {
                 let actual_message = e.to_string().replace("\r\n", "\n");
                 if expected_message != actual_message {
                     eprintln!(
-                        "Unexpected error message.\n\nExpected:\n\n{expected_message}\nActual:\n\n{actual_message}\n",
+                        "Unexpected error message.\n\nExpected:\n\n`{expected_message}`\nActual:\n\n`{actual_message}`\n",
                     );
                     failure_count += 1;
                 }

--- a/test/fixtures/test_grammars/indirect_recursion_in_transitions/expected_error.txt
+++ b/test/fixtures/test_grammars/indirect_recursion_in_transitions/expected_error.txt
@@ -1,0 +1,1 @@
+Grammar contains an indirectly recursive rule: type_expression -> _expression -> identifier_expression -> type_expression

--- a/test/fixtures/test_grammars/indirect_recursion_in_transitions/grammar.js
+++ b/test/fixtures/test_grammars/indirect_recursion_in_transitions/grammar.js
@@ -1,0 +1,16 @@
+module.exports = grammar({
+  name: 'indirect_recursive_in_single_symbol_transitions',
+  rules: {
+    source_file: $ => repeat($._statement),
+
+    _statement: $ => seq($.initialization_part, $.type_expression),
+
+    type_expression: $ => choice('int', $._expression),
+
+    initialization_part: $ => seq('=', $._expression),
+
+    _expression: $ => choice($.identifier_expression, $.type_expression),
+
+    identifier_expression: $ => choice(/[a-zA-Z_][a-zA-Z0-9_]*/, $.type_expression),
+  }
+});


### PR DESCRIPTION
If a grammar's rules can create a cycle via indirect recursion (i.e. A->B->A), this can cause parsing to loop infinitely in certain cases (i.e. near EOF). This is also just a bad idea from a grammar perspective, so we'll return an error during generation.

- Closes #2197