### PR TITLE
nix: support single-checkout and multi-workspace direnv setups

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,4 @@
-use flake
+source_up_if_exists
+if [ -z "${IN_NIX_SHELL:-}" ]; then
+  use flake path:.
+fi


### PR DESCRIPTION
The current `.envrc` unconditionally runs `use flake`, which breaks multi-workspace
jj setups where workspace subdirectories each have their own `.envrc`. Entering a
workspace unloads the root's nix env even when the workspace `.envrc` is blocked,
because direnv always unloads the parent env on any `.envrc` transition.

`source_up_if_exists` re-runs the parent `.envrc` and inherits its nix env in a
multi-workspace setup (fast due to caching). The `IN_NIX_SHELL` guard then skips
`use flake path:.`, which only runs in a plain single checkout where no parent
`.envrc` exists and `IN_NIX_SHELL` is unset.