### PR TITLE
fix(ci): add wasm-stdlib.h to cache key

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -21,5 +21,6 @@ runs:
           'lib/src/parser.h',
           'lib/src/array.h',
           'lib/src/alloc.h',
+          'lib/src/wasm/wasm-stdlib.h',
           'test/fixtures/grammars/*/**/src/*.c',
           '.github/actions/cache/action.yml') }}


### PR DESCRIPTION
I've seen several wasm CI failures over the last few days that have been solved via `gh cache delete --all --repo git@github.com:tree-sitter/tree-sitter.git` and re-running. This should fix it.