### PR TITLE
feat(cli): add `--verbose` flag to `build` command

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -188,6 +188,9 @@ struct Build {
     /// Compile a parser in debug mode
     #[arg(long, short = '0')]
     pub debug: bool,
+    /// Display verbose build information
+    #[arg(short, long)]
+    pub verbose: bool,
 }
 
 #[derive(Args)]
@@ -964,6 +967,7 @@ impl Build {
         let grammar_path = current_dir.join(self.path.unwrap_or_default());
 
         loader.debug_build(self.debug);
+        loader.verbose_build(self.verbose);
 
         if self.wasm {
             let output_path = self.output.map(|path| current_dir.join(path));

--- a/docs/src/cli/build.md
+++ b/docs/src/cli/build.md
@@ -51,6 +51,10 @@ in the external scanner does so using their allocator.
 Compile the parser with debug flags enabled. This is useful when debugging issues that require a debugger like `gdb` or
 `lldb`.
 
+### `-v/--verbose`
+
+Display verbose build information including working directory (if present), compiler, arguments, and environment variables.
+
 [Known_Folder]: https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid
 [wasi_sdk]: https://github.com/WebAssembly/wasi-sdk
 [XDG]: https://specifications.freedesktop.org/basedir/latest/


### PR DESCRIPTION
This displays the working directory of the command (if present), compiler used, all of its arguments, and any environment variables set.

tree-sitter-vim with various build commands:

<img width="1919" height="669" alt="image" src="https://github.com/user-attachments/assets/d4eeeaf2-e3fb-43fa-8955-53c55de54b59" />
