### PR TITLE
web: add default export to CJS bundle

### DIFF
--- a/lib/binding_web/script/build.js
+++ b/lib/binding_web/script/build.js
@@ -44,6 +44,9 @@ async function build() {
     keepNames: true,
     external: ['fs/*', 'fs/promises'],
     resolveExtensions: ['.ts', '.js', format === 'esm' ? '.mjs' : '.cjs'],
+    ...(format === 'cjs' ? {
+      footer: { js: 'module.exports.default = module.exports;' },
+    } : {}),
   });
 
   // Copy the Wasm files to the appropriate spot, as esbuild doesn't "bundle" Wasm files


### PR DESCRIPTION
Why?
====

The CJS bundle sets __esModule: true and exports named members
(Parser, Language, etc.) but has no .default property. When
TypeScript consumers use module: "commonjs" + esModuleInterop:
true, the __importDefault helper sees __esModule and returns
module.default — which is undefined. This causes
`import Parser from 'web-tree-sitter'` to silently resolve to
undefined at runtime despite typechecking cleanly.

Reproduction: https://github.com/chadxz/web-tree-sitter-default-export-type-issue

How?
====

- Traced the issue by inspecting the CJS bundle output and
  confirming __esModule is set but no .default exists
- Added `module.exports.default = module.exports;` via
  esbuild's footer option, conditionally for CJS builds only
- Verified by patching the published 0.26.3 bundle in a repro
  project and confirming the default import resolves correctly
- Built the full ESM + CJS bundles from source to confirm the
  footer appears in the CJS output and the .d.cts types align
