### PR TITLE
feat: free memory automatically

### DIFF
--- a/lib/binding_web/src/finalization_registry.ts
+++ b/lib/binding_web/src/finalization_registry.ts
@@ -1,0 +1,8 @@
+export function newFinalizer<T>(handler: (value: T) => void): FinalizationRegistry<T> | undefined {
+  try {
+    return new FinalizationRegistry(handler);
+  } catch(e) {
+    console.error('Unsupported FinalizationRegistry:', e);
+    return;
+  }
+}

--- a/lib/binding_web/test/memory.test.ts
+++ b/lib/binding_web/test/memory.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { gc, event, Finalizer } from './memory';
+
+// hijack finalization registry before import web-tree-sitter
+globalThis.FinalizationRegistry = Finalizer;
+
+describe('Memory Management', () => {
+  describe('call .delete()', () => {
+    it('test free memory manually', async () => {
+      const timer = setInterval(() => {
+        gc();
+      }, 100);
+      let done = 0; 
+      event.on('gc', () => {
+        done++;
+      });
+      await (async () => {
+        const { JavaScript } = await (await import('./helper')).default;
+        const  { Parser, Query } = await import('../src');
+        const parser = new Parser();
+        parser.setLanguage(JavaScript);
+        const tree = parser.parse('1+1')!;
+        const copyTree = tree.copy();
+        const cursor = tree.walk();
+        const copyCursor = cursor.copy();
+        const lookaheadIterator = JavaScript.lookaheadIterator(cursor.currentNode.nextParseState)!;
+        const query = new Query(JavaScript, '(identifier) @element');
+        parser.delete();
+        tree.delete();
+        copyTree.delete();
+        cursor.delete();
+        copyCursor.delete();
+        lookaheadIterator.delete();
+        query.delete();
+      })();
+      // wait for gc
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      clearInterval(timer);
+      // expect no gc event fired
+      expect(done).toBe(0);
+    });
+  });
+
+  describe('do not call .delete()', () => {
+    it('test free memory automatically', async () => {
+      const timer = setInterval(() => {
+        gc();
+      }, 100);
+      let done = 0;
+      const promise = new Promise((resolve) => {
+        event.on('gc', () => {
+          if (++done === 7) {
+            resolve(undefined);
+            clearInterval(timer);
+          }
+          console.log('free memory times: ', done);
+        });
+      });
+      await (async () => {
+        const { JavaScript } = await (await import('./helper')).default;
+        const  { Parser, Query } = await import('../src');
+        const parser = new Parser(); // 1
+        parser.setLanguage(JavaScript);
+        const tree = parser.parse('1+1')!; // 2
+        tree.copy(); // 3
+        const cursor = tree.walk(); // 4
+        cursor.copy(); // 5
+        JavaScript.lookaheadIterator(cursor.currentNode.nextParseState)!; // 6
+        new Query(JavaScript, '(identifier) @element'); // 7
+      })();
+      await promise;
+    });
+  });
+});

--- a/lib/binding_web/test/memory.ts
+++ b/lib/binding_web/test/memory.ts
@@ -1,0 +1,20 @@
+import { EventEmitter } from 'events';
+import { Session } from 'inspector';
+
+const session = new Session();
+session.connect();
+
+export function gc() {
+  session.post('HeapProfiler.collectGarbage');
+}
+
+export const event = new EventEmitter();
+
+export class Finalizer<T> extends FinalizationRegistry<T> {
+  constructor(handler: (value: T) => void) {
+    super((value) => {
+      handler(value);
+      event.emit('gc');
+    });
+  }
+}

--- a/lib/binding_web/test/memory_unsupported.test.ts
+++ b/lib/binding_web/test/memory_unsupported.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from 'vitest';
+
+describe('FinalizationRegistry is unsupported', () => {
+  it('test FinalizationRegistry is unsupported', async () => {
+    // @ts-expect-error: test FinalizationRegistry is not supported
+    globalThis.FinalizationRegistry = undefined;
+    const { JavaScript } = await (await import('./helper')).default;
+    const  { Parser, Query } = await import('../src');
+    const parser = new Parser();
+    parser.setLanguage(JavaScript);
+    const tree = parser.parse('1+1')!;
+    const copyTree = tree.copy();
+    const cursor = tree.walk();
+    const copyCursor = cursor.copy();
+    const lookaheadIterator = JavaScript.lookaheadIterator(cursor.currentNode.nextParseState)!;
+    const query = new Query(JavaScript, '(identifier) @element');
+    parser.delete();
+    tree.delete();
+    copyTree.delete();
+    cursor.delete();
+    copyCursor.delete();
+    lookaheadIterator.delete();
+    query.delete();
+  });
+});


### PR DESCRIPTION
Manual memory management can lead to memory leak easily. I think it's better to manage memory through the `FinalizationRegistry` automatically.

test case.
```js
import { Parser, Language } from './web-tree-sitter.js';
import path from 'path';

async function main() {
  await Parser.init();
  const wasm =  path.join(process.cwd(), `../../target/release/tree-sitter-javascript.wasm`);
  const javascript = await Language.load(wasm);
  const parser = new Parser();
  parser.setLanguage(javascript);
  parser.parse('abc + cde');
  setInterval(() => {
    gc();
  }, 100);
}

main();
```
1. Add `console.log('finalizationRegistry', value);` in callback of `FinalizationRegistry`(`finalization_registry.ts`).
2. Run `npm run build && node --expose-gc demo.js`, the output is as follow.
```
finalizationRegistry { type: 1, argv: [ 474240 ] }
finalizationRegistry { type: 2, argv: [ 460032, 462512 ] }
```
