### PR TITLE
fix(generate): return error when generated grammar's state count exceeds the maximum allowed value.

### DIFF
--- a/crates/generate/src/build_tables.rs
+++ b/crates/generate/src/build_tables.rs
@@ -100,6 +100,10 @@ pub fn build_tables(
         );
     }
 
+    if parse_table.states.len() > u16::MAX as usize {
+        Err(ParseTableBuilderError::StateCount(parse_table.states.len()))?;
+    }
+
     Ok(Tables {
         parse_table,
         main_lex_table: lex_tables.main_lex_table,

--- a/crates/generate/src/build_tables/build_parse_table.rs
+++ b/crates/generate/src/build_tables/build_parse_table.rs
@@ -77,6 +77,8 @@ pub enum ParseTableBuilderError {
         "The non-terminal rule `{0}` is used in a non-terminal `extra` rule, which is not allowed."
     )]
     ImproperNonTerminalExtra(String),
+    #[error("State count `{0}` exceeds the max value {max}.", max=u16::MAX)]
+    StateCount(usize),
 }
 
 #[derive(Default, Debug, Serialize)]


### PR DESCRIPTION
- Closes #693

State ids are represented using a `u16` in the C library, so generation shouldn't complete for any grammar whose state count exceeds 65,535. This check runs after any information for the `--report-states-for-rule` flag is outputted to ease the debugging process.