### PR TITLE
fix(lib): allow anonymous nodes in the supertype query syntax

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -238,6 +238,20 @@ fn test_query_errors_on_invalid_syntax() {
             ]
             .join("\n")
         );
+        assert_eq!(
+            Query::new(&language, "(statement / export_statement)").unwrap_err(),
+            QueryError {
+                row: 0,
+                offset: 11,
+                column: 11,
+                kind: QueryErrorKind::Syntax,
+                message: [
+                    "(statement / export_statement)", //
+                    "           ^"
+                ]
+                .join("\n")
+            }
+        );
     });
 }
 

--- a/docs/src/using-parsers/queries/1-syntax.md
+++ b/docs/src/using-parsers/queries/1-syntax.md
@@ -115,6 +115,12 @@ match a `binary_expression` only if it is a child of `expression`:
 (expression/binary_expression) @binary-expression
 ```
 
+This also applies to anonymous nodes. For example, this pattern would match `"()"` only if it is a child of `expression`:
+
+```query
+(expression/"()") @empty-expression
+```
+
 [grammar]: ../../creating-parsers/3-writing-the-grammar.md#structuring-rules-well
 [node-field-names]: ../2-basic-parsing.md#node-field-names
 [named-vs-anonymous-nodes]: ../2-basic-parsing.md#named-vs-anonymous-nodes

--- a/docs/src/using-parsers/queries/3-predicates-and-directives.md
+++ b/docs/src/using-parsers/queries/3-predicates-and-directives.md
@@ -140,7 +140,7 @@ see fit.
 
 ```query
 ((comment) @injection.content
-  (#lua-match? @injection.content "/[*\/][!*\/]<?[^a-zA-Z]")
+  (#match? @injection.content "/[*\/][!*\/]<?[^a-zA-Z]")
   (#set! injection.language "doxygen"))
 ```
 

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -2452,8 +2452,6 @@ static TSQueryError ts_query__parse_pattern(
         step->is_named = true;
       }
 
-      stream_skip_whitespace(stream);
-
       // Parse a supertype symbol
       if (stream->next == '/') {
         if (!step->supertype_symbol) {
@@ -2516,9 +2514,9 @@ static TSQueryError ts_query__parse_pattern(
             return TSQueryErrorStructure;
           }
         }
-
-        stream_skip_whitespace(stream);
       }
+
+      stream_skip_whitespace(stream);
 
       // Parse the child patterns
       bool child_is_immediate = false;


### PR DESCRIPTION
- Closes #4297

### Problem

The supertype syntax has 2 issues:

- It does not validate that the child is a valid subtype if not using the `/` syntax (e.g. `(supertype (subtype))`, and instead captures every instance of subtype regardless of its parent.
- It does not work with anonymous nodes (e.g. `(supertype/"subtype")`

### Solution

In this PR, I've added support for anonymous node subtypes in the supertype syntax, and added validation for subtype children to ensure invalid patterns do not successfully compile.
