### PR TITLE
fix(bindings): fix root detection on windows

### DIFF
--- a/crates/cli/src/templates/index.js
+++ b/crates/cli/src/templates/index.js
@@ -1,4 +1,6 @@
-const root = new URL("../..", import.meta.url).pathname;
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
 
 const binding = typeof process.versions.bun === "string"
   // Support `bun build --compile` by being statically analyzable enough to find the .node file at build-time


### PR DESCRIPTION
### Problem

The node bindings test fails on Windows with the following error when using ESM:

```
# Error: Test "can load grammar" at bindings\\node\\binding_test.js:5:1 generated asynchronous activity after the test ended. This activity created the error "AssertionError [ERR_ASSERTION]: Got unwanted rejection.\\nActual message: "No native build was found for platform=win32 arch=x64 runtime=node abi=127 uv=1 libc=glibc node=22.19.0\\n"" and would have caused the test to fail, but instead triggered an unhandledRejection event.
# Subtest: bindings\\node\\binding_test.js
not ok 1 - bindings\\node\\binding_test.js
```

### Solution

Use `fileURLToPath` to get the correct root path.