### PR TITLE
fix(loader): link with libc on OpenBSD to compile parser

### DIFF
--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -1276,6 +1276,8 @@ impl Loader {
             } else {
                 command.arg("-shared");
                 command.arg("-Wl,--no-undefined");
+                #[cfg(target_os = "openbsd")]
+                command.arg("-lc");
             }
             command.args(cc_config.get_files());
             command.arg("-o").arg(output_path);


### PR DESCRIPTION
Fix tree-sitter/tree-sitter#5333

---

**Tests OK on OpenBSD/amd64** when generating/building parser from TS grammars for Javascript

- Build `tree-sitter` CLI with Rust 1.93.1
```sh
$ LIBCLANG_PATH=/usr/local/llvm19/lib cargo build -v
(...)
$ ./target/debug/tree-sitter -V
tree-sitter 0.27.0
```
- Clone sources from https://github.com/tree-sitter/tree-sitter-javascript
- Generate and build parser for `tree-sitter-javascript`
```sh
$ cd tree-sitter-javascript
$ ../tree-sitter.git/target/debug/tree-sitter generate
$ git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   src/parser.c
        modified:   src/tree_sitter/array.h

no changes added to commit (use "git add" and/or "git commit -a")
$ ../tree-sitter.git/target/debug/tree-sitter build
Warning: Failed to run `nm` to verify symbols in /home/fox/dev/tree-sitter-javascript/javascript.so
$ ls -l javascript.so
-rwxr-xr-x  1 fox  fox  436448 Feb 28 18:35 javascript.so
```