### PR TITLE
fix(generate): use correct state id when adding terminal states to non terminal extras

### DIFF
--- a/crates/generate/src/build_tables/build_parse_table.rs
+++ b/crates/generate/src/build_tables/build_parse_table.rs
@@ -326,9 +326,10 @@ impl<'a> ParseTableBuilder<'a> {
                 ))?;
             }
 
-            self.non_terminal_extra_states
-                .push((terminal, self.parse_table.states.len()));
-            self.add_parse_state(&Vec::new(), &Vec::new(), item_set);
+            // Add the parse state, and *then* push the terminal and the state id into the
+            // list of nonterminal extra states
+            let state_id = self.add_parse_state(&Vec::new(), &Vec::new(), item_set);
+            self.non_terminal_extra_states.push((terminal, state_id));
         }
 
         while let Some(entry) = self.parse_state_queue.pop_front() {

--- a/test/fixtures/test_grammars/extra_non_terminals/corpus.txt
+++ b/test/fixtures/test_grammars/extra_non_terminals/corpus.txt
@@ -12,11 +12,12 @@ a b c d
 Extras
 ==============
 
-a (one) b (two) (three) c d
+a (one) b (two) (three) c d // e
 
 ---
 
 (module
-  (comment)
-  (comment)
-  (comment))
+  (comment (paren_comment))
+  (comment (paren_comment))
+  (comment (paren_comment))
+  (comment (line_comment)))

--- a/test/fixtures/test_grammars/extra_non_terminals/grammar.js
+++ b/test/fixtures/test_grammars/extra_non_terminals/grammar.js
@@ -9,7 +9,12 @@ module.exports = grammar({
   ],
 
   rules: {
-    module: $ => seq('a', 'b', 'c', 'd'),
-    comment: $ => seq('(', repeat(/[a-z]+/), ')'),
+    module: _ => seq('a', 'b', 'c', 'd'),
+
+    comment: $ => choice($.paren_comment, $.line_comment),
+
+    paren_comment: _ => token(seq('(', repeat(/[a-z]+/), ')')),
+
+    line_comment: _ => token(seq('//', /.*/)),
   }
 })


### PR DESCRIPTION
### The Problem

When adding terminal states for non-terminal extras, we unconditionally use the length of the parse table's state vector to assign an id to the newly added terminal state. This assumes we're going to push to `self.parse_table.states`, which does not happen if `add_parse_state` is called with a state has already been added.

### The Solution

Use the correct parse state id returned by `add_parse_state`.

- Closes #1168