### PR TITLE
docs(web): add WASM version compatibility section

### DIFF
--- a/lib/binding_web/README.md
+++ b/lib/binding_web/README.md
@@ -191,6 +191,29 @@ npx tree-sitter build --wasm node_modules/tree-sitter-javascript
 
 If everything is fine, file `tree-sitter-javascript.wasm` should be generated in current directory.
 
+### WASM Version Compatibility
+
+> [!IMPORTANT]
+> WASM language files must be generated with a compatible version of `tree-sitter-cli`.
+
+The WASM binary format includes ABI (Application Binary Interface) information that must match between `web-tree-sitter` and the generated `.wasm` files. Using incompatible versions will cause `Language.load()` to fail.
+
+| web-tree-sitter | Compatible tree-sitter-cli |
+|-----------------|---------------------------|
+| 0.26.x          | 0.26.x                    |
+| 0.25.x          | 0.20.x - 0.25.x           |
+| 0.24.x          | 0.20.x - 0.24.x           |
+
+**If you're using pre-built WASM files** from third-party packages (e.g., `tree-sitter-wasms`), ensure they were built with a compatible `tree-sitter-cli` version.
+
+**Recommended**: Generate WASM files with the same major.minor version of `tree-sitter-cli` as your `web-tree-sitter` version:
+
+```sh
+# For web-tree-sitter@0.26.x, use tree-sitter-cli@0.26.x
+npm install tree-sitter-cli@0.26
+npx tree-sitter build --wasm node_modules/tree-sitter-javascript
+```
+
 ### Running .wasm in Node.js
 
 Notice that executing `.wasm` files in Node.js is considerably slower than running [Node.js bindings][node bindings].


### PR DESCRIPTION
## Summary

Add documentation about WASM version compatibility requirements between `web-tree-sitter` and `tree-sitter-cli`.

## Problem

Users who use pre-built WASM files from third-party packages (like `tree-sitter-wasms`) may experience `Language.load()` failures when upgrading `web-tree-sitter` to 0.26.x. This happens because the WASM files were built with older `tree-sitter-cli` versions (e.g., 0.20.x) that have incompatible ABI.

Currently, there's no documentation explaining this version compatibility requirement, leading to confusion when things break after upgrades.

## Solution

Add a "WASM Version Compatibility" section to `lib/binding_web/README.md` that:

1. Explains the ABI compatibility requirement
2. Provides a version compatibility matrix
3. Warns users about third-party pre-built WASM packages
4. Recommends matching `tree-sitter-cli` version with `web-tree-sitter`

## Changes

- `lib/binding_web/README.md`: Added new "WASM Version Compatibility" section after "Generating .wasm files"

## Related

Closes #5171