### PR TITLE
Fix CMake Integration and Not Found Headers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,7 +175,7 @@ jobs:
       if: ${{ matrix.platform == 'windows-x64' }}
       shell: msys2 {0}
       run: |
-        cmake -G Ninja -S lib -B build/static \
+        cmake -G Ninja -S . -B build/static \
           -DBUILD_SHARED_LIBS=OFF \
           -DCMAKE_BUILD_TYPE=Debug \
           -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
@@ -184,7 +184,7 @@ jobs:
         cmake --build build/static
         rm -rf build/static
 
-        cmake -G Ninja -S lib -B build/shared \
+        cmake -G Ninja -S . -B build/shared \
           -DBUILD_SHARED_LIBS=ON \
           -DCMAKE_BUILD_TYPE=Debug \
           -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
@@ -225,14 +225,14 @@ jobs:
     - name: Build C library (CMake)
       if: ${{ !matrix.use-cross }}
       run: |
-        cmake -S lib -B build/static \
+        cmake -S . -B build/static \
           -DBUILD_SHARED_LIBS=OFF \
           -DCMAKE_BUILD_TYPE=Debug \
           -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
           -DTREE_SITTER_FEATURE_WASM=$WASM
         cmake --build build/static --verbose
 
-        cmake -S lib -B build/shared \
+        cmake -S . -B build/shared \
           -DBUILD_SHARED_LIBS=ON \
           -DCMAKE_BUILD_TYPE=Debug \
           -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \

--- a/.github/workflows/wasm_exports.yml
+++ b/.github/workflows/wasm_exports.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - lib/include/tree_sitter/api.h
       - lib/binding_rust/bindings.rs
-      - lib/CMakeLists.txt
+      - CMakeLists.txt
 
 jobs:
   check-wasm-exports:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,15 +11,15 @@ option(TREE_SITTER_FEATURE_WASM "Enable the Wasm feature" OFF)
 option(AMALGAMATED "Build using an amalgamated source" OFF)
 
 if(AMALGAMATED)
-  set(TS_SOURCE_FILES "${PROJECT_SOURCE_DIR}/src/lib.c")
+  set(TS_SOURCE_FILES "${PROJECT_SOURCE_DIR}/lib/src/lib.c")
 else()
-  file(GLOB TS_SOURCE_FILES src/*.c)
-  list(REMOVE_ITEM TS_SOURCE_FILES "${PROJECT_SOURCE_DIR}/src/lib.c")
+  file(GLOB TS_SOURCE_FILES lib/src/*.c)
+  list(REMOVE_ITEM TS_SOURCE_FILES "${PROJECT_SOURCE_DIR}/lib/src/lib.c")
 endif()
 
 add_library(tree-sitter ${TS_SOURCE_FILES})
 
-target_include_directories(tree-sitter PRIVATE src src/wasm PUBLIC include)
+target_include_directories(tree-sitter PRIVATE lib/src lib/src/wasm PUBLIC lib/include)
 
 if(MSVC)
   target_compile_options(tree-sitter PRIVATE
@@ -85,9 +85,9 @@ target_compile_definitions(tree-sitter PRIVATE _POSIX_C_SOURCE=200112L _DEFAULT_
 
 include(GNUInstallDirs)
 
-configure_file(tree-sitter.pc.in "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter.pc" @ONLY)
+configure_file(lib/tree-sitter.pc.in "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter.pc" @ONLY)
 
-install(FILES include/tree_sitter/api.h
+install(FILES lib/include/tree_sitter/api.h
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tree_sitter")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter.pc"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/crates/xtask/src/bump.rs
+++ b/crates/xtask/src/bump.rs
@@ -190,7 +190,7 @@ fn tag_next_version(next_version: &Version) -> Result<()> {
             "crates/highlight/Cargo.toml",
             "crates/loader/Cargo.toml",
             "crates/tags/Cargo.toml",
-            "lib/CMakeLists.txt",
+            "CMakeLists.txt",
             "lib/Cargo.toml",
             "lib/binding_web/package.json",
             "lib/binding_web/package-lock.json",
@@ -241,7 +241,7 @@ fn update_makefile(next_version: &Version) -> Result<()> {
 }
 
 fn update_cmake(next_version: &Version) -> Result<()> {
-    let cmake = std::fs::read_to_string("lib/CMakeLists.txt")?;
+    let cmake = std::fs::read_to_string("CMakeLists.txt")?;
     let cmake = cmake
         .lines()
         .map(|line| {
@@ -261,7 +261,7 @@ fn update_cmake(next_version: &Version) -> Result<()> {
         .join("\n")
         + "\n";
 
-    std::fs::write("lib/CMakeLists.txt", cmake)?;
+    std::fs::write("CMakeLists.txt", cmake)?;
 
     Ok(())
 }

--- a/lib/package.nix
+++ b/lib/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     pkg-config
   ];
 
-  sourceRoot = "source/lib";
+  sourceRoot = "source";
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"


### PR DESCRIPTION
Fixes the use case where tree-sitter is added as a dependency via the CMake [FetchContent](https://cmake.org/cmake/help/v3.28/module/FetchContent.html) machinery. Marks the scope of the public headers as public. Moves the `lib/CMakeLists.txt` file to the source root so that it is recognised as a CMake-based project and can subsequently be consumed as such. Adjusts file paths.