### PR TITLE
rust: bump language crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,7 +2075,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-language"
-version = "0.1.7"
+version = "0.1.8"
 
 [[package]]
 name = "tree-sitter-loader"

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-language"
 description = "The tree-sitter Language type, used by the library and by language implementations"
-version = "0.1.7"
+version = "0.1.8"
 authors.workspace = true
 edition.workspace = true
 rust-version = "1.77"


### PR DESCRIPTION
The language crate's version had to be bumped to 0.1.7 on the 0.26 release branch, so bump to 0.1.8 on master