### PR TITLE
fix: generated node bindings work out of the box

### DIFF
--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -337,7 +337,7 @@ pub fn generate_grammar_files(
                     "tree-sitter-cli":"#},
                     indoc! {r#"
                     "prebuildify": "^6.0.1",
-                    "tree-sitter": "^0.22.4",
+                    "tree-sitter": "^0.25.0",
                     "tree-sitter-cli":"#},
                 );
             if !contents.contains("module") {

--- a/crates/cli/src/templates/package.json
+++ b/crates/cli/src/templates/package.json
@@ -38,11 +38,11 @@
   },
   "devDependencies": {
     "prebuildify": "^6.0.1",
-    "tree-sitter": "^0.22.4",
+    "tree-sitter": "^0.25.0",
     "tree-sitter-cli": "^CLI_VERSION"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.22.4"
+    "tree-sitter": "^0.25.0"
   },
   "peerDependenciesMeta": {
     "tree-sitter": {


### PR DESCRIPTION
Fixes #5081.

This looks a bit too obvious, so I assume I misunderstood something, although it does solve the problem on my side.