### PR TITLE
docs: fix typo in the page about ABI version

### DIFF
--- a/docs/src/using-parsers/7-abi-versions.md
+++ b/docs/src/using-parsers/7-abi-versions.md
@@ -14,7 +14,7 @@ A given version of the tree-sitter library is only able to load parsers which ha
 | >=0.20.3, <=0.24    | 13                     | 14                     |
 | >=0.25              | 13                     | 15                     |
 
-By default, the tree-sitter CLI will generate parser using the latest available ABI for that version. Grammar authors can specify an older ABI (within the constraints _of the CLI_, which may be stricter than the library!) via the `--abi` option to the `generate` command:
+By default, the tree-sitter CLI will generate parsers using the latest available ABI for that version. Grammar authors can specify an older ABI (within the constraints _of the CLI_, which may be stricter than the library!) via the `--abi` option to the `generate` command:
 ```
 tree-sitter generate --abi=<DESIRED-ABI>
 ```


### PR DESCRIPTION
Of course I only catch that once they are already published…