### PR TITLE
ci(dependabot): update package.json as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,7 @@ updates:
       actions:
         patterns: ["*"]
   - package-ecosystem: "npm"
+    versioning-strategy: increase
     directories:
       - "/crates/npm"
       - "/crates/eslint"


### PR DESCRIPTION
Fixes errors like this:
```
npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm error
npm error Invalid: lock file's typescript@5.9.2 does not satisfy typescript@5.8.3
```