### PR TITLE
fix(cli): warn user when `nm` can't be run to verify the symbols inside the parser being built

### DIFF
--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -1305,6 +1305,11 @@ impl Loader {
                     }));
                 }
             }
+        } else {
+            warn!(
+                "Failed to run `nm` to verify symbols in {}",
+                library_path.display()
+            );
         }
 
         Ok(())


### PR DESCRIPTION
Noticed this while looking into https://github.com/nvim-treesitter/nvim-treesitter/discussions/8443

Silent failures aren't good, we should warn users when something (potentially) breaks.