### PR TITLE
Fix CJS build

### DIFF
--- a/crates/xtask/src/build_wasm.rs
+++ b/crates/xtask/src/build_wasm.rs
@@ -199,7 +199,7 @@ pub fn run_wasm(args: &BuildWasm) -> Result<()> {
         "-I", "lib/include",
         "--js-library", "lib/binding_web/lib/imports.js",
         "--pre-js",     "lib/binding_web/lib/prefix.js",
-        "-o",           if args.cjs { binding_file!("cjs") } else { binding_file!(".mjs") },
+        "-o",           if args.cjs { binding_file!(".cjs") } else { binding_file!(".mjs") },
         "lib/src/lib.c",
         "lib/binding_web/lib/tree-sitter.c",
     ]);


### PR DESCRIPTION
should be `".cjs"`
not `"cjs"`
https://github.com/tree-sitter/tree-sitter/commit/07986471b3f722a4a83ae83749810b484723272f#r165729739

<img width="1130" height="508" alt="image" src="https://github.com/user-attachments/assets/96304b6d-b011-477d-b08e-8fec0e82ad5d" />
