### PR TITLE
docs(cli): fix wrong file path for Java bindings test

### DIFF
--- a/docs/src/cli/init.md
+++ b/docs/src/cli/init.md
@@ -157,7 +157,7 @@ if you have one.
 
 - `pom.xml` - This file is the manifest of the Maven package.
 - `bindings/java/main/namespace/language/TreeSitterLanguage.java` - This file wraps your language in a Java class.
-- `bindings/java/test/namespace/language/TreeSitterLanguageTest.java` - This file contains a test for the Java package.
+- `bindings/java/test/TreeSitterLanguageTest.java` - This file contains a test for the Java package.
 
 ### Python
 


### PR DESCRIPTION
Follow-up for #4681

The test is currently generated in the default (= unnamed) package, see
https://github.com/tree-sitter/tree-sitter/blob/744e556f7ea96087bd8cc2433a2d1ce951684204/crates/cli/src/init.rs#L1093-L1099
