### PR TITLE
fix(docs): appease clippy regarding spacing in README

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -36,10 +36,10 @@ The `tree-sitter` binary itself has no dependencies, but specific commands have 
 ### Commands
 
 * `generate` - The `tree-sitter generate` command will generate a Tree-sitter parser based on the grammar in the current
-working directory. See [the documentation] for more information.
+  working directory. See [the documentation] for more information.
 
 * `test` - The `tree-sitter test` command will run the unit tests for the Tree-sitter parser in the current working directory.
-See [the documentation] for more information.
+  See [the documentation] for more information.
 
 * `parse` - The `tree-sitter parse` command will parse a file (or list of files) using Tree-sitter parsers.
 


### PR DESCRIPTION
See https://github.com/tree-sitter/tree-sitter/actions/runs/21020853534/job/60444891613?pr=5207

Introduced by me in #5228, but wasn't caught in CI because clippy doesn't run if only markdown files are edited. Maybe the ignore paths should be tweaked? Regardless, this should unblock other PRs on top of that commit.