### PR TITLE
fix(playground): check that `languageVersion` exists for compat

### DIFF
--- a/docs/src/assets/js/playground.js
+++ b/docs/src/assets/js/playground.js
@@ -206,10 +206,10 @@ window.initializePlayground = async (opts) => {
     languageName = newLanguageName;
 
     const metadata = languagesByName[languageName].metadata;
-    if (metadata) {
+    if (languageVersion && metadata) {
       languageVersion.textContent = `v${metadata.major_version}.${metadata.minor_version}.${metadata.patch_version}`;
       languageVersion.style.visibility = 'visible';
-    } else {
+    } else if (languageVersion) {
       languageVersion.style.visibility = 'hidden';
     }
 


### PR DESCRIPTION
- Closes #4822

The problem here is that older playground files do not have `languageVersion` defined. Our cli releases should really always bundle the playground files for stability.