### PR TITLE
fix(wasm): don't wasm-opt twice

### DIFF
--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -1387,6 +1387,7 @@ impl Loader {
             output_path,
             "-fPIC",
             "-shared",
+            "--no-wasm-opt",
             if self.debug_build { "-g" } else { "-Os" },
             format!("-Wl,--export=tree_sitter_{language_name}").as_str(),
             "-Wl,--allow-undefined",


### PR DESCRIPTION
Now that we run `wasm-opt` explicitly after compilation, skip it during
the `clang` compile and link phase.

Also disable `-Os` optimizations (saves time, and final wasm blob size
is even slightly smaller this way).
