### PR TITLE
fix(rust): specify workspace dependency of `tree-sitter-language` crate as "0.1"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,4 +160,4 @@ tree-sitter-config = { version = "0.26.0", path = "./crates/config" }
 tree-sitter-highlight = { version = "0.26.0", path = "./crates/highlight" }
 tree-sitter-tags = { version = "0.26.0", path = "./crates/tags" }
 
-tree-sitter-language = { version = "0.1.5", path = "./crates/language" }
+tree-sitter-language = { version = "0.1", path = "./crates/language" }


### PR DESCRIPTION
If a rust project depends on both the tree-sitter lib bindings and the language crate, cargo needs to be able to resolve a common version of the tree-sitter-language crate. Specifying exactly "0.1.5" for the lib bindings is overly restrictive, and could lead to future headaches. By specifying "0.1", any "0.1.x" version should be available to resolve to.


For reference, the lib dependency on tree-sitter-language was changed from unspecified to "0.1.4" in https://github.com/tree-sitter/tree-sitter/pull/4867. Before that, it was specified to "0.1", which was changed in https://github.com/tree-sitter/tree-sitter/pull/4496/files#diff-fac5fcf0ea8031f2c9c7f88852c186b2dba12657d9c8c1a3dca4ffbad12602af