### PR TITLE
fix(wasm): pass target triple to clang

### DIFF
--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -1388,6 +1388,7 @@ impl Loader {
 
         let mut compile_command = Command::new(&clang_exe);
         compile_command.current_dir(src_path).args([
+            "--target=wasm32-unknown-wasi",
             "-o",
             output_path,
             "-fPIC",


### PR DESCRIPTION
While the downloader WASI-SDK defaults to building WASM binaries, users might want to use the system's clang instead to safe some disk storage.

By adding the target triple an `export TREE_SITTER_WASI_SDK_PATH=/usr` allows using the system's `clang`. (Tested using 0.26.6 release.)

Passing the default target triple explicitly to WASI-SDK's `clang` should have no impact.