### PR TITLE
use provided by RedoxOS byte orders implementations

### DIFF
--- a/lib/src/portable/endian.h
+++ b/lib/src/portable/endian.h
@@ -20,14 +20,14 @@
     defined(__GNU__) || \
     defined(__HAIKU__) || \
     defined(__illumos__) || \
+    defined(__redox__) || \
     defined(__NetBSD__) || \
     defined(__OpenBSD__) || \
     defined(__CYGWIN__) || \
     defined(__MSYS__) || \
     defined(__EMSCRIPTEN__) || \
     defined(__wasi__) || \
-    defined(__wasm__) || \
-    defined(__redox__)
+    defined(__wasm__)
 
 #if defined(__NetBSD__)
 #define _NETBSD_SOURCE 1


### PR DESCRIPTION
Hi!
It adds basic Redox OS support to portable/endian.h by including __redox__ in the platform checks. Redox OS uses Relibc, which provides <endian.h> declarations for htobeXX/beXXtoh functions. This avoids the #error "platform not supported" .

The change is minimal and non-breaking for other platforms.
It was created as part of porting Helix editor to Redox OS.

Thanks.