### PR TITLE
fix(test): trim trailing carriage return unconditionally in test contents

### DIFF
--- a/crates/cli/src/test.rs
+++ b/crates/cli/src/test.rs
@@ -1027,7 +1027,6 @@ fn parse_test_content(name: String, content: &str, file_path: Option<PathBuf>) -
 
                     // Remove trailing newline from the input.
                     input.pop();
-                    #[cfg(target_os = "windows")]
                     if input.last() == Some(&b'\r') {
                         input.pop();
                     }


### PR DESCRIPTION
- Closes #4553 

After discussing with @amaanq, I think it makes the most sense to remove the platform specific-behavior from the test loading code. Before, tests with a trailing `\r\n` would have the `\r\n` trimmed on windows, but just the `\n` on other platforms. With this PR, `\r\n` will be trimmed on all platforms.