### PR TITLE
fix(cli): trailing whitespace after multiline text nodes in CST

### DIFF
--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -887,7 +887,7 @@ fn write_node_text(
                 write!(
                     out,
                     "{}{}{}{}{}{}",
-                    if multiline { "\n" } else { "" },
+                    if multiline { "\n" } else { " " },
                     if multiline {
                         render_node_range(opts, cursor, is_named, true, total_width, node_range)
                     } else {
@@ -1011,10 +1011,9 @@ fn cst_render_node(
         } else {
             opts.parse_theme.node_kind
         };
-        write!(out, "{}", paint(kind_color, node.kind()),)?;
+        write!(out, "{}", paint(kind_color, node.kind()))?;
 
         if node.child_count() == 0 {
-            write!(out, " ")?;
             // Node text from a pattern or external scanner
             write_node_text(
                 opts,


### PR DESCRIPTION
## Problem

The CST printer emits trailing whitespace after multiline text nodes. With 1704c604bf663801876572fe08b746e787cd7fdb and `:cst` corpus tests this causes trailing spaces to appear on `test --update`. These spaces cannot be removed afterward, as the test runner expects an exact character-for-character match for CST tests.

For example, using the https://github.com/tree-sitter/tree-sitter-rust grammar:

<img width="1515" height="1341" alt="1765752365_screenshot" src="https://github.com/user-attachments/assets/2596038f-aeed-469f-85ec-0b021989a87c" />

## Solution

Print whitespace only if node is not multiline.