### PR TITLE
docs: more detailed description of `build -w`

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -173,7 +173,9 @@ struct Generate {
 #[derive(Args)]
 #[command(alias = "b")]
 struct Build {
-    /// Build a Wasm module instead of a dynamic library
+    /// Build a Wasm module instead of a dynamic library. Firstly it tries to compile using
+    /// a local installation of emscripten using the `emcc` command, if the command
+    /// is not found then it will try to to automatically install and use emscripten using docker, then podman.
     #[arg(short, long)]
     pub wasm: bool,
     /// The path to output the compiled file

--- a/docs/src/cli/build.md
+++ b/docs/src/cli/build.md
@@ -18,7 +18,9 @@ will attempt to build the parser in the current working directory.
 
 ### `-w/--wasm`
 
-Compile the parser as a Wasm module.
+Compile the parser as a Wasm module. Firstly tries to compile using a local installation of emscripten using the
+[`emcc`](https://emscripten.org/docs/compiling/Building-Projects.html#manually-using-emcc) command, if the command
+is not found then it will try to to automatically install and use emscripten using docker, then podman.
 
 ### `-o/--output`
 


### PR DESCRIPTION
Improved the docs of `build -w` because I had to look at the source code of tree-sitter-cli to undertand why it was pulling docker image of emscripten even after I've installed the [arch /extra package of emscripten](https://archlinux.org/packages/extra/x86_64/emscripten/), the issue was that by default in arch, the `emcc` command is not added to the PATH after the installation.

