### PR TITLE
Add node stability test

### DIFF
--- a/lib/binding_web/test/node-id-stability.test.ts
+++ b/lib/binding_web/test/node-id-stability.test.ts
@@ -24,9 +24,7 @@ describe("node id stability", () => {
   });
 
   it("node ID of existing variable_declarator is stable after inserting second declaration", () => {
-    const source1 = `
-      let name = "John Doe";
-    `;
+    const source1 = `let name = "John Doe";\n`;
     tree = parser.parse(source1);
 
     const variableDeclaratorsBefore = tree?.rootNode.descendantsOfType(
@@ -36,9 +34,7 @@ describe("node id stability", () => {
 
     expect(firstDeclarationIdBefore).toBeTypeOf("number");
 
-    const source2 = `
-      let age = 31;
-    `;
+    const source2 = `let age = 31;\n`;
 
     const startIndex = 0;
     const startPosition = { row: 0, column: 0 };

--- a/lib/binding_web/test/node-id-stability.test.ts
+++ b/lib/binding_web/test/node-id-stability.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import { Language, Tree, Edit } from "../src";
+import { Parser } from "../src";
+import helper from "./helper";
+
+describe("node id stability", () => {
+  let parser: Parser;
+  let tree: Tree | null;
+  let JavaScript: Language;
+
+  beforeAll(async () => {
+    ({ JavaScript } = await helper);
+  });
+
+  beforeEach(() => {
+    tree = null;
+    parser = new Parser();
+    parser.setLanguage(JavaScript);
+  });
+
+  afterEach(() => {
+    parser.delete();
+    tree!.delete();
+  });
+
+  it("node ID of existing variable_declarator is stable after inserting second declaration", () => {
+    const source1 = `
+      let name = "John Doe";
+    `;
+    tree = parser.parse(source1);
+
+    const variableDeclaratorsBefore = tree?.rootNode.descendantsOfType(
+      "variable_declarator"
+    );
+    const firstDeclarationIdBefore = variableDeclaratorsBefore?.[0]?.id;
+
+    expect(firstDeclarationIdBefore).toBeTypeOf("number");
+
+    const source2 = `
+      let age = 31;
+    `;
+
+    const startIndex = 0;
+    const startPosition = { row: 0, column: 0 };
+    const newEndPosition = { row: 1, column: 0 };
+
+    const edit = new Edit({
+      startIndex,
+      oldEndIndex: startIndex,
+      newEndIndex: startIndex + source2.length,
+      startPosition,
+      oldEndPosition: startPosition,
+      newEndPosition,
+    });
+
+    tree?.edit(edit);
+
+    const newText = source2 + source1;
+    tree = parser.parse(newText, tree);
+
+    const variableDeclaratorsAfter = tree?.rootNode.descendantsOfType(
+      "variable_declarator"
+    );
+    const nodeIds = variableDeclaratorsAfter?.map((n) => n.id);
+
+    expect(nodeIds).toContain(firstDeclarationIdBefore);
+  });
+});


### PR DESCRIPTION
Hi y'all, the [node ID docs](https://github.com/tree-sitter/tree-sitter/blob/13d4db8bb484064e5bfe0de22382c0e2bf391fd7/lib/binding_web/src/node.ts#L47-L59) say that node IDs are supposed to be stable when reusing trees, but that seems not to be the case. I'm not sure how to fix it yet, but I've added a test that reproduces the issue.

It starts with this JS fixture:
1. 
```js
let name = "John Doe";
```
2. gets the ID of the variable declaration node.
3. Calls `tree.edit` and `parser.parse` using the tree
4. Adds another variable declaration and gets their nodes
```js
let age = 31;
let name = "John Doe";
```

5. Checks that the ID we got in step 2 exists in the nodes

Is this expected behavior?  It doesn't seem to be in line with the incremental parsing goal of the library. If incremental parsing is a core tree-sitter principle, I believe supporting stable IDs can enable some really cool use-cases for users. Incremental renderers using ASTs for example.

Seems like other people have also encountered the issue: https://github.com/tree-sitter/tree-sitter/discussions/2553#discussioncomment-14887885

