### PR TITLE
fix(lib): account for unreachable patterns with children

### DIFF
--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -1759,8 +1759,13 @@ static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
     // If this pattern cannot match, store the pattern index so that it can be
     // returned to the caller.
     if (analysis.finished_parent_symbols.size == 0) {
-      ts_assert(analysis.final_step_indices.size > 0);
-      uint16_t impossible_step_index = *array_back(&analysis.final_step_indices);
+      uint16_t impossible_step_index;
+      if (analysis.final_step_indices.size > 0) {
+        impossible_step_index = *array_back(&analysis.final_step_indices);
+      } else {
+        // If there isn't a final step, then that means the parent step itself is unreachable.
+        impossible_step_index = parent_step_index;
+      }
       uint32_t j, impossible_exists;
       array_search_sorted_by(&self->step_offsets, .step_index, impossible_step_index, &j, &impossible_exists);
       if (j >= self->step_offsets.size) j = self->step_offsets.size - 1;


### PR DESCRIPTION
- Closes #4872

### Problem

Given a language with a grammar construct designed in such a way where a given rule can never actually be reached, but is referenced, querying for this rule *with* a child leads to a crash. This is because during query analysis, when we walk the parse table for a subgraph, it's assumed that a valid transition would be found for a pattern that's considered *valid* (not impossible).

However, a pattern could be completely unreachable in the parse table, because of how it's written in the grammar (for example, it's given a lower precedence in a case where a reduction being performed leads to another symbol sequence, and never the one for the pattern). Due to this, we'll never actually have a final step index when the finished parent symbols are empty.

### Solution

Instead of asserting that the final step indices isn't empty, we use the parent step index as the impossible step index, signifying that the parent node is truly unreachable. This way, we avoid crashing, and the user gets a clear message that this node is technically impossible to reach.

The only downside here is that a user *could* get confused and wonder why, but if they have a test case that they would think should reach the target rule and doesn't, it would become apparent to them. Given that this has only *just* been reported after so long, I don't think we need any additional variant in `TSQueryError` for this specific case.