### PR TITLE
fix(rust): correct crate versions in root Cargo.toml file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,9 +156,9 @@ walkdir = "2.5.0"
 wasmparser = "0.224.0"
 webbrowser = "1.0.3"
 
-tree-sitter = { version = "0.25.1", path = "./lib" }
-tree-sitter-generate = { version = "0.25.1", path = "./cli/generate" }
-tree-sitter-loader = { version = "0.25.1", path = "./cli/loader" }
-tree-sitter-config = { version = "0.25.1", path = "./cli/config" }
-tree-sitter-highlight = { version = "0.25.1", path = "./highlight" }
-tree-sitter-tags = { version = "0.25.1", path = "./tags" }
+tree-sitter = { version = "0.25.9", path = "./lib" }
+tree-sitter-generate = { version = "0.25.9", path = "./cli/generate" }
+tree-sitter-loader = { version = "0.25.9", path = "./cli/loader" }
+tree-sitter-config = { version = "0.25.9", path = "./cli/config" }
+tree-sitter-highlight = { version = "0.25.9", path = "./highlight" }
+tree-sitter-tags = { version = "0.25.9", path = "./tags" }


### PR DESCRIPTION
It looks like these values are silently overridden by `version.workspace = true` in each of the subcrates' `Cargo.toml` files, but it can't hurt to clean this up just for the sake of clarity. 