### PR TITLE
feat(rust): add `reborrow` method to `ParseOptions`

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -183,6 +183,20 @@ impl<'a> ParseOptions<'a> {
         self.progress_callback = Some(callback);
         self
     }
+
+    /// Create a new `ParseOptions` with a shorter lifetime, borrowing from this one.
+    ///
+    /// This is useful when you need to reuse parse options multiple times, e.g., calling
+    /// [`Parser::parse_with_options`] multiple times with the same options.
+    #[must_use]
+    pub fn reborrow(&mut self) -> ParseOptions {
+        ParseOptions {
+            progress_callback: match &mut self.progress_callback {
+                Some(cb) => Some(*cb),
+                None => None,
+            },
+        }
+    }
 }
 
 #[derive(Default)]
@@ -203,6 +217,20 @@ impl<'a> QueryCursorOptions<'a> {
     ) -> Self {
         self.progress_callback = Some(callback);
         self
+    }
+
+    /// Create a new `QueryCursorOptions` with a shorter lifetime, borrowing from this one.
+    ///
+    /// This is useful when you need to reuse query cursor options multiple times, e.g., calling
+    /// [`QueryCursor::matches`] multiple times with the same options.
+    #[must_use]
+    pub fn reborrow(&mut self) -> QueryCursorOptions {
+        QueryCursorOptions {
+            progress_callback: match &mut self.progress_callback {
+                Some(cb) => Some(*cb),
+                None => None,
+            },
+        }
     }
 }
 


### PR DESCRIPTION
- Closes #4527

### Problem

Reusing the parse options isn't trivial with the current API, because the parse functions take owned options. It'd be annoying to a) break the API and b) take in `Option<&mut ParseOptions>` for parsing.

### Solution

I've added a `reborrow` method to both `ParseOptions` and `QueryCursorOptions`, inspired by [bevy](https://docs.rs/bevy/latest/bevy/prelude/struct.Mut.html#method.reborrow). This allows users to call `reborrow` on a reference to get another owned instance.