### PR TITLE
fix(docs): Install tree-sitter-cli globally using npm

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -20,7 +20,7 @@ cargo install --locked tree-sitter-cli
 or with `npm`:
 
 ```sh
-npm install tree-sitter-cli
+npm install -g tree-sitter-cli
 ```
 
 You can also download a pre-built binary for your platform from [the releases page].


### PR DESCRIPTION
I was following the instructions, and the `npm install tree-sitter-cli` command will install the tool in the current working directory (cwd) and not as a global dependency. I assume we want this to be globally available; if not, feel free to reject this PR :)