### PR TITLE
refactor!: rename `stage` flag to `emit`

### DIFF
--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -572,10 +572,10 @@ pub fn generate_grammar_files(
                                 "},
                                 indoc! {r"
                                 $(SRC_DIR)/grammar.json: grammar.js
-                                	$(TS) generate --stage=json $^
+                                	$(TS) generate --emit=json $^
 
                                 $(PARSER): $(SRC_DIR)/grammar.json
-                                	$(TS) generate --stage=parser $^
+                                	$(TS) generate --emit=parser $^
                                 "}
                             );
                         write_file(path, contents)?;
@@ -623,14 +623,14 @@ pub fn generate_grammar_files(
                             add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
                                                DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/grammar.js"
                                                COMMAND "${TREE_SITTER_CLI}" generate grammar.js
-                                                        --stage=json
+                                                        --emit=json
                                                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                                                COMMENT "Generating grammar.json")
 
                             add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
                                                DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
                                                COMMAND "${TREE_SITTER_CLI}" generate src/grammar.json
-                                                        --stage=parser --abi=${TREE_SITTER_ABI_VERSION}
+                                                        --emit=parser --abi=${TREE_SITTER_ABI_VERSION}
                                                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                                                COMMENT "Generating parser.c")
                             "#}

--- a/crates/cli/src/templates/cmakelists.cmake
+++ b/crates/cli/src/templates/cmakelists.cmake
@@ -22,14 +22,14 @@ find_program(TREE_SITTER_CLI tree-sitter DOC "Tree-sitter CLI")
 add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
                    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/grammar.js"
                    COMMAND "${TREE_SITTER_CLI}" generate grammar.js
-                            --stage=json
+                            --emit=json
                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                    COMMENT "Generating grammar.json")
 
 add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
                    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
                    COMMAND "${TREE_SITTER_CLI}" generate src/grammar.json
-                            --stage=parser --abi=${TREE_SITTER_ABI_VERSION}
+                            --emit=parser --abi=${TREE_SITTER_ABI_VERSION}
                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                    COMMENT "Generating parser.c")
 

--- a/crates/cli/src/templates/makefile
+++ b/crates/cli/src/templates/makefile
@@ -73,10 +73,10 @@ $(LANGUAGE_NAME).pc: bindings/c/$(LANGUAGE_NAME).pc.in
 		-e 's|@CMAKE_INSTALL_PREFIX@|$(PREFIX)|' $< > $@
 
 $(SRC_DIR)/grammar.json: grammar.js
-	$(TS) generate --stage=json $^
+	$(TS) generate --emit=json $^
 
 $(PARSER): $(SRC_DIR)/grammar.json
-	$(TS) generate --stage=parser $^
+	$(TS) generate --emit=parser $^
 
 install: all
 	install -d '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/KEBAB_PARSER_NAME '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter '$(DESTDIR)$(PCLIBDIR)' '$(DESTDIR)$(LIBDIR)'

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -49,7 +49,7 @@ static JSON_COMMENT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         .unwrap()
 });
 
-struct JSONStageOutput {
+struct JSONOutput {
     #[cfg(feature = "load")]
     node_types_json: String,
     syntax_grammar: SyntaxGrammar,
@@ -296,9 +296,7 @@ pub fn generate_parser_for_grammar(
     Ok((input_grammar.name, parser.c_code))
 }
 
-fn generate_node_types_from_grammar(
-    input_grammar: &InputGrammar,
-) -> GenerateResult<JSONStageOutput> {
+fn generate_node_types_from_grammar(input_grammar: &InputGrammar) -> GenerateResult<JSONOutput> {
     let (syntax_grammar, lexical_grammar, inlines, simple_aliases) =
         prepare_grammar(input_grammar)?;
     let variable_info =
@@ -311,7 +309,7 @@ fn generate_node_types_from_grammar(
         &simple_aliases,
         &variable_info,
     )?;
-    Ok(JSONStageOutput {
+    Ok(JSONOutput {
         #[cfg(feature = "load")]
         node_types_json: serde_json::to_string_pretty(&node_types_json).unwrap(),
         syntax_grammar,
@@ -328,7 +326,7 @@ fn generate_parser_for_grammar_with_opts(
     semantic_version: Option<(u8, u8, u8)>,
     report_symbol_name: Option<&str>,
 ) -> GenerateResult<GeneratedParser> {
-    let JSONStageOutput {
+    let JSONOutput {
         syntax_grammar,
         lexical_grammar,
         inlines,


### PR DESCRIPTION


I meant to do this before the release, but....

This PR renames the new cli flag `stage` to `emit`. I think the name fits better.