### PR TITLE
ci(release): use node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Set up Rust


### PR DESCRIPTION
Node 20 installs an outdated version of npm which doesn't support trusted publishing.