### PR TITLE
Include `symbol_ids` field in node-types.json

### DIFF
--- a/crates/cli/src/tests/node_test.rs
+++ b/crates/cli/src/tests/node_test.rs
@@ -1317,11 +1317,6 @@ fn test_cpp_parser_and_node_types_compatibility() {
 }
 
 #[test]
-fn test_embedded_template_parser_and_node_types_compatibility() {
-    test_parser_and_node_types_compatibility("embedded_template");
-}
-
-#[test]
 fn test_go_parser_and_node_types_compatibility() {
     test_parser_and_node_types_compatibility("go");
 }

--- a/crates/cli/src/tests/node_test.rs
+++ b/crates/cli/src/tests/node_test.rs
@@ -1275,11 +1275,18 @@ fn test_parser_and_node_types_compatibility(grammar_name: &str) {
 
     let mut symbol_ids_by_kind_from_language: HashMap<(String, bool), Vec<u16>> = HashMap::new();
     for i in 0..kind_count as u16 {
-        let kind = language.node_kind_for_id(i).unwrap().to_string();
-        let id = language.node_kind_is_named(i);
+        let kind = language.node_kind_for_id(i).unwrap();
+        let named = language.node_kind_is_named(i);
+
+        // workaround maybe?
+        let kind = if kind.is_empty() {
+            "\0".to_string()
+        } else {
+            kind.to_string()
+        };
 
         symbol_ids_by_kind_from_language
-            .entry((kind, id))
+            .entry((kind, named))
             .or_insert_with(Vec::new)
             .push(i);
     }

--- a/crates/cli/src/tests/node_test.rs
+++ b/crates/cli/src/tests/node_test.rs
@@ -1,5 +1,7 @@
+use std::{collections::HashMap, fs};
+
 use tree_sitter::{InputEdit, Node, Parser, Point, Tree};
-use tree_sitter_generate::load_grammar_file;
+use tree_sitter_generate::{load_grammar_file, NodeInfoJSON};
 
 use super::{
     get_random_edit,
@@ -1242,4 +1244,112 @@ fn parse_json_example() -> Tree {
     let mut parser = Parser::new();
     parser.set_language(&get_language("json")).unwrap();
     parser.parse(JSON_EXAMPLE, None).unwrap()
+}
+
+fn test_parser_and_node_types_compatibility(grammar_name: &str) {
+    let language = get_language(grammar_name);
+    let node_types: Vec<NodeInfoJSON> = {
+        let node_types_path = fixtures_dir()
+            .join("grammars")
+            .join(grammar_name)
+            .join("src")
+            .join("node-types.json");
+
+        let node_types_content = fs::read_to_string(&node_types_path)
+            .unwrap_or_else(|_| panic!("Failed to read node-types.json at {:?}", node_types_path));
+
+        serde_json::from_str(&node_types_content)
+            .unwrap_or_else(|e| panic!("Failed to parse node-types.json: {}", e))
+    };
+
+    let symbol_ids_by_kind_from_node_types: HashMap<(String, bool), Option<&Vec<u16>>> = node_types
+        .iter()
+        .map(|node_type| {
+            (
+                (node_type.kind.clone(), node_type.named),
+                node_type.symbol_ids.as_ref(), // .unwrap_or(Vec::new()),
+            )
+        })
+        .collect();
+    let kind_count = language.node_kind_count();
+
+    let mut symbol_ids_by_kind_from_language: HashMap<(String, bool), Vec<u16>> = HashMap::new();
+    for i in 0..kind_count as u16 {
+        let kind = language.node_kind_for_id(i).unwrap().to_string();
+        let id = language.node_kind_is_named(i);
+
+        symbol_ids_by_kind_from_language
+            .entry((kind, id))
+            .or_insert_with(Vec::new)
+            .push(i);
+    }
+
+    for (key, symbol_ids) in symbol_ids_by_kind_from_node_types {
+        assert_eq!(symbol_ids_by_kind_from_language.get(&key), symbol_ids);
+    }
+}
+
+#[test]
+fn test_bash_parser_and_node_types_compatibility() {
+    test_parser_and_node_types_compatibility("bash");
+}
+
+#[test]
+fn test_c_parser_and_node_types_compatibility() {
+    test_parser_and_node_types_compatibility("c");
+}
+
+#[test]
+fn test_cpp_parser_and_node_types_compatibility() {
+    test_parser_and_node_types_compatibility("cpp");
+}
+
+#[test]
+fn test_embedded_template_parser_and_node_types_compatibility() {
+    test_parser_and_node_types_compatibility("embedded_template");
+}
+
+#[test]
+fn test_go_parser_and_node_types_compatibility() {
+    test_parser_and_node_types_compatibility("go");
+}
+
+#[test]
+fn test_html_parser_and_node_types_compatibility() {
+    test_parser_and_node_types_compatibility("html");
+}
+
+#[test]
+fn test_java_parser_and_node_types_compatibility() {
+    test_parser_and_node_types_compatibility("java");
+}
+
+#[test]
+fn test_javascript_parser_and_node_types_compatibility() {
+    test_parser_and_node_types_compatibility("javascript");
+}
+
+#[test]
+fn test_jsdoc_parser_and_node_types_compatibility() {
+    test_parser_and_node_types_compatibility("jsdoc");
+}
+
+#[test]
+fn test_json_parser_and_node_types_compatibility() {
+    test_parser_and_node_types_compatibility("json");
+}
+
+#[test]
+fn test_python_parser_and_node_types_compatibility() {
+    test_parser_and_node_types_compatibility("python");
+}
+
+#[test]
+fn test_ruby_parser_and_node_types_compatibility() {
+    test_parser_and_node_types_compatibility("ruby");
+}
+
+#[test]
+fn test_rust_parser_and_node_types_compatibility() {
+    test_parser_and_node_types_compatibility("rust");
 }

--- a/crates/cli/src/tests/node_test.rs
+++ b/crates/cli/src/tests/node_test.rs
@@ -1292,7 +1292,12 @@ fn test_parser_and_node_types_compatibility(grammar_name: &str) {
     }
 
     for (key, symbol_ids) in symbol_ids_by_kind_from_node_types {
-        assert_eq!(symbol_ids_by_kind_from_language.get(&key), symbol_ids);
+        assert_eq!(
+            symbol_ids,
+            symbol_ids_by_kind_from_language.get(&key),
+            "{:?}",
+            key
+        );
     }
 }
 

--- a/crates/cli/src/tests/node_test.rs
+++ b/crates/cli/src/tests/node_test.rs
@@ -1278,7 +1278,9 @@ fn test_parser_and_node_types_compatibility(grammar_name: &str) {
         let kind = language.node_kind_for_id(i).unwrap();
         let named = language.node_kind_is_named(i);
 
-        // workaround maybe?
+        // TODO: find a better way
+        // In Go grammar, there is a node kind with an empty string.
+        // In node-types.json, it is "\u0000" but in parser.c, it is "\0" and not distinguishable from "".
         let kind = if kind.is_empty() {
             "\0".to_string()
         } else {

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -34,6 +34,8 @@ mod tables;
 pub use build_tables::ParseTableBuilderError;
 use introspect_grammar::{introspect_grammar, GrammarIntrospection};
 pub use node_types::{SuperTypeCycleError, VariableInfoError};
+#[cfg(feature = "load")]
+pub use node_types::{FieldInfoJSON, NodeInfoJSON, NodeTypeJSON};
 use parse_grammar::parse_grammar;
 pub use parse_grammar::ParseGrammarError;
 pub use prepare_grammar::PrepareGrammarError;

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -296,6 +296,7 @@ where
         &lexical_grammar,
         &simple_aliases,
         &variable_info,
+        &symbol_ids,
     )?;
 
     write_file(

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::LazyLock,
-};
+use std::sync::LazyLock;
 #[cfg(feature = "load")]
 use std::{
     env, fs,
@@ -14,7 +11,6 @@ use anyhow::Result;
 use bitflags::bitflags;
 use log::warn;
 use regex::{Regex, RegexBuilder};
-use rules::{Alias, Symbol};
 #[cfg(feature = "load")]
 use semver::Version;
 #[cfg(feature = "load")]
@@ -44,8 +40,6 @@ pub use parse_grammar::ParseGrammarError;
 pub use prepare_grammar::PrepareGrammarError;
 use render::render_c_code;
 pub use render::{ABI_VERSION_MAX, ABI_VERSION_MIN};
-
-use crate::{build_tables::Tables, node_types::ChildType};
 
 static JSON_COMMENT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     RegexBuilder::new("^\\s*//.*")

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -56,21 +56,6 @@ static JSON_COMMENT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         .unwrap()
 });
 
-struct JSONOutput {
-    #[cfg(feature = "load")]
-    node_types_json: String,
-    syntax_grammar: SyntaxGrammar,
-    lexical_grammar: LexicalGrammar,
-    inlines: InlinedProductionMap,
-    simple_aliases: BTreeMap<Symbol, Alias>,
-    variable_info: Vec<VariableInfo>,
-}
-
-struct GeneratedParser {
-    c_code: String,
-    #[cfg(feature = "load")]
-    node_types_json: String,
-}
 struct GrammarIntrospection {
     syntax_grammar: SyntaxGrammar,
     lexical_grammar: LexicalGrammar,

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -78,7 +78,7 @@ struct GrammarIntrospection {
     variable_info: Vec<VariableInfo>,
     supertype_symbol_map: BTreeMap<Symbol, Vec<ChildType>>,
     tables: Tables,
-    symbol_ids: HashMap<Symbol, String>,
+    symbol_ids: HashMap<Symbol, (String, u16)>,
     alias_ids: HashMap<Alias, String>,
     unique_aliases: Vec<Alias>,
 }
@@ -405,7 +405,7 @@ fn introspect_grammar(
         optimizations,
     )?;
 
-    // Generate symbol IDs before rendering C code
+    // Generate symbol IDs (both string and numeric) before rendering C code
     let (symbol_ids, alias_ids, unique_aliases) = generate_symbol_ids(
         &tables.parse_table,
         &syntax_grammar,

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -41,7 +41,7 @@ use parse_grammar::parse_grammar;
 pub use parse_grammar::ParseGrammarError;
 use prepare_grammar::prepare_grammar;
 pub use prepare_grammar::PrepareGrammarError;
-use render::render_c_code;
+use render::{generate_symbol_ids, render_c_code};
 pub use render::{ABI_VERSION_MAX, ABI_VERSION_MIN};
 
 static JSON_COMMENT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
@@ -373,12 +373,24 @@ fn generate_parser_for_grammar_with_opts(
         report_symbol_name,
         optimizations,
     )?;
+
+    // Generate symbol IDs before rendering C code
+    let (symbol_ids, alias_ids, unique_aliases) = generate_symbol_ids(
+        &tables.parse_table,
+        &syntax_grammar,
+        &lexical_grammar,
+        &simple_aliases,
+    );
+
     let c_code = render_c_code(
         &input_grammar.name,
         tables,
         syntax_grammar,
         lexical_grammar,
         simple_aliases,
+        symbol_ids,
+        alias_ids,
+        unique_aliases,
         abi_version,
         semantic_version,
         supertype_symbol_map,

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -266,6 +266,7 @@ where
         &syntax_grammar,
         &lexical_grammar,
         &simple_aliases,
+        &unique_aliases,
         &variable_info,
         &symbol_ids,
     )?;

--- a/crates/generate/src/introspect_grammar.rs
+++ b/crates/generate/src/introspect_grammar.rs
@@ -1,12 +1,15 @@
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    fmt::Write,
+};
 
 use crate::{
     build_tables::{build_tables, Tables},
-    grammars::{InputGrammar, LexicalGrammar, SyntaxGrammar},
+    grammars::{InputGrammar, LexicalGrammar, SyntaxGrammar, VariableType},
     node_types::{self, ChildType, VariableInfo},
     prepare_grammar::prepare_grammar,
-    render::generate_symbol_ids,
-    rules::{Alias, Symbol},
+    rules::{Alias, AliasMap, Symbol, SymbolType},
+    tables::ParseTable,
     GenerateError, OptLevel,
 };
 
@@ -63,4 +66,299 @@ pub fn introspect_grammar(
         alias_ids,
         unique_aliases,
     })
+}
+
+/// Generates symbol IDs and alias IDs for the given parse table and grammars.
+///
+/// This function must be called before `render_c_code` to generate the symbol mappings
+/// that will be used in the generated C code.
+///
+/// # Arguments
+///
+/// * `parse_table` - The generated parse table for the language
+/// * `syntax_grammar` - The syntax grammar extracted from the language's grammar
+/// * `lexical_grammar` - The lexical grammar extracted from the language's grammar
+/// * `default_aliases` - A map describing the global rename rules that should apply
+///
+/// # Returns
+///
+/// A tuple containing:
+/// * `symbol_ids` - HashMap mapping each Symbol to (C identifier string, numeric ID)
+/// * `alias_ids` - HashMap mapping each Alias to its C identifier string
+/// * `unique_aliases` - Sorted vector of unique aliases
+pub fn generate_symbol_ids(
+    parse_table: &ParseTable,
+    syntax_grammar: &SyntaxGrammar,
+    lexical_grammar: &LexicalGrammar,
+    default_aliases: &AliasMap,
+) -> (
+    HashMap<Symbol, (String, u16)>,
+    HashMap<Alias, String>,
+    Vec<Alias>,
+) {
+    let mut symbol_ids = HashMap::new();
+    let mut alias_ids = HashMap::new();
+    let mut unique_aliases = Vec::new();
+    let mut symbol_identifiers = HashSet::new();
+
+    // Generate symbol IDs with numeric IDs
+    // Symbol::end() gets 0, then other symbols get 1, 2, 3...
+    let mut numeric_id = 0u16;
+    for &symbol in &parse_table.symbols {
+        assign_symbol_id(
+            symbol,
+            syntax_grammar,
+            lexical_grammar,
+            &mut symbol_ids,
+            &mut symbol_identifiers,
+            numeric_id,
+        );
+        numeric_id += 1;
+    }
+
+    symbol_ids.insert(
+        Symbol::end_of_nonterminal_extra(),
+        symbol_ids[&Symbol::end()].clone(),
+    );
+
+    // Build symbol map to find canonical symbols for aliases
+    let mut symbol_map = HashMap::new();
+    for symbol in &parse_table.symbols {
+        let mut mapping = symbol;
+
+        if let Some(alias) = default_aliases.get(symbol) {
+            let kind = alias.kind();
+            for other_symbol in &parse_table.symbols {
+                if let Some(other_alias) = default_aliases.get(other_symbol) {
+                    if other_symbol < mapping && other_alias == alias {
+                        mapping = other_symbol;
+                    }
+                } else {
+                    let (other_name, other_kind) =
+                        metadata_for_symbol(*other_symbol, syntax_grammar, lexical_grammar);
+                    if (other_name, other_kind) == (alias.value.as_str(), kind) {
+                        mapping = other_symbol;
+                        break;
+                    }
+                }
+            }
+        } else if symbol.is_terminal() {
+            let metadata = metadata_for_symbol(*symbol, syntax_grammar, lexical_grammar);
+            for other_symbol in &parse_table.symbols {
+                let other_metadata =
+                    metadata_for_symbol(*other_symbol, syntax_grammar, lexical_grammar);
+                if other_metadata == metadata {
+                    if let Some(mapped) = symbol_map.get(other_symbol) {
+                        if mapped == symbol {
+                            break;
+                        }
+                    }
+                    mapping = other_symbol;
+                    break;
+                }
+            }
+        }
+
+        symbol_map.insert(*symbol, *mapping);
+    }
+
+    // Generate alias IDs
+    for production_info in &parse_table.production_infos {
+        for alias in &production_info.alias_sequence {
+            if let Some(alias) = &alias {
+                // Find symbols that match this alias
+                let matching_symbols: Vec<Symbol> = parse_table
+                    .symbols
+                    .iter()
+                    .copied()
+                    .filter(|symbol| {
+                        default_aliases.get(symbol).map_or_else(
+                            || {
+                                let (name, kind) =
+                                    metadata_for_symbol(*symbol, syntax_grammar, lexical_grammar);
+                                name == alias.value && kind == alias.kind()
+                            },
+                            |default_alias| default_alias == alias,
+                        )
+                    })
+                    .collect();
+
+                // Some aliases match an existing symbol in the grammar.
+                let alias_id = if let Some(existing_symbol) = matching_symbols.first() {
+                    symbol_ids[&symbol_map[existing_symbol]].0.clone()
+                }
+                // Other aliases don't match any existing symbol, and need their own identifiers.
+                else {
+                    if let Err(i) = unique_aliases.binary_search(alias) {
+                        unique_aliases.insert(i, alias.clone());
+                    }
+
+                    if alias.is_named {
+                        format!("alias_sym_{}", sanitize_identifier(&alias.value))
+                    } else {
+                        format!("anon_alias_sym_{}", sanitize_identifier(&alias.value))
+                    }
+                };
+
+                alias_ids.entry(alias.clone()).or_insert(alias_id);
+            }
+        }
+    }
+
+    (symbol_ids, alias_ids, unique_aliases)
+}
+
+/// Helper function to sanitize identifiers for C code generation.
+pub fn sanitize_identifier(name: &str) -> String {
+    let mut result = String::with_capacity(name.len());
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' {
+            result.push(c);
+        } else {
+            'special_chars: {
+                let replacement = match c {
+                    ' ' if name.len() == 1 => "SPACE",
+                    '~' => "TILDE",
+                    '`' => "BQUOTE",
+                    '!' => "BANG",
+                    '@' => "AT",
+                    '#' => "POUND",
+                    '$' => "DOLLAR",
+                    '%' => "PERCENT",
+                    '^' => "CARET",
+                    '&' => "AMP",
+                    '*' => "STAR",
+                    '(' => "LPAREN",
+                    ')' => "RPAREN",
+                    '-' => "DASH",
+                    '+' => "PLUS",
+                    '=' => "EQ",
+                    '{' => "LBRACE",
+                    '}' => "RBRACE",
+                    '[' => "LBRACK",
+                    ']' => "RBRACK",
+                    '\\' => "BSLASH",
+                    '|' => "PIPE",
+                    ':' => "COLON",
+                    ';' => "SEMI",
+                    '"' => "DQUOTE",
+                    '\'' => "SQUOTE",
+                    '<' => "LT",
+                    '>' => "GT",
+                    ',' => "COMMA",
+                    '.' => "DOT",
+                    '?' => "QMARK",
+                    '/' => "SLASH",
+                    '\n' => "LF",
+                    '\r' => "CR",
+                    '\t' => "TAB",
+                    '\0' => "NULL",
+                    '\u{0001}' => "SOH",
+                    '\u{0002}' => "STX",
+                    '\u{0003}' => "ETX",
+                    '\u{0004}' => "EOT",
+                    '\u{0005}' => "ENQ",
+                    '\u{0006}' => "ACK",
+                    '\u{0007}' => "BEL",
+                    '\u{0008}' => "BS",
+                    '\u{000b}' => "VTAB",
+                    '\u{000c}' => "FF",
+                    '\u{000e}' => "SO",
+                    '\u{000f}' => "SI",
+                    '\u{0010}' => "DLE",
+                    '\u{0011}' => "DC1",
+                    '\u{0012}' => "DC2",
+                    '\u{0013}' => "DC3",
+                    '\u{0014}' => "DC4",
+                    '\u{0015}' => "NAK",
+                    '\u{0016}' => "SYN",
+                    '\u{0017}' => "ETB",
+                    '\u{0018}' => "CAN",
+                    '\u{0019}' => "EM",
+                    '\u{001a}' => "SUB",
+                    '\u{001b}' => "ESC",
+                    '\u{001c}' => "FS",
+                    '\u{001d}' => "GS",
+                    '\u{001e}' => "RS",
+                    '\u{001f}' => "US",
+                    '\u{007F}' => "DEL",
+                    '\u{FEFF}' => "BOM",
+                    '\u{0080}'..='\u{FFFF}' => {
+                        write!(result, "u{:04x}", c as u32).unwrap();
+                        break 'special_chars;
+                    }
+                    '\u{10000}'..='\u{10FFFF}' => {
+                        write!(result, "U{:08x}", c as u32).unwrap();
+                        break 'special_chars;
+                    }
+                    '0'..='9' | 'a'..='z' | 'A'..='Z' | '_' => unreachable!(),
+                    ' ' => break 'special_chars,
+                };
+                if !result.is_empty() && !result.ends_with('_') {
+                    result.push('_');
+                }
+                result += replacement;
+            }
+        }
+    }
+    result
+}
+
+/// Helper function to get metadata for a symbol.
+pub fn metadata_for_symbol<'a>(
+    symbol: Symbol,
+    syntax_grammar: &'a SyntaxGrammar,
+    lexical_grammar: &'a LexicalGrammar,
+) -> (&'a str, VariableType) {
+    match symbol.kind {
+        SymbolType::End | SymbolType::EndOfNonTerminalExtra => ("end", VariableType::Hidden),
+        SymbolType::NonTerminal => {
+            let variable = &syntax_grammar.variables[symbol.index];
+            (&variable.name as &str, variable.kind)
+        }
+        SymbolType::Terminal => {
+            let variable = &lexical_grammar.variables[symbol.index];
+            (&variable.name as &str, variable.kind)
+        }
+        SymbolType::External => {
+            let token = &syntax_grammar.external_tokens[symbol.index];
+            (&token.name as &str, token.kind)
+        }
+    }
+}
+
+/// Helper function to assign a symbol ID.
+fn assign_symbol_id(
+    symbol: Symbol,
+    syntax_grammar: &SyntaxGrammar,
+    lexical_grammar: &LexicalGrammar,
+    symbol_ids: &mut HashMap<Symbol, (String, u16)>,
+    used_identifiers: &mut HashSet<String>,
+    numeric_id: u16,
+) {
+    let mut id;
+    if symbol == Symbol::end() {
+        id = "ts_builtin_sym_end".to_string();
+    } else {
+        let (name, kind) = metadata_for_symbol(symbol, syntax_grammar, lexical_grammar);
+        id = match kind {
+            VariableType::Auxiliary => format!("aux_sym_{}", sanitize_identifier(name)),
+            VariableType::Anonymous => format!("anon_sym_{}", sanitize_identifier(name)),
+            VariableType::Hidden | VariableType::Named => {
+                format!("sym_{}", sanitize_identifier(name))
+            }
+        };
+
+        let mut suffix_number = 1;
+        let mut suffix = String::new();
+        while used_identifiers.contains(&id) {
+            id.drain(id.len() - suffix.len()..);
+            suffix_number += 1;
+            suffix = suffix_number.to_string();
+            id += &suffix;
+        }
+    }
+
+    used_identifiers.insert(id.clone());
+    symbol_ids.insert(symbol, (id, numeric_id));
 }

--- a/crates/generate/src/introspect_grammar.rs
+++ b/crates/generate/src/introspect_grammar.rs
@@ -1,0 +1,66 @@
+use std::collections::{BTreeMap, HashMap};
+
+use crate::{
+    build_tables::{build_tables, Tables},
+    grammars::{InputGrammar, LexicalGrammar, SyntaxGrammar},
+    node_types::{self, ChildType, VariableInfo},
+    prepare_grammar::prepare_grammar,
+    render::generate_symbol_ids,
+    rules::{Alias, Symbol},
+    GenerateError, OptLevel,
+};
+
+pub struct GrammarIntrospection {
+    pub syntax_grammar: SyntaxGrammar,
+    pub lexical_grammar: LexicalGrammar,
+    pub simple_aliases: BTreeMap<Symbol, Alias>,
+    pub variable_info: Vec<VariableInfo>,
+    pub supertype_symbol_map: BTreeMap<Symbol, Vec<ChildType>>,
+    pub tables: Tables,
+    pub symbol_ids: HashMap<Symbol, (String, u16)>,
+    pub alias_ids: HashMap<Alias, String>,
+    pub unique_aliases: Vec<Alias>,
+}
+
+pub fn introspect_grammar(
+    input_grammar: &InputGrammar,
+    report_symbol_name: Option<&str>,
+    optimizations: OptLevel,
+) -> Result<GrammarIntrospection, GenerateError> {
+    let (syntax_grammar, lexical_grammar, inlines, simple_aliases) =
+        prepare_grammar(input_grammar)?;
+    let variable_info =
+        node_types::get_variable_info(&syntax_grammar, &lexical_grammar, &simple_aliases)?;
+
+    let supertype_symbol_map =
+        node_types::get_supertype_symbol_map(&syntax_grammar, &simple_aliases, &variable_info);
+    let tables = build_tables(
+        &syntax_grammar,
+        &lexical_grammar,
+        &simple_aliases,
+        &variable_info,
+        &inlines,
+        report_symbol_name,
+        optimizations,
+    )?;
+
+    // Generate symbol IDs (both string and numeric) before rendering C code
+    let (symbol_ids, alias_ids, unique_aliases) = generate_symbol_ids(
+        &tables.parse_table,
+        &syntax_grammar,
+        &lexical_grammar,
+        &simple_aliases,
+    );
+
+    Ok(GrammarIntrospection {
+        syntax_grammar,
+        lexical_grammar,
+        simple_aliases,
+        variable_info,
+        supertype_symbol_map,
+        tables,
+        symbol_ids,
+        alias_ids,
+        unique_aliases,
+    })
+}

--- a/crates/generate/src/introspect_grammar.rs
+++ b/crates/generate/src/introspect_grammar.rs
@@ -22,7 +22,7 @@ pub struct GrammarIntrospection {
     pub tables: Tables,
     pub symbol_ids: HashMap<Symbol, (String, u16)>,
     pub alias_ids: HashMap<Alias, String>,
-    pub unique_aliases: Vec<Alias>,
+    pub unique_aliases: Vec<(Alias, u16)>,
 }
 
 pub fn introspect_grammar(
@@ -94,7 +94,7 @@ pub fn generate_symbol_ids(
 ) -> (
     HashMap<Symbol, (String, u16)>,
     HashMap<Alias, String>,
-    Vec<Alias>,
+    Vec<(Alias, u16)>,
 ) {
     let mut symbol_ids = HashMap::new();
     let mut alias_ids = HashMap::new();
@@ -205,7 +205,18 @@ pub fn generate_symbol_ids(
         }
     }
 
-    (symbol_ids, alias_ids, unique_aliases)
+    (
+        symbol_ids,
+        alias_ids,
+        unique_aliases
+            .into_iter()
+            .map(|alias| {
+                let id = numeric_id;
+                numeric_id += 1;
+                (alias, id)
+            })
+            .collect(),
+    )
 }
 
 /// Helper function to sanitize identifiers for C code generation.

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -46,7 +46,7 @@ pub struct NodeInfoJSON {
     #[serde(skip_serializing_if = "Option::is_none")]
     subtypes: Option<Vec<NodeTypeJSON>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    symbol_id: Option<String>,
+    symbol_id: Option<u16>,
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -475,7 +475,7 @@ pub fn generate_node_types_json(
     lexical_grammar: &LexicalGrammar,
     default_aliases: &AliasMap,
     variable_info: &[VariableInfo],
-    symbol_ids: &HashMap<Symbol, String>,
+    symbol_ids: &HashMap<Symbol, (String, u16)>,
 ) -> SuperTypeCycleResult<Vec<NodeInfoJSON>> {
     let mut node_types_json = BTreeMap::new();
 
@@ -575,7 +575,7 @@ pub fn generate_node_types_json(
                         fields: None,
                         children: None,
                         subtypes: None,
-                        symbol_id: symbol_ids.get(&symbol).cloned(),
+                        symbol_id: symbol_ids.get(&symbol).map(|t| t.1),
                     });
             let mut subtypes = info
                 .children
@@ -620,7 +620,7 @@ pub fn generate_node_types_json(
                         fields: Some(BTreeMap::new()),
                         children: None,
                         subtypes: None,
-                        symbol_id: symbol_ids.get(&symbol).cloned(),
+                        symbol_id: symbol_ids.get(&symbol).map(|t| t.1),
                     }
                 });
 
@@ -758,7 +758,7 @@ pub fn generate_node_types_json(
                             fields: None,
                             children: None,
                             subtypes: None,
-                            symbol_id: symbol_ids.get(&symbol).cloned(),
+                            symbol_id: symbol_ids.get(&symbol).map(|t| t.1),
                         });
                 if let Some(children) = &mut node_type_json.children {
                     children.required = false;
@@ -777,7 +777,7 @@ pub fn generate_node_types_json(
                 fields: None,
                 children: None,
                 subtypes: None,
-                symbol_id: symbol_ids.get(&symbol).cloned(),
+                symbol_id: symbol_ids.get(&symbol).map(|t| t.1),
             }),
             _ => {}
         }

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::{
@@ -28,40 +28,40 @@ pub struct VariableInfo {
     pub has_multi_step_production: bool,
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq, Default, PartialOrd, Ord)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, PartialOrd, Ord)]
 #[cfg(feature = "load")]
 pub struct NodeInfoJSON {
     #[serde(rename = "type")]
-    kind: String,
-    named: bool,
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
-    root: bool,
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
-    extra: bool,
+    pub kind: String,
+    pub named: bool,
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub root: bool,
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub extra: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    fields: Option<BTreeMap<String, FieldInfoJSON>>,
+    pub fields: Option<BTreeMap<String, FieldInfoJSON>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    children: Option<FieldInfoJSON>,
+    pub children: Option<FieldInfoJSON>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subtypes: Option<Vec<NodeTypeJSON>>,
+    pub subtypes: Option<Vec<NodeTypeJSON>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    symbol_ids: Option<Vec<u16>>,
+    pub symbol_ids: Option<Vec<u16>>,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg(feature = "load")]
 pub struct NodeTypeJSON {
     #[serde(rename = "type")]
-    kind: String,
-    named: bool,
+    pub kind: String,
+    pub named: bool,
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg(feature = "load")]
 pub struct FieldInfoJSON {
-    multiple: bool,
-    required: bool,
-    types: Vec<NodeTypeJSON>,
+    pub multiple: bool,
+    pub required: bool,
+    pub types: Vec<NodeTypeJSON>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1551,7 +1551,7 @@ mod tests {
                 subtypes: None,
                 children: None,
                 fields: None,
-                symbol_ids: None,
+                symbol_ids: Some(vec![7]),
             })
         );
     }

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -858,7 +858,6 @@ mod tests {
             InputGrammar, LexicalVariable, Production, ProductionStep, SyntaxVariable, Variable,
         },
         introspect_grammar,
-        prepare_grammar::prepare_grammar,
         rules::Rule,
         GrammarIntrospection, OptLevel,
     };
@@ -931,7 +930,7 @@ mod tests {
                     .into_iter()
                     .collect()
                 ),
-                symbol_id: None,
+                symbol_id: Some(4),
             }
         );
         assert_eq!(
@@ -944,7 +943,7 @@ mod tests {
                 subtypes: None,
                 children: None,
                 fields: None,
-                symbol_id: None,
+                symbol_id: Some(1),
             }
         );
         assert_eq!(
@@ -957,7 +956,7 @@ mod tests {
                 subtypes: None,
                 children: None,
                 fields: None,
-                symbol_id: None,
+                symbol_id: Some(2),
             }
         );
     }
@@ -1034,7 +1033,7 @@ mod tests {
                     .into_iter()
                     .collect()
                 ),
-                symbol_id: None,
+                symbol_id: Some(4),
             }
         );
         assert_eq!(
@@ -1047,7 +1046,7 @@ mod tests {
                 subtypes: None,
                 children: None,
                 fields: None,
-                symbol_id: None,
+                symbol_id: Some(1),
             }
         );
         assert_eq!(
@@ -1060,7 +1059,7 @@ mod tests {
                 subtypes: None,
                 children: None,
                 fields: None,
-                symbol_id: None,
+                symbol_id: Some(2),
             }
         );
         assert_eq!(
@@ -1073,7 +1072,7 @@ mod tests {
                 subtypes: None,
                 children: None,
                 fields: None,
-                symbol_id: None,
+                symbol_id: Some(3),
             }
         );
     }
@@ -1150,7 +1149,7 @@ mod tests {
                     .into_iter()
                     .collect()
                 ),
-                symbol_id: None,
+                symbol_id: Some(5),
             }
         );
         assert_eq!(
@@ -1163,7 +1162,7 @@ mod tests {
                 subtypes: None,
                 children: None,
                 fields: Some(BTreeMap::default()),
-                symbol_id: None,
+                symbol_id: Some(6),
             }
         );
         assert_eq!(
@@ -1176,7 +1175,7 @@ mod tests {
                 subtypes: None,
                 children: None,
                 fields: None,
-                symbol_id: None,
+                symbol_id: Some(1),
             }
         );
         assert_eq!(
@@ -1189,7 +1188,7 @@ mod tests {
                 subtypes: None,
                 children: None,
                 fields: None,
-                symbol_id: None,
+                symbol_id: Some(2),
             }
         );
     }
@@ -1251,7 +1250,7 @@ mod tests {
                         named: true,
                     },
                 ]),
-                symbol_id: None,
+                symbol_id: Some(5),
             }
         );
         assert_eq!(
@@ -1278,7 +1277,7 @@ mod tests {
                     .into_iter()
                     .collect()
                 ),
-                symbol_id: None,
+                symbol_id: Some(4),
             }
         );
     }
@@ -1357,7 +1356,7 @@ mod tests {
                     .into_iter()
                     .collect()
                 ),
-                symbol_id: None,
+                symbol_id: Some(5),
             }
         );
         assert_eq!(
@@ -1377,7 +1376,7 @@ mod tests {
                     },]
                 }),
                 fields: Some(BTreeMap::new()),
-                symbol_id: None,
+                symbol_id: Some(6),
             }
         );
     }
@@ -1431,7 +1430,7 @@ mod tests {
                     ]
                 }),
                 fields: Some(BTreeMap::new()),
-                symbol_id: None,
+                symbol_id: Some(3),
             }
         );
     }
@@ -1496,7 +1495,7 @@ mod tests {
                 subtypes: None,
                 children: None,
                 fields: None,
-                symbol_id: None,
+                symbol_id: Some(2),
             })
         );
         assert_eq!(
@@ -1509,7 +1508,7 @@ mod tests {
                 subtypes: None,
                 children: None,
                 fields: None,
-                symbol_id: None,
+                symbol_id: Some(2),
             })
         );
     }
@@ -1575,7 +1574,7 @@ mod tests {
                     .into_iter()
                     .collect()
                 ),
-                symbol_id: None,
+                symbol_id: Some(3),
             }
         );
     }
@@ -1605,7 +1604,7 @@ mod tests {
                 fields: Some(BTreeMap::new()),
                 children: None,
                 subtypes: None,
-                symbol_id: None,
+                symbol_id: Some(3),
             }]
         );
     }
@@ -1713,7 +1712,7 @@ mod tests {
                         .into_iter()
                         .collect()
                     ),
-                    symbol_id: None,
+                    symbol_id: Some(7),
                 },
                 NodeInfoJSON {
                     kind: "script".to_string(),
@@ -1731,7 +1730,7 @@ mod tests {
                         }]
                     }),
                     fields: Some(BTreeMap::new()),
-                    symbol_id: None,
+                    symbol_id: Some(6),
                 }
             ]
         );
@@ -1788,7 +1787,7 @@ mod tests {
                     }]
                 }),
                 fields: Some(BTreeMap::new()),
-                symbol_id: None,
+                symbol_id: Some(5),
             }
         );
     }
@@ -2101,7 +2100,7 @@ mod tests {
             variable_info,
             supertype_symbol_map: _,
             tables: _,
-            symbol_ids: _,
+            symbol_ids,
             alias_ids: _,
             unique_aliases: _,
         } = introspect_grammar(grammar, None, OptLevel::default()).unwrap();
@@ -2111,8 +2110,7 @@ mod tests {
             &lexical_grammar,
             &simple_aliases,
             &variable_info,
-            // TODO: use `symbol_ids`
-            &HashMap::new(),
+            &symbol_ids,
         );
 
         return x;

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -736,9 +736,11 @@ pub fn generate_node_types_json(
                     .unwrap_or(&empty)
                     .iter()
                     .map(move |alias| {
-                        alias.as_ref().map_or((&token.name, token.kind, symbol), |alias| {
-                            (&alias.value, alias.kind(), symbol)
-                        })
+                        alias
+                            .as_ref()
+                            .map_or((&token.name, token.kind, symbol), |alias| {
+                                (&alias.value, alias.kind(), symbol)
+                            })
                     })
             });
 

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -2155,7 +2155,7 @@ mod tests {
             &unique_aliases,
             &variable_info,
             &symbol_ids,
-        );
+        )
     }
 
     fn build_syntax_grammar(

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -663,7 +663,7 @@ pub fn generate_node_types_json(
                         fields: Some(BTreeMap::new()),
                         children: None,
                         subtypes: None,
-                        symbol_ids: kind_to_symbol_ids.get(&(kind.clone(), true)).cloned(),
+                        symbol_ids: kind_to_symbol_ids.get(&(kind.clone(), is_named)).cloned(),
                     }
                 });
 

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 
 use super::{
     grammars::{LexicalGrammar, SyntaxGrammar, VariableType},
+    introspect_grammar::metadata_for_symbol,
     rules::{Alias, AliasMap, Symbol, SymbolType},
 };
 
@@ -487,19 +488,13 @@ pub fn generate_node_types_json(
             (alias.value.clone(), alias.is_named)
         } else {
             match symbol.kind {
-                SymbolType::NonTerminal => {
-                    let variable = &syntax_grammar.variables[symbol.index];
-                    (variable.name.clone(), variable.kind == VariableType::Named)
+                // TODO: check if `SymbolType::EndOfNonTerminalExtra` is correct
+                SymbolType::End => continue,
+                _ => {
+                    let (name, kind) =
+                        metadata_for_symbol(*symbol, syntax_grammar, lexical_grammar);
+                    (name.to_string(), kind == VariableType::Named)
                 }
-                SymbolType::Terminal => {
-                    let variable = &lexical_grammar.variables[symbol.index];
-                    (variable.name.clone(), variable.kind == VariableType::Named)
-                }
-                SymbolType::External => {
-                    let token = &syntax_grammar.external_tokens[symbol.index];
-                    (token.name.clone(), token.kind == VariableType::Named)
-                }
-                SymbolType::End | SymbolType::EndOfNonTerminalExtra => continue,
             }
         };
         kind_to_symbol_ids

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -1104,7 +1104,7 @@ mod tests {
                 Variable {
                     name: "v3".to_string(),
                     kind: VariableType::Named,
-                    rule: Rule::seq(vec![Rule::string("y"), Rule::repeat(Rule::string("z"))]),
+                    rule: Rule::seq(vec![Rule::string("y"), Rule::string("z")]),
                 },
             ],
             ..Default::default()
@@ -1480,6 +1480,7 @@ mod tests {
                     rule: Rule::pattern("[\\w-]+", ""),
                 },
             ],
+            expected_conflicts: vec![vec!["type".to_string(), "expression".to_string()]],
             ..Default::default()
         })
         .unwrap();

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -474,6 +474,7 @@ pub fn generate_node_types_json(
     syntax_grammar: &SyntaxGrammar,
     lexical_grammar: &LexicalGrammar,
     default_aliases: &AliasMap,
+    unique_aliases: &Vec<(Alias, u16)>,
     variable_info: &[VariableInfo],
     symbol_ids: &HashMap<Symbol, (String, u16)>,
 ) -> SuperTypeCycleResult<Vec<NodeInfoJSON>> {
@@ -506,6 +507,13 @@ pub fn generate_node_types_json(
             .entry((kind, is_named))
             .or_insert_with(Vec::new)
             .push(*numeric_id);
+    }
+
+    for unique_alias in unique_aliases {
+        kind_to_symbol_ids.insert(
+            (unique_alias.0.value.clone(), unique_alias.0.is_named),
+            vec![unique_alias.1],
+        );
     }
 
     // Sort the symbol IDs for each kind to ensure consistent ordering
@@ -2138,18 +2146,17 @@ mod tests {
             tables: _,
             symbol_ids,
             alias_ids: _,
-            unique_aliases: _,
+            unique_aliases,
         } = introspect_grammar(grammar, None, OptLevel::default()).unwrap();
 
-        let x = generate_node_types_json(
+        generate_node_types_json(
             &syntax_grammar,
             &lexical_grammar,
             &simple_aliases,
+            &unique_aliases,
             &variable_info,
             &symbol_ids,
         );
-
-        return x;
     }
 
     fn build_syntax_grammar(

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -857,8 +857,10 @@ mod tests {
         grammars::{
             InputGrammar, LexicalVariable, Production, ProductionStep, SyntaxVariable, Variable,
         },
+        introspect_grammar,
         prepare_grammar::prepare_grammar,
         rules::Rule,
+        GrammarIntrospection, OptLevel,
     };
 
     #[test]
@@ -2091,17 +2093,28 @@ mod tests {
     }
 
     fn get_node_types(grammar: &InputGrammar) -> SuperTypeCycleResult<Vec<NodeInfoJSON>> {
-        let (syntax_grammar, lexical_grammar, _, default_aliases) =
-            prepare_grammar(grammar).unwrap();
-        let variable_info =
-            get_variable_info(&syntax_grammar, &lexical_grammar, &default_aliases).unwrap();
-        generate_node_types_json(
+        let GrammarIntrospection {
+            syntax_grammar,
+            lexical_grammar,
+            simple_aliases,
+            variable_info,
+            supertype_symbol_map: _,
+            tables: _,
+            symbol_ids: _,
+            alias_ids: _,
+            unique_aliases: _,
+        } = introspect_grammar(grammar, None, OptLevel::default()).unwrap();
+
+        let x = generate_node_types_json(
             &syntax_grammar,
             &lexical_grammar,
-            &default_aliases,
+            &simple_aliases,
             &variable_info,
+            // TODO: use `symbol_ids`
             &HashMap::new(),
-        )
+        );
+
+        return x;
     }
 
     fn build_syntax_grammar(

--- a/crates/generate/src/render.rs
+++ b/crates/generate/src/render.rs
@@ -1,11 +1,14 @@
 use std::{
     cmp,
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
     fmt::Write,
     mem::swap,
 };
 
-use crate::LANGUAGE_VERSION;
+use crate::{
+    introspect_grammar::{metadata_for_symbol, sanitize_identifier},
+    LANGUAGE_VERSION,
+};
 use indoc::indoc;
 
 use super::{
@@ -245,9 +248,9 @@ impl Generator {
                             }
 
                             if alias.is_named {
-                                format!("alias_sym_{}", self.sanitize_identifier(&alias.value))
+                                format!("alias_sym_{}", sanitize_identifier(&alias.value))
                             } else {
-                                format!("anon_alias_sym_{}", self.sanitize_identifier(&alias.value))
+                                format!("anon_alias_sym_{}", sanitize_identifier(&alias.value))
                             }
                         };
 
@@ -1700,10 +1703,7 @@ impl Generator {
     }
 
     fn external_token_id(&self, token: &ExternalToken) -> String {
-        format!(
-            "ts_external_token_{}",
-            self.sanitize_identifier(&token.name)
-        )
+        format!("ts_external_token_{}", sanitize_identifier(&token.name))
     }
 
     fn field_id(&self, field_name: &str) -> String {
@@ -1729,10 +1729,6 @@ impl Generator {
                 )
             })
             .collect()
-    }
-
-    fn sanitize_identifier(&self, name: &str) -> String {
-        sanitize_identifier(name)
     }
 
     fn sanitize_string(&self, name: &str) -> String {
@@ -1778,301 +1774,6 @@ impl Generator {
             }
         }
     }
-}
-
-/// Helper function to sanitize identifiers for C code generation.
-fn sanitize_identifier(name: &str) -> String {
-    let mut result = String::with_capacity(name.len());
-    for c in name.chars() {
-        if c.is_ascii_alphanumeric() || c == '_' {
-            result.push(c);
-        } else {
-            'special_chars: {
-                let replacement = match c {
-                    ' ' if name.len() == 1 => "SPACE",
-                    '~' => "TILDE",
-                    '`' => "BQUOTE",
-                    '!' => "BANG",
-                    '@' => "AT",
-                    '#' => "POUND",
-                    '$' => "DOLLAR",
-                    '%' => "PERCENT",
-                    '^' => "CARET",
-                    '&' => "AMP",
-                    '*' => "STAR",
-                    '(' => "LPAREN",
-                    ')' => "RPAREN",
-                    '-' => "DASH",
-                    '+' => "PLUS",
-                    '=' => "EQ",
-                    '{' => "LBRACE",
-                    '}' => "RBRACE",
-                    '[' => "LBRACK",
-                    ']' => "RBRACK",
-                    '\\' => "BSLASH",
-                    '|' => "PIPE",
-                    ':' => "COLON",
-                    ';' => "SEMI",
-                    '"' => "DQUOTE",
-                    '\'' => "SQUOTE",
-                    '<' => "LT",
-                    '>' => "GT",
-                    ',' => "COMMA",
-                    '.' => "DOT",
-                    '?' => "QMARK",
-                    '/' => "SLASH",
-                    '\n' => "LF",
-                    '\r' => "CR",
-                    '\t' => "TAB",
-                    '\0' => "NULL",
-                    '\u{0001}' => "SOH",
-                    '\u{0002}' => "STX",
-                    '\u{0003}' => "ETX",
-                    '\u{0004}' => "EOT",
-                    '\u{0005}' => "ENQ",
-                    '\u{0006}' => "ACK",
-                    '\u{0007}' => "BEL",
-                    '\u{0008}' => "BS",
-                    '\u{000b}' => "VTAB",
-                    '\u{000c}' => "FF",
-                    '\u{000e}' => "SO",
-                    '\u{000f}' => "SI",
-                    '\u{0010}' => "DLE",
-                    '\u{0011}' => "DC1",
-                    '\u{0012}' => "DC2",
-                    '\u{0013}' => "DC3",
-                    '\u{0014}' => "DC4",
-                    '\u{0015}' => "NAK",
-                    '\u{0016}' => "SYN",
-                    '\u{0017}' => "ETB",
-                    '\u{0018}' => "CAN",
-                    '\u{0019}' => "EM",
-                    '\u{001a}' => "SUB",
-                    '\u{001b}' => "ESC",
-                    '\u{001c}' => "FS",
-                    '\u{001d}' => "GS",
-                    '\u{001e}' => "RS",
-                    '\u{001f}' => "US",
-                    '\u{007F}' => "DEL",
-                    '\u{FEFF}' => "BOM",
-                    '\u{0080}'..='\u{FFFF}' => {
-                        write!(result, "u{:04x}", c as u32).unwrap();
-                        break 'special_chars;
-                    }
-                    '\u{10000}'..='\u{10FFFF}' => {
-                        write!(result, "U{:08x}", c as u32).unwrap();
-                        break 'special_chars;
-                    }
-                    '0'..='9' | 'a'..='z' | 'A'..='Z' | '_' => unreachable!(),
-                    ' ' => break 'special_chars,
-                };
-                if !result.is_empty() && !result.ends_with('_') {
-                    result.push('_');
-                }
-                result += replacement;
-            }
-        }
-    }
-    result
-}
-
-/// Helper function to get metadata for a symbol.
-fn metadata_for_symbol<'a>(
-    symbol: Symbol,
-    syntax_grammar: &'a SyntaxGrammar,
-    lexical_grammar: &'a LexicalGrammar,
-) -> (&'a str, VariableType) {
-    match symbol.kind {
-        SymbolType::End | SymbolType::EndOfNonTerminalExtra => ("end", VariableType::Hidden),
-        SymbolType::NonTerminal => {
-            let variable = &syntax_grammar.variables[symbol.index];
-            (&variable.name as &str, variable.kind)
-        }
-        SymbolType::Terminal => {
-            let variable = &lexical_grammar.variables[symbol.index];
-            (&variable.name as &str, variable.kind)
-        }
-        SymbolType::External => {
-            let token = &syntax_grammar.external_tokens[symbol.index];
-            (&token.name as &str, token.kind)
-        }
-    }
-}
-
-/// Helper function to assign a symbol ID.
-fn assign_symbol_id(
-    symbol: Symbol,
-    syntax_grammar: &SyntaxGrammar,
-    lexical_grammar: &LexicalGrammar,
-    symbol_ids: &mut HashMap<Symbol, (String, u16)>,
-    used_identifiers: &mut HashSet<String>,
-    numeric_id: u16,
-) {
-    let mut id;
-    if symbol == Symbol::end() {
-        id = "ts_builtin_sym_end".to_string();
-    } else {
-        let (name, kind) = metadata_for_symbol(symbol, syntax_grammar, lexical_grammar);
-        id = match kind {
-            VariableType::Auxiliary => format!("aux_sym_{}", sanitize_identifier(name)),
-            VariableType::Anonymous => format!("anon_sym_{}", sanitize_identifier(name)),
-            VariableType::Hidden | VariableType::Named => {
-                format!("sym_{}", sanitize_identifier(name))
-            }
-        };
-
-        let mut suffix_number = 1;
-        let mut suffix = String::new();
-        while used_identifiers.contains(&id) {
-            id.drain(id.len() - suffix.len()..);
-            suffix_number += 1;
-            suffix = suffix_number.to_string();
-            id += &suffix;
-        }
-    }
-
-    used_identifiers.insert(id.clone());
-    symbol_ids.insert(symbol, (id, numeric_id));
-}
-
-/// Generates symbol IDs and alias IDs for the given parse table and grammars.
-///
-/// This function must be called before `render_c_code` to generate the symbol mappings
-/// that will be used in the generated C code.
-///
-/// # Arguments
-///
-/// * `parse_table` - The generated parse table for the language
-/// * `syntax_grammar` - The syntax grammar extracted from the language's grammar
-/// * `lexical_grammar` - The lexical grammar extracted from the language's grammar
-/// * `default_aliases` - A map describing the global rename rules that should apply
-///
-/// # Returns
-///
-/// A tuple containing:
-/// * `symbol_ids` - HashMap mapping each Symbol to (C identifier string, numeric ID)
-/// * `alias_ids` - HashMap mapping each Alias to its C identifier string
-/// * `unique_aliases` - Sorted vector of unique aliases
-pub fn generate_symbol_ids(
-    parse_table: &ParseTable,
-    syntax_grammar: &SyntaxGrammar,
-    lexical_grammar: &LexicalGrammar,
-    default_aliases: &AliasMap,
-) -> (
-    HashMap<Symbol, (String, u16)>,
-    HashMap<Alias, String>,
-    Vec<Alias>,
-) {
-    let mut symbol_ids = HashMap::new();
-    let mut alias_ids = HashMap::new();
-    let mut unique_aliases = Vec::new();
-    let mut symbol_identifiers = HashSet::new();
-
-    // Generate symbol IDs with numeric IDs
-    // Symbol::end() gets 0, then other symbols get 1, 2, 3...
-    let mut numeric_id = 0u16;
-    for &symbol in &parse_table.symbols {
-        assign_symbol_id(
-            symbol,
-            syntax_grammar,
-            lexical_grammar,
-            &mut symbol_ids,
-            &mut symbol_identifiers,
-            numeric_id,
-        );
-        numeric_id += 1;
-    }
-
-    symbol_ids.insert(
-        Symbol::end_of_nonterminal_extra(),
-        symbol_ids[&Symbol::end()].clone(),
-    );
-
-    // Build symbol map to find canonical symbols for aliases
-    let mut symbol_map = HashMap::new();
-    for symbol in &parse_table.symbols {
-        let mut mapping = symbol;
-
-        if let Some(alias) = default_aliases.get(symbol) {
-            let kind = alias.kind();
-            for other_symbol in &parse_table.symbols {
-                if let Some(other_alias) = default_aliases.get(other_symbol) {
-                    if other_symbol < mapping && other_alias == alias {
-                        mapping = other_symbol;
-                    }
-                } else {
-                    let (other_name, other_kind) =
-                        metadata_for_symbol(*other_symbol, syntax_grammar, lexical_grammar);
-                    if (other_name, other_kind) == (alias.value.as_str(), kind) {
-                        mapping = other_symbol;
-                        break;
-                    }
-                }
-            }
-        } else if symbol.is_terminal() {
-            let metadata = metadata_for_symbol(*symbol, syntax_grammar, lexical_grammar);
-            for other_symbol in &parse_table.symbols {
-                let other_metadata =
-                    metadata_for_symbol(*other_symbol, syntax_grammar, lexical_grammar);
-                if other_metadata == metadata {
-                    if let Some(mapped) = symbol_map.get(other_symbol) {
-                        if mapped == symbol {
-                            break;
-                        }
-                    }
-                    mapping = other_symbol;
-                    break;
-                }
-            }
-        }
-
-        symbol_map.insert(*symbol, *mapping);
-    }
-
-    // Generate alias IDs
-    for production_info in &parse_table.production_infos {
-        for alias in &production_info.alias_sequence {
-            if let Some(alias) = &alias {
-                // Find symbols that match this alias
-                let matching_symbols: Vec<Symbol> = parse_table
-                    .symbols
-                    .iter()
-                    .copied()
-                    .filter(|symbol| {
-                        default_aliases.get(symbol).map_or_else(
-                            || {
-                                let (name, kind) =
-                                    metadata_for_symbol(*symbol, syntax_grammar, lexical_grammar);
-                                name == alias.value && kind == alias.kind()
-                            },
-                            |default_alias| default_alias == alias,
-                        )
-                    })
-                    .collect();
-
-                // Some aliases match an existing symbol in the grammar.
-                let alias_id = if let Some(existing_symbol) = matching_symbols.first() {
-                    symbol_ids[&symbol_map[existing_symbol]].0.clone()
-                }
-                // Other aliases don't match any existing symbol, and need their own identifiers.
-                else {
-                    if let Err(i) = unique_aliases.binary_search(alias) {
-                        unique_aliases.insert(i, alias.clone());
-                    }
-
-                    if alias.is_named {
-                        format!("alias_sym_{}", sanitize_identifier(&alias.value))
-                    } else {
-                        format!("anon_alias_sym_{}", sanitize_identifier(&alias.value))
-                    }
-                };
-
-                alias_ids.entry(alias.clone()).or_insert(alias_id);
-            }
-        }
-    }
-
-    (symbol_ids, alias_ids, unique_aliases)
 }
 
 /// Returns a String of C code for the given components of a parser.

--- a/crates/generate/src/render.rs
+++ b/crates/generate/src/render.rs
@@ -1700,7 +1700,6 @@ impl Generator {
         )
     }
 
-
     fn field_id(&self, field_name: &str) -> String {
         format!("field_{field_name}")
     }

--- a/crates/generate/src/render.rs
+++ b/crates/generate/src/render.rs
@@ -231,32 +231,6 @@ impl Generator {
                     self.field_names.insert(i, field_name.clone());
                 }
             }
-
-            for alias in &production_info.alias_sequence {
-                // Generate a mapping from aliases to C identifiers.
-                if let Some(alias) = &alias {
-                    // Some aliases match an existing symbol in the grammar.
-                    let alias_id =
-                        if let Some(existing_symbol) = self.symbols_for_alias(alias).first() {
-                            self.symbol_ids[&self.symbol_map[existing_symbol]].0.clone()
-                        }
-                        // Other aliases don't match any existing symbol, and need their own
-                        // identifiers.
-                        else {
-                            if let Err(i) = self.unique_aliases.binary_search(alias) {
-                                self.unique_aliases.insert(i, alias.clone());
-                            }
-
-                            if alias.is_named {
-                                format!("alias_sym_{}", sanitize_identifier(&alias.value))
-                            } else {
-                                format!("anon_alias_sym_{}", sanitize_identifier(&alias.value))
-                            }
-                        };
-
-                    self.alias_ids.entry(alias.clone()).or_insert(alias_id);
-                }
-            }
         }
 
         for (ix, (symbol, _)) in self.large_character_sets.iter().enumerate() {

--- a/crates/generate/src/render.rs
+++ b/crates/generate/src/render.rs
@@ -175,15 +175,7 @@ impl Generator {
     }
 
     fn init(&mut self) {
-        let mut symbol_identifiers = HashSet::new();
-        for i in 0..self.parse_table.symbols.len() {
-            self.assign_symbol_id(self.parse_table.symbols[i], &mut symbol_identifiers);
-        }
-        self.symbol_ids.insert(
-            Symbol::end_of_nonterminal_extra(),
-            self.symbol_ids[&Symbol::end()].clone(),
-        );
-
+        // symbol_ids and alias_ids are now passed in from the constructor
         self.symbol_map = HashMap::new();
 
         for symbol in &self.parse_table.symbols {
@@ -1708,54 +1700,13 @@ impl Generator {
         )
     }
 
-    fn assign_symbol_id(&mut self, symbol: Symbol, used_identifiers: &mut HashSet<String>) {
-        let mut id;
-        if symbol == Symbol::end() {
-            id = "ts_builtin_sym_end".to_string();
-        } else {
-            let (name, kind) = self.metadata_for_symbol(symbol);
-            id = match kind {
-                VariableType::Auxiliary => format!("aux_sym_{}", self.sanitize_identifier(name)),
-                VariableType::Anonymous => format!("anon_sym_{}", self.sanitize_identifier(name)),
-                VariableType::Hidden | VariableType::Named => {
-                    format!("sym_{}", self.sanitize_identifier(name))
-                }
-            };
-
-            let mut suffix_number = 1;
-            let mut suffix = String::new();
-            while used_identifiers.contains(&id) {
-                id.drain(id.len() - suffix.len()..);
-                suffix_number += 1;
-                suffix = suffix_number.to_string();
-                id += &suffix;
-            }
-        }
-
-        used_identifiers.insert(id.clone());
-        self.symbol_ids.insert(symbol, id);
-    }
 
     fn field_id(&self, field_name: &str) -> String {
         format!("field_{field_name}")
     }
 
     fn metadata_for_symbol(&self, symbol: Symbol) -> (&str, VariableType) {
-        match symbol.kind {
-            SymbolType::End | SymbolType::EndOfNonTerminalExtra => ("end", VariableType::Hidden),
-            SymbolType::NonTerminal => {
-                let variable = &self.syntax_grammar.variables[symbol.index];
-                (&variable.name, variable.kind)
-            }
-            SymbolType::Terminal => {
-                let variable = &self.lexical_grammar.variables[symbol.index];
-                (&variable.name, variable.kind)
-            }
-            SymbolType::External => {
-                let token = &self.syntax_grammar.external_tokens[symbol.index];
-                (&token.name, token.kind)
-            }
-        }
+        metadata_for_symbol(symbol, &self.syntax_grammar, &self.lexical_grammar)
     }
 
     fn symbols_for_alias(&self, alias: &Alias) -> Vec<Symbol> {
@@ -1776,98 +1727,7 @@ impl Generator {
     }
 
     fn sanitize_identifier(&self, name: &str) -> String {
-        let mut result = String::with_capacity(name.len());
-        for c in name.chars() {
-            if c.is_ascii_alphanumeric() || c == '_' {
-                result.push(c);
-            } else {
-                'special_chars: {
-                    let replacement = match c {
-                        ' ' if name.len() == 1 => "SPACE",
-                        '~' => "TILDE",
-                        '`' => "BQUOTE",
-                        '!' => "BANG",
-                        '@' => "AT",
-                        '#' => "POUND",
-                        '$' => "DOLLAR",
-                        '%' => "PERCENT",
-                        '^' => "CARET",
-                        '&' => "AMP",
-                        '*' => "STAR",
-                        '(' => "LPAREN",
-                        ')' => "RPAREN",
-                        '-' => "DASH",
-                        '+' => "PLUS",
-                        '=' => "EQ",
-                        '{' => "LBRACE",
-                        '}' => "RBRACE",
-                        '[' => "LBRACK",
-                        ']' => "RBRACK",
-                        '\\' => "BSLASH",
-                        '|' => "PIPE",
-                        ':' => "COLON",
-                        ';' => "SEMI",
-                        '"' => "DQUOTE",
-                        '\'' => "SQUOTE",
-                        '<' => "LT",
-                        '>' => "GT",
-                        ',' => "COMMA",
-                        '.' => "DOT",
-                        '?' => "QMARK",
-                        '/' => "SLASH",
-                        '\n' => "LF",
-                        '\r' => "CR",
-                        '\t' => "TAB",
-                        '\0' => "NULL",
-                        '\u{0001}' => "SOH",
-                        '\u{0002}' => "STX",
-                        '\u{0003}' => "ETX",
-                        '\u{0004}' => "EOT",
-                        '\u{0005}' => "ENQ",
-                        '\u{0006}' => "ACK",
-                        '\u{0007}' => "BEL",
-                        '\u{0008}' => "BS",
-                        '\u{000b}' => "VTAB",
-                        '\u{000c}' => "FF",
-                        '\u{000e}' => "SO",
-                        '\u{000f}' => "SI",
-                        '\u{0010}' => "DLE",
-                        '\u{0011}' => "DC1",
-                        '\u{0012}' => "DC2",
-                        '\u{0013}' => "DC3",
-                        '\u{0014}' => "DC4",
-                        '\u{0015}' => "NAK",
-                        '\u{0016}' => "SYN",
-                        '\u{0017}' => "ETB",
-                        '\u{0018}' => "CAN",
-                        '\u{0019}' => "EM",
-                        '\u{001a}' => "SUB",
-                        '\u{001b}' => "ESC",
-                        '\u{001c}' => "FS",
-                        '\u{001d}' => "GS",
-                        '\u{001e}' => "RS",
-                        '\u{001f}' => "US",
-                        '\u{007F}' => "DEL",
-                        '\u{FEFF}' => "BOM",
-                        '\u{0080}'..='\u{FFFF}' => {
-                            write!(result, "u{:04x}", c as u32).unwrap();
-                            break 'special_chars;
-                        }
-                        '\u{10000}'..='\u{10FFFF}' => {
-                            write!(result, "U{:08x}", c as u32).unwrap();
-                            break 'special_chars;
-                        }
-                        '0'..='9' | 'a'..='z' | 'A'..='Z' | '_' => unreachable!(),
-                        ' ' => break 'special_chars,
-                    };
-                    if !result.is_empty() && !result.ends_with('_') {
-                        result.push('_');
-                    }
-                    result += replacement;
-                }
-            }
-        }
-        result
+        sanitize_identifier(name)
     }
 
     fn sanitize_string(&self, name: &str) -> String {
@@ -1915,23 +1775,311 @@ impl Generator {
     }
 }
 
+/// Helper function to sanitize identifiers for C code generation.
+fn sanitize_identifier(name: &str) -> String {
+    let mut result = String::with_capacity(name.len());
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' {
+            result.push(c);
+        } else {
+            'special_chars: {
+                let replacement = match c {
+                    ' ' if name.len() == 1 => "SPACE",
+                    '~' => "TILDE",
+                    '`' => "BQUOTE",
+                    '!' => "BANG",
+                    '@' => "AT",
+                    '#' => "POUND",
+                    '$' => "DOLLAR",
+                    '%' => "PERCENT",
+                    '^' => "CARET",
+                    '&' => "AMP",
+                    '*' => "STAR",
+                    '(' => "LPAREN",
+                    ')' => "RPAREN",
+                    '-' => "DASH",
+                    '+' => "PLUS",
+                    '=' => "EQ",
+                    '{' => "LBRACE",
+                    '}' => "RBRACE",
+                    '[' => "LBRACK",
+                    ']' => "RBRACK",
+                    '\\' => "BSLASH",
+                    '|' => "PIPE",
+                    ':' => "COLON",
+                    ';' => "SEMI",
+                    '"' => "DQUOTE",
+                    '\'' => "SQUOTE",
+                    '<' => "LT",
+                    '>' => "GT",
+                    ',' => "COMMA",
+                    '.' => "DOT",
+                    '?' => "QMARK",
+                    '/' => "SLASH",
+                    '\n' => "LF",
+                    '\r' => "CR",
+                    '\t' => "TAB",
+                    '\0' => "NULL",
+                    '\u{0001}' => "SOH",
+                    '\u{0002}' => "STX",
+                    '\u{0003}' => "ETX",
+                    '\u{0004}' => "EOT",
+                    '\u{0005}' => "ENQ",
+                    '\u{0006}' => "ACK",
+                    '\u{0007}' => "BEL",
+                    '\u{0008}' => "BS",
+                    '\u{000b}' => "VTAB",
+                    '\u{000c}' => "FF",
+                    '\u{000e}' => "SO",
+                    '\u{000f}' => "SI",
+                    '\u{0010}' => "DLE",
+                    '\u{0011}' => "DC1",
+                    '\u{0012}' => "DC2",
+                    '\u{0013}' => "DC3",
+                    '\u{0014}' => "DC4",
+                    '\u{0015}' => "NAK",
+                    '\u{0016}' => "SYN",
+                    '\u{0017}' => "ETB",
+                    '\u{0018}' => "CAN",
+                    '\u{0019}' => "EM",
+                    '\u{001a}' => "SUB",
+                    '\u{001b}' => "ESC",
+                    '\u{001c}' => "FS",
+                    '\u{001d}' => "GS",
+                    '\u{001e}' => "RS",
+                    '\u{001f}' => "US",
+                    '\u{007F}' => "DEL",
+                    '\u{FEFF}' => "BOM",
+                    '\u{0080}'..='\u{FFFF}' => {
+                        write!(result, "u{:04x}", c as u32).unwrap();
+                        break 'special_chars;
+                    }
+                    '\u{10000}'..='\u{10FFFF}' => {
+                        write!(result, "U{:08x}", c as u32).unwrap();
+                        break 'special_chars;
+                    }
+                    '0'..='9' | 'a'..='z' | 'A'..='Z' | '_' => unreachable!(),
+                    ' ' => break 'special_chars,
+                };
+                if !result.is_empty() && !result.ends_with('_') {
+                    result.push('_');
+                }
+                result += replacement;
+            }
+        }
+    }
+    result
+}
+
+/// Helper function to get metadata for a symbol.
+fn metadata_for_symbol<'a>(
+    symbol: Symbol,
+    syntax_grammar: &'a SyntaxGrammar,
+    lexical_grammar: &'a LexicalGrammar,
+) -> (&'a str, VariableType) {
+    match symbol.kind {
+        SymbolType::End | SymbolType::EndOfNonTerminalExtra => ("end", VariableType::Hidden),
+        SymbolType::NonTerminal => {
+            let variable = &syntax_grammar.variables[symbol.index];
+            (&variable.name as &str, variable.kind)
+        }
+        SymbolType::Terminal => {
+            let variable = &lexical_grammar.variables[symbol.index];
+            (&variable.name as &str, variable.kind)
+        }
+        SymbolType::External => {
+            let token = &syntax_grammar.external_tokens[symbol.index];
+            (&token.name as &str, token.kind)
+        }
+    }
+}
+
+/// Helper function to assign a symbol ID.
+fn assign_symbol_id(
+    symbol: Symbol,
+    syntax_grammar: &SyntaxGrammar,
+    lexical_grammar: &LexicalGrammar,
+    symbol_ids: &mut HashMap<Symbol, String>,
+    used_identifiers: &mut HashSet<String>,
+) {
+    let mut id;
+    if symbol == Symbol::end() {
+        id = "ts_builtin_sym_end".to_string();
+    } else {
+        let (name, kind) = metadata_for_symbol(symbol, syntax_grammar, lexical_grammar);
+        id = match kind {
+            VariableType::Auxiliary => format!("aux_sym_{}", sanitize_identifier(name)),
+            VariableType::Anonymous => format!("anon_sym_{}", sanitize_identifier(name)),
+            VariableType::Hidden | VariableType::Named => {
+                format!("sym_{}", sanitize_identifier(name))
+            }
+        };
+
+        let mut suffix_number = 1;
+        let mut suffix = String::new();
+        while used_identifiers.contains(&id) {
+            id.drain(id.len() - suffix.len()..);
+            suffix_number += 1;
+            suffix = suffix_number.to_string();
+            id += &suffix;
+        }
+    }
+
+    used_identifiers.insert(id.clone());
+    symbol_ids.insert(symbol, id);
+}
+
+/// Generates symbol IDs and alias IDs for the given parse table and grammars.
+///
+/// This function must be called before `render_c_code` to generate the symbol mappings
+/// that will be used in the generated C code.
+///
+/// # Arguments
+///
+/// * `parse_table` - The generated parse table for the language
+/// * `syntax_grammar` - The syntax grammar extracted from the language's grammar
+/// * `lexical_grammar` - The lexical grammar extracted from the language's grammar
+/// * `default_aliases` - A map describing the global rename rules that should apply
+///
+/// # Returns
+///
+/// A tuple containing:
+/// * `symbol_ids` - HashMap mapping each Symbol to its C identifier string
+/// * `alias_ids` - HashMap mapping each Alias to its C identifier string
+/// * `unique_aliases` - Sorted vector of unique aliases
+pub fn generate_symbol_ids(
+    parse_table: &ParseTable,
+    syntax_grammar: &SyntaxGrammar,
+    lexical_grammar: &LexicalGrammar,
+    default_aliases: &AliasMap,
+) -> (HashMap<Symbol, String>, HashMap<Alias, String>, Vec<Alias>) {
+    let mut symbol_ids = HashMap::new();
+    let mut alias_ids = HashMap::new();
+    let mut unique_aliases = Vec::new();
+    let mut symbol_identifiers = HashSet::new();
+
+    // Generate symbol IDs
+    for i in 0..parse_table.symbols.len() {
+        assign_symbol_id(
+            parse_table.symbols[i],
+            syntax_grammar,
+            lexical_grammar,
+            &mut symbol_ids,
+            &mut symbol_identifiers,
+        );
+    }
+
+    symbol_ids.insert(
+        Symbol::end_of_nonterminal_extra(),
+        symbol_ids[&Symbol::end()].clone(),
+    );
+
+    // Build symbol map to find canonical symbols for aliases
+    let mut symbol_map = HashMap::new();
+    for symbol in &parse_table.symbols {
+        let mut mapping = symbol;
+
+        if let Some(alias) = default_aliases.get(symbol) {
+            let kind = alias.kind();
+            for other_symbol in &parse_table.symbols {
+                if let Some(other_alias) = default_aliases.get(other_symbol) {
+                    if other_symbol < mapping && other_alias == alias {
+                        mapping = other_symbol;
+                    }
+                } else {
+                    let (other_name, other_kind) =
+                        metadata_for_symbol(*other_symbol, syntax_grammar, lexical_grammar);
+                    if (other_name, other_kind) == (alias.value.as_str(), kind) {
+                        mapping = other_symbol;
+                        break;
+                    }
+                }
+            }
+        } else if symbol.is_terminal() {
+            let metadata = metadata_for_symbol(*symbol, syntax_grammar, lexical_grammar);
+            for other_symbol in &parse_table.symbols {
+                let other_metadata =
+                    metadata_for_symbol(*other_symbol, syntax_grammar, lexical_grammar);
+                if other_metadata == metadata {
+                    if let Some(mapped) = symbol_map.get(other_symbol) {
+                        if mapped == symbol {
+                            break;
+                        }
+                    }
+                    mapping = other_symbol;
+                    break;
+                }
+            }
+        }
+
+        symbol_map.insert(*symbol, *mapping);
+    }
+
+    // Generate alias IDs
+    for production_info in &parse_table.production_infos {
+        for alias in &production_info.alias_sequence {
+            if let Some(alias) = &alias {
+                // Find symbols that match this alias
+                let matching_symbols: Vec<Symbol> = parse_table
+                    .symbols
+                    .iter()
+                    .copied()
+                    .filter(|symbol| {
+                        default_aliases.get(symbol).map_or_else(
+                            || {
+                                let (name, kind) =
+                                    metadata_for_symbol(*symbol, syntax_grammar, lexical_grammar);
+                                name == alias.value && kind == alias.kind()
+                            },
+                            |default_alias| default_alias == alias,
+                        )
+                    })
+                    .collect();
+
+                // Some aliases match an existing symbol in the grammar.
+                let alias_id = if let Some(existing_symbol) = matching_symbols.first() {
+                    symbol_ids[&symbol_map[existing_symbol]].clone()
+                }
+                // Other aliases don't match any existing symbol, and need their own identifiers.
+                else {
+                    if let Err(i) = unique_aliases.binary_search(alias) {
+                        unique_aliases.insert(i, alias.clone());
+                    }
+
+                    if alias.is_named {
+                        format!("alias_sym_{}", sanitize_identifier(&alias.value))
+                    } else {
+                        format!("anon_alias_sym_{}", sanitize_identifier(&alias.value))
+                    }
+                };
+
+                alias_ids.entry(alias.clone()).or_insert(alias_id);
+            }
+        }
+    }
+
+    (symbol_ids, alias_ids, unique_aliases)
+}
+
 /// Returns a String of C code for the given components of a parser.
 ///
 /// # Arguments
 ///
 /// * `name` - A string slice containing the name of the language
-/// * `parse_table` - The generated parse table for the language
-/// * `main_lex_table` - The generated lexing table for the language
-/// * `keyword_lex_table` - The generated keyword lexing table for the language
-/// * `keyword_capture_token` - A symbol indicating which token is used for keyword capture, if any.
+/// * `tables` - The generated tables for the language
 /// * `syntax_grammar` - The syntax grammar extracted from the language's grammar
 /// * `lexical_grammar` - The lexical grammar extracted from the language's grammar
 /// * `default_aliases` - A map describing the global rename rules that should apply. the keys are
 ///   symbols that are *always* aliased in the same way, and the values are the aliases that are
 ///   applied to those symbols.
+/// * `symbol_ids` - HashMap mapping each Symbol to its C identifier string
+/// * `alias_ids` - HashMap mapping each Alias to its C identifier string
+/// * `unique_aliases` - Sorted vector of unique aliases
 /// * `abi_version` - The language ABI version that should be generated. Usually you want
 ///   Tree-sitter's current version, but right after making an ABI change, it may be useful to
 ///   generate code with the previous ABI.
+/// * `semantic_version` - Optional semantic version of the parser
+/// * `supertype_symbol_map` - Map of supertype symbols
 #[allow(clippy::too_many_arguments)]
 pub fn render_c_code(
     name: &str,
@@ -1939,6 +2087,9 @@ pub fn render_c_code(
     syntax_grammar: SyntaxGrammar,
     lexical_grammar: LexicalGrammar,
     default_aliases: AliasMap,
+    symbol_ids: HashMap<Symbol, String>,
+    alias_ids: HashMap<Alias, String>,
+    unique_aliases: Vec<Alias>,
     abi_version: usize,
     semantic_version: Option<(u8, u8, u8)>,
     supertype_symbol_map: BTreeMap<Symbol, Vec<ChildType>>,
@@ -1958,6 +2109,9 @@ pub fn render_c_code(
         syntax_grammar,
         lexical_grammar,
         default_aliases,
+        symbol_ids,
+        alias_ids,
+        unique_aliases,
         abi_version,
         metadata: semantic_version.map(|(major_version, minor_version, patch_version)| Metadata {
             major_version,

--- a/docs/src/assets/schemas/node-types.schema.json
+++ b/docs/src/assets/schemas/node-types.schema.json
@@ -42,8 +42,11 @@
             "$ref": "#/definitions/NodeType"
           }
         },
-        "symbol_id": {
-          "type": "integer"
+        "symbol_ids": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
         }
       },
       "oneOf": [

--- a/docs/src/assets/schemas/node-types.schema.json
+++ b/docs/src/assets/schemas/node-types.schema.json
@@ -41,6 +41,9 @@
           "items": {
             "$ref": "#/definitions/NodeType"
           }
+        },
+        "symbol_id": {
+          "type": "integer"
         }
       },
       "oneOf": [

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756787288,
-        "narHash": "sha256-rw/PHa1cqiePdBxhF66V7R+WAP8WekQ0mCDG4CFqT8Y=",
+        "lastModified": 1762977756,
+        "narHash": "sha256-4PqRErxfe+2toFJFgcRKZ0UI9NSIOJa+7RXVtBhy4KE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d0fc30899600b9b3466ddb260fd83deb486c32f1",
+        "rev": "c5ae371f1a6a7fd27823bc500d9390b38c05fa55",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -326,7 +326,7 @@
               clippy
               rust-analyzer
               rustfmt
-              cargo-llvm-cov
+              # cargo-llvm-cov
 
               cmake
               gnumake


### PR DESCRIPTION
This PR addresses issue #3276.
I’ve tested this change with a small toy grammar, but it still needs further validation and review.
Please let me know if there are additional steps or improvements I should make.

# Notes
I separated [`enum ts_symbol_identifiers` value generation](https://github.com/tree-sitter/tree-sitter/blob/877782a8a41d830f9e7f0f22dfcb67b3c2e50418/crates/generate/src/render.rs#L424-L443) from [render.rs](https://github.com/tree-sitter/tree-sitter/blob/master/crates/generate/src/render.rs). Each numeric id of the symbols is generated in [generate_symbol_ids](https://github.com/bglgwyng/tree-sitter/blob/fc747bce5329833ddb6a59ff306c662450531160/crates/generate/src/introspect_grammar.rs#L89) and used both in the generation of `node-types.json` and `parser.c`. This implementation guarantees that both will use the same value for it.

# Questions
- I added `symbol_ids` field to each node types. In my case, it gives enough information to handle the retrieved AST, like [this](https://github.com/github/semantic/blob/main/semantic-json/src/Language/JSON/AST.hs#L107). Is it generally enough?
- I added `introspect_grammar` but it seems needlessly separated from `prepare_grammar`. What about merging `introspect_grammar` into `prepare_grammar`? Then `prepare_grammar` builds parsing tables also.
- To print proper parsing error message, which indicates which symbol is expected to come, Do we need to add `symbol_id` field in `grammar.json` to look for the corresponding symbol name of its id? This job is not done yet.