### PR TITLE
fix(query): prevent cross-branch capture contamination in alternations with quantifiers

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -3076,6 +3076,41 @@ fn test_query_matches_with_deeply_nested_patterns_with_fields() {
 }
 
 #[test]
+fn test_query_alternation_with_inner_quantifier() {
+    let language = get_language("c");
+    let source_code = "#include <foo>
+#include <bar>
+#include <baz>
+
+// comment";
+    let matches = &[
+        (
+            0,
+            vec![
+                ("capture", "#include <foo>\n"),
+                ("capture", "#include <bar>\n"),
+                ("capture", "#include <baz>\n"),
+            ],
+        ),
+        (0, vec![("capture", "// comment")]),
+    ];
+
+    let query = "[
+       (preproc_include)+
+       (comment)
+    ] @capture";
+    let query = Query::new(&language, query).unwrap();
+    assert_query_matches(&language, &query, source_code, matches);
+
+    let query = "[
+       (comment)
+       (preproc_include)+
+    ] @capture";
+    let query = Query::new(&language, query).unwrap();
+    assert_query_matches(&language, &query, source_code, matches);
+}
+
+#[test]
 fn test_query_matches_with_alternations_and_predicates() {
     allocations::record(|| {
         let language = get_language("java");


### PR DESCRIPTION
When a branch inside an alternation has a + or * quantifier, the quantifier's pass_through step loops back to the branch's first step. The alternation linking also sets that step's alternative_index to point to the next branch. This causes the quantifier loop-back to incorrectly explore other branches in the case of a failed match that follows a successful match, contaminating captures.

This is corrected by redirecting the quantifier loop-back to a "clean" copy of the target step without the alternative index pointing to the next alternation branch.

CC @ribru17 Thanks for providing such a nice report and test case for this bug!

- Closes #4949