### PR TITLE
fix(rust): place `std::env::set_var` inside `unsafe` blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ used_underscore_items = "allow"
 
 [workspace.lints.rust]
 mismatched_lifetime_syntaxes = "allow"
+deprecated_safe_2024 = "deny"
 
 [profile.optimize]
 inherits = "release"

--- a/crates/cli/src/highlight.rs
+++ b/crates/cli/src/highlight.rs
@@ -474,7 +474,7 @@ mod tests {
         assert_eq!(style.css, None);
 
         // darkcyan is an ANSI color and is preserved
-        env::set_var("COLORTERM", "");
+        unsafe { env::set_var("COLORTERM", "") };
         parse_style(&mut style, Value::String(DARK_CYAN.to_string()));
         assert_eq!(
             style.ansi.get_fg_color(),
@@ -483,7 +483,7 @@ mod tests {
         assert_eq!(style.css, Some("color: #00af87".to_string()));
 
         // junglegreen is not an ANSI color and is preserved when the terminal supports it
-        env::set_var("COLORTERM", "truecolor");
+        unsafe { env::set_var("COLORTERM", "truecolor") };
         parse_style(&mut style, Value::String(JUNGLE_GREEN.to_string()));
         assert_eq!(
             style.ansi.get_fg_color(),
@@ -492,7 +492,7 @@ mod tests {
         assert_eq!(style.css, Some("color: #26a69a".to_string()));
 
         // junglegreen gets approximated as cadetblue when the terminal does not support it
-        env::set_var("COLORTERM", "");
+        unsafe { env::set_var("COLORTERM", "") };
         parse_style(&mut style, Value::String(JUNGLE_GREEN.to_string()));
         assert_eq!(
             style.ansi.get_fg_color(),
@@ -501,9 +501,9 @@ mod tests {
         assert_eq!(style.css, Some("color: #26a69a".to_string()));
 
         if let Ok(environment_variable) = original_environment_variable {
-            env::set_var("COLORTERM", environment_variable);
+            unsafe { env::set_var("COLORTERM", environment_variable) };
         } else {
-            env::remove_var("COLORTERM");
+            unsafe { env::remove_var("COLORTERM") };
         }
     }
 }

--- a/crates/xtask/src/benchmark.rs
+++ b/crates/xtask/src/benchmark.rs
@@ -4,18 +4,20 @@ use crate::{bail_on_err, Benchmark};
 
 pub fn run(args: &Benchmark) -> Result<()> {
     if let Some(ref example) = args.example_file_name {
-        std::env::set_var("TREE_SITTER_BENCHMARK_EXAMPLE_FILTER", example);
+        unsafe { std::env::set_var("TREE_SITTER_BENCHMARK_EXAMPLE_FILTER", example) };
     }
 
     if let Some(ref language) = args.language {
-        std::env::set_var("TREE_SITTER_BENCHMARK_LANGUAGE_FILTER", language);
+        unsafe { std::env::set_var("TREE_SITTER_BENCHMARK_LANGUAGE_FILTER", language) };
     }
 
     if args.repetition_count != 5 {
-        std::env::set_var(
-            "TREE_SITTER_BENCHMARK_REPETITION_COUNT",
-            args.repetition_count.to_string(),
-        );
+        unsafe {
+            std::env::set_var(
+                "TREE_SITTER_BENCHMARK_REPETITION_COUNT",
+                args.repetition_count.to_string(),
+            );
+        };
     }
 
     if args.debug {

--- a/crates/xtask/src/test.rs
+++ b/crates/xtask/src/test.rs
@@ -11,7 +11,7 @@ use crate::{bail_on_err, Test};
 
 pub fn run(args: &Test) -> Result<()> {
     let test_flags = if args.address_sanitizer {
-        env::set_var("CFLAGS", "-fsanitize=undefined,address");
+        unsafe { env::set_var("CFLAGS", "-fsanitize=undefined,address") };
 
         // When the Tree-sitter C library is compiled with the address sanitizer, the address
         // sanitizer runtime library needs to be linked into the final test executable. When
@@ -21,12 +21,14 @@ pub fn run(args: &Test) -> Result<()> {
         bail_on_err(&output, "Failed to get clang runtime dir")?;
         let runtime_dir = String::from_utf8(output.stdout)?;
         if runtime_dir.contains("/Xcode.app/") {
-            env::set_var(
-                "RUSTFLAGS",
-                format!(
-                    "-C link-arg=-L{runtime_dir} -C link-arg=-lclang_rt.asan_osx_dynamic -C link-arg=-Wl,-rpath,{runtime_dir}"
-                ),
-            );
+            unsafe {
+                env::set_var(
+                    "RUSTFLAGS",
+                    format!(
+                        "-C link-arg=-L{runtime_dir} -C link-arg=-lclang_rt.asan_osx_dynamic -C link-arg=-Wl,-rpath,{runtime_dir}"
+                    ),
+                );
+            };
         }
 
         // Specify a `--target` explicitly. This is required for address sanitizer support.
@@ -46,22 +48,34 @@ pub fn run(args: &Test) -> Result<()> {
         String::new()
     };
     if let Some(language) = &args.language {
-        env::set_var("TREE_SITTER_LANGUAGE", language);
+        unsafe {
+            env::set_var("TREE_SITTER_LANGUAGE", language);
+        }
     }
     if let Some(example) = &args.example {
-        env::set_var("TREE_SITTER_EXAMPLE_INCLUDE", example);
+        unsafe {
+            env::set_var("TREE_SITTER_EXAMPLE_INCLUDE", example);
+        }
     }
     if let Some(seed) = args.seed {
-        env::set_var("TREE_SITTER_SEED", seed.to_string());
+        unsafe {
+            env::set_var("TREE_SITTER_SEED", seed.to_string());
+        }
     }
     if let Some(iterations) = args.iterations {
-        env::set_var("TREE_SITTER_ITERATIONS", iterations.to_string());
+        unsafe {
+            env::set_var("TREE_SITTER_ITERATIONS", iterations.to_string());
+        }
     }
     if args.debug {
-        env::set_var("TREE_SITTER_LOG", "1");
+        unsafe {
+            env::set_var("TREE_SITTER_LOG", "1");
+        }
     }
     if args.debug_graph {
-        env::set_var("TREE_SITTER_LOG_GRAPHS", "1");
+        unsafe {
+            env::set_var("TREE_SITTER_LOG_GRAPHS", "1");
+        }
     }
 
     if args.g {


### PR DESCRIPTION
This is optional for the 2021 edition but required for 2024. The function is unsafe either way and should be marked as such.

This change will have to be done when we migrate to Rust 2024 edition, so it's best to just get it out of the way now and prevent future additions to the problem. 

- All of the calls in `xtask` are fine, all code is blocking so we have no risk of a race condition.
- The calls inside the `highlight` test are a bit more sketchy, as Rust's test runner is multi-threaded by default. However, this is the _only_ test interacting with that environment variable, and all code within the test is blocking.