### PR TITLE
chore(parser): return `NULL`, not `false`, for incomplete parse

### DIFF
--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -2179,7 +2179,7 @@ balance:
   ts_assert(self->finished_tree.ptr);
   if (!ts_parser__balance_subtree(self)) {
     self->canceled_balancing = true;
-    return false;
+    return NULL;
   }
   self->canceled_balancing = false;
   LOG("done");


### PR DESCRIPTION
Small nit; `NULL` is returned everywhere else in this function for an incomplete parse.