### PR TITLE
feat: allow `-` in grammar names

### DIFF
--- a/docs/src/assets/schemas/config.schema.json
+++ b/docs/src/assets/schemas/config.schema.json
@@ -13,7 +13,7 @@
           "name": {
             "type": "string",
             "description": "The name of the grammar.",
-            "pattern": "^[a-z0-9_]+$"
+            "pattern": "^[a-z0-9_-]+$"
           },
           "camelcase": {
             "type": "string",


### PR DESCRIPTION
A number of grammars in the wild have this character in their name:

- https://github.com/sogaiu/tree-sitter-janet-simple/pull/7
- https://github.com/tree-sitter/tree-sitter-c-sharp/pull/408
- https://github.com/tree-sitter/tree-sitter-embedded-template/pull/45
- https://github.com/tree-sitter/tree-sitter-ql-dbscheme/pull/7

I read through https://github.com/tree-sitter/tree-sitter/pull/3700 and https://github.com/tree-sitter/tree-sitter/issues/3637, and it doesn't look like there was much discussion about this name regex, so hopefully this is an acceptable change?