### PR TITLE
fix(cli): correct discrepancy with cst for `--no-ranges`

### DIFF
--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -883,35 +883,24 @@ fn write_node_text(
                     0
                 };
             let formatted_line = render_line_feed(line, opts);
-            if !opts.no_ranges {
-                write!(
-                    out,
-                    "{}{}{}{}{}{}",
-                    if multiline { "\n" } else { " " },
-                    if multiline {
-                        render_node_range(opts, cursor, is_named, true, total_width, node_range)
-                    } else {
-                        String::new()
-                    },
-                    if multiline {
-                        "  ".repeat(indent_level + 1)
-                    } else {
-                        String::new()
-                    },
-                    paint(quote_color, &String::from(quote)),
-                    &paint(color, &render_node_text(&formatted_line)),
-                    paint(quote_color, &String::from(quote)),
-                )?;
-            } else {
-                write!(
-                    out,
-                    "\n{}{}{}{}",
-                    "  ".repeat(indent_level + 1),
-                    paint(quote_color, &String::from(quote)),
-                    &paint(color, &render_node_text(&formatted_line)),
-                    paint(quote_color, &String::from(quote)),
-                )?;
-            }
+            write!(
+                out,
+                "{}{}{}{}{}{}",
+                if multiline { "\n" } else { " " },
+                if multiline && !opts.no_ranges {
+                    render_node_range(opts, cursor, is_named, true, total_width, node_range)
+                } else {
+                    String::new()
+                },
+                if multiline {
+                    "  ".repeat(indent_level + 1)
+                } else {
+                    String::new()
+                },
+                paint(quote_color, &String::from(quote)),
+                paint(color, &render_node_text(&formatted_line)),
+                paint(quote_color, &String::from(quote)),
+            )?;
         }
     }
 


### PR DESCRIPTION
Followup to https://github.com/tree-sitter/tree-sitter/pull/4147. Note that because we currently always include ranges for the `cst` test type, this change isn't breaking.

The improved display of node text wasn't applied when `--no-ranges` was passed.

Before:

<img width="402" height="638" alt="image" src="https://github.com/user-attachments/assets/0db8d187-6bf4-49d6-80d3-a14659f74218" />

After:

<img width="524" height="594" alt="image" src="https://github.com/user-attachments/assets/40054d37-4e07-4a5d-b272-ab359e8c5b49" />


This is more consistent with the display when ranges are included:

<img width="637" height="577" alt="image" src="https://github.com/user-attachments/assets/73e040ee-57b1-48e9-b3bd-4729233a4a80" />
