### PR TITLE
fix(web): add early version check in Language.load()

### DIFF
--- a/lib/binding_web/src/language.ts
+++ b/lib/binding_web/src/language.ts
@@ -1,7 +1,7 @@
 import { C, INTERNAL, Internal, assertInternal, SIZE_OF_INT, SIZE_OF_SHORT } from './constants';
 import { LookaheadIterator } from './lookahead_iterator';
 import { unmarshalLanguageMetadata } from './marshal';
-import { TRANSFER_BUFFER } from './parser';
+import { TRANSFER_BUFFER, LANGUAGE_VERSION, MIN_COMPATIBLE_VERSION } from './parser';
 
 const LANGUAGE_FUNCTION_REGEX = /^tree_sitter_\w+$/;
 
@@ -226,6 +226,8 @@ export class Language {
   /**
    * Load a language from a WebAssembly module.
    * The module can be provided as a path to a file or as a buffer.
+   *
+   * @throws {Error} If the WASM file was built with an incompatible version of tree-sitter-cli.
    */
   static async load(input: string | Uint8Array): Promise<Language> {
     let binary: Uint8Array | WebAssembly.Module;
@@ -263,6 +265,19 @@ export class Language {
         throw new Error('Language.load failed: no language function found in Wasm file');
     }
     const languageAddress = mod[functionName]();
-    return new Language(INTERNAL, languageAddress);
+    const language = new Language(INTERNAL, languageAddress);
+
+    // Early version compatibility check
+    const version = language.abiVersion;
+    if (version < MIN_COMPATIBLE_VERSION || LANGUAGE_VERSION < version) {
+      throw new Error(
+        `Incompatible language version ${version}. ` +
+        `Compatibility range ${MIN_COMPATIBLE_VERSION} through ${LANGUAGE_VERSION}. ` +
+        `The WASM file may have been built with an incompatible version of tree-sitter-cli. ` +
+        `Please regenerate the WASM file using a compatible tree-sitter-cli version.`
+      );
+    }
+
+    return language;
   }
 }

--- a/lib/binding_web/src/language.ts
+++ b/lib/binding_web/src/language.ts
@@ -270,7 +270,7 @@ export class Language {
     // Early version compatibility check
     const version = language.abiVersion;
     if (version < MIN_COMPATIBLE_VERSION || LANGUAGE_VERSION < version) {
-      throw new Error(
+      throw new RangeError(
         `Incompatible language version ${version}. ` +
         `Compatibility range ${MIN_COMPATIBLE_VERSION} through ${LANGUAGE_VERSION}. ` +
         `The WASM file may have been built with an incompatible version of tree-sitter-cli. ` +

--- a/lib/binding_web/src/language.ts
+++ b/lib/binding_web/src/language.ts
@@ -227,7 +227,7 @@ export class Language {
    * Load a language from a WebAssembly module.
    * The module can be provided as a path to a file or as a buffer.
    *
-   * @throws {Error} If the WASM file was built with an incompatible version of tree-sitter-cli.
+   * @throws {RangeError} If the Wasm file was built with an incompatible version of tree-sitter-cli.
    */
   static async load(input: string | Uint8Array): Promise<Language> {
     let binary: Uint8Array | WebAssembly.Module;

--- a/lib/binding_web/src/language.ts
+++ b/lib/binding_web/src/language.ts
@@ -273,8 +273,7 @@ export class Language {
       throw new RangeError(
         `Incompatible language version ${version}. ` +
         `Compatibility range ${MIN_COMPATIBLE_VERSION} through ${LANGUAGE_VERSION}. ` +
-        `The WASM file may have been built with an incompatible version of tree-sitter-cli. ` +
-        `Please regenerate the WASM file using a compatible tree-sitter-cli version.`
+        `The Wasm file may have been built with an incompatible version of tree-sitter-cli. `
       );
     }
 


### PR DESCRIPTION
## Summary

Add ABI version compatibility check immediately after loading a WASM language file in `Language.load()`.

## Problem

Currently, when loading a WASM file built with an incompatible `tree-sitter-cli` version:

1. `Language.load()` succeeds
2. `parser.setLanguage()` fails with: `Incompatible language version X. Compatibility range Y through Z.`

This is confusing because:
- The error occurs at `setLanguage()`, not at load time
- The error message doesn't indicate the root cause (incompatible WASM build)
- Users don't know how to fix it

This commonly affects users of third-party WASM packages like `tree-sitter-wasms` that may be built with older `tree-sitter-cli` versions.

## Solution

Add version check in `Language.load()` right after loading the WASM module:

```typescript
const version = language.abiVersion;
if (version < MIN_COMPATIBLE_VERSION || LANGUAGE_VERSION < version) {
  throw new Error(
    `Incompatible language version ${version}. ` +
    `Compatibility range ${MIN_COMPATIBLE_VERSION} through ${LANGUAGE_VERSION}. ` +
    `The WASM file may have been built with an incompatible version of tree-sitter-cli. ` +
    `Please regenerate the WASM file using a compatible tree-sitter-cli version.`
  );
}
```

## Benefits

1. **Earlier failure** - Fails at load time instead of `setLanguage()`
2. **Better error message** - Clearly indicates the WASM file might be built with incompatible CLI
3. **Actionable guidance** - Tells users to regenerate the WASM file

## Changes

- `lib/binding_web/src/language.ts`:
  - Import `LANGUAGE_VERSION` and `MIN_COMPATIBLE_VERSION` from `parser.ts`
  - Add version compatibility check after loading WASM
  - Add `@throws` JSDoc annotation

## Related

- #5171 - Issue describing the compatibility problem
- #5172 - Documentation PR for version compatibility