### PR TITLE
Fix generate crate testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,12 +285,6 @@ jobs:
       if: ${{ !matrix.no-run && inputs.run-test }}
       run: $BUILD_CMD test --target=${{ matrix.target }} --features=${{ matrix.features }}
 
-    - name: Run generate unit tests
-      if: ${{ !matrix.no-run && inputs.run-test }}
-      run: |
-        cd crates/generate
-        $BUILD_CMD test --target=${{ matrix.target }}
-
     - name: Run wasm tests
       if: ${{ !matrix.no-run && !matrix.use-cross && inputs.run-test }}
       run: $BUILD_CMD run -p xtask --target=${{ matrix.target }} -- test-wasm

--- a/crates/cli/src/tree_sitter_cli.rs
+++ b/crates/cli/src/tree_sitter_cli.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../README.md")]
+#![cfg_attr(not(any(test, doctest)), doc = include_str!("../README.md"))]
 
 pub mod fuzz;
 pub mod highlight;

--- a/crates/config/src/tree_sitter_config.rs
+++ b/crates/config/src/tree_sitter_config.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../README.md")]
+#![cfg_attr(not(any(test, doctest)), doc = include_str!("../README.md"))]
 
 use std::{env, fs, path::PathBuf};
 

--- a/crates/highlight/src/highlight.rs
+++ b/crates/highlight/src/highlight.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../README.md")]
+#![cfg_attr(not(any(test, doctest)), doc = include_str!("../README.md"))]
 
 pub mod c_lib;
 use core::slice;

--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../README.md")]
+#![cfg_attr(not(any(test, doctest)), doc = include_str!("../README.md"))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(any(feature = "tree-sitter-highlight", feature = "tree-sitter-tags"))]

--- a/crates/tags/src/tags.rs
+++ b/crates/tags/src/tags.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../README.md")]
+#![cfg_attr(not(any(test, doctest)), doc = include_str!("../README.md"))]
 
 pub mod c_lib;
 

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -584,7 +584,7 @@ impl Language {
     /// generate completion suggestions or valid symbols in error nodes.
     ///
     /// Example:
-    /// ```
+    /// ```ignore
     /// let state = language.next_state(node.parse_state(), node.grammar_id());
     /// ```
     #[doc(alias = "ts_language_next_state")]

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("./README.md")]
+#![cfg_attr(not(any(test, doctest)), doc = include_str!("../README.md"))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 


### PR DESCRIPTION
### Problem

The fix in #4563 could've been simplified by just using the `--all` flag to run every crate's tests.

### Solution

This PR adds the `--all` flag in the test xtask's invocation of `cargo test` to run all tests. However, there was a problem where doc tests in the README were run, so those have been conditionally disabled if we're running tests/doctests. Additionally ,I've removed the CI step that manually tested the generate crate as that's no longer needed.