### PR TITLE
fix(generate): add node_modules to quickjs resolver

### DIFF
--- a/crates/generate/src/quickjs.rs
+++ b/crates/generate/src/quickjs.rs
@@ -261,6 +261,7 @@ pub fn execute_native_runtime(grammar_path: &Path) -> JSResult<String> {
     let context = Context::full(&runtime)?;
 
     let resolver = FileResolver::default()
+        .with_path("./node_modules")
         .with_path("./")
         .with_pattern("{}.mjs");
     let loader = ScriptLoader::default().with_extension("mjs");


### PR DESCRIPTION
The custom `require` function worked, but ESM imports failed with an error like this:
```
    Failed to load grammar.js -- QuickJS error: Message: Error resolving module 'tree-sitter-cpp/grammar' from 'grammar.js'
```

I tested this in the Arduino grammar, which imports C++, which imports C…

More things I noticed during testing:
1. All of the grammars **must** be ES modules for ESM imports to work in the native runtime.
2. The Node and Deno runtimes **require** the `.js` extension in the import.
3. Grammars like C which export helper functions/constants have to be imported as:
```js
const C = await import('tree-sitter-c/grammar.js');
// or
import * as C from 'tree-sitter-c/grammar.js';
// but not
import C from 'tree-sitter-c/grammar.js';
```