### PR TITLE
fix(cli): remove `--emit=lib` generate option

### DIFF
--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -572,14 +572,14 @@ pub fn generate_grammar_files(
                             .replace(
                                 indoc! {r"
                                 $(PARSER): $(SRC_DIR)/grammar.json
-                                	$(TS) generate $^
+                                        $(TS) generate $^
                                 "},
                                 indoc! {r"
                                 $(SRC_DIR)/grammar.json: grammar.js
-                                	$(TS) generate --emit=json $^
+                                        $(TS) generate --no-parser $^
 
                                 $(PARSER): $(SRC_DIR)/grammar.json
-                                	$(TS) generate --emit=parser $^
+                                        $(TS) generate $^
                                 "}
                             );
                         write_file(path, contents)?;
@@ -627,14 +627,14 @@ pub fn generate_grammar_files(
                             add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
                                                DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/grammar.js"
                                                COMMAND "${TREE_SITTER_CLI}" generate grammar.js
-                                                        --emit=json
+                                                        --no-parser
                                                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                                                COMMENT "Generating grammar.json")
 
                             add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
                                                DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
                                                COMMAND "${TREE_SITTER_CLI}" generate src/grammar.json
-                                                        --emit=parser --abi=${TREE_SITTER_ABI_VERSION}
+                                                        --abi=${TREE_SITTER_ABI_VERSION}
                                                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                                                COMMENT "Generating parser.c")
                             "#}

--- a/crates/cli/src/templates/cmakelists.cmake
+++ b/crates/cli/src/templates/cmakelists.cmake
@@ -22,14 +22,14 @@ find_program(TREE_SITTER_CLI tree-sitter DOC "Tree-sitter CLI")
 add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
                    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/grammar.js"
                    COMMAND "${TREE_SITTER_CLI}" generate grammar.js
-                            --emit=json
+                            --no-parser
                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                    COMMENT "Generating grammar.json")
 
 add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
                    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
                    COMMAND "${TREE_SITTER_CLI}" generate src/grammar.json
-                            --emit=parser --abi=${TREE_SITTER_ABI_VERSION}
+                            --abi=${TREE_SITTER_ABI_VERSION}
                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                    COMMENT "Generating parser.c")
 

--- a/crates/cli/src/templates/makefile
+++ b/crates/cli/src/templates/makefile
@@ -73,10 +73,10 @@ $(LANGUAGE_NAME).pc: bindings/c/$(LANGUAGE_NAME).pc.in
 		-e 's|@CMAKE_INSTALL_PREFIX@|$(PREFIX)|' $< > $@
 
 $(SRC_DIR)/grammar.json: grammar.js
-	$(TS) generate --emit=json $^
+	$(TS) generate --no-parser $^
 
 $(PARSER): $(SRC_DIR)/grammar.json
-	$(TS) generate --emit=parser $^
+	$(TS) generate $^
 
 install: all
 	install -d '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/KEBAB_PARSER_NAME '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter '$(DESTDIR)$(PCLIBDIR)' '$(DESTDIR)$(LIBDIR)'

--- a/docs/src/cli/generate.md
+++ b/docs/src/cli/generate.md
@@ -30,13 +30,9 @@ what keywords were extracted, what states were split and why, and the entry poin
 
 The ABI to use for parser generation. The default is ABI 15, with ABI 14 being a supported target.
 
-### `--emit`
+### `--no-parser`
 
-What generated files to emit. Possible values:
-
-- `json`: Generate `grammar.json` and `node-types.json`
-- `parser` (default): Generate `parser.c` and related files.
-- `lib`: Compile to a library (equivalent of the deprecated `--build` option)
+Only generate `grammar.json` and `node-types.json`
 
 ### `-0/--debug-build`
 


### PR DESCRIPTION
This also replaces the `--emit` option with an `--emit-json` flag. The default value is false, meaning a parser is still generated by default.

See https://github.com/tree-sitter/tree-sitter/pull/4601#issuecomment-3472303711

Partially addresses #5013

CC @clason 