### PR TITLE
Revert "0.26.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.27.0"
+version = "0.26.0"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-cli"
-version = "0.27.0"
+version = "0.26.0"
 dependencies = [
  "ansi_colours",
  "anstyle",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-config"
-version = "0.27.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "etcetera",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-generate"
-version = "0.27.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "dunce",
@@ -1979,7 +1979,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-highlight"
-version = "0.27.0"
+version = "0.26.0"
 dependencies = [
  "regex",
  "streaming-iterator",
@@ -1993,7 +1993,7 @@ version = "0.1.4"
 
 [[package]]
 name = "tree-sitter-loader"
-version = "0.27.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-tags"
-version = "0.27.0"
+version = "0.26.0"
 dependencies = [
  "memchr",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.27.0"
+version = "0.26.0"
 authors = [
   "Max Brunsfeld <maxbrunsfeld@gmail.com>",
   "Amaan Qureshi <amaanq12@gmail.com>",
@@ -151,10 +151,10 @@ walkdir = "2.5.0"
 wasmparser = "0.229.0"
 webbrowser = "1.0.5"
 
-tree-sitter = { version = "0.27.0", path = "./lib" }
-tree-sitter-generate = { version = "0.27.0", path = "./crates/generate" }
+tree-sitter = { version = "0.26.0", path = "./lib" }
+tree-sitter-generate = { version = "0.26.0", path = "./crates/generate" }
 tree-sitter-language = { path = "./crates/language" }
-tree-sitter-loader = { version = "0.27.0", path = "./crates/loader" }
-tree-sitter-config = { version = "0.27.0", path = "./crates/config" }
-tree-sitter-highlight = { version = "0.27.0", path = "./crates/highlight" }
-tree-sitter-tags = { version = "0.27.0", path = "./crates/tags" }
+tree-sitter-loader = { version = "0.26.0", path = "./crates/loader" }
+tree-sitter-config = { version = "0.26.0", path = "./crates/config" }
+tree-sitter-highlight = { version = "0.26.0", path = "./crates/highlight" }
+tree-sitter-tags = { version = "0.26.0", path = "./crates/tags" }

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
       eachSystem = lib.genAttrs systems;
       pkgsFor = inputs.nixpkgs.legacyPackages;
 
-          version = "0.26.0";
+      version = "0.26.0";
 
       fs = lib.fileset;
       src = fs.toSource {


### PR DESCRIPTION
This reverts commit 9be3e2bdd8e1e62ad259e3c8ee7de7ebaed0553f.

Problem: This commit doesn't follow the release workflow (release,
branch, bump) and did not consistently update the version in the
manifests.

Solution: Revert and wait for a coordinated release.
