### PR TITLE
fix(generate): error if a supertype is defined as a terminal

### DIFF
--- a/test/fixtures/test_grammars/terminal_supertype/expected_error.txt
+++ b/test/fixtures/test_grammars/terminal_supertype/expected_error.txt
@@ -1,0 +1,1 @@
+Terminal rule 'A' cannot be used as a supertype

--- a/test/fixtures/test_grammars/terminal_supertype/grammar.js
+++ b/test/fixtures/test_grammars/terminal_supertype/grammar.js
@@ -1,0 +1,18 @@
+module.exports = grammar({
+  name: 'terminal_supertype',
+
+  supertypes: $ => [$.A],
+  extras: $ => [$.lineComment, $.lineComment2],
+
+  rules: {
+    source_file: $ => choice(
+      $.B,
+      $.A,
+    ),
+    lineComment: $ => /;;.*/,
+    lineComment2: $ => /##.*/,
+    A: $ => /xyz/,
+    C: $ => "xyz",
+    B: $ => seq('abc', $.C),
+  }
+});


### PR DESCRIPTION
The assumption that supertypes are nonterminals (and thus *not* moved into the lexical grammar following token extraction) is very baked into the generate code. When this assumption is broken, a common crash (or worse, silent corruption) happens when the terminal supertype's `index` is used to access the grammar's `variables`. There are several places where this error could be caught, but this was the earliest reasonable place. If a supertype symbol has been marked as a terminal, it must have been moved into the lexical grammar, so we grab its name that way and report the error to the user.

Open to suggestions for improving the error message.

- Closes #5265