### PR TITLE
fix(cli): require tree-sitter CLI in CMake template

### DIFF
--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -752,6 +752,10 @@ pub fn generate_grammar_files(
                     let replaced_contents = contents
                         .replace("add_custom_target(test", "add_custom_target(ts-test")
                         .replace(
+                            "find_program(TREE_SITTER_CLI tree-sitter DOC \"Tree-sitter CLI\")",
+                            "find_program(TREE_SITTER_CLI tree-sitter DOC \"Tree-sitter CLI\" REQUIRED)",
+                        )
+                        .replace(
                             &formatdoc! {r#"
                             install(FILES bindings/c/tree-sitter-{language_name}.h
                                     DESTINATION "${{CMAKE_INSTALL_INCLUDEDIR}}/tree_sitter")

--- a/crates/cli/src/templates/cmakelists.cmake
+++ b/crates/cli/src/templates/cmakelists.cmake
@@ -17,7 +17,7 @@ endif()
 
 include(GNUInstallDirs)
 
-find_program(TREE_SITTER_CLI tree-sitter DOC "Tree-sitter CLI")
+find_program(TREE_SITTER_CLI tree-sitter DOC "Tree-sitter CLI" REQUIRED)
 
 add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
                           "${CMAKE_CURRENT_SOURCE_DIR}/src/node-types.json"


### PR DESCRIPTION
This issue was originally caught in https://github.com/tree-sitter/tree-sitter-cpp/pull/347, this PR brings the fix into the core library. Tested locally in tree-sitter-c.