### PR TITLE
fix(wasm): pass target triple to clang (#5385)

### DIFF
--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -1292,6 +1292,7 @@ impl Loader {
 
         let mut command = Command::new(&clang_executable);
         command.current_dir(src_path).args([
+            "--target=wasm32-unknown-wasi",
             "-o",
             output_path.to_str().unwrap(),
             "-fPIC",


### PR DESCRIPTION
Problem: The `clang` binary contained in the WASI-SDK releases downloaded from Github does not work on all platforms (e.g., Alpine/MUSL), but a custom (LLVM) `clang` built for the platform will default to that target, making it impossible to build wasm parsers.

Solution: Always pass `wasm32` target triple when calling clang to compile to wasm.

Notes:
* This assumes the custom `clang` is (installed or linked) to `$TREE_SITTER_WASI_SDK_PATH/bin`.
* This requires a full LLVM clang; Apple clang does not support `wasm` targets.
* Tree-sitter expects a specified version of WASI-SDK, including a specific `clang` version. Other versions may but are not guaranteed to work.
