### PR TITLE
cli(init): fix `Package.swift` scanner detection when used as a dependency

### DIFF
--- a/crates/cli/src/templates/package.swift
+++ b/crates/cli/src/templates/package.swift
@@ -1,10 +1,11 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 
 import Foundation
 import PackageDescription
 
+let dir = Context.packageDirectory
 var sources = ["src/parser.c"]
-if FileManager.default.fileExists(atPath: "src/scanner.c") {
+if FileManager.default.fileExists(atPath: "\(dir)/src/scanner.c") {
     sources.append("src/scanner.c")
 }
 


### PR DESCRIPTION
## Context

The template used `FileManager.default.fileExists(atPath: "src/scanner.c")` with a relative path, which resolves against the process cwd. When SwiftPM evaluates a dependency's manifest, the cwd is the consumer's directory, so the check returns `false` even when `scanner.c` exists, causing undefined symbol linker errors.

## Solution

This commit uses `Context.packageDirectory`, which is available since `swift-tools-version:5.6`, to resolve the path against the package root. This does bump the minimum tools version from 5.3 to 5.6.

## Motivation

See https://github.com/tree-sitter/tree-sitter-javascript/pull/372

