### PR TITLE
fix(rust): pass correct fd to C lib's ts_tree_print_dot_graph

### DIFF
--- a/crates/cli/src/tests/parser_test.rs
+++ b/crates/cli/src/tests/parser_test.rs
@@ -88,7 +88,6 @@ fn test_parsing_with_logging() {
 }
 
 #[test]
-#[cfg(unix)]
 fn test_parsing_with_debug_graph_enabled() {
     use std::io::{BufRead, BufReader, Seek};
 

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1386,6 +1386,11 @@ impl Drop for Parser {
     }
 }
 
+#[cfg(windows)]
+extern "C" {
+    fn _open_osfhandle(osfhandle: isize, flags: core::ffi::c_int) -> core::ffi::c_int;
+}
+
 impl Tree {
     /// Get the root node of the syntax tree.
     #[doc(alias = "ts_tree_root_node")]
@@ -1495,7 +1500,8 @@ impl Tree {
         #[cfg(windows)]
         {
             let handle = file.as_raw_handle();
-            unsafe { ffi::ts_tree_print_dot_graph(self.0.as_ptr(), handle as i32) }
+            let fd = unsafe { _open_osfhandle(handle as isize, 0) };
+            unsafe { ffi::ts_tree_print_dot_graph(self.0.as_ptr(), fd) }
         }
     }
 }


### PR DESCRIPTION
Also enable the corresponding test for windows platforms.

- Closes #4856