### PR TITLE
fix(loader)!: correct arguments passed to `select_language`

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1109,7 +1109,7 @@ impl Parse {
                     let path = Path::new(&path);
                     let language = loader
                         .select_language(
-                            path,
+                            Some(path),
                             current_dir,
                             self.scope.as_deref(),
                             lib_info.as_ref(),
@@ -1140,7 +1140,12 @@ impl Parse {
 
                 let language = if let Some(ref lib_path) = self.lib_path {
                     &loader
-                        .select_language(lib_path, current_dir, None, lib_info.as_ref())
+                        .select_language(
+                            None,
+                            current_dir,
+                            self.scope.as_deref(),
+                            lib_info.as_ref(),
+                        )
                         .with_context(|| {
                             anyhow!(
                                 "Failed to load language for path \"{}\"",
@@ -1174,8 +1179,12 @@ impl Parse {
 
                 let path = get_tmp_source_file(&contents)?;
                 let name = "stdin";
-                let language =
-                    loader.select_language(&path, current_dir, None, lib_info.as_ref())?;
+                let language = loader.select_language(
+                    None,
+                    current_dir,
+                    self.scope.as_deref(),
+                    lib_info.as_ref(),
+                )?;
 
                 parse::parse_file_at_path(
                     &mut parser,
@@ -1256,7 +1265,7 @@ impl Test {
             let lib_info =
                 get_lib_info(self.lib_path.as_ref(), self.lang_name.as_ref(), current_dir);
             &loader
-                .select_language(lib_path, current_dir, None, lib_info.as_ref())
+                .select_language(None, current_dir, None, lib_info.as_ref())
                 .with_context(|| {
                     anyhow!(
                         "Failed to load language for path \"{}\"",
@@ -1437,7 +1446,7 @@ impl Fuzz {
             let lang_name = lib_info.1.to_string();
             &(
                 loader
-                    .select_language(lib_path, current_dir, None, Some(&lib_info))
+                    .select_language(None, current_dir, None, Some(&lib_info))
                     .with_context(|| {
                         anyhow!(
                             "Failed to load language for path \"{}\"",
@@ -1505,7 +1514,7 @@ impl Query {
         match input {
             CliInput::Paths(paths) => {
                 let language = loader.select_language(
-                    Path::new(&paths[0]),
+                    Some(Path::new(&paths[0])),
                     current_dir,
                     self.scope.as_deref(),
                     lib_info.as_ref(),
@@ -1541,7 +1550,7 @@ impl Query {
                 let languages = loader.languages_at_path(current_dir)?;
                 let language = if let Some(ref lib_path) = self.lib_path {
                     &loader
-                        .select_language(lib_path, current_dir, None, lib_info.as_ref())
+                        .select_language(None, current_dir, None, lib_info.as_ref())
                         .with_context(|| {
                             anyhow!(
                                 "Failed to load language for path \"{}\"",
@@ -1575,7 +1584,7 @@ impl Query {
 
                 let path = get_tmp_source_file(&contents)?;
                 let language =
-                    loader.select_language(&path, current_dir, None, lib_info.as_ref())?;
+                    loader.select_language(None, current_dir, None, lib_info.as_ref())?;
                 let opts = QueryFileOptions {
                     ordered_captures: self.captures,
                     byte_range,

--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -1702,7 +1702,7 @@ impl Loader {
 
     pub fn select_language(
         &mut self,
-        path: &Path,
+        path: Option<&Path>,
         current_dir: &Path,
         scope: Option<&str>,
         // path to dynamic library, name of language
@@ -1720,7 +1720,7 @@ impl Loader {
             } else {
                 Err(LoaderError::UnknownScope(scope.to_string()))
             }
-        } else if let Some((lang, _)) =
+        } else if let Some((lang, _)) = if let Some(path) = path {
             self.language_configuration_for_file_name(path)
                 .map_err(|e| {
                     LoaderError::FileNameLoad(
@@ -1728,7 +1728,9 @@ impl Loader {
                         Box::new(e),
                     )
                 })?
-        {
+        } else {
+            None
+        } {
             Ok(lang)
         } else if let Some(id) = self.language_configuration_in_current_path {
             Ok(self.language_for_id(self.language_configurations[id].language_id)?)
@@ -1739,7 +1741,11 @@ impl Loader {
             .cloned()
         {
             Ok(lang.0)
-        } else if let Some(lang) = self.language_configuration_for_first_line_regex(path)? {
+        } else if let Some(lang) = if let Some(path) = path {
+            self.language_configuration_for_first_line_regex(path)?
+        } else {
+            None
+        } {
             Ok(lang.0)
         } else {
             Err(LoaderError::NoLanguage)


### PR DESCRIPTION
The `--scope` option wasn't being forward to `select_language` when parsing from stdin. Additionally, in several cases it doesn't make sense to consider the source path (or there isn't one) when selecting a language for a parse.

- Fixes #5108 