### PR TITLE
feat: allow the external scanner to use the internal character ranges

### DIFF
--- a/crates/cli/src/tests.rs
+++ b/crates/cli/src/tests.rs
@@ -29,6 +29,6 @@ pub use crate::fuzz::{
 
 /// This is a simple wrapper around [`tree_sitter_generate::generate_parser_for_grammar`], because
 /// our tests do not need to pass in a version number, only the grammar JSON.
-fn generate_parser(grammar_json: &str) -> GenerateResult<(String, String)> {
+fn generate_parser(grammar_json: &str) -> GenerateResult<(String, String, String)> {
     tree_sitter_generate::generate_parser_for_grammar(grammar_json, Some((0, 0, 0)))
 }

--- a/crates/cli/src/tests/corpus_test.rs
+++ b/crates/cli/src/tests/corpus_test.rs
@@ -404,8 +404,9 @@ fn test_feature_corpus_files() {
             }
 
             let corpus_path = test_path.join("corpus.txt");
-            let c_code = generate_result.unwrap().1;
-            let language = get_test_language(language_name, &c_code, Some(&test_path));
+            let (_, c_code, header_code) = generate_result.unwrap();
+            let language =
+                get_test_language(language_name, &c_code, &header_code, Some(&test_path));
             let test = parse_tests(&corpus_path).unwrap();
             let tests = flatten_tests(test, EXAMPLE_INCLUDE.as_ref(), EXAMPLE_EXCLUDE.as_ref());
 

--- a/crates/cli/src/tests/node_test.rs
+++ b/crates/cli/src/tests/node_test.rs
@@ -555,11 +555,17 @@ fn test_node_named_child() {
 
 #[test]
 fn test_node_named_child_with_aliases_and_extras() {
-    let (parser_name, parser_code) = generate_parser(GRAMMAR_WITH_ALIASES_AND_EXTRAS).unwrap();
+    let (parser_name, parser_code, header_code) =
+        generate_parser(GRAMMAR_WITH_ALIASES_AND_EXTRAS).unwrap();
 
     let mut parser = Parser::new();
     parser
-        .set_language(&get_test_language(&parser_name, &parser_code, None))
+        .set_language(&get_test_language(
+            &parser_name,
+            &parser_code,
+            &header_code,
+            None,
+        ))
         .unwrap();
 
     let tree = parser.parse("b ... b ... c", None).unwrap();
@@ -948,7 +954,7 @@ fn test_node_sexp() {
 
 #[test]
 fn test_node_field_names() {
-    let (parser_name, parser_code) = generate_parser(
+    let (parser_name, parser_code, header_code) = generate_parser(
         r#"
         {
             "name": "test_grammar_with_fields",
@@ -1020,7 +1026,7 @@ fn test_node_field_names() {
     .unwrap();
 
     let mut parser = Parser::new();
-    let language = get_test_language(&parser_name, &parser_code, None);
+    let language = get_test_language(&parser_name, &parser_code, &header_code, None);
     parser.set_language(&language).unwrap();
 
     let tree = parser
@@ -1058,7 +1064,7 @@ fn test_node_field_names() {
 
 #[test]
 fn test_node_field_calls_in_language_without_fields() {
-    let (parser_name, parser_code) = generate_parser(
+    let (parser_name, parser_code, header_code) = generate_parser(
         r#"
         {
             "name": "test_grammar_with_no_fields",
@@ -1090,7 +1096,7 @@ fn test_node_field_calls_in_language_without_fields() {
     .unwrap();
 
     let mut parser = Parser::new();
-    let language = get_test_language(&parser_name, &parser_code, None);
+    let language = get_test_language(&parser_name, &parser_code, &header_code, None);
     parser.set_language(&language).unwrap();
 
     let tree = parser.parse("b c d", None).unwrap();
@@ -1116,10 +1122,10 @@ fn test_node_is_named_but_aliased_as_anonymous() {
     )
     .unwrap();
 
-    let (parser_name, parser_code) = generate_parser(&grammar_json).unwrap();
+    let (parser_name, parser_code, header_code) = generate_parser(&grammar_json).unwrap();
 
     let mut parser = Parser::new();
-    let language = get_test_language(&parser_name, &parser_code, None);
+    let language = get_test_language(&parser_name, &parser_code, &header_code, None);
     parser.set_language(&language).unwrap();
 
     let tree = parser.parse("B C B", None).unwrap();

--- a/crates/cli/src/tests/parser_hang_test.rs
+++ b/crates/cli/src/tests/parser_hang_test.rs
@@ -91,9 +91,14 @@ fn hang_test() {
         .join("get_col_should_hang_not_crash");
 
     let grammar_json = load_grammar_file(&test_grammar_dir.join("grammar.js"), None).unwrap();
-    let (parser_name, parser_code) = generate_parser(grammar_json.as_str()).unwrap();
+    let (parser_name, parser_code, header_code) = generate_parser(grammar_json.as_str()).unwrap();
 
-    let language = get_test_language(&parser_name, &parser_code, Some(test_grammar_dir.as_path()));
+    let language = get_test_language(
+        &parser_name,
+        &parser_code,
+        &header_code,
+        Some(test_grammar_dir.as_path()),
+    );
 
     let mut parser = Parser::new();
     parser.set_language(&language).unwrap();

--- a/crates/cli/src/tests/parser_test.rs
+++ b/crates/cli/src/tests/parser_test.rs
@@ -1552,7 +1552,7 @@ fn test_parsing_with_a_newly_included_range() {
 
 #[test]
 fn test_parsing_with_included_ranges_and_missing_tokens() {
-    let (parser_name, parser_code) = generate_parser(
+    let (parser_name, parser_code, header_code) = generate_parser(
         r#"{
             "name": "test_leading_missing_token",
             "rules": {
@@ -1578,7 +1578,12 @@ fn test_parsing_with_included_ranges_and_missing_tokens() {
 
     let mut parser = Parser::new();
     parser
-        .set_language(&get_test_language(&parser_name, &parser_code, None))
+        .set_language(&get_test_language(
+            &parser_name,
+            &parser_code,
+            &header_code,
+            None,
+        ))
         .unwrap();
 
     // There's a missing `a` token at the beginning of the code. It must be inserted
@@ -1613,7 +1618,7 @@ fn test_parsing_with_included_ranges_and_missing_tokens() {
 
 #[test]
 fn test_grammars_that_can_hang_on_eof() {
-    let (parser_name, parser_code) = generate_parser(
+    let (parser_name, parser_code, header_code) = generate_parser(
         r#"
         {
             "name": "test_single_null_char_regex",
@@ -1635,11 +1640,16 @@ fn test_grammars_that_can_hang_on_eof() {
 
     let mut parser = Parser::new();
     parser
-        .set_language(&get_test_language(&parser_name, &parser_code, None))
+        .set_language(&get_test_language(
+            &parser_name,
+            &parser_code,
+            &header_code,
+            None,
+        ))
         .unwrap();
     parser.parse("\"", None).unwrap();
 
-    let (parser_name, parser_code) = generate_parser(
+    let (parser_name, parser_code, header_code) = generate_parser(
         r#"
         {
             "name": "test_null_char_with_next_char_regex",
@@ -1660,11 +1670,16 @@ fn test_grammars_that_can_hang_on_eof() {
     .unwrap();
 
     parser
-        .set_language(&get_test_language(&parser_name, &parser_code, None))
+        .set_language(&get_test_language(
+            &parser_name,
+            &parser_code,
+            &header_code,
+            None,
+        ))
         .unwrap();
     parser.parse("\"", None).unwrap();
 
-    let (parser_name, parser_code) = generate_parser(
+    let (parser_name, parser_code, header_code) = generate_parser(
         r#"
         {
             "name": "test_null_char_with_range_regex",
@@ -1685,7 +1700,12 @@ fn test_grammars_that_can_hang_on_eof() {
     .unwrap();
 
     parser
-        .set_language(&get_test_language(&parser_name, &parser_code, None))
+        .set_language(&get_test_language(
+            &parser_name,
+            &parser_code,
+            &header_code,
+            None,
+        ))
         .unwrap();
     parser.parse("\"", None).unwrap();
 }

--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -5295,7 +5295,7 @@ fn test_grammar_with_aliased_literal_query() {
     //     expansion: $ => seq('}'),
     //   },
     // });
-    let (parser_name, parser_code) = generate_parser(
+    let (parser_name, parser_code, header_code) = generate_parser(
         r#"
         {
             "name": "test",
@@ -5352,7 +5352,7 @@ fn test_grammar_with_aliased_literal_query() {
     )
     .unwrap();
 
-    let language = get_test_language(&parser_name, &parser_code, None);
+    let language = get_test_language(&parser_name, &parser_code, &header_code, None);
 
     let query = Query::new(
         &language,

--- a/test/fixtures/test_grammars/unicode_classes/corpus.txt
+++ b/test/fixtures/test_grammars/unicode_classes/corpus.txt
@@ -41,3 +41,14 @@ Letterlike numeric characters
 
 (program
   (letter_number) (letter_number) (letter_number))
+
+================================================================================
+Letterlike numeric characters with a prefix
+================================================================================
+
+!ᛯ !Ⅵ !〩
+
+---
+
+(program
+  (letter_number_with_prefix) (letter_number_with_prefix) (letter_number_with_prefix))

--- a/test/fixtures/test_grammars/unicode_classes/grammar.js
+++ b/test/fixtures/test_grammars/unicode_classes/grammar.js
@@ -1,12 +1,15 @@
 export default grammar({
   name: 'unicode_classes',
 
+  externals: $ => [$.letter_number_with_prefix],
+
   rules: {
     program: $ => repeat(choice(
       $.lower,
       $.upper,
       $.math_sym,
       $.letter_number,
+      $.letter_number_with_prefix,
     )),
 
     lower: _ => /\p{Ll}\p{L}*/,

--- a/test/fixtures/test_grammars/unicode_classes/scanner.c
+++ b/test/fixtures/test_grammars/unicode_classes/scanner.c
@@ -1,0 +1,40 @@
+#include "tree_sitter/parser.h"
+
+#include <wctype.h>
+
+enum TokenType {
+  LETTER_NUMBER_WITH_PREFIX,
+};
+
+void *tree_sitter_unicode_classes_external_scanner_create() { return NULL; }
+
+void tree_sitter_unicode_classes_external_scanner_destroy(void *payload) { }
+
+unsigned tree_sitter_unicode_classes_external_scanner_serialize(void *payload, char *buffer) { return 0; }
+
+void tree_sitter_unicode_classes_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) { }
+
+bool tree_sitter_unicode_classes_external_scanner_scan(
+  void *payload,
+  TSLexer *lexer,
+  const bool *valid_symbols
+) {
+  while (iswspace(lexer->lookahead)) {
+    lexer->advance(lexer, false);
+  }
+
+  // If the letter number starts with a `!`, we've found the prefix, and can leverage
+  // the new `matches` functions to consume the rest of the token without having to
+  // duplicate the character set here.
+  if (valid_symbols[LETTER_NUMBER_WITH_PREFIX] && lexer->lookahead == '!') {
+    lexer->advance(lexer, false);
+    if (matches_sym_letter_number(lexer->lookahead)) {
+      lexer->advance(lexer, false);
+      while (matches_sym_letter_number(lexer->lookahead)) {
+        lexer->advance(lexer, false);
+      }
+      lexer->result_symbol = LETTER_NUMBER_WITH_PREFIX;
+      return true;
+    }
+  }
+}


### PR DESCRIPTION
- Closes #2620

### Problem

Currently, grammars with complex tokens cannot make use of the character sets generated in the parser. This causes friction, where now users have to either copy the character set in the scanner or give up on matching the entirety of the complex token.

### Solution

Now, tree-sitter will generate helper functions that can be used in a scanner to match against these complex tokens. For every token with a "complex" token, tree-sitter will generate a function in the form of `matches_sym_{name}`. For tokens with multiple distinct groups (e.g. `[a-zA-Z][a-zA-Z0-9]*` consists of two groups), tree-sitter will now generate a function that matches each distinct group, in case you only want to match a specific part of the token. A more detailed explanation along with an example can be found in the docs changes.