### PR TITLE
ci(release): dispatch individual jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,20 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      release:
+        description: GitHub release
+        type: boolean
+        default: true
+      crates:
+        description: crates packages
+        type: boolean
+        default: true
+      npm:
+        description: npm packages
+        type: boolean
+        default: true
+
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
@@ -16,6 +30,7 @@ jobs:
     name: Release on GitHub
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name == 'push' || github.event.inputs.release
     permissions:
       id-token: write
       attestations: write
@@ -64,14 +79,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-  crates_io:
+  crates:
     name: Publish packages to Crates.io
     runs-on: ubuntu-latest
     environment: crates
+    needs: build
+    if: github.event_name == 'push' || github.event.inputs.crates
     permissions:
       id-token: write
       contents: read
-    needs: release
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -92,10 +108,11 @@ jobs:
     name: Publish packages to npmjs.com
     runs-on: ubuntu-latest
     environment: npm
+    needs: build
+    if: github.event_name == 'push' || github.event.inputs.npm
     permissions:
       id-token: write
       contents: read
-    needs: release
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Useful when individual jobs fail, but requires all the jobs to depend on `build` instead of having `crates` & `npm` depend on `release`, since I don't know whether the `needs` field supports conditions.

This means that the crates & npm packages may be published even when the GitHub release fails, but this change will allow us to manually dispatch the workflow with just the release enabled in that case.