### PR TITLE
ci: use macos-15-intel runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           - { platform: windows-x64     , target: x86_64-pc-windows-msvc        , os: windows-2025     }
           - { platform: windows-x86     , target: i686-pc-windows-msvc          , os: windows-2025     }
           - { platform: macos-arm64     , target: aarch64-apple-darwin          , os: macos-15         }
-          - { platform: macos-x64       , target: x86_64-apple-darwin           , os: macos-13         }
+          - { platform: macos-x64       , target: x86_64-apple-darwin           , os: macos-15-intel   }
           - { platform: wasm32          , target: wasm32-unknown-unknown        , os: ubuntu-24.04     }
 
           # Extra features


### PR DESCRIPTION
The macos-13 runner will soon be removed.