### PR TITLE
fix(docs): don't show mdbook help popup when using query editor

### DIFF
--- a/docs/src/assets/js/playground.js
+++ b/docs/src/assets/js/playground.js
@@ -146,8 +146,9 @@ window.initializePlayground = async (opts) => {
   });
 
   queryEditor.on('keydown', (_, event) => {
-    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
-      event.stopPropagation(); // Prevent mdBook from going back/forward
+    const key = event.key;
+    if (key === 'ArrowLeft' || key === 'ArrowRight' || key === '?') {
+      event.stopPropagation(); // Prevent mdBook from going back/forward, or showing help
     }
   });
 


### PR DESCRIPTION
Follow-up for #4550
That PR only fixed it for the Code editor, but not the Query editor. Typing a `?` there still opened the mdbook help dialog instead.