### PR TITLE
Revert "fix(rust): specify workspace dependency of `tree-sitter-language` crate"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(tree-sitter
-        VERSION "0.26.1"
+        VERSION "0.26.2"
         DESCRIPTION "An incremental parsing system for programming tools"
         HOMEPAGE_URL "https://tree-sitter.github.io/tree-sitter/"
         LANGUAGES C)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "bindgen",
  "cc",
@@ -1986,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-cli"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "ansi_colours",
  "anstyle",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-config"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "etcetera",
  "log",
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-generate"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "bitflags 2.10.0",
  "dunce",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-highlight"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "regex",
  "streaming-iterator",
@@ -2082,7 +2082,7 @@ version = "0.1.5"
 
 [[package]]
 name = "tree-sitter-loader"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "cc",
  "etcetera",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-tags"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "memchr",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.26.1"
+version = "0.26.2"
 authors = [
   "Max Brunsfeld <maxbrunsfeld@gmail.com>",
   "Amaan Qureshi <amaanq12@gmail.com>",
@@ -153,11 +153,11 @@ walkdir = "2.5.0"
 wasmparser = "0.243.0"
 webbrowser = "1.0.5"
 
-tree-sitter = { version = "0.26.1", path = "./lib" }
-tree-sitter-generate = { version = "0.26.1", path = "./crates/generate" }
-tree-sitter-loader = { version = "0.26.1", path = "./crates/loader" }
-tree-sitter-config = { version = "0.26.1", path = "./crates/config" }
-tree-sitter-highlight = { version = "0.26.1", path = "./crates/highlight" }
-tree-sitter-tags = { version = "0.26.1", path = "./crates/tags" }
+tree-sitter = { version = "0.26.2", path = "./lib" }
+tree-sitter-generate = { version = "0.26.2", path = "./crates/generate" }
+tree-sitter-loader = { version = "0.26.2", path = "./crates/loader" }
+tree-sitter-config = { version = "0.26.2", path = "./crates/config" }
+tree-sitter-highlight = { version = "0.26.2", path = "./crates/highlight" }
+tree-sitter-tags = { version = "0.26.2", path = "./crates/tags" }
 
 tree-sitter-language = { version = "0.1.5", path = "./crates/language" }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.26.1
+VERSION := 0.26.2
 DESCRIPTION := An incremental parsing system for programming tools
 HOMEPAGE_URL := https://tree-sitter.github.io/tree-sitter/
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .tree_sitter,
     .fingerprint = 0x841224b447ac0d4f,
-    .version = "0.26.1",
+    .version = "0.26.2",
     .minimum_zig_version = "0.14.1",
     .paths = .{
         "build.zig",

--- a/crates/cli/npm/package-lock.json
+++ b/crates/cli/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-cli",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-cli",
-      "version": "0.26.1",
+      "version": "0.26.2",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/crates/cli/npm/package.json
+++ b/crates/cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-cli",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "author": {
     "name": "Max Brunsfeld",
     "email": "maxbrunsfeld@gmail.com"

--- a/docs/src/cli/generate.md
+++ b/docs/src/cli/generate.md
@@ -51,7 +51,7 @@ Report conflicts in a JSON format.
 ### `--js-runtime <EXECUTABLE>`
 
 The path to the JavaScript runtime executable to use when generating the parser. The default is `node`.
-Note that you can also set this with `TREE_SITTER_JS_RUNTIME`. Starting from version 0.26.1, you can
+Note that you can also set this with `TREE_SITTER_JS_RUNTIME`. Starting from version 0.26.2, you can
 also pass in `native` to use the experimental native QuickJS runtime that comes bundled with the CLI.
 This avoids the dependency on a JavaScript runtime entirely. The native QuickJS runtime is compatible
 with ESM as well as with CommonJS in strict mode. If your grammar depends on `npm` to install dependencies such as base grammars, the native runtime can be used *after* running `npm install`.

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
       eachSystem = lib.genAttrs systems;
       pkgsFor = inputs.nixpkgs.legacyPackages;
 
-      version = "0.26.1";
+      version = "0.26.2";
 
       fs = lib.fileset;
       src = fs.toSource {

--- a/lib/binding_web/package-lock.json
+++ b/lib/binding_web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-tree-sitter",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-tree-sitter",
-      "version": "0.26.1",
+      "version": "0.26.2",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.1",

--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-tree-sitter",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "Tree-sitter bindings for the web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Apparently not. Let's try that again.