### PR TITLE
docs: Add troubleshooting section to tree-sitter-cli README

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -42,3 +42,18 @@ The `tree-sitter` binary itself has no dependencies, but specific commands have 
 
 [the documentation]: https://tree-sitter.github.io/tree-sitter/creating-parsers
 [the releases page]: https://github.com/tree-sitter/tree-sitter/releases/latest
+
+### Troubleshooting
+
+Run the following commands to diagnose Tree-sitter issues.
+
+**In Neovim:**
+- `:checkhealth tree-sitter`  
+  Checks Tree-sitter integration in Neovim, including parser status, CLI availability, and compiler support.
+
+**In your terminal:**
+- `which tree-sitter`  
+  Verifies that the Tree-sitter CLI is installed and available in your `$PATH`.
+
+- `tree-sitter --version`  
+  Confirms that the Tree-sitter CLI is executable and shows the installed version.


### PR DESCRIPTION
### Summary

Added a troubleshooting section with commands for diagnosing Tree-sitter issues in both Neovim and the terminal.

### Background

I had trouble returning to Neovim because Tree-sitter kept spamming errors related to `build-wasm`.  
I initially tried installing newer `tree-sitter-cli` via `cargo`, but the issue persisted.

After further investigation, I discovered that an **older `tree-sitter-cli` installed via `yarn`** was still present in `$PATH` and was being used instead of the newer version. 

Uninstalling the older CLI resolved the issue.

### Notes

The commands included in the troubleshooting section are the same ones used to debug and diagnose this problem.