### PR TITLE
wasm: Fix alias map parsing + add test

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -19,7 +19,7 @@ use tree_sitter_cli::{
         LOG_GRAPH_ENABLED, START_SEED,
     },
     highlight::{self, HighlightOptions},
-    init::{generate_grammar_files, get_root_path, JsonConfigOpts},
+    init::{generate_grammar_files, JsonConfigOpts},
     input::{get_input, get_tmp_source_file, CliInput},
     logger,
     parse::{self, ParseDebugType, ParseFileOptions, ParseOutput, ParseTheme},
@@ -895,14 +895,7 @@ impl Build {
 
         if self.wasm {
             let output_path = self.output.map(|path| current_dir.join(path));
-            let root_path = get_root_path(&grammar_path.join("tree-sitter.json"))?;
-            wasm::compile_language_to_wasm(
-                &loader,
-                Some(&root_path),
-                &grammar_path,
-                current_dir,
-                output_path,
-            )?;
+            wasm::compile_language_to_wasm(&loader, &grammar_path, current_dir, output_path)?;
         } else {
             let output_path = if let Some(ref path) = self.output {
                 let path = Path::new(path);

--- a/crates/cli/src/tests/helpers/fixtures.rs
+++ b/crates/cli/src/tests/helpers/fixtures.rs
@@ -23,6 +23,19 @@ static TEST_LOADER: LazyLock<Loader> = LazyLock::new(|| {
     loader
 });
 
+#[cfg(feature = "wasm")]
+pub static ENGINE: LazyLock<tree_sitter::wasmtime::Engine> = LazyLock::new(Default::default);
+
+#[cfg(feature = "wasm")]
+static TEST_WASM_LOADER: LazyLock<Loader> = LazyLock::new(|| {
+    let mut loader = Loader::with_parser_lib_path(SCRATCH_DIR.clone());
+    loader.use_wasm(&ENGINE);
+    if env::var("TREE_SITTER_GRAMMAR_DEBUG").is_ok() {
+        loader.debug_build(true);
+    }
+    loader
+});
+
 pub fn test_loader() -> &'static Loader {
     &TEST_LOADER
 }
@@ -42,11 +55,20 @@ pub fn get_language(name: &str) -> Language {
     TEST_LOADER.load_language_at_path(config).unwrap()
 }
 
-pub fn get_test_fixture_language(name: &str) -> Language {
+fn get_test_fixture_language_internal(name: &str, wasm: bool) -> Language {
     let grammar_dir_path = fixtures_dir().join("test_grammars").join(name);
     let grammar_json = load_grammar_file(&grammar_dir_path.join("grammar.js"), None).unwrap();
     let (parser_name, parser_code) = generate_parser(&grammar_json).unwrap();
-    get_test_language(&parser_name, &parser_code, Some(&grammar_dir_path))
+    get_test_language_internal(&parser_name, &parser_code, Some(&grammar_dir_path), wasm)
+}
+
+pub fn get_test_fixture_language(name: &str) -> Language {
+    get_test_fixture_language_internal(name, false)
+}
+
+#[cfg(feature = "wasm")]
+pub fn get_test_fixture_language_wasm(name: &str) -> Language {
+    get_test_fixture_language_internal(name, true)
 }
 
 pub fn get_language_queries_path(language_name: &str) -> PathBuf {
@@ -87,6 +109,15 @@ pub fn get_tags_config(language_name: &str) -> TagsConfiguration {
 }
 
 pub fn get_test_language(name: &str, parser_code: &str, path: Option<&Path>) -> Language {
+    get_test_language_internal(name, parser_code, path, false)
+}
+
+fn get_test_language_internal(
+    name: &str,
+    parser_code: &str,
+    path: Option<&Path>,
+    wasm: bool,
+) -> Language {
     let src_dir = scratch_dir().join("src").join(name);
     fs::create_dir_all(&src_dir).unwrap();
 
@@ -136,5 +167,18 @@ pub fn get_test_language(name: &str, parser_code: &str, path: Option<&Path>) -> 
     config.header_paths = vec![&HEADER_DIR];
     config.name = name.to_string();
 
-    TEST_LOADER.load_language_at_path_with_name(config).unwrap()
+    if wasm {
+        #[cfg(feature = "wasm")]
+        {
+            TEST_WASM_LOADER
+                .load_language_at_path_with_name(config)
+                .unwrap()
+        }
+        #[cfg(not(feature = "wasm"))]
+        {
+            unimplemented!("WASM feature is not enabled")
+        }
+    } else {
+        TEST_LOADER.load_language_at_path_with_name(config).unwrap()
+    }
 }

--- a/crates/cli/src/tests/wasm_language_test.rs
+++ b/crates/cli/src/tests/wasm_language_test.rs
@@ -110,14 +110,11 @@ fn test_load_fixture_language_wasm() {
     allocations::record(|| {
         let store = WasmStore::new(&ENGINE).unwrap();
         let mut parser = Parser::new();
-        let language = get_test_fixture_language_wasm("external_extra_tokens");
+        let language = get_test_fixture_language_wasm("epsilon_external_tokens");
         parser.set_wasm_store(store).unwrap();
         parser.set_language(&language).unwrap();
-        let tree = parser.parse("x = # a comment\ny", None).unwrap();
-        assert_eq!(
-            tree.root_node().to_sexp(),
-            "(assignment (variable) (comment) (variable))"
-        );
+        let tree = parser.parse("hello", None).unwrap();
+        assert_eq!(tree.root_node().to_sexp(), "(document (zero_width))");
     });
 }
 

--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -773,7 +773,6 @@ impl Loader {
             if recompile {
                 self.compile_parser_to_wasm(
                     &config.name,
-                    None,
                     config.src_path,
                     config
                         .scanner_path
@@ -1026,7 +1025,6 @@ impl Loader {
     pub fn compile_parser_to_wasm(
         &self,
         language_name: &str,
-        _root_path: Option<&Path>,
         src_path: &Path,
         scanner_filename: Option<&Path>,
         output_path: &Path,

--- a/lib/src/wasm_store.c
+++ b/lib/src/wasm_store.c
@@ -1377,11 +1377,12 @@ const TSLanguage *ts_wasm_store_load_language(
       if (symbol == 0) break;
       uint16_t value_count;
       memcpy(&value_count, &memory[wasm_language.alias_map + alias_map_size], sizeof(value_count));
+      alias_map_size += sizeof(uint16_t);
       alias_map_size += value_count * sizeof(TSSymbol);
     }
     language->alias_map = copy(
       &memory[wasm_language.alias_map],
-      alias_map_size * sizeof(TSSymbol)
+      alias_map_size
     );
     language->alias_sequences = copy(
       &memory[wasm_language.alias_sequences],

--- a/test/fixtures/test_grammars/external_tokens/scanner.c
+++ b/test/fixtures/test_grammars/external_tokens/scanner.c
@@ -30,7 +30,7 @@ void tree_sitter_external_tokens_external_scanner_destroy(void *payload) {
 unsigned tree_sitter_external_tokens_external_scanner_serialize(
   void *payload,
   char *buffer
-) { return true; }
+) { return 0; }
 
 void tree_sitter_external_tokens_external_scanner_deserialize(
   void *payload,


### PR DESCRIPTION
The current code for parsing wasm grammars doesn't read the alias map correctly, as it fails to offset its internal index to account for the size of the actual `value_count` field itself. This can lead to extraneous data being copied into the language struct, and under the wrong conditions this can result in a segfault (see https://github.com/zed-industries/zed/issues/29827 - attempting to load the html-django grammar from https://github.com/interdependence/tree-sitter-htmldjango reliably segfaults).

The python grammar appears to also have an alias map set, so it was added as a test here. Note that it can still spuriously pass even without this, and on my machine it indeed does - but this should be a useful smoke test at least.