### PR TITLE
fix: skip missing Makefile in version command

### DIFF
--- a/crates/cli/src/version.rs
+++ b/crates/cli/src/version.rs
@@ -292,6 +292,9 @@ impl Version {
         } else {
             self.current_dir.join("Makefile")
         };
+        if !makefile_path.exists() {
+            return Ok(());
+        }
 
         Self::update_file_with(&makefile_path, |content| {
             content


### PR DESCRIPTION
Fixes #5383 `tree-sitter version` fails when the project has no `Makefile` (e.g., grammars created before the current `tree-sitter init` flow, or projects with C bindings disabled).
- `update_makefile` was the only `update_*` method in `version.rs` that did not check for file existence before attempting to read it. All other methods (`update_cargo_toml`, `update_package_json`, `update_cmakelists_txt`, `update_pyproject_toml`, `update_zig_zon`) already guard with `if !path.exists() { return Ok(()); }`.

This adds the same check, consistent with the rest of the file.
Tested against [tree-sitter-vim](https://github.com/tree-sitter-grammars/tree-sitter-vim) (the reproduction case from the issue).