### PR TITLE
fix(rust): remove unused dependencies from loader and lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,7 +1934,6 @@ dependencies = [
  "bindgen",
  "cc",
  "regex",
- "regex-syntax",
  "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
@@ -2042,7 +2041,6 @@ version = "0.27.0"
 dependencies = [
  "cc",
  "etcetera",
- "indoc",
  "libloading 0.9.0",
  "log",
  "once_cell",

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -30,7 +30,6 @@ wasm    = [ "tree-sitter/wasm" ]
 [dependencies]
 cc.workspace         = true
 etcetera.workspace   = true
-indoc.workspace      = true
 libloading.workspace = true
 log.workspace        = true
 once_cell.workspace  = true

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -38,12 +38,11 @@ workspace = true
 
 [features]
 default = [ "std" ]
-std     = [ "regex/std", "regex/perf", "regex-syntax/unicode" ]
+std     = [ "regex/std", "regex/perf" ]
 wasm    = [ "std", "wasmtime-c-api" ]
 
 [dependencies]
 regex                          = { default-features = false, features = [ "unicode" ], version = "1.12.3" }
-regex-syntax                   = { default-features = false, version = "0.8.9" }
 streaming-iterator             = "0.1.9"
 tree-sitter-language.workspace = true
 


### PR DESCRIPTION
Found via [cargo-machete](https://github.com/bnjbvr/cargo-machete).

Note that even  though we're removing `regex-syntax` as an explicit dependency, it's still pulled in unconditionally as a transitive dependency via `regex` because of the `unicode` feature.