### PR TITLE
feat(cli) `tree-sitter test --show-diff-symbols`

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -343,6 +343,9 @@ struct Test {
     /// Force showing fields in test diffs
     #[arg(long)]
     pub show_fields: bool,
+    /// Force showing '+' and '-' in test diffs
+    #[arg(long)]
+    pub show_diff_markers: bool,
     /// Show parsing statistics
     #[arg(long)]
     pub stat: Option<TestStats>,
@@ -1342,6 +1345,7 @@ impl Test {
         let test_dir = current_dir.join("test");
         let mut test_summary =
             TestSummary::new(stat, self.update, self.overview_only, self.json_summary);
+        test_summary.use_markers = self.show_diff_markers;
 
         // Run the corpus tests. Look for them in `test/corpus`.
         let test_corpus_dir = test_dir.join("corpus");

--- a/crates/cli/src/test.rs
+++ b/crates/cli/src/test.rs
@@ -207,6 +207,9 @@ pub struct TestSummary {
     // Options passed in from the CLI which control how the summary is displayed
     #[schemars(skip)]
     #[serde(skip)]
+    pub use_markers: bool,
+    #[schemars(skip)]
+    #[serde(skip)]
     pub overview_only: bool,
     #[schemars(skip)]
     #[serde(skip)]
@@ -567,12 +570,17 @@ impl TestSummary {
                 } else {
                     writeln!(f, "\n  {}. {name}:", i + 1)?;
                     if *is_cst {
-                        writeln!(f, "{}", TestDiff::new(actual, expected))?;
+                        writeln!(
+                            f,
+                            "{}",
+                            TestDiff::new(actual, expected).with_markers(self.use_markers)
+                        )?;
                     } else {
                         writeln!(
                             f,
                             "{}",
                             TestDiff::new(&format_sexp(actual, 2), &format_sexp(expected, 2))
+                                .with_markers(self.use_markers)
                         )?;
                     }
                 }
@@ -725,51 +733,48 @@ impl DiffKey {
 pub struct TestDiff<'a> {
     pub actual: &'a str,
     pub expected: &'a str,
+    /// Force `+`/`-` markers even when color is enabled. Markers are always
+    /// shown when color is disabled, regardless of this flag.
+    pub use_markers: bool,
 }
 
 impl<'a> TestDiff<'a> {
     #[must_use]
     pub const fn new(actual: &'a str, expected: &'a str) -> Self {
-        Self { actual, expected }
+        Self {
+            actual,
+            expected,
+            use_markers: false,
+        }
+    }
+
+    #[must_use]
+    pub const fn with_markers(mut self, use_markers: bool) -> Self {
+        self.use_markers = use_markers;
+        self
     }
 }
 
 impl std::fmt::Display for TestDiff<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let diff = TextDiff::from_lines(self.actual, self.expected);
-        for diff in diff.iter_all_changes() {
-            match diff.tag() {
-                ChangeTag::Equal => {
-                    if color_enabled() {
-                        write!(f, "{diff}")?;
-                    } else {
-                        write!(f, " {diff}")?;
-                    }
+        let use_markers = !color_enabled() || self.use_markers;
+        let text_diff = TextDiff::from_lines(self.actual, self.expected);
+        for diff in text_diff.iter_all_changes() {
+            let tag = diff.tag();
+            let (symbol, color) = match tag {
+                ChangeTag::Equal => (' ', None),
+                ChangeTag::Insert => ('+', Some(AnsiColor::Green)),
+                ChangeTag::Delete => ('-', Some(AnsiColor::Red)),
+            };
+            match (color, use_markers) {
+                (Some(color), true) => {
+                    write!(f, "{}", paint(Some(color), format!("{symbol}{diff}")))?;
                 }
-                ChangeTag::Insert => {
-                    if color_enabled() {
-                        write!(
-                            f,
-                            "{}",
-                            paint(Some(AnsiColor::Green), diff.as_str().unwrap())
-                        )?;
-                    } else {
-                        write!(f, "+{diff}")?;
-                    }
-                    if diff.missing_newline() {
-                        writeln!(f)?;
-                    }
+                (Some(color), false) => {
+                    write!(f, "{}", paint(Some(color), diff))?;
                 }
-                ChangeTag::Delete => {
-                    if color_enabled() {
-                        write!(f, "{}", paint(Some(AnsiColor::Red), diff.as_str().unwrap()))?;
-                    } else {
-                        write!(f, "-{diff}")?;
-                    }
-                    if diff.missing_newline() {
-                        writeln!(f)?;
-                    }
-                }
+                (None, true) => write!(f, "{symbol}{diff}")?,
+                (None, false) => write!(f, "{diff}")?,
             }
         }
 

--- a/docs/src/cli/test.md
+++ b/docs/src/cli/test.md
@@ -70,6 +70,10 @@ information.
 
 Force showing fields in test diffs.
 
+### `--show-diff-markers`
+
+Force showing '+' and '-' in test diffs.
+
 ### `--stat <STAT>`
 
 Show parsing statistics when tests are being run. One of `all`, `outliers-and-total`, or `total-only`.


### PR DESCRIPTION
Added `tree-sitter test` option `--show-diff-symbols` so both color and symbols can use simultaneously.

<img width="339" height="224" alt="image" src="https://github.com/user-attachments/assets/78e7e404-b2f4-4f6b-9d7c-550ed38533b1" />
