### PR TITLE
Swift bindings: scanner detection, unneeded dependency

### DIFF
--- a/crates/cli/src/templates/package.swift
+++ b/crates/cli/src/templates/package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 
 import Foundation
 import PackageDescription
 
 var sources = ["src/parser.c"]
-if FileManager.default.fileExists(atPath: "src/scanner.c") {
+if FileManager.default.fileExists(atPath: Context.packageDirectory + "/src/scanner.c") {
     sources.append("src/scanner.c")
 }
 
@@ -13,13 +13,9 @@ let package = Package(
     products: [
         .library(name: "PARSER_CLASS_NAME", targets: ["PARSER_CLASS_NAME"]),
     ],
-    dependencies: [
-        .package(name: "SwiftTreeSitter", url: "https://github.com/tree-sitter/swift-tree-sitter", from: "0.9.0"),
-    ],
     targets: [
         .target(
             name: "PARSER_CLASS_NAME",
-            dependencies: [],
             path: ".",
             sources: sources,
             resources: [
@@ -31,7 +27,6 @@ let package = Package(
         .testTarget(
             name: "PARSER_CLASS_NAMETests",
             dependencies: [
-                "SwiftTreeSitter",
                 "PARSER_CLASS_NAME",
             ],
             path: "bindings/swift/PARSER_CLASS_NAMETests"

--- a/crates/cli/src/templates/tests.swift
+++ b/crates/cli/src/templates/tests.swift
@@ -1,12 +1,9 @@
 import XCTest
-import SwiftTreeSitter
 import PARSER_CLASS_NAME
 
 final class PARSER_CLASS_NAMETests: XCTestCase {
     func testCanLoadGrammar() throws {
-        let parser = Parser()
-        let language = Language(language: tree_sitter_LOWER_PARSER_NAME())
-        XCTAssertNoThrow(try parser.setLanguage(language),
-                         "Error loading TITLE_PARSER_NAME grammar")
+        // just building validates the module creation, and linking validates the binary
+        XCTAssertNotNil(tree_sitter_LOWER_PARSER_NAME())
     }
 }


### PR DESCRIPTION
Hello!

I've noticed a serious issue with the Swift binding generation process. The original code was checking for the presence of a path relative to the current working directory. This had the unfortunate effect of working for tests executed within a grammar directory itself, but failing for all practical uses of the package.

The fix was straightforward. It requires using a new package API, which involved bumping the minimum required tools version. This is no big deal, as anything < 6.0 is virtually impossible to support for real projects anyways.

While I'm here I also removed the dependency on SwiftTreeSitter. It's totally unnecessary to validate the grammar module creation.

However, I need a little help to get this over the finish line.

I was trying to test on the YAML grammar, which is impacted by this bug. I cannot get `tree-sitter generate` to actually create any bindings for me locally. I wasn't able to find any documentation around how or even if this should work and my rust is... well let's just say it is not strong.

Speaking of which, I also see some code in `crates/cli/src/init.rs` that seems very related. But I'm not 100% sure what it was doing and how to best modify it.

Some pointers would be very appreciated!