### PR TITLE
feat: add option to disable parse state optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,6 +1959,7 @@ name = "tree-sitter-generate"
 version = "0.26.0"
 dependencies = [
  "anyhow",
+ "bitflags 2.9.4",
  "dunce",
  "indexmap",
  "indoc",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -32,6 +32,7 @@ use tree_sitter_cli::{
     wasm,
 };
 use tree_sitter_config::Config;
+use tree_sitter_generate::OptLevel;
 use tree_sitter_highlight::Highlighter;
 use tree_sitter_loader::{self as loader, Bindings, TreeSitterJSON};
 use tree_sitter_tags::TagsContext;
@@ -162,6 +163,11 @@ struct Generate {
     /// The name or path of the JavaScript runtime to use for generating parsers, specify `native`
     /// to use the native `QuickJS` runtime
     pub js_runtime: Option<String>,
+
+    /// Disable optimizations when generating the parser. Currently, this only affects
+    /// the merging of compatible parse states.
+    #[arg(long)]
+    pub disable_optimizations: bool,
 }
 
 #[derive(Args)]
@@ -868,6 +874,11 @@ impl Generate {
             self.report_states_for_rule.as_deref(),
             self.js_runtime.as_deref(),
             self.emit != GenerationEmit::Json,
+            if self.disable_optimizations {
+                OptLevel::empty()
+            } else {
+                OptLevel::default()
+            },
         ) {
             if self.json {
                 eprintln!("{}", serde_json::to_string_pretty(&err)?);

--- a/crates/generate/Cargo.toml
+++ b/crates/generate/Cargo.toml
@@ -26,6 +26,7 @@ qjs-rt = ["load", "rquickjs", "pathdiff"]
 
 [dependencies]
 anyhow.workspace = true
+bitflags = "2.9.4"
 dunce = "1.0.5"
 indexmap.workspace = true
 indoc.workspace = true

--- a/crates/generate/src/build_tables.rs
+++ b/crates/generate/src/build_tables.rs
@@ -27,6 +27,7 @@ use crate::{
     node_types::VariableInfo,
     rules::{AliasMap, Symbol, SymbolType, TokenSet},
     tables::{LexTable, ParseAction, ParseTable, ParseTableEntry},
+    OptLevel,
 };
 
 pub struct Tables {
@@ -43,6 +44,7 @@ pub fn build_tables(
     variable_info: &[VariableInfo],
     inlines: &InlinedProductionMap,
     report_symbol_name: Option<&str>,
+    optimizations: OptLevel,
 ) -> BuildTableResult<Tables> {
     let item_set_builder = ParseItemSetBuilder::new(syntax_grammar, lexical_grammar, inlines);
     let following_tokens =
@@ -78,6 +80,7 @@ pub fn build_tables(
         simple_aliases,
         &token_conflict_map,
         &keywords,
+        optimizations,
     );
     let lex_tables = build_lex_table(
         &mut parse_table,

--- a/crates/generate/src/build_tables/minimize_parse_table.rs
+++ b/crates/generate/src/build_tables/minimize_parse_table.rs
@@ -11,6 +11,7 @@ use crate::{
     grammars::{LexicalGrammar, SyntaxGrammar, VariableType},
     rules::{AliasMap, Symbol, TokenSet},
     tables::{GotoAction, ParseAction, ParseState, ParseStateId, ParseTable, ParseTableEntry},
+    OptLevel,
 };
 
 pub fn minimize_parse_table(
@@ -20,6 +21,7 @@ pub fn minimize_parse_table(
     simple_aliases: &AliasMap,
     token_conflict_map: &TokenConflictMap,
     keywords: &TokenSet,
+    optimizations: OptLevel,
 ) {
     let mut minimizer = Minimizer {
         parse_table,
@@ -29,7 +31,9 @@ pub fn minimize_parse_table(
         keywords,
         simple_aliases,
     };
-    minimizer.merge_compatible_states();
+    if optimizations.contains(OptLevel::MergeStates) {
+        minimizer.merge_compatible_states();
+    }
     minimizer.remove_unit_reductions();
     minimizer.remove_unused_states();
     minimizer.reorder_states_by_descending_size();


### PR DESCRIPTION
- Closes #4711

### Problem

Users of the lookahead iterator that want to provide accurate information regarding possible completions for a given parse state can run into cases where there's more valid lookahead tokens than expected. This is because of the merging of compatible parse states that tree-sitter does during generation, where compatible states have their terminal and non-terminal entries extended.

### Solution

This PR adds a cli flag, `--disable-optimizations`, that allows users to opt out of this. I thought about making this more granular in the form of an enum or a number, but I think that's very premature and likely not even needed. Using an enum would be very weird for one member, and it's probable that we won't need to add anything else. I'd rather keep the flag simpler now, and then if we do need to change it in the future, we can just deprecate it and *then* use an enum.