### PR TITLE
cli: `init -u` fixes

### DIFF
--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -892,7 +892,7 @@ pub fn generate_grammar_files(
                 },
                 |path| {
                     let contents = fs::read_to_string(path)?;
-                    if !contents.contains("uncomment these to include any queries") {
+                    if contents.contains("uncomment these to include any queries") {
                         info!("Replacing __init__.py");
                         generate_file(path, INIT_PY_TEMPLATE, language_name, &generate_opts)?;
                     }


### PR DESCRIPTION
Follow up to #5362, see commit messages. I kept these  separate so that the two fixes could be easily cherry-picked for a manual backport to the release branch. Tested locally with fresh grammars init'd from 0.25.10 and 0.26.5.