### PR TITLE
fix(cli)!: deprecate `--build` flag for `generate` command

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -114,13 +114,13 @@ struct Generate {
     /// Only generate `grammar.json` and `node-types.json`
     #[arg(long)]
     pub no_parser: bool,
-    /// Compile all defined languages in the current dir
+    /// Deprecated: use the `build` command
     #[arg(long, short = 'b')]
     pub build: bool,
-    /// Compile a parser in debug mode
+    /// Deprecated: use the `build` command
     #[arg(long, short = '0')]
     pub debug_build: bool,
-    /// The path to the directory containing the parser library
+    /// Deprecated: use the `build` command
     #[arg(long, value_name = "PATH")]
     pub libdir: Option<PathBuf>,
     /// The path to output the generated source files
@@ -905,6 +905,7 @@ impl Generate {
             }
         }
         if self.build {
+            warn!("--build is deprecated, use the `build` command");
             if let Some(path) = self.libdir {
                 loader = loader::Loader::with_parser_lib_path(path);
             }

--- a/docs/src/cli/generate.md
+++ b/docs/src/cli/generate.md
@@ -34,17 +34,6 @@ The ABI to use for parser generation. The default is ABI 15, with ABI 14 being a
 
 Only generate `grammar.json` and `node-types.json`
 
-### `-0/--debug-build`
-
-Compile the parser with debug flags enabled. This is useful when debugging issues that require a debugger like `gdb` or `lldb`.
-
-### `--libdir <PATH>`
-
-The directory to place the compiled parser(s) in.
-On Unix systems, the default path is `$XDG_CACHE_HOME/tree-sitter` if `$XDG_CACHE_HOME` is set,
-otherwise `$HOME/.config/tree-sitter` is used. On Windows, the default path is `%LOCALAPPDATA%\tree-sitter` if available,
-otherwise `$HOME\AppData\Local\tree-sitter` is used.
-
 ### `-o/--output`
 
 The directory to place the generated parser in. The default is `src/` in the current directory.


### PR DESCRIPTION
This PR is meant to serve as a proposal/place of discussion around deprecating the `--build` flag for the `generate` command. 

Some points for removal:

- The `--build` flag was added in https://github.com/tree-sitter/tree-sitter/pull/2013 *before* the CLI had a separate `build` command. I'm not sure it still makes sense to support this when the functionality has a real place to "live".
- It doesn't offer feature parity with the `build` command, so we're effectively offering two slightly different ways to do the same thing.
- For commands like `parse`, `query`, etc., the CLI tool already "automagically" recompiles parsers when needed. This works fairly well for common use cases, and we offer the `--lib-path` argument for more advanced use cases. Point being, offering `--build` may be misleading to some end users.

I'd like to hear any arguments for keeping it, or potential alternatives the CLI could provide to fill a use case this currently covers. 