### PR TITLE
fix(query): prevent infinite loop with `+` and `?` quantifiers

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -5032,6 +5032,26 @@ fn test_query_quantified_captures() {
                 ("comment.documentation", "// quuz"),
             ],
         },
+        Row {
+            description: "multiple quantifiers should not hang query parsing",
+            language: get_language("c"),
+            code: indoc! {"
+            // foo
+            // bar
+            // baz
+        "},
+            pattern: r"
+                ((comment) ?+ @comment)
+            ",
+            // This should be identical to the `*` quantifier.
+            captures: &[
+                ("comment", "// foo"),
+                ("comment", "// foo"),
+                ("comment", "// foo"),
+                ("comment", "// bar"),
+                ("comment", "// baz"),
+            ],
+        },
     ];
 
     allocations::record(|| {


### PR DESCRIPTION
**Problem:** A query with a `?` quantifier followed by a `+` quantifier would hang at 100% CPU usage while iterating through a tree, regardless of the source content.

**Solution:** Collect all quantifiers in one step, and then add the required repeat/optional step logic *after* we have determined the composite quantifier we need to use for the current step.