### PR TITLE
feat(bindings): generate zig fingerprint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,6 +1909,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_complete_nushell",
+ "crc32fast",
  "ctor",
  "ctrlc",
  "dialoguer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ clap = { version = "4.5.45", features = [
 ] }
 clap_complete = "4.5.57"
 clap_complete_nushell = "4.5.8"
+crc32fast = "1.5.0"
 ctor = "0.2.9"
 ctrlc = { version = "3.5.0", features = ["termination"] }
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -42,6 +42,7 @@ bstr.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
 clap_complete_nushell.workspace = true
+crc32fast.workspace = true
 ctor.workspace = true
 ctrlc.workspace = true
 dialoguer.workspace = true

--- a/crates/cli/src/templates/build.zig.zon
+++ b/crates/cli/src/templates/build.zig.zon
@@ -1,5 +1,6 @@
 .{
     .name = .tree_sitter_PARSER_NAME,
+    .fingerprint = PARSER_FINGERPRINT,
     .version = "PARSER_VERSION",
     .dependencies = .{
         .tree_sitter = .{


### PR DESCRIPTION
### Problem

Parser maintainers are unlikely to run `zig build` and add the generated fingerprint to `build.zig.zon` manually.

### Solution

We automatically generate the fingerprint by combining a CRC32 hash of the package name with a randomly generated 32bit integer. Note that the order changes depending on the endianness to reflect Zig's packed struct behaviour.

We already depended on `crc32fast` (indirectly) and `rand` so this doesn't introduce any new dependencies.

See: https://github.com/ziglang/zig/blob/0.15.1/src/Package.zig#L13-L34
