### PR TITLE
fix(loader): set correct runtime host for cc while cross-compiling

### DIFF
--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -557,7 +557,6 @@ impl Config {
 }
 
 const BUILD_TARGET: &str = env!("BUILD_TARGET");
-const BUILD_HOST: &str = env!("BUILD_HOST");
 
 pub struct LanguageConfiguration<'a> {
     pub scope: Option<String>,
@@ -1107,7 +1106,10 @@ impl Loader {
             .cargo_metadata(false)
             .cargo_warnings(false)
             .target(BUILD_TARGET)
-            .host(BUILD_HOST)
+            // BUILD_TARGET from the build environment becomes a runtime host for cc.
+            // Otherwise, when cross compiled, cc will keep looking for a cross-compiler
+            // on the target system instead of the native compiler.
+            .host(BUILD_TARGET)
             .debug(self.debug_build)
             .file(&config.parser_path)
             .includes(&config.header_paths)


### PR DESCRIPTION
Pass the BUILD_TARGET variable from the build environment as 'host' for the cc crate. Otherwise, when cross-compiled, cc will keep looking for a cross-compiler instead of the native one on the target system. The initial BUILD_TARGET represents a runtime host after all. The change will have no effect outside of the case of cross-compiling tree-sitter's CLI tool.

Fixes #5067.