### PR TITLE
Revert "feat(generate): allow more characters for keywords"

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -17,10 +17,9 @@ runs:
           test/fixtures/grammars
           target/release/tree-sitter-*.wasm
         key: fixtures-${{ join(matrix.*, '_') }}-${{ hashFiles(
-          'cli/generate/src/**',
+          'crates/generate/src/**',
           'lib/src/parser.h',
           'lib/src/array.h',
           'lib/src/alloc.h',
-          'xtask/src/*',
           'test/fixtures/grammars/*/**/src/*.c',
           '.github/actions/cache/action.yml') }}

--- a/crates/generate/src/build_tables.rs
+++ b/crates/generate/src/build_tables.rs
@@ -334,7 +334,7 @@ fn identify_keywords(
         .enumerate()
         .filter_map(|(i, variable)| {
             cursor.reset(vec![variable.start_state]);
-            if all_chars_are_valid_for_keywords(&cursor)
+            if all_chars_are_alphabetical(&cursor)
                 && token_conflict_map.does_match_same_string(i, word_token.index)
                 && !token_conflict_map.does_match_different_string(i, word_token.index)
             {
@@ -531,17 +531,12 @@ fn report_state_info<'a>(
     }
 }
 
-/// This definition should match the set of characters that are typically
-/// allowed in programming language keywords. Note that it is provisional,
-/// and can be adjusted if necessary.
-fn all_chars_are_valid_for_keywords(cursor: &NfaCursor) -> bool {
+fn all_chars_are_alphabetical(cursor: &NfaCursor) -> bool {
     cursor.transition_chars().all(|(chars, is_sep)| {
         if is_sep {
             true
         } else {
-            chars
-                .chars()
-                .all(|c| c.is_alphanumeric() || "_!@#$-:.?/`".contains(c))
+            chars.chars().all(|c| c.is_alphabetic() || c == '_')
         }
     })
 }


### PR DESCRIPTION
This reverts commit 0269357.

CI is failing, because the Bash parser was regenerated with the changes reverted here, and was aggressively extracting keywords. Ideally, the candidate tokens that are allowed for keyword extraction should be configurable by the user, but this would be a pretty niche feature that most people wouldn't need, maybe something like `keyword` where users can pass in a custom pattern to override the default.