### PR TITLE
loader: invalidate cached wasm toolchains on version mismatch

### DIFF
--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -1498,6 +1498,7 @@ impl Loader {
         if let Some(path) = Self::get_existing_tool(
             "clang",
             "wasi-sdk",
+            WASI_SDK_VERSION,
             &possible_executables,
             "TREE_SITTER_WASI_SDK_PATH",
         )? {
@@ -1515,6 +1516,7 @@ impl Loader {
         Self::download_tool(
             "clang",
             "wasi-sdk",
+            WASI_SDK_VERSION,
             &sdk_filename,
             &sdk_url,
             &possible_executables,
@@ -1538,6 +1540,7 @@ impl Loader {
         if let Some(path) = Self::get_existing_tool(
             "wasm-opt",
             "binaryen",
+            BINARYEN_VERSION,
             &possible_executables,
             "TREE_SITTER_BINARYEN_PATH",
         )? {
@@ -1552,6 +1555,7 @@ impl Loader {
         Self::download_tool(
             "wasm-opt",
             "binaryen",
+            BINARYEN_VERSION,
             &binaryen_filename,
             &binaryen_url,
             &possible_executables,
@@ -1561,6 +1565,7 @@ impl Loader {
     fn get_existing_tool(
         tool_name: &'static str,
         toolchain: &'static str,
+        version: &str,
         possible_exes: &[&'static str],
         env_var: &str,
     ) -> LoaderResult<Option<PathBuf>> {
@@ -1593,7 +1598,24 @@ impl Loader {
             })
         })?;
 
-        let tool_dir = cache_dir.join(toolchain).join("bin");
+        let toolchain_dir = cache_dir.join(toolchain);
+        let version_file = toolchain_dir.join(".version");
+
+        // If a cached toolchain exists but the version doesn't match, remove it
+        if toolchain_dir.exists() {
+            let cached_version =
+                fs::read_to_string(&version_file).unwrap_or_else(|_| "unknown".to_string());
+            if cached_version.trim() != version {
+                info!(
+                    "Cached {toolchain} version ({}) doesn't match expected version ({version}), re-downloading",
+                    cached_version.trim(),
+                );
+                fs::remove_dir_all(&toolchain_dir).ok();
+                return Ok(None);
+            }
+        }
+
+        let tool_dir = toolchain_dir.join("bin");
 
         for exe in possible_exes {
             let tool_exe = tool_dir.join(exe);
@@ -1608,6 +1630,7 @@ impl Loader {
     fn download_tool(
         tool_name: &'static str,
         toolchain: &'static str,
+        version: &str,
         filename: &str,
         url: &str,
         possible_exes: &[&'static str],
@@ -1651,6 +1674,8 @@ impl Loader {
 
         info!("Extracting {tool_name} to {}...", tool_dir.display());
         Self::extract_tar_gz_with_strip(&temp_tar_path, &tool_dir)?;
+
+        fs::write(tool_dir.join(".version"), version).ok();
 
         for exe in possible_exes {
             let tool_exe = tool_dir.join("bin").join(exe);

--- a/crates/xtask/src/build_wasm.rs
+++ b/crates/xtask/src/build_wasm.rs
@@ -372,6 +372,7 @@ pub fn ensure_wasi_sdk_exists() -> Result<PathBuf> {
     if let Some(path) = get_existing_tool(
         "clang",
         "wasi-sdk",
+        WASI_SDK_VERSION,
         &possible_executables,
         "TREE_SITTER_WASI_SDK_PATH",
     )? {
@@ -389,6 +390,7 @@ pub fn ensure_wasi_sdk_exists() -> Result<PathBuf> {
     download_tool(
         "clang",
         "wasi-sdk",
+        WASI_SDK_VERSION,
         &sdk_filename,
         &sdk_url,
         &possible_executables,
@@ -418,6 +420,7 @@ pub fn ensure_binaryen_exists() -> Result<PathBuf> {
     if let Some(path) = get_existing_tool(
         "wasm-opt",
         "binaryen",
+        BINARYEN_VERSION,
         &possible_executables,
         "TREE_SITTER_BINARYEN_PATH",
     )? {
@@ -432,6 +435,7 @@ pub fn ensure_binaryen_exists() -> Result<PathBuf> {
     download_tool(
         "wasm-opt",
         "binaryen",
+        BINARYEN_VERSION,
         &binaryen_filename,
         &binaryen_url,
         &possible_executables,
@@ -441,6 +445,7 @@ pub fn ensure_binaryen_exists() -> Result<PathBuf> {
 fn get_existing_tool(
     tool_name: &'static str,
     toolchain: &'static str,
+    version: &str,
     possible_exes: &[&'static str],
     env_var: &str,
 ) -> Result<Option<PathBuf>> {
@@ -473,7 +478,24 @@ fn get_existing_tool(
         })
     })?;
 
-    let tool_dir = cache_dir.join(toolchain).join("bin");
+    let toolchain_dir = cache_dir.join(toolchain);
+    let version_file = toolchain_dir.join(".version");
+
+    // If a cached toolchain exists but the version doesn't match, remove it
+    if toolchain_dir.exists() {
+        let cached_version =
+            fs::read_to_string(&version_file).unwrap_or_else(|_| "unknown".to_string());
+        if cached_version.trim() != version {
+            eprintln!(
+                "Cached {toolchain} version ({}) doesn't match expected version ({version}), re-downloading",
+                cached_version.trim(),
+            );
+            fs::remove_dir_all(&toolchain_dir).ok();
+            return Ok(None);
+        }
+    }
+
+    let tool_dir = toolchain_dir.join("bin");
 
     for exe in possible_exes {
         let tool_exe = tool_dir.join(exe);
@@ -488,6 +510,7 @@ fn get_existing_tool(
 fn download_tool(
     tool_name: &'static str,
     toolchain: &'static str,
+    version: &str,
     filename: &str,
     url: &str,
     possible_exes: &[&'static str],
@@ -525,6 +548,8 @@ fn download_tool(
 
     eprintln!("Extracting {tool_name} to {}...", tool_dir.display());
     extract_tar_gz_with_strip(&temp_tar_path, &tool_dir)?;
+
+    fs::write(tool_dir.join(".version"), version).ok();
 
     fs::remove_file(temp_tar_path).ok();
     for exe in possible_exes {


### PR DESCRIPTION
### Problem

Previously, `get_existing_tool` checked only for the existence of binaries in the cache directory without verifying their version, meaning bumping the version files had no effect until users manually deleted the cache directories. 

### Solution

This commit writes a `.version` marker file after downloading and checks it on subsequent runs, removing stale caches automatically when the expected version changes.