### PR TITLE
fix(wasm): missing `UINT8_MAX`

### DIFF
--- a/crates/language/wasm/include/stdint.h
+++ b/crates/language/wasm/include/stdint.h
@@ -23,6 +23,8 @@ typedef long unsigned int size_t;
 
 typedef long unsigned int uintptr_t;
 
+#define UINT8_MAX 255
+
 #define UINT16_MAX 65535
 
 #define UINT32_MAX 4294967295U


### PR DESCRIPTION
the scanner need `UINT8_MAX` which is not defined in our `wasm/stdint.h`

https://github.com/polarmutex/tree-sitter-beancount/blob/653cce316fbff8d212a2488ae13df648efb542a4/src/scanner.c#L153-L154