### PR TITLE
fix(cli): increase verbosity of `tree-sitter init -u` updates

### DIFF
--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -123,7 +123,7 @@ const BUILD_ZIG_ZON_TEMPLATE: &str = include_str!("./templates/build.zig.zon");
 const ROOT_ZIG_TEMPLATE: &str = include_str!("./templates/root.zig");
 const TEST_ZIG_TEMPLATE: &str = include_str!("./templates/test.zig");
 
-const TREE_SITTER_JSON_SCHEMA: &str =
+pub const TREE_SITTER_JSON_SCHEMA: &str =
     "https://tree-sitter.github.io/tree-sitter/assets/schemas/config.schema.json";
 
 #[derive(Serialize, Deserialize, Clone)]


### PR DESCRIPTION
Also, use `info` logs rather than `warn`

Opening this to start a discussion regarding what (and how much) information should be displayed for the `tree-sitter init` command. In this PR's current state, I've updated all log statements to use `info` rather than `warn`. As any updates made to a grammar's files through this command was explicitly requested via the `-u` flag, this seems more appropriate. I've also clarified "updating" in several logs where this could be confused with updating the dependencies in a lock file.

After some feedback/discussion here, I hope we can settle on a more uniform stream of logs for the actions taken for this command. A few questions to get started:
- Should the command output a log when a file is generated for the first time?
- Should specific information be displayed regarding *what* in a file is being updated (as I've done for a few logs here), or just that changes are being done?
- Should a log be displayed if a particular language's bindings are disabled, stating that no generation/updates will be done?