### PR TITLE
fix(generate): don't short-circuit within `extend_sorted`

### DIFF
--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -829,12 +829,12 @@ fn extend_sorted<'a, T>(vec: &mut Vec<T>, values: impl IntoIterator<Item = &'a T
 where
     T: 'a + Clone + Eq + Ord,
 {
-    values.into_iter().any(|value| {
+    values.into_iter().fold(false, |acc, value| {
         if let Err(i) = vec.binary_search(value) {
             vec.insert(i, value.clone());
             true
         } else {
-            false
+            acc
         }
     })
 }


### PR DESCRIPTION
The use of `any` in `extend_sorted` means that if two or more items from `values` have not been inserted into `vec`, only the first will be added. 

I did a spot check within nvim-treesitter's grammars and found no changes in the `node-types.json` file, however I still think this change makes sense from a correctness perspective.

Since we're potentially iterating over more elements with this change, I ran a few benchmarks to see f there was any performance impact. There is either a slightly positive or no impact at all.

tree-sitter-c:

<img width="1654" height="488" alt="image" src="https://github.com/user-attachments/assets/b73c5c8c-ce6a-4cf2-b270-156247db24d2" />

I can guess that without `any`'s early exit the loop might be vectorized more easily, but that's only a guess.

tree-sitter-ocaml:

<img width="1652" height="505" alt="image" src="https://github.com/user-attachments/assets/b1aca232-6a74-4ce9-9535-597b54833744" />