### PR TITLE
fix(cli): don't load languages for `build` command

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -939,9 +939,6 @@ impl Build {
 
             loader.force_rebuild(true);
 
-            let config = Config::load(None)?;
-            let loader_config = config.get()?;
-            loader.find_all_languages(&loader_config).unwrap();
             loader
                 .compile_parser_at_path(&grammar_path, output_path, flags)
                 .unwrap();


### PR DESCRIPTION
We don't need to load languages at all in order to run the `build` command. It looks like these lines were a copy-paste error from the others (i.e. `parse`, `query`, `highlight`, etc.) when the command was first added.

- Closes #4933 