### PR TITLE
fix(rust)!: return `u32` from `Node::child_count`

### DIFF
--- a/crates/cli/src/fuzz/corpus_test.rs
+++ b/crates/cli/src/fuzz/corpus_test.rs
@@ -23,7 +23,7 @@ pub fn check_consistent_sizes(tree: &Tree, input: &[u8]) {
         let mut some_child_has_changes = false;
         let mut actual_named_child_count = 0;
         for i in 0..node.child_count() {
-            let child = node.child(i as u32).unwrap();
+            let child = node.child(i).unwrap();
             assert!(child.start_byte() >= last_child_end_byte);
             assert!(child.start_position() >= last_child_end_point);
             check(child, line_offsets);

--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -545,7 +545,7 @@ pub fn parse_file_at_path(
                         write!(&mut stdout, "</{}>", tag.expect("there is a tag"))?;
                         // we only write a line in the case where it's the last sibling
                         if let Some(parent) = node.parent() {
-                            if parent.child(parent.child_count() as u32 - 1).unwrap() == node {
+                            if parent.child(parent.child_count() - 1).unwrap() == node {
                                 stdout.write_all(b"\n")?;
                             }
                         }

--- a/crates/cli/src/tests/parser_test.rs
+++ b/crates/cli/src/tests/parser_test.rs
@@ -995,9 +995,9 @@ fn test_parsing_with_timeout_during_balancing() {
         let mut parser = Parser::new();
         parser.set_language(&get_language("javascript")).unwrap();
 
-        let function_count = 100;
+        let function_count: u32 = 100;
 
-        let code = "function() {}\n".repeat(function_count);
+        let code = "function() {}\n".repeat(function_count as usize);
         let mut current_byte_offset = 0;
         let mut in_balancing = false;
         let tree = parser.parse_with_options(

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1717,8 +1717,8 @@ impl<'tree> Node<'tree> {
     /// Get this node's number of children.
     #[doc(alias = "ts_node_child_count")]
     #[must_use]
-    pub fn child_count(&self) -> usize {
-        unsafe { ffi::ts_node_child_count(self.0) as usize }
+    pub fn child_count(&self) -> u32 {
+        unsafe { ffi::ts_node_child_count(self.0) }
     }
 
     /// Get this node's *named* child at the given index.


### PR DESCRIPTION
This matches the type returned from the underlying C library, and also composes more cleanly with other functions like `Node::child`.

One _could_ make the argument for `usize` here because it's the natural "indexing" type in Rust, but (in my opinion) it makes more sense to more closely match what's going on in the core C library.

- Followup to #4664
- Closes #5312