### PR TITLE
docs: remove manual bindings update steps for scanner

### DIFF
--- a/docs/src/creating-parsers/4-external-scanners.md
+++ b/docs/src/creating-parsers/4-external-scanners.md
@@ -23,10 +23,7 @@ grammar({
 });
 ```
 
-Then, add another C source file to your project. Its path must be src/scanner.c for the CLI to recognize it. Be sure to add
-this file to the sources section of your `binding.gyp` file so that it will be included when your project is compiled by
-Node.js and uncomment the appropriate block in your bindings/rust/build.rs file so that it will be included in your Rust
-crate.
+Then, add another C source file to your project. Its path must be src/scanner.c for the CLI to recognize it.
 
 In this new source file, define an [`enum`][enum] type containing the names of all of your external tokens. The ordering
 of this enum must match the order in your grammar's `externals` array; the actual names do not matter.


### PR DESCRIPTION
Since 66dab20462fcaf2b7ffe77a46af16419a1aded2a, bindings automatically detect external scanner, making the instructions for manual updating outdated. Avoids confusion about missing commented lines in Rust bindings.