### PR TITLE
feat(bindings): use CapsuleType in Python stub

### DIFF
--- a/crates/cli/src/templates/__init__.pyi
+++ b/crates/cli/src/templates/__init__.pyi
@@ -1,4 +1,5 @@
 from typing import Final
+from typing_extensions import CapsuleType
 
 # NOTE: uncomment these to include any queries that this grammar contains:
 
@@ -7,4 +8,4 @@ from typing import Final
 # LOCALS_QUERY: Final[str]
 # TAGS_QUERY: Final[str]
 
-def language() -> object: ...
+def language() -> CapsuleType: ...


### PR DESCRIPTION
`CapsuleType` was added to [typing-extensions](https://github.com/python/typing_extensions/releases/tag/4.12.0) 15 months ago so it should be safe to use at this point.