### PR TITLE
fix(cli): restore test summary output for `tree-sitter test`

### DIFF
--- a/crates/cli/src/test.rs
+++ b/crates/cli/src/test.rs
@@ -595,6 +595,8 @@ impl std::fmt::Display for TestSummary {
             render_assertion_results("queries", &self.query_results)?;
         }
 
+        write!(f, "{}", self.parse_stats)?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Problem
After commit f02d7e7e335dc4d9355d4d2ca61729368bc4e959 (#4908) the `tree-sitter test` command no longer printed the final test summary, leaving empty line. The `Stats` struct was embedded into `TestSummary`, and the explicit call to print it was removed.

```
  ...
  types:
    138. ✓ The unit type
    139. ✓ Tuple types
    140. ✓ Reference types
    141. ✓ Raw pointer types
    142. ✓ Generic types
    143. ✓ Scoped types
    144. ✓ Array types
    145. ✓ Function types
    146. ✓ Unsafe and extern function types
    147. ✓ Trait objects
    148. ✓ Type cast expressions with generics


tree-sitter-rust $ tree-sitter -V
tree-sitter 0.26.3
tree-sitter-rust $
```

## Solution
Print `parse_stats` from `TestSummary.fmt()` implementation.

```
  ...
  types:
    138. ✓ The unit type
    139. ✓ Tuple types
    140. ✓ Reference types
    141. ✓ Raw pointer types
    142. ✓ Generic types
    143. ✓ Scoped types
    144. ✓ Array types
    145. ✓ Function types
    146. ✓ Unsafe and extern function types
    147. ✓ Trait objects
    148. ✓ Type cast expressions with generics

Total parses: 148; successful parses: 148; failed parses: 0; success percentage: 100.00%; average speed: 4149 bytes/ms

tree-sitter-rust $
```