### PR TITLE
fix(cli): cst printing improvements

### DIFF
--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -515,7 +515,6 @@ pub fn parse_file_at_path(
 
         if opts.output == ParseOutput::Cst {
             render_cst(&source_code, &tree, &mut cursor, opts, &mut stdout)?;
-            println!();
         }
 
         if opts.output == ParseOutput::Xml {


### PR DESCRIPTION
Fixes extra prefix whitespaces with `--no-ranges` flag.
Removes the trailing newline to make CST output consistent with other formats. 

See commit messages for details.

Comparison before/after:
```
tree-sitter-rust $ ts parse --cst --no-ranges test.rs
  source_file
    type_item
      "type"
      name: type_identifier `A`
      "="
      type: tuple_type
        "("
        primitive_type `i32`
        ","
        type_identifier `String`
        ")"
      ";"

tree-sitter-rust $ ts parse --cst --no-ranges test.rs
source_file
  type_item
    "type"
    name: type_identifier `A`
    "="
    type: tuple_type
      "("
      primitive_type `i32`
      ","
      type_identifier `String`
      ")"
    ";"
tree-sitter-rust $
```
