### PR TITLE
feat(ci): ensure `wasm-stdlib.h` is regenerated when wasm stdlib source files are modified

### DIFF
--- a/.github/scripts/wasm_stdlib.js
+++ b/.github/scripts/wasm_stdlib.js
@@ -1,0 +1,25 @@
+module.exports = async ({ github, context, core }) => {
+  if (context.eventName !== 'pull_request') return;
+
+  const prNumber = context.payload.pull_request.number;
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+
+  const { data: files } = await github.rest.pulls.listFiles({
+    owner,
+    repo,
+    pull_number: prNumber
+  });
+
+  const changedFiles = files.map(file => file.filename);
+
+  const wasmStdLibSrc = 'crates/language/wasm/';
+  const dirChanged = changedFiles.some(file => file.startsWith(wasmStdLibSrc));
+
+  if (!dirChanged) return;
+
+  const wasmStdLibHeader = 'lib/src/wasm/wasm-stdlib.h';
+  const requiredChanged = changedFiles.includes(wasmStdLibHeader);
+
+  if (!requiredChanged) core.setFailed(`Changes detected in ${wasmStdLibSrc} but ${wasmStdLibHeader} was not modified.`);
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,6 @@ jobs:
 
   build:
     uses: ./.github/workflows/build.yml
+
+  check-wasm-stdlib:
+    uses: ./.github/workflows/wasm_stdlib.yml

--- a/.github/workflows/wasm_stdlib.yml
+++ b/.github/workflows/wasm_stdlib.yml
@@ -1,0 +1,19 @@
+name: Check Wasm Stdlib build
+
+on:
+  workflow_call:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Check directory changes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const scriptPath = `${process.env.GITHUB_WORKSPACE}/.github/scripts/wasm_stdlib.js`;
+            const script = require(scriptPath);
+            return script({ github, context, core });


### PR DESCRIPTION
Follow up to https://github.com/tree-sitter/tree-sitter/pull/5199#issuecomment-3714376444

If any files inside `crates/language/wasm/` are changed and `lib/src/wasm/wasm-stdlib.h` is *not* modified, the check will fail. This is a fairly rough check, but should catch the common case of PR authors updating wasm stdlib source files and forgetting (or not knowing) to run `cargo xtask build-wasm-stdlib`.

Tested in my fork here: https://github.com/WillLillis/tree-sitter/pull/8 (ignore [f62cf2b](https://github.com/WillLillis/tree-sitter/pull/8/commits/f62cf2b5826bd19151ae89d65a75f598b7f7b75d) and [d5e4bcd](https://github.com/WillLillis/tree-sitter/pull/8/commits/d5e4bcd6fd9a36841f0a7d0079900d209636eec8), those changes have been squashed into the parent commit)