### PR TITLE
query: add recursive back-reference (^) syntax for alternations (for #880)

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -6528,3 +6528,469 @@ fn test_query_recursive_ref_nested_alternations() {
         );
     });
 }
+
+// -----------------------------------------------------------------------
+// Recursive back-reference: capture ordering along the recursion path
+//
+// All tests use C pointer/array declarations for compact nesting:
+//   int ***c;          - 3 pointer levels
+//   int c2[10][20][30]; - 3 array levels
+//   int **g[10];       - mixed: 2 ptr + 1 arr (3 total)
+//   int *h[10][20];    - mixed: 1 ptr + 2 arr (3 total)
+// -----------------------------------------------------------------------
+
+// Test 1: Capture only root type and leaf identifier - no intermediate
+// recursion captures. Each declaration produces a single match with
+// scalar (non-repeated) captures regardless of nesting depth.
+#[test]
+fn test_query_recursive_ref_capture_root_and_leaf_only() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            "(declaration type: (_) @type declarator: [(pointer_declarator declarator: (^)) (identifier) @name])",
+        ).unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "int *a; int **b; int ***c;",
+            &[
+                (0, vec![("type", "int"), ("name", "a")]),
+                (0, vec![("type", "int"), ("name", "b")]),
+                (0, vec![("type", "int"), ("name", "c")]),
+            ],
+        );
+    });
+}
+
+// Test 2: Capture root, leaf, AND each recursion step.
+// The @ptr capture appears once per pointer_declarator traversed -
+// including the outermost one - in DFS (= source) order.
+#[test]
+fn test_query_recursive_ref_capture_all_steps() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            "(declaration type: (_) @type declarator: [(pointer_declarator declarator: (^)) @ptr (identifier) @name])",
+        ).unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "int *a; int **b; int ***c;",
+            &[
+                // depth 1: single ptr captured, then base case
+                (0, vec![("type", "int"), ("ptr", "*a"), ("name", "a")]),
+                // depth 2: two ptrs in source order (outer first)
+                (0, vec![("type", "int"), ("ptr", "**b"), ("ptr", "*b"), ("name", "b")]),
+                // depth 3: three ptrs in source order
+                (0, vec![("type", "int"), ("ptr", "***c"), ("ptr", "**c"), ("ptr", "*c"), ("name", "c")]),
+            ],
+        );
+    });
+}
+
+// Test 3: Three recursive alternatives (pointer_declarator,
+// array_declarator, parenthesized_declarator) captured under the SAME
+// name @step. parenthesized_declarator is transparent (no capture),
+// so paren levels are invisible in the capture list.
+#[test]
+fn test_query_recursive_ref_mixed_alternatives_same_name() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(declaration type: (_) @type declarator: [",
+                "  (pointer_declarator declarator: (^)) @step",
+                "  (array_declarator declarator: (^)) @step",
+                "  (parenthesized_declarator (^))",
+                "  (identifier) @name",
+                "])",
+            ),
+        ).unwrap();
+
+        // int ***c;          ~> ptr(ptr(ptr(id)))
+        // int d[10][20][30]; ~> arr(arr(arr(id)))
+        // int **g[10];       ~> ptr(ptr(arr(id)))
+        // int *h[10][20];    ~> ptr(arr(arr(id)))
+        // int (*e)[10];      ~> arr(paren(ptr(id))) - paren level skipped
+        assert_query_matches(
+            &language,
+            &query,
+            "int ***c; int d[10][20][30]; int **g[10]; int *h[10][20]; int (*e)[10];",
+            &[
+                (0, vec![("type", "int"), ("step", "***c"), ("step", "**c"), ("step", "*c"), ("name", "c")]),
+                (0, vec![("type", "int"), ("step", "d[10][20][30]"), ("step", "d[10][20]"), ("step", "d[10]"), ("name", "d")]),
+                (0, vec![("type", "int"), ("step", "**g[10]"), ("step", "*g[10]"), ("step", "g[10]"), ("name", "g")]),
+                (0, vec![("type", "int"), ("step", "*h[10][20]"), ("step", "h[10][20]"), ("step", "h[10]"), ("name", "h")]),
+                (0, vec![("type", "int"), ("step", "(*e)[10]"), ("step", "*e"), ("name", "e")]),
+            ],
+        );
+    });
+}
+
+// Test 4: Recursive alternatives captured under SEPARATE names
+// @ptr and @arr. parenthesized_declarator passes through without
+// capture. Each list only contains matches from its own branch.
+#[test]
+fn test_query_recursive_ref_mixed_alternatives_separate_names() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(declaration type: (_) @type declarator: [",
+                "  (pointer_declarator declarator: (^)) @ptr",
+                "  (array_declarator declarator: (^)) @arr",
+                "  (parenthesized_declarator (^))",
+                "  (identifier) @name",
+                "])",
+            ),
+        ).unwrap();
+
+        // int ***c;              ~> ptr, ptr, ptr (3 @ptr)
+        // int d[10][20][30];     ~> arr, arr, arr (3 @arr)
+        // int **g[10];           ~> ptr, ptr, arr (2 @ptr + 1 @arr)
+        // int *h[10][20];        ~> ptr, arr, arr (1 @ptr + 2 @arr)
+        // int (*e)[10];          ~> arr, paren, ptr (1 @arr + 1 @ptr)
+        // int (*(*f)[10])[20];   ~> arr, paren, ptr, arr, paren, ptr (2 @arr + 2 @ptr)
+        assert_query_matches(
+            &language,
+            &query,
+            "int ***c; int d[10][20][30]; int **g[10]; int *h[10][20]; int (*e)[10]; int (*(*f)[10])[20];",
+            &[
+                (0, vec![("type", "int"), ("ptr", "***c"), ("ptr", "**c"), ("ptr", "*c"), ("name", "c")]),
+                (0, vec![("type", "int"), ("arr", "d[10][20][30]"), ("arr", "d[10][20]"), ("arr", "d[10]"), ("name", "d")]),
+                (0, vec![("type", "int"), ("ptr", "**g[10]"), ("ptr", "*g[10]"), ("arr", "g[10]"), ("name", "g")]),
+                (0, vec![("type", "int"), ("ptr", "*h[10][20]"), ("arr", "h[10][20]"), ("arr", "h[10]"), ("name", "h")]),
+                (0, vec![("type", "int"), ("arr", "(*e)[10]"), ("ptr", "*e"), ("name", "e")]),
+                (0, vec![("type", "int"), ("arr", "(*(*f)[10])[20]"), ("ptr", "*(*f)[10]"), ("arr", "(*f)[10]"), ("ptr", "*f"), ("name", "f")]),
+            ],
+        );
+    });
+}
+
+// Test 5: Capture ONE specific recursive alternative (@ptr only) PLUS
+// the alternation itself (@step on [...]). @step captures every
+// recursion level; @ptr captures only pointer_declarator levels.
+// This gives two lists: one complete, one filtered.
+#[test]
+fn test_query_recursive_ref_partial_capture_plus_alternation() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(declaration type: (_) @type declarator: [",
+                "  (pointer_declarator declarator: (^)) @ptr",
+                "  (array_declarator declarator: (^))",
+                "  (identifier) @name",
+                "] @step)",
+            ),
+        ).unwrap();
+
+        // int *h[10][20]; - ptr(arr[20](arr[10](id)))
+        // @step fires at every level; @ptr fires only for pointer levels.
+        // Capture order within a level: branch capture before alternation capture.
+        assert_query_matches(
+            &language,
+            &query,
+            "int *h[10][20];",
+            &[
+                (0, vec![
+                    ("type", "int"),
+                    ("ptr", "*h[10][20]"), ("step", "*h[10][20]"),
+                    ("step", "h[10][20]"),
+                    ("step", "h[10]"),
+                    ("name", "h"), ("step", "h"),
+                ]),
+            ],
+        );
+    });
+}
+
+// Test 6: Same as test 5, but the specific-branch capture and the
+// alternation capture share the SAME name @step. When a pointer branch
+// matches, it is captured twice under @step (once from the branch,
+// once from the alternation). Array branches and the base case produce
+// one @step each.
+#[test]
+fn test_query_recursive_ref_partial_capture_same_name_as_alternation() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(declaration type: (_) @type declarator: [",
+                "  (pointer_declarator declarator: (^)) @step",
+                "  (array_declarator declarator: (^))",
+                "  (identifier) @name",
+                "] @step)",
+            ),
+        ).unwrap();
+
+        // int *h[10][20]; - ptr(arr(arr(id)))
+        // ptr level: branch @step + alternation @step ~> duplicated
+        // arr levels: only alternation @step
+        // id level: @name + alternation @step
+        assert_query_matches(
+            &language,
+            &query,
+            "int *h[10][20];",
+            &[
+                (0, vec![
+                    ("type", "int"),
+                    ("step", "*h[10][20]"), ("step", "*h[10][20]"),
+                    ("step", "h[10][20]"),
+                    ("step", "h[10]"),
+                    ("name", "h"), ("step", "h"),
+                ]),
+            ],
+        );
+    });
+}
+
+// Edge case: plain identifier (no ptr/arr nesting)
+// should produce no matches - the alternation requires at least one
+// pointer_declarator wrapper before the identifier base case.
+#[test]
+fn test_query_recursive_ref_capture_no_match_plain_decl() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            "(declaration type: (_) @type declarator: [(pointer_declarator declarator: (^)) @ptr (identifier) @name])",
+        ).unwrap();
+
+        // int x; - declarator is identifier directly; needs pointer_declarator
+        // as the alternation is inside (declaration declarator: [...])
+        // and identifier IS in the alternation as a base case, so it
+        // SHOULD match (the alternation sits in declarator: position).
+        assert_query_matches(
+            &language,
+            &query,
+            "int x;",
+            &[
+                (0, vec![("type", "int"), ("name", "x")]),
+            ],
+        );
+    });
+}
+
+// -----------------------------------------------------------------------
+// Recursive back-reference: field combinations on alternation entry vs (^)
+//
+// The alternation `[...]` may sit behind a field prefix (from the outer
+// node), and the `(^)` inside a branch may sit behind its own field.
+// Many combinations of fielded and unfielded exist
+
+// Test 1: entry field=0, (^) field=0.
+#[test]
+fn test_query_recursive_ref_field_both_unnamed() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(expression_statement",
+                "  [(parenthesized_expression (^))",
+                "   (identifier) @leaf",
+                "]) @root",
+            ),
+        ).unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "void f() { a; (a); ((a)); }",
+            &[
+                (0, vec![("root", "a;"), ("leaf", "a")]),
+                (0, vec![("root", "(a);"), ("leaf", "a")]),
+                (0, vec![("root", "((a));"), ("leaf", "a")]),
+            ],
+        );
+    });
+}
+
+// Test 2: entry field=A, (^) field=0.
+#[test]
+fn test_query_recursive_ref_field_root_named() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(pointer_expression argument:",
+                "  [(parenthesized_expression (^))",
+                "   (identifier) @leaf",
+                "]) @root",
+            ),
+        ).unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "void f() { *a; *(a); *((a)); }",
+            &[
+                (0, vec![("root", "*a"), ("leaf", "a")]),
+                (0, vec![("root", "*(a)"), ("leaf", "a")]),
+                (0, vec![("root", "*((a))"), ("leaf", "a")]),
+            ],
+        );
+    });
+}
+
+// Test 3: recursion named only - entry field=0, (^) field=A.
+#[test]
+fn test_query_recursive_ref_field_recursion_named() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(expression_statement",
+                "  [(parenthesized_expression",
+                "     (binary_expression left: (^)))",
+                "   (identifier) @leaf",
+                "]) @root",
+            ),
+        ).unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "void f() { a; (a+1); ((a+1)+2); }",
+            &[
+                (0, vec![("root", "a;"), ("leaf", "a")]),
+                (0, vec![("root", "(a+1);"), ("leaf", "a")]),
+                (0, vec![("root", "((a+1)+2);"), ("leaf", "a")]),
+            ],
+        );
+    });
+}
+
+// Test 4: recursion uses different name - entry field=A, (^) field=B.
+#[test]
+fn test_query_recursive_ref_field_different_names() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(pointer_expression argument:",
+                "  [(cast_expression value: (^))",
+                "   (identifier) @leaf",
+                "]) @root",
+            ),
+        ).unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "void f() { *a; *(int)a; *(int)(float)a; }",
+            &[
+                (0, vec![("root", "*a"), ("leaf", "a")]),
+                (0, vec![("root", "*(int)a"), ("leaf", "a")]),
+                (0, vec![("root", "*(int)(float)a"), ("leaf", "a")]),
+            ],
+        );
+    });
+}
+
+// Test 5: recursion uses same name - entry field=A, (^) field=A.
+#[test]
+fn test_query_recursive_ref_field_same_name() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(pointer_expression argument:",
+                "  [(unary_expression argument: (^))",
+                "   (identifier) @leaf",
+                "]) @root",
+            ),
+        ).unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "void f() { *a; *!a; *!!a; }",
+            &[
+                (0, vec![("root", "*a"), ("leaf", "a")]),
+                (0, vec![("root", "*!a"), ("leaf", "a")]),
+                (0, vec![("root", "*!!a"), ("leaf", "a")]),
+            ],
+        );
+    });
+}
+
+// Test 6: multiple recursions, entry field=A and (^) field=B or field=0
+#[test]
+fn test_query_recursive_ref_field_multi_chain_2() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(pointer_expression argument:",
+                "  [(cast_expression value: (^))",
+                "   (parenthesized_expression (^))",
+                "   (identifier) @leaf",
+                "]) @root",
+            ),
+        ).unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "void f() { *a; *(int)a; *(a); *(int)(a); *((int)a); }",
+            &[
+                (0, vec![("root", "*a"), ("leaf", "a")]),
+                (0, vec![("root", "*(int)a"), ("leaf", "a")]),
+                (0, vec![("root", "*(a)"), ("leaf", "a")]),
+                (0, vec![("root", "*(int)(a)"), ("leaf", "a")]),
+                (0, vec![("root", "*((int)a)"), ("leaf", "a")]),
+            ],
+        );
+    });
+}
+
+// Test 7: Multiple declarations sharing one parse, verifying that
+// captures from different matches don't leak across match boundaries.
+#[test]
+fn test_query_recursive_ref_capture_isolation_across_matches() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(declaration type: (_) @type declarator: [",
+                "  (pointer_declarator declarator: (^)) @ptr",
+                "  (array_declarator declarator: (^)) @arr",
+                "  (parenthesized_declarator (^))",
+                "  (identifier) @name",
+                "])",
+            ),
+        ).unwrap();
+
+        // Six declarations of increasing complexity in one source.
+        // Every level goes through the alternation - outermost included.
+        assert_query_matches(
+            &language,
+            &query,
+            "int *a; int b[10]; int **c[10]; int *d[10][20]; int ***e; int (*f)[10];",
+            &[
+                (0, vec![("type", "int"), ("ptr", "*a"), ("name", "a")]),
+                (0, vec![("type", "int"), ("arr", "b[10]"), ("name", "b")]),
+                (0, vec![("type", "int"), ("ptr", "**c[10]"), ("ptr", "*c[10]"), ("arr", "c[10]"), ("name", "c")]),
+                (0, vec![("type", "int"), ("ptr", "*d[10][20]"), ("arr", "d[10][20]"), ("arr", "d[10]"), ("name", "d")]),
+                (0, vec![("type", "int"), ("ptr", "***e"), ("ptr", "**e"), ("ptr", "*e"), ("name", "e")]),
+                (0, vec![("type", "int"), ("arr", "(*f)[10]"), ("ptr", "*f"), ("name", "f")]),
+            ],
+        );
+    });
+}

--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -6994,3 +6994,431 @@ fn test_query_recursive_ref_capture_isolation_across_matches() {
         );
     });
 }
+
+// =========================================================================
+// Labeled recursive references: (^label ...body) and (^label)
+// =========================================================================
+
+#[test]
+fn test_query_labeled_ref_parse_errors() {
+    allocations::record(|| {
+        let language = get_language("c");
+
+        // (^label) referencing an undefined label
+        assert_eq!(
+            Query::new(&language, "(function_definition (^nosuch))").unwrap_err().kind,
+            QueryErrorKind::Syntax,
+        );
+
+        // (^label) at top level with no definition
+        assert_eq!(
+            Query::new(&language, "(^label)").unwrap_err().kind,
+            QueryErrorKind::Syntax,
+        );
+
+        // Forward reference: (^label) before (^label ...body)
+        assert_eq!(
+            Query::new(
+                &language,
+                "(function_definition (^label) (^label (compound_statement)))",
+            )
+            .unwrap_err()
+            .kind,
+            QueryErrorKind::Syntax,
+        );
+
+        // Self-loop: (^d) as bare branch directly inside (^d [...])
+        // Same as [(^) (identifier)] - zero-width loop, rejected as Structure error.
+        assert_eq!(
+            Query::new(
+                &language,
+                "(declaration declarator: (^d [(^d) (identifier)]))",
+            )
+            .unwrap_err()
+            .kind,
+            QueryErrorKind::Structure,
+        );
+
+        // Out-of-scope: (^label) after (^label ...body) has closed
+        assert_eq!(
+            Query::new(
+                &language,
+                "(function_definition (^d (compound_statement)) (^d))",
+            )
+            .unwrap_err()
+            .kind,
+            QueryErrorKind::Syntax,
+        );
+    });
+}
+
+#[test]
+fn test_query_labeled_ref_valid_parse() {
+    allocations::record(|| {
+        let language = get_language("c");
+
+        // Basic labeled recursion on declarator chain
+        assert!(Query::new(
+            &language,
+            "(declaration declarator: (^d [(pointer_declarator declarator: (^d)) (identifier) @name]))",
+        )
+        .is_ok());
+
+        // Label above alternation - the key motivating case
+        assert!(Query::new(
+            &language,
+            concat!(
+                "(declaration declarator: (^rec (parenthesized_declarator [",
+                "  (pointer_declarator declarator: (^rec)) @ptr",
+                "  (identifier) @name",
+                "])))",
+            ),
+        )
+        .is_ok());
+    });
+}
+
+#[test]
+fn test_query_labeled_ref_equivalent_to_anonymous() {
+    // A labeled ref targeting the alternation itself should behave identically
+    // to an anonymous (^).
+    allocations::record(|| {
+        let language = get_language("c");
+
+        // (^d [...]) wraps the alternation directly - equivalent to bare (^).
+        let query = Query::new(
+            &language,
+            concat!(
+                "(declaration type: (_) @type declarator: (^d [",
+                "  (pointer_declarator declarator: (^d)) @ptr",
+                "  (identifier) @name",
+                "]))",
+            ),
+        )
+        .unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "int *a; int **b; int ***c;",
+            &[
+                (0, vec![("type", "int"), ("ptr", "*a"), ("name", "a")]),
+                (0, vec![("type", "int"), ("ptr", "**b"), ("ptr", "*b"), ("name", "b")]),
+                (0, vec![("type", "int"), ("ptr", "***c"), ("ptr", "**c"), ("ptr", "*c"), ("name", "c")]),
+            ],
+        );
+    });
+}
+
+#[test]
+fn test_query_labeled_ref_above_alternation() {
+    // The label wraps compound_statement, which is ABOVE the alternation.
+    // This avoids duplicating compound_statement in each branch.
+    //
+    // Without labels, you'd need:
+    //   [(compound_statement (if ... consequence: (^))) (compound_statement (return))]
+    // With a label above:
+    //   (^rec (compound_statement [(if ... consequence: (^rec)) (return)]))
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(function_definition body: (^rec (compound_statement [",
+                "  (if_statement consequence: (^rec)) @if",
+                "  (return_statement) @ret",
+                "])))",
+            ),
+        )
+        .unwrap();
+
+        // Single-line source avoids long whitespace escapes in expected output.
+        assert_query_matches(
+            &language,
+            &query,
+            "int f(int x, int y) { if (x) { if (y) { return 2; } return 1; } return 0; }",
+            &[
+                (0, vec![
+                    ("if", "if (x) { if (y) { return 2; } return 1; }"),
+                    ("if", "if (y) { return 2; }"),
+                    ("ret", "return 2;"),
+                ]),
+                (0, vec![
+                    ("if", "if (x) { if (y) { return 2; } return 1; }"),
+                    ("ret", "return 1;"),
+                ]),
+                (0, vec![("ret", "return 0;")]),
+            ],
+        );
+    });
+}
+
+#[test]
+fn test_query_labeled_ref_nested_shadow() {
+    // Two (^d ...) definitions with the same name at different depths.
+    // Outer: recurses through pointer_declarator, array_declarator, and identifier.
+    // Inner (shadows, inside array_declarator): recurses through pointer_declarator
+    // and identifier only - no array_declarator.
+    //
+    // The (^d) inside the inner definition targets the inner (pointer-only) label,
+    // not the outer (pointer+array) label. This means once we enter an
+    // array_declarator, further recursion only peels pointers - not more arrays.
+    // Demonstrated by: `int a[10][20]` produces NO match (inner label blocks nested
+    // arrays), while `int *a[10]` and `int a[10]` work fine.
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(declaration type: (_) @type declarator: (^d [",
+                "  (pointer_declarator declarator: (^d)) @ptr",
+                "  (array_declarator declarator: (^d [",
+                "    (pointer_declarator declarator: (^d)) @inner_ptr",
+                "    (identifier) @name",
+                "  ])) @arr",
+                "  (identifier) @name",
+                "]))",
+            ),
+        )
+        .unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "int *a[10]; int a[10][20]; int **b; int a[10];",
+            &[
+                // int *a[10] - outer ptr ~> outer arr ~> inner name
+                (0, vec![("type", "int"), ("ptr", "*a[10]"), ("arr", "a[10]"), ("name", "a")]),
+                
+                // int a[10][20] - outer arr, but inner label has no arr branch ~> NO MATCH
+                
+                // int **b - outer ptr ~> outer ptr ~> outer name (no arrays involved)
+                (0, vec![("type", "int"), ("ptr", "**b"), ("ptr", "*b"), ("name", "b")]),
+                
+                // int a[10] - outer arr ~> inner name
+                (0, vec![("type", "int"), ("arr", "a[10]"), ("name", "a")]),
+            ],
+        );
+    });
+}
+
+#[test]
+fn test_query_two_labels_unary_paren() {
+    // Two labels (^a, ^b) - neither directly on an alternation.
+    // (^a) wraps unary_expression, (^b) wraps parenthesized_expression.
+    // Every unary op must pass through parens to reach its argument;
+    // parens can self-nest via (^b) or contain another unary via (^a).
+    //
+    // Matches: +(a), +((b)), +(+(c)), -(!(e))
+    // No match: +d (no parens around arg), (e) (no unary at top)
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(expression_statement",
+                "  (^a (unary_expression",
+                "    (^b (parenthesized_expression [",
+                "      (^a) (^b) (identifier) @name",
+                "    ]) @paren)",
+                "  ) @unary)",
+                ")",
+            ),
+        )
+        .unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "void f() { +(a); +((b)); +(+(c)); -(!(e)); +d; (g); }",
+            &[
+                (0, vec![("unary", "+(a)"), ("paren", "(a)"), ("name", "a")]),
+                (0, vec![("unary", "+((b))"), ("paren", "((b))"), ("paren", "(b)"), ("name", "b")]),
+                (0, vec![("unary", "+(+(c))"), ("paren", "(+(c))"), ("unary", "+(c)"), ("paren", "(c)"), ("name", "c")]),
+                (0, vec![("unary", "-(!(e))"), ("paren", "(!(e))"), ("unary", "!(e)"), ("paren", "(e)"), ("name", "e")]),
+                // +d - no match (unary arg is not parenthesized)
+                // (g) - no match (top level is not unary_expression)
+            ],
+        );
+    });
+}
+
+#[test]
+fn test_query_two_labels_two_domains() {
+    // Two labels creating distinct recursion domains.
+    // (^outer) wraps parenthesized_expression - every level must go through parens.
+    // Inside parens:
+    //   - unary_expression recurses to (^outer) via non-bare ref
+    //   - (^inner) wraps a second parenthesized_expression for paren-only nesting
+    //   - identifier is the base case at both levels
+    //
+    // Once in the inner-paren domain, recursion can only self-nest parens or
+    // reach identifier - unary is unreachable.  This demonstrates two labels
+    // governing independent recursion scopes.
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(expression_statement",
+                "  (^outer (parenthesized_expression [",
+                "    (unary_expression (^outer)) @un",
+                "    (^inner (parenthesized_expression [",
+                "      (^inner)",
+                "      (identifier) @name",
+                "    ]) @inner_paren)",
+                "    (identifier) @name",
+                "  ]) @paren)",
+                ")",
+            ),
+        )
+        .unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "void f() { (a); ((b)); (+(c)); (+((d))); (((e))); (+(+(f))); ((+(g))); +(h); }",
+            &[
+                // (a) - outer paren, identifier base case
+                (0, vec![("paren", "(a)"), ("name", "a")]),
+                
+                // ((b)) - outer paren, inner paren, identifier
+                (0, vec![("paren", "((b))"), ("inner_paren", "(b)"), ("name", "b")]),
+                
+                // (+(c)) - outer paren, unary recurse, outer paren, identifier
+                (0, vec![("paren", "(+(c))"), ("un", "+(c)"), ("paren", "(c)"), ("name", "c")]),
+
+                // (+((d))) - outer + unary + outer + inner + identifier
+                (0, vec![("paren", "(+((d)))"), ("un", "+((d))"), ("paren", "((d))"), ("inner_paren", "(d)"), ("name", "d")]),
+
+                // (((e))) - outer + inner + inner self-recurse + identifier
+                (0, vec![("paren", "(((e)))"), ("inner_paren", "((e))"), ("inner_paren", "(e)"), ("name", "e")]),
+                
+                // (+(+(f))) - outer + unary + outer + unary + outer + identifier
+                (0, vec![("paren", "(+(+(f)))"), ("un", "+(+(f))"), ("paren", "(+(f))"), ("un", "+(f)"), ("paren", "(f)"), ("name", "f")]),
+
+                // ((+(g))) - inner paren wraps +(g), but inner has no unary branch ~> no match
+
+                // +(h) - top level is unary, not parenthesized ~> no match
+            ],
+        );
+    });
+}
+
+#[test]
+fn test_query_kitchen_sink_all_refs() {
+    // Kitchen-sink test using both recursion mechanisms twice:
+    //   (^outer)  - labeled back-reference to outer paren scope
+    //   (^inner …) - labeled scope for inner paren domain
+    //   (^)       - anonymous self-recurse (inner paren nesting)
+    //   (^^)      - anonymous outer-recurse (escape inner ~> outer alt)
+    //
+    // Outer scope: (parenthesized_expression [ unary ~> (^outer) | (^inner paren[…]) | id ])
+    // Inner scope: (parenthesized_expression [ (paren (^))@deep | (^^) | id ])
+    //
+    // (^) requires a real node before it (bare self-ref is a self-loop), so
+    // inner's self-recurse is (parenthesized_expression (^)) - paren nesting.
+    // (^^) escapes from inner domain to outer alt, reaching unary_expression.
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(expression_statement",
+                "  (^outer (parenthesized_expression [",
+                "    (unary_expression (^outer)) @un",
+                "    (^inner (parenthesized_expression [",
+                "      (parenthesized_expression (^)) @deep_paren",
+                "      (^^)",
+                "      (identifier) @name",
+                "    ]) @inner_paren)",
+                "    (identifier) @name",
+                "  ]) @paren)",
+                ")",
+            ),
+        )
+        .unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "void f() { (a); ((b)); (+(a)); (((c))); ((+(a))); ((+((d)))); (+(+(a))); }",
+            &[
+                // (a) - base case: outer paren ~> identifier
+                (0, vec![("paren", "(a)"), ("name", "a")]),
+
+                // ((b)) - (^inner) scope: outer ~> inner ~> identifier
+                (0, vec![("paren", "((b))"), ("inner_paren", "(b)"), ("name", "b")]),
+
+                // (+(a)) - (^outer) labeled ref: outer ~> unary ~> outer ~> identifier
+                (0, vec![("paren", "(+(a))"), ("un", "+(a)"), ("paren", "(a)"), ("name", "a")]),
+
+                // (((c))) - (^) anonymous self: outer ~> inner ~> deep_paren ~> inner ~> identifier
+                (0, vec![("paren", "(((c)))"), ("inner_paren", "((c))"), ("deep_paren", "(c)"), ("name", "c")]),
+
+                // (((c))) - also via (^^) ~> outer ~> inner chain (inner_paren at both levels)
+                (0, vec![("paren", "(((c)))"), ("inner_paren", "((c))"), ("inner_paren", "(c)"), ("name", "c")]),
+
+                // ((+(a))) - (^^) escape: outer ~> inner ~> (^^) ~> outer ~> unary ~> (^outer) ~> paren ~> id
+                (0, vec![("paren", "((+(a)))"), ("inner_paren", "(+(a))"), ("un", "+(a)"), ("paren", "(a)"), ("name", "a")]),
+
+                // ((+((d)))) - (^^) + full chain: inner ~> (^^) ~> outer.unary ~> (^outer) ~> paren ~> inner ~> id
+                (0, vec![("paren", "((+((d))))"), ("inner_paren", "(+((d)))"), ("un", "+((d))"), ("paren", "((d))"), ("inner_paren", "(d)"), ("name", "d")]),
+
+                // (+(+(a))) - double (^outer): outer ~> unary ~> outer ~> unary ~> outer ~> identifier
+                (0, vec![("paren", "(+(+(a)))"), ("un", "+(+(a))"), ("paren", "(+(a))"), ("un", "+(a)"), ("paren", "(a)"), ("name", "a")]),
+            ],
+        );
+    });
+}
+
+#[test]
+fn test_query_recursive_ref_unlabeled_outer_dup() {
+    // Demonstrates spurious duplicate matches using only unlabeled (^^).
+    // No labels involved - the issue is purely about recursion targets
+    // coinciding with outer alternation branch starts.
+    //
+    // Outer alt: [ (unary_expression (paren [inner_alt])) | (identifier) ]
+    // Inner alt: [ (^^) | (identifier) ]
+    //
+    // (^^) escapes the inner paren domain to the outer alt, enabling
+    // unary nesting through parens: (+(+(a))).  But when the inner alt
+    // is entered, the (^^) pass-through creates a copy to the inner
+    // identifier branch, AND the dead-end jump to the outer alt start
+    // follows that step's outer alt link to the outer identifier branch,
+    // producing a spurious duplicate.
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(expression_statement",
+                "  (parenthesized_expression [",
+                "    (unary_expression",
+                "      (parenthesized_expression [",
+                "        (^^)",
+                "        (identifier) @name",
+                "      ]) @inner_paren",
+                "    ) @un",
+                "    (identifier) @name",
+                "  ]) @paren",
+                ")",
+            ),
+        )
+        .unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "void f() { (a); (+(a)); (+(+(a))); }",
+            &[
+                // (a) - base case, no recursion, no dup
+                (0, vec![("paren", "(a)"), ("name", "a")]),
+                // (+(a)) - unary, inner paren, identifier via inner alt
+                (0, vec![("paren", "(+(a))"), ("un", "+(a)"), ("inner_paren", "(a)"), ("name", "a")]),
+                // (+(+(a))) - (^^) recurse: unary, inner paren, (^^) ~> outer, unary, inner paren, identifier
+                (0, vec![("paren", "(+(+(a)))"), ("un", "+(+(a))"), ("inner_paren", "(+(a))"), ("un", "+(a)"), ("inner_paren", "(a)"), ("name", "a")]),
+            ],
+        );
+    });
+}

--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -3323,14 +3323,10 @@ fn test_query_alternation_inner_star_multistep_multiple_matches() {
         (return_statement) @ret)";
     let query = Query::new(&language, query_str).unwrap();
 
-    let expected = &[(
-        0,
-        vec![
-            ("cap", "x = 1;"),
-            ("cap", "y = 2;"),
-            ("ret", "return;"),
-        ],
-    )];
+    let expected = &[
+        (0, vec![("cap", "x = 1;"), ("ret", "return;")]),
+        (0, vec![("cap", "y = 2;"), ("ret", "return;")]),
+    ];
     assert_query_matches(&language, &query, source_code, expected);
 }
 
@@ -3346,13 +3342,8 @@ fn test_query_alternation_inner_plus_multistep_no_leakage() {
     let query = Query::new(&language, query_str).unwrap();
 
     let expected = &[
-        (
-            0,
-            vec![
-                ("cap", "x = 1;"),
-                ("cap", "y = 2;"),
-            ],
-        ),
+        (0, vec![("cap", "x = 1;")]),
+        (0, vec![("cap", "y = 2;")]),
         (0, vec![("cap", "break;")]),
     ];
     assert_query_matches(&language, &query, source_code, expected);
@@ -6304,4 +6295,236 @@ export default grammar({
     let source = "foo()\n()";
 
     assert_query_matches(&language, &query, source, &[(0, vec![("tuple", "()")])]);
+}
+
+// -----------------------------------------------------------------------
+// Recursive back-reference (^) tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_query_recursive_ref_parse_errors() {
+    allocations::record(|| {
+        let language = get_language("c");
+
+        // (^) outside any alternation
+        assert_eq!(
+            Query::new(&language, "(function_definition (^))").unwrap_err().kind,
+            QueryErrorKind::Syntax,
+        );
+
+        // bare (^) at top level
+        assert_eq!(
+            Query::new(&language, "(^)").unwrap_err().kind,
+            QueryErrorKind::Syntax,
+        );
+
+        // (^^) with only one enclosing alternation
+        assert_eq!(
+            Query::new(&language, "[(_ (^^)) (return_statement) @ret]")
+                .unwrap_err()
+                .kind,
+            QueryErrorKind::Syntax,
+        );
+
+        // (^^^) with only two enclosing alternations
+        assert_eq!(
+            Query::new(
+                &language,
+                "[(_ [(_ (^^^)) (identifier)]) (return_statement)]",
+            )
+            .unwrap_err()
+            .kind,
+            QueryErrorKind::Syntax,
+        );
+
+        // all-recursive alternation with no base case
+        assert_eq!(
+            Query::new(&language, "[(^)]").unwrap_err().kind,
+            QueryErrorKind::Structure,
+        );
+
+        // bare (^) as direct branch - doesn't consume input
+        assert_eq!(
+            Query::new(&language, "[(^) (return_statement) @ret]")
+                .unwrap_err()
+                .kind,
+            QueryErrorKind::Structure,
+        );
+    });
+}
+
+#[test]
+fn test_query_recursive_ref_valid_parse() {
+    allocations::record(|| {
+        let language = get_language("c");
+
+        // basic wildcard descent
+        assert!(Query::new(
+            &language,
+            "[(_ (^)) (return_statement) @ret]",
+        )
+        .is_ok());
+
+        // (^) in field position
+        assert!(Query::new(
+            &language,
+            "[(if_statement consequence: (^)) (return_statement) @ret]",
+        )
+        .is_ok());
+
+        // (^^) with two levels of alternation
+        assert!(Query::new(
+            &language,
+            "[(_ [(_ (^^)) (identifier)]) (return_statement)]",
+        )
+        .is_ok());
+
+        // multiple recursive branches
+        assert!(Query::new(
+            &language,
+            concat!(
+                "[(if_statement consequence: (compound_statement (^))) ",
+                "(if_statement consequence: (^)) ",
+                "(return_statement) @ret]",
+            ),
+        )
+        .is_ok());
+    });
+}
+
+#[test]
+fn test_query_recursive_ref_wildcard_descent() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            "(function_definition body: (compound_statement [(_ (^)) (return_statement) @ret]))",
+        )
+        .unwrap();
+
+        // Returns at various depths: direct, inside one if, inside two ifs
+        assert_query_matches(
+            &language,
+            &query,
+            "
+            int shallow(void) {
+                return 1;
+            }
+            int one_deep(int x) {
+                if (x) { return 1; }
+                return 0;
+            }
+            int two_deep(int x, int y) {
+                if (x) {
+                    if (y) { return 2; }
+                    return 1;
+                }
+                return 0;
+            }
+            ",
+            &[
+                (0, vec![("ret", "return 1;")]),
+                (0, vec![("ret", "return 1;")]),
+                (0, vec![("ret", "return 0;")]),
+                (0, vec![("ret", "return 2;")]),
+                (0, vec![("ret", "return 1;")]),
+                (0, vec![("ret", "return 0;")]),
+            ],
+        );
+    });
+}
+
+#[test]
+fn test_query_recursive_ref_constrained_descent() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(function_definition body: (compound_statement [",
+                "  (if_statement consequence: (compound_statement (^))) @if",
+                "  (if_statement consequence: (^)) @if",
+                "  (return_statement) @ret",
+                "]))",
+            ),
+        )
+        .unwrap();
+
+        // Constrained descent only through if-statement consequence chains
+        assert_query_matches(
+            &language,
+            &query,
+            "
+            int f(int x) {
+                if (x) { return 1; }
+                return 0;
+            }
+            ",
+            &[
+                (
+                    0,
+                    vec![
+                        ("if", "if (x) { return 1; }"),
+                        ("ret", "return 1;"),
+                    ],
+                ),
+                (0, vec![("ret", "return 0;")]),
+            ],
+        );
+    });
+}
+
+#[test]
+fn test_query_recursive_ref_nested_alternations() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            concat!(
+                "(function_definition body: (compound_statement",
+                "  [(_ [(_ (^^)) (return_statement) @inner]) (return_statement) @outer]",
+                "))",
+            ),
+        )
+        .unwrap();
+
+        // Direct returns and depth-1 returns are @outer.
+        // The (^^) path goes inner->outer, so its base case is @outer.
+        // @inner only fires when the inner alternation's own base case matches.
+        assert_query_matches(
+            &language,
+            &query,
+            "
+            int f(void) { return 0; }
+            int g(int x) {
+                if (x) { return 1; }
+                return 0;
+            }
+            ",
+            &[
+                (0, vec![("outer", "return 0;")]),
+                (0, vec![("outer", "return 1;")]),
+                (0, vec![("outer", "return 0;")]),
+            ],
+        );
+
+        assert_query_matches(
+            &language,
+            &query,
+            "
+            int h(int x, int y) {
+                if (x) {
+                    if (y) { return 2; }
+                    return 1;
+                }
+                return 0;
+            }
+            ",
+            &[
+                (0, vec![("outer", "return 2;")]),
+                (0, vec![("outer", "return 1;")]),
+                (0, vec![("outer", "return 0;")]),
+            ],
+        );
+    });
 }

--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -3144,6 +3144,278 @@ fn test_query_alternation_with_outer_quantifier() {
     assert_query_matches(&language, &query, source_code, matches);
 }
 
+// Tests for inner quantifiers on alternation branches.
+//
+// When a branch inside [...] has a ? or * quantifier, the branch can match zero
+// nodes.  This makes the alternation as a whole optional - it should be able to
+// match nothing.  We test this by placing the alternation before a required
+// sibling: (compound_statement [alt] (return_statement) @ret).  If the
+// alternation is correctly optional, the return_statement matches even when
+// the compound_statement has no break/continue.
+
+#[test]
+fn test_query_alternation_inner_optional_first_branch() {
+    // [A? B] - first branch is optional.
+    // A? can match zero ~> alternation should be optional.
+    let language = get_language("c");
+    let source_code = "void f() { return; }";
+
+    let query_str = "(compound_statement
+        [(break_statement)? (continue_statement)] @cap
+        (return_statement) @ret)";
+    let query = Query::new(&language, query_str).unwrap();
+
+    let expected = &[(0, vec![("ret", "return;")])];
+    assert_query_matches(&language, &query, source_code, expected);
+}
+
+#[test]
+fn test_query_alternation_inner_optional_last_branch() {
+    // [A B?] - last branch is optional.
+    let language = get_language("c");
+    let source_code = "void f() { return; }";
+
+    let query_str = "(compound_statement
+        [(break_statement) (continue_statement)?] @cap
+        (return_statement) @ret)";
+    let query = Query::new(&language, query_str).unwrap();
+
+    let expected = &[(0, vec![("ret", "return;")])];
+    assert_query_matches(&language, &query, source_code, expected);
+}
+
+#[test]
+fn test_query_alternation_inner_optional_both_branches() {
+    // [A? B?] - both branches optional.
+    let language = get_language("c");
+    let source_code = "void f() { return; }";
+
+    let query_str = "(compound_statement
+        [(break_statement)? (continue_statement)?] @cap
+        (return_statement) @ret)";
+    let query = Query::new(&language, query_str).unwrap();
+
+    let expected = &[(0, vec![("ret", "return;")])];
+    assert_query_matches(&language, &query, source_code, expected);
+}
+
+#[test]
+fn test_query_alternation_inner_zero_or_more() {
+    // [A* B] - A* can match zero ~> alternation optional.
+    let language = get_language("c");
+    let source_code = "void f() { return; }";
+
+    let query_str = "(compound_statement
+        [(break_statement)* (continue_statement)] @cap
+        (return_statement) @ret)";
+    let query = Query::new(&language, query_str).unwrap();
+
+    let expected = &[(0, vec![("ret", "return;")])];
+    assert_query_matches(&language, &query, source_code, expected);
+}
+
+#[test]
+fn test_query_alternation_inner_plus_no_leakage() {
+    // [A+ B] - A+ should not leak into B branch.
+    // 3 breaks then continue ~> two separate matches.
+    let language = get_language("c");
+    let source_code = "void f() { break; break; break; continue; }";
+
+    let query_str = "(compound_statement
+        [(break_statement)+ (continue_statement)] @cap)";
+    let query = Query::new(&language, query_str).unwrap();
+
+    let expected = &[
+        (
+            0,
+            vec![
+                ("cap", "break;"),
+                ("cap", "break;"),
+                ("cap", "break;"),
+            ],
+        ),
+        (0, vec![("cap", "continue;")]),
+    ];
+    assert_query_matches(&language, &query, source_code, expected);
+}
+
+#[test]
+fn test_query_alternation_inner_star_no_leakage() {
+    // [A* B] - A* should not leak into B branch.
+    let language = get_language("c");
+    let source_code = "void f() { break; break; break; continue; }";
+
+    let query_str = "(compound_statement
+        [(break_statement)* (continue_statement)] @cap)";
+    let query = Query::new(&language, query_str).unwrap();
+
+    let expected = &[
+        (
+            0,
+            vec![
+                ("cap", "break;"),
+                ("cap", "break;"),
+                ("cap", "break;"),
+            ],
+        ),
+        (0, vec![("cap", "continue;")]),
+    ];
+    assert_query_matches(&language, &query, source_code, expected);
+}
+
+// Multi-step branch tests: branches with child patterns, not just single node types.
+
+#[test]
+fn test_query_alternation_inner_optional_multistep_zero_match() {
+    // [(expression_statement (assignment_expression))? (break_statement)]
+    // Multi-step first branch is optional.  Source has only return ~> should skip.
+    let language = get_language("c");
+    let source_code = "void f() { return; }";
+
+    let query_str = "(compound_statement
+        [(expression_statement (assignment_expression))? (break_statement)] @cap
+        (return_statement) @ret)";
+    let query = Query::new(&language, query_str).unwrap();
+
+    let expected = &[(0, vec![("ret", "return;")])];
+    assert_query_matches(&language, &query, source_code, expected);
+}
+
+#[test]
+fn test_query_alternation_inner_optional_multistep_does_match() {
+    // Same query, but source has an assignment before return ~> optional branch matches.
+    let language = get_language("c");
+    let source_code = "void f() { x = 1; return; }";
+
+    let query_str = "(compound_statement
+        [(expression_statement (assignment_expression))? (break_statement)] @cap
+        (return_statement) @ret)";
+    let query = Query::new(&language, query_str).unwrap();
+
+    let expected = &[(0, vec![("cap", "x = 1;"), ("ret", "return;")])];
+    assert_query_matches(&language, &query, source_code, expected);
+}
+
+#[test]
+fn test_query_alternation_inner_star_multistep_zero_match() {
+    // [(expression_statement (assignment_expression))* (break_statement)]
+    // Multi-step star, source has only return ~> zero matches, skip.
+    let language = get_language("c");
+    let source_code = "void f() { return; }";
+
+    let query_str = "(compound_statement
+        [(expression_statement (assignment_expression))* (break_statement)] @cap
+        (return_statement) @ret)";
+    let query = Query::new(&language, query_str).unwrap();
+
+    let expected = &[(0, vec![("ret", "return;")])];
+    assert_query_matches(&language, &query, source_code, expected);
+}
+
+#[test]
+fn test_query_alternation_inner_star_multistep_multiple_matches() {
+    // Multi-step star, source has two assignments then return ~> star matches both.
+    let language = get_language("c");
+    let source_code = "void f() { x = 1; y = 2; return; }";
+
+    let query_str = "(compound_statement
+        [(expression_statement (assignment_expression))* (break_statement)] @cap
+        (return_statement) @ret)";
+    let query = Query::new(&language, query_str).unwrap();
+
+    let expected = &[(
+        0,
+        vec![
+            ("cap", "x = 1;"),
+            ("cap", "y = 2;"),
+            ("ret", "return;"),
+        ],
+    )];
+    assert_query_matches(&language, &query, source_code, expected);
+}
+
+#[test]
+fn test_query_alternation_inner_plus_multistep_no_leakage() {
+    // [(expression_statement (assignment_expression))+ (break_statement)]
+    // Two assignments then a break ~> separate matches, no leakage.
+    let language = get_language("c");
+    let source_code = "void f() { x = 1; y = 2; break; }";
+
+    let query_str = "(compound_statement
+        [(expression_statement (assignment_expression))+ (break_statement)] @cap)";
+    let query = Query::new(&language, query_str).unwrap();
+
+    let expected = &[
+        (
+            0,
+            vec![
+                ("cap", "x = 1;"),
+                ("cap", "y = 2;"),
+            ],
+        ),
+        (0, vec![("cap", "break;")]),
+    ];
+    assert_query_matches(&language, &query, source_code, expected);
+}
+
+// Three-branch alternation with middle branch optional.
+
+#[test]
+fn test_query_alternation_three_branches_middle_optional() {
+    // [(break_statement) (continue_statement)? (return_statement)]
+    // Middle branch is optional ~> whole alternation should be optional.
+    // Source: only an expression_statement (none of the three), then a return.
+    let language = get_language("c");
+    let source_code = "void f() { x = 1; }";
+
+    let query_str = "(compound_statement
+        [(break_statement) (continue_statement)? (return_statement)] @cap
+        (expression_statement) @expr)";
+    let query = Query::new(&language, query_str).unwrap();
+
+    let expected = &[(0, vec![("expr", "x = 1;")])];
+    assert_query_matches(&language, &query, source_code, expected);
+}
+
+// Nested alternation: inner alternation has an optional branch.
+
+#[test]
+fn test_query_alternation_nested_inner_optional() {
+    // [[(break_statement)? (continue_statement)] (return_statement)]
+    // Inner alternation [(break)? (continue)] - break branch is optional,
+    // so inner alternation is optional, so its branch in the outer alternation
+    // can match zero nodes.
+    // Source: only "x = 1;" - neither break, continue, nor return.
+    let language = get_language("c");
+    let source_code = "void f() { x = 1; }";
+
+    let query_str = "(compound_statement
+        [[(break_statement)? (continue_statement)] (return_statement)] @cap
+        (expression_statement) @expr)";
+    let query = Query::new(&language, query_str).unwrap();
+
+    let expected = &[(0, vec![("expr", "x = 1;")])];
+    assert_query_matches(&language, &query, source_code, expected);
+}
+
+// Multi-step branch with field constraint.
+
+#[test]
+fn test_query_alternation_inner_optional_with_field() {
+    // [(if_statement consequence: (compound_statement))? (break_statement)]
+    // Multi-step with field constraint, optional.
+    let language = get_language("c");
+    let source_code = "void f() { return; }";
+
+    let query_str = "(compound_statement
+        [(if_statement consequence: (compound_statement))? (break_statement)] @cap
+        (return_statement) @ret)";
+    let query = Query::new(&language, query_str).unwrap();
+
+    let expected = &[(0, vec![("ret", "return;")])];
+    assert_query_matches(&language, &query, source_code, expected);
+}
+
 #[test]
 fn test_query_matches_with_alternations_and_predicates() {
     allocations::record(|| {

--- a/docs/src/using-parsers/queries/2-operators.md
+++ b/docs/src/using-parsers/queries/2-operators.md
@@ -173,6 +173,48 @@ cases work:
 ; Regex equivalent: [ab]
 ```
 
+### Recursive Alternations
+
+Inside an alternation, the special pattern `(^)` is a recursive back-reference to the
+enclosing `[...]`. It causes the query engine to loop back and try all alternatives again,
+one level deeper in the tree. This enables matching nodes at arbitrary nesting depth without
+writing out every possible depth by hand.
+
+A recursive alternation needs at least two branches: one or more *recursive* branches that
+descend into a child and end with `(^)`, and one or more *base-case* branches that match the
+target node.
+
+For example, to find every `return_statement` at any depth inside a function body:
+
+```query
+(function_definition
+  body: (compound_statement
+    [(_ (^)) (return_statement) @ret]))
+```
+
+The `(_ (^))` branch matches any child node and recurses. The `(return_statement) @ret` branch
+is the base case that captures the target. Together they express "descend through any number of
+intermediate nodes until a `return_statement` is found."
+
+Recursive branches can be constrained to specific node types. This pattern only descends
+through `if_statement` consequence chains (with or without braces):
+
+```query
+(function_definition
+  body: (compound_statement [
+    (if_statement consequence: (compound_statement (^))) @if
+    (if_statement consequence: (^)) @if
+    (return_statement) @ret
+  ]))
+```
+
+When alternations are nested, `(^^)` refers to the next outer `[...]`, `(^^^)` to the one
+beyond that, and so on. This allows inner and outer alternations to recurse independently,
+enabling multi-level patterns that distinguish different nesting depths.
+
+Note: `(^)` must be the last element in its branch (tail position). It cannot be followed
+by sibling steps or have child steps of its own.
+
 ## Anchors
 
 The anchor operator, `.`, is used to constrain the ways in which child patterns are matched. It has different behaviors

--- a/docs/src/using-parsers/queries/2-operators.md
+++ b/docs/src/using-parsers/queries/2-operators.md
@@ -175,14 +175,12 @@ cases work:
 
 ### Recursive Alternations
 
-Inside an alternation, the special pattern `(^)` is a recursive back-reference to the
-enclosing `[...]`. It causes the query engine to loop back and try all alternatives again,
-one level deeper in the tree. This enables matching nodes at arbitrary nesting depth without
-writing out every possible depth by hand.
+Inside an alternation, the special pattern `(^)` is a recursive back-reference to the enclosing `[...]`. It causes the query 
+engine to loop back and try all alternatives again, one level deeper in the tree. This enables matching nodes at arbitrary 
+nesting depth without writing out every possible depth by hand.
 
-A recursive alternation needs at least two branches: one or more *recursive* branches that
-descend into a child and end with `(^)`, and one or more *base-case* branches that match the
-target node.
+A recursive alternation needs at least two branches: one or more *recursive* branches that descend into a child and end with 
+`(^)`, and one or more *base-case* branches that match the target node.
 
 For example, to find every `return_statement` at any depth inside a function body:
 
@@ -192,12 +190,11 @@ For example, to find every `return_statement` at any depth inside a function bod
     [(_ (^)) (return_statement) @ret]))
 ```
 
-The `(_ (^))` branch matches any child node and recurses. The `(return_statement) @ret` branch
-is the base case that captures the target. Together they express "descend through any number of
-intermediate nodes until a `return_statement` is found."
+The `(_ (^))` branch matches any child node and recurses. The `(return_statement) @ret` branch is the base case that captures 
+the target. Together they express "descend through any number of intermediate nodes until a `return_statement` is found."
 
-Recursive branches can be constrained to specific node types. This pattern only descends
-through `if_statement` consequence chains (with or without braces):
+Recursive branches can be constrained to specific node types. This pattern only descends through `if_statement` consequence 
+chains (with or without braces):
 
 ```query
 (function_definition
@@ -208,12 +205,41 @@ through `if_statement` consequence chains (with or without braces):
   ]))
 ```
 
-When alternations are nested, `(^^)` refers to the next outer `[...]`, `(^^^)` to the one
-beyond that, and so on. This allows inner and outer alternations to recurse independently,
-enabling multi-level patterns that distinguish different nesting depths.
+When alternations are nested, `(^^)` refers to the next outer `[...]`, `(^^^)` to the one beyond that, and so on. This allows 
+inner and outer alternations to recurse independently, enabling multi-level patterns that distinguish different nesting 
+depths.
 
-Note: `(^)` must be the last element in its branch (tail position). It cannot be followed
-by sibling steps or have child steps of its own.
+#### Labeled Recursion
+
+The anonymous `(^)` / `(^^)` references target alternations by counting nesting levels (De Bruijn indices). When patterns grow 
+complex, this becomes hard to read and fragile under refactoring. **Labeled recursion** lets you name a recursion scope and 
+refer to it by name.
+
+`(^label ...)` defines a labeled scope - the body (one or more child patterns) becomes a recursion target. `(^label)` (without 
+a body) is a back-reference that jumps to the most recent scope with that name.
+
+For example, to match C pointer-declarator chains like `***x`, stripping the type and capturing each layer:
+
+```query
+(declaration
+  type: (_) @type
+  declarator: (^ptr (pointer_declarator
+    declarator: [(^ptr) (identifier) @name]
+  ) @star))
+```
+
+Here `(^ptr ...)` wraps the `pointer_declarator` node. The back-reference `(^ptr)` jumps back to the scope entry - re-entering 
+at the `pointer_declarator` match, one level deeper. This cannot be expressed with anonymous `(^)`, because `(^)` can only 
+target an enclosing `[...]`, and the recursion target here is the node pattern above the alternation.
+
+Labels are scoped to their body - a `(^label)` reference is only valid inside the corresponding `(^label ...)` body. 
+Referencing an undefined or out-of-scope label is a parse error.
+
+Labeled and counted references can coexist. Inside a labeled scope that directly wraps an alternation, both `(^)` (targeting 
+the alternation) and `(^label)` (targeting the labeled scope) resolve to the same point.
+
+Note: `(^)`, `(^^)`, and `(^label)` must be the last element in their branch (tail position). They cannot be followed by 
+sibling steps or have child steps of their own.
 
 ## Anchors
 

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -16,7 +16,7 @@
 #include "./unicode.h"
 #include <wctype.h>
 
-// #define DEBUG_ANALYZE_QUERY
+#define DEBUG_ANALYZE_QUERY
 // #define DEBUG_EXECUTE_QUERY
 
 #define MAX_STEP_CAPTURE_COUNT 3
@@ -115,6 +115,7 @@ typedef struct {
   bool is_last_child: 1;
   bool is_pass_through: 1;
   bool is_dead_end: 1;
+  bool is_field_gate: 1;
   bool is_inside_alternation: 1;
   bool contains_captures: 1;
   bool root_pattern_guaranteed: 1;
@@ -222,6 +223,7 @@ typedef struct {
   bool has_in_progress_alternatives: 1;
   bool dead: 1;
   bool needs_parent: 1;
+  TSFieldId required_field;
 } QueryState;
 
 typedef Array(TSQueryCapture) CaptureList;
@@ -263,6 +265,7 @@ typedef struct {
   uint16_t depth;
   uint16_t step_index;
   TSSymbol root_symbol;
+  TSFieldId required_field;
 } AnalysisState;
 
 typedef Array(AnalysisState *) AnalysisStateSet;
@@ -1266,6 +1269,16 @@ static void ts_query__perform_analysis(
         }
       }
 
+      // Record the gate's field in the state so it persists across iterations.
+      {
+        const QueryStep *s = array_get(&self->steps, state->step_index);
+        while (s->is_field_gate) {
+          state->required_field = s->field;
+          state->step_index++; // skip the gate step
+          s = array_get(&self->steps, state->step_index);
+        }
+      }
+
       const TSStateId parse_state = analysis_state__top(state)->parse_state;
       const TSSymbol parent_symbol = analysis_state__top(state)->parent_symbol;
       const TSFieldId parent_field_id = analysis_state__top(state)->field_id;
@@ -1360,7 +1373,7 @@ static void ts_query__perform_analysis(
             } else if (step->symbol != visible_symbol) {
               does_match = false;
             }
-            if (step->field && step->field != field_id) {
+            if (state->required_field && state->required_field != field_id) {
               does_match = false;
             }
             if (
@@ -1416,6 +1429,8 @@ static void ts_query__perform_analysis(
           // over any descendant steps of the current child.
           const QueryStep *next_step = step;
           if (does_match) {
+            // Clear the field constraint after a successful match.
+            next_state.required_field = 0;
             for (;;) {
               next_state.step_index++;
               next_step = array_get(&self->steps, next_state.step_index);
@@ -1435,6 +1450,14 @@ static void ts_query__perform_analysis(
             if (next_step->is_pass_through) {
               next_state.step_index++;
               next_step++;
+              continue;
+            }
+
+            // Skip field-gate steps, recording the field constraint.
+            if (next_step->is_field_gate) {
+              next_state.required_field = next_step->field;
+              next_state.step_index++;
+              next_step = array_get(&self->steps, next_state.step_index);
               continue;
             }
 
@@ -1818,6 +1841,14 @@ static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
         // If there isn't a final step, then that means the parent step itself is unreachable.
         impossible_step_index = parent_step_index;
       }
+      // If the impossible step is preceded by a field-gate, report the
+      // error at the gate's position (the field name) instead.
+      if (impossible_step_index > 0) {
+        QueryStep *prev = array_get(&self->steps, impossible_step_index - 1);
+        if (prev->is_field_gate) {
+          impossible_step_index--;
+        }
+      }
       uint32_t j, impossible_exists;
       array_search_sorted_by(&self->step_offsets, .step_index, impossible_step_index, &j, &impossible_exists);
       if (j >= self->step_offsets.size) j = self->step_offsets.size - 1;
@@ -1881,6 +1912,16 @@ static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
     }
   }
 
+  // Clear guaranteed flags on field-gate dead-end steps. Gates are not matchable
+  // steps, so they should not block the backwards fallibility propagation.
+  for (unsigned i = 0; i < self->steps.size; i++) {
+    QueryStep *step = array_get(&self->steps, i);
+    if (step->is_field_gate) {
+      step->root_pattern_guaranteed = false;
+      step->parent_pattern_guaranteed = false;
+    }
+  }
+
   // Propagate fallibility. If a pattern is fallible at a given step, then it is
   // fallible at all of its preceding steps.
   bool done = self->steps.size == 0;
@@ -1889,6 +1930,12 @@ static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
     for (unsigned i = self->steps.size - 1; i > 0; i--) {
       QueryStep *step = array_get(&self->steps, i);
       if (step->depth == PATTERN_DONE_MARKER) continue;
+
+      // Field-gate steps are transparent - look through to the guarded
+      // step so that gates don't block guarantee propagation.
+      if (step->is_field_gate) {
+        step = array_get(&self->steps, i + 1);
+      }
 
       // Determine if this step is definite or has definite alternatives.
       bool parent_pattern_guaranteed = false;
@@ -2254,7 +2301,7 @@ static TSQueryError ts_query__parse_pattern(
   if (stream->next == 0) return TSQueryErrorSyntax;
   if (stream->next == ')' || stream->next == ']') return PARENT_DONE;
 
-  const uint32_t starting_step_index = self->steps.size;
+  uint32_t starting_step_index = self->steps.size;
 
   // Store the byte offset of each step in the query.
   if (
@@ -2792,7 +2839,30 @@ static TSQueryError ts_query__parse_pattern(
     stream_advance(stream);
     stream_skip_whitespace(stream);
 
-    // Parse the pattern
+    // Resolve the field name before parsing the child pattern.
+    TSFieldId field_id = ts_language_field_id_for_name(
+      self->language,
+      field_name,
+      length
+    );
+    if (!field_id) {
+      stream->input = field_name;
+      return TSQueryErrorField;
+    }
+
+    // Emit a field-gate step: a dead-end that sets the field constraint
+    // in the QueryState. The child step always follows at gate_index + 1.
+    QueryStep gate = query_step__new(0, depth, false);
+    gate.is_dead_end = true;
+    gate.is_field_gate = true;
+    gate.field = field_id;
+    array_push(&self->steps, gate);
+
+    // The child steps start after the gate. Update starting_step_index
+    // so that captures and quantifiers apply to the child, not the gate.
+    starting_step_index = self->steps.size;
+
+    // Parse the child pattern.
     CaptureQuantifiers field_capture_quantifiers = capture_quantifiers_new();
     TSQueryError e = ts_query__parse_pattern(
       self,
@@ -2806,33 +2876,6 @@ static TSQueryError ts_query__parse_pattern(
       capture_quantifiers_delete(&field_capture_quantifiers);
       if (e == PARENT_DONE) e = TSQueryErrorSyntax;
       return e;
-    }
-
-    // Add the field name to the first step of the pattern
-    TSFieldId field_id = ts_language_field_id_for_name(
-      self->language,
-      field_name,
-      length
-    );
-    if (!field_id) {
-      stream->input = field_name;
-      return TSQueryErrorField;
-    }
-
-    uint32_t step_index = starting_step_index;
-    QueryStep *step = array_get(&self->steps, step_index);
-    for (;;) {
-      step->field = field_id;
-      if (
-        step->alternative_index != NONE &&
-        step->alternative_index > step_index &&
-        step->alternative_index < self->steps.size
-      ) {
-        step_index = step->alternative_index;
-        step = array_get(&self->steps, step_index);
-      } else {
-        break;
-      }
     }
 
     capture_quantifiers_add_all(capture_quantifiers, &field_capture_quantifiers);
@@ -3256,7 +3299,13 @@ bool ts_query_is_pattern_guaranteed_at_step(
     step_index = step_offset->step_index;
   }
   if (step_index < self->steps.size) {
-    return array_get(&self->steps, step_index)->root_pattern_guaranteed;
+    // Skip field-gate dead-end steps to the actual matching step.
+    QueryStep *step = array_get(&self->steps, step_index);
+    while (step->is_field_gate) {
+      step_index++;
+      step = array_get(&self->steps, step_index);
+    }
+    return step->root_pattern_guaranteed;
   } else {
     return false;
   }
@@ -3683,6 +3732,7 @@ static void ts_query_cursor__add_state(
     .has_in_progress_alternatives = false,
     .needs_parent = step->depth == 1,
     .dead = false,
+    .required_field = 0,
   }));
 }
 
@@ -4105,6 +4155,15 @@ static inline bool ts_query_cursor__advance(
           state->has_in_progress_alternatives = false;
           copy_count = 0;
 
+          // Process field-gate steps transparently. These dead-end steps
+          // set the field constraint in the state and advance to the next
+          // step without consuming a node.
+          while (step->is_field_gate) {
+            state->required_field = step->field;
+            state->step_index++;
+            step = array_get(&self->query->steps, state->step_index);
+          }
+
           // Check that the node matches all of the criteria for the next
           // step of the pattern.
           if ((uint32_t)state->start_depth + (uint32_t)step->depth != self->depth) continue;
@@ -4139,8 +4198,8 @@ static inline bool ts_query_cursor__advance(
             }
             if (!has_supertype) node_does_match = false;
           }
-          if (step->field) {
-            if (step->field == field_id) {
+          if (state->required_field) {
+            if (state->required_field == field_id) {
               if (!can_have_later_siblings_with_this_field) {
                 later_sibling_can_match = false;
               }
@@ -4244,6 +4303,7 @@ static inline bool ts_query_cursor__advance(
           }
 
           // Advance this state to the next step of its pattern.
+          state->required_field = 0;
           state->step_index++;
           LOG(
             "  advance state. pattern:%u, step:%u\n",
@@ -4276,15 +4336,25 @@ static inline bool ts_query_cursor__advance(
           for (unsigned k = j; k < end_index; k++) {
             QueryState *child_state = array_get(&self->states, k);
             QueryStep *child_step = array_get(&self->query->steps, child_state->step_index);
+
+            // Skip field-gate steps transparently: set the field constraint
+            // and advance, so that the branching logic below sees the real
+            // step (which may carry alternation links from [A B] linking).
+            while (child_step->is_field_gate) {
+              child_state->required_field = child_step->field;
+              child_state->step_index++;
+              child_step = array_get(&self->query->steps, child_state->step_index);
+            }
+
             if (child_step->alternative_index != NONE) {
               // A "dead-end" step exists only to add a non-sequential jump into the step sequence,
               // via its alternative index. When a state reaches a dead-end step, it jumps straight
               // to the step's alternative.
               if (child_step->is_dead_end) {
                 // A backward-pointing dead-end is a recursive back-reference (^).
-                // Adjust start_depth so the target steps' compile-time depths
-                // align with the current tree position.
                 if (child_step->alternative_index < child_state->step_index) {
+                  // Adjust start_depth so the target steps' compile-time depths
+                  // align with the current tree position.
                   QueryStep *target_step = array_get(&self->query->steps, child_step->alternative_index);
                   child_state->start_depth += child_step->depth - target_step->depth;
                 }

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -16,7 +16,7 @@
 #include "./unicode.h"
 #include <wctype.h>
 
-#define DEBUG_ANALYZE_QUERY
+// #define DEBUG_ANALYZE_QUERY
 // #define DEBUG_EXECUTE_QUERY
 
 #define MAX_STEP_CAPTURE_COUNT 3
@@ -124,14 +124,21 @@ typedef struct {
 } QueryStep;
 
 /*
- * EnclosingAlternation - A singly-linked list tracking the start step indices
- * of enclosing [...] alternations during query parsing. Used to resolve (^)
- * recursive back-references to the correct alternation level.
+ * EntryPoint - A singly-linked list (stack) tracking recursion entry points
+ * during query parsing.  Both anonymous alternations ([...]) and labeled
+ * scopes (^label ...) push an entry; it is popped when the scope closes.
+ *
+ * Anonymous entries (name == NULL) are counted by (^), (^^), (^^^), etc.
+ * Labeled entries (name != NULL) are found by name for (^label) references.
+ * Because both share one stack, label scoping is automatic - a label is
+ * only visible inside its body.
  */
-typedef struct EnclosingAlternation {
+typedef struct EntryPoint {
   uint32_t start_step_index;
-  const struct EnclosingAlternation *parent;
-} EnclosingAlternation;
+  const char *name;          // NULL for anonymous alternation entries
+  uint32_t name_length;
+  const struct EntryPoint *parent;
+} EntryPoint;
 
 /*
  * Slice - A slice of an external array. Within a query, capture names,
@@ -2296,7 +2303,7 @@ static TSQueryError ts_query__parse_pattern(
   uint32_t depth,
   bool is_immediate,
   CaptureQuantifiers *capture_quantifiers,
-  const EnclosingAlternation *enclosing_alternations
+  const EntryPoint *entry_points
 ) {
   if (stream->next == 0) return TSQueryErrorSyntax;
   if (stream->next == ')' || stream->next == ']') return PARENT_DONE;
@@ -2322,9 +2329,11 @@ static TSQueryError ts_query__parse_pattern(
     // Parse each branch, and add a placeholder step in between the branches.
     Array(uint32_t) branch_step_indices = array_new();
     CaptureQuantifiers branch_capture_quantifiers = capture_quantifiers_new();
-    EnclosingAlternation alt_entry = {
+    EntryPoint alt_entry = {
       .start_step_index = self->steps.size,
-      .parent = enclosing_alternations,
+      .name = NULL,
+      .name_length = 0,
+      .parent = entry_points,
     };
     for (;;) {
       uint32_t start_index = self->steps.size;
@@ -2375,11 +2384,21 @@ static TSQueryError ts_query__parse_pattern(
           : self->steps.size;
         QueryStep *last_step = array_get(&self->steps, branch_end - 1);
         bool branch_is_recursive = last_step->is_dead_end &&
-          last_step->alternative_index < alt_entry.start_step_index + 1;
+          last_step->alternative_index == alt_entry.start_step_index;
         if (branch_is_recursive) {
-          // A recursive branch that is just (^) with no preceding node
-          // would loop forever without descending into any child.
-          if (branch_end - branch_start <= 1) {
+          // A recursive branch that is just (^) or (^label) targeting THIS
+          // alternation with no real node step would loop forever.  Check
+          // that the branch contains at least one step that matches a node
+          // (not just pass-throughs and dead-ends).
+          bool has_real_step = false;
+          for (uint32_t s = branch_start; s < branch_end; s++) {
+            QueryStep *bs = array_get(&self->steps, s);
+            if (!bs->is_dead_end && !bs->is_pass_through) {
+              has_real_step = true;
+              break;
+            }
+          }
+          if (!has_real_step) {
             capture_quantifiers_delete(&branch_capture_quantifiers);
             array_delete(&branch_step_indices);
             return TSQueryErrorStructure;
@@ -2471,7 +2490,7 @@ static TSQueryError ts_query__parse_pattern(
           depth,
           child_is_immediate,
           &child_capture_quantifiers,
-          enclosing_alternations
+          entry_points
         );
         if (e == PARENT_DONE) {
           if (stream->next == ')') {
@@ -2499,29 +2518,121 @@ static TSQueryError ts_query__parse_pattern(
       return ts_query__parse_predicate(self, stream);
     }
 
-    // A caret indicates a recursive back-reference to an enclosing alternation.
-    // (^) refers to the immediately enclosing [...], (^^) to the next outer, etc.
+    // A caret indicates a recursive back-reference.
+    // (^)        - refers to the immediately enclosing [...]
+    // (^^)       - refers to the next outer [...] (De Bruijn)
+    // (^label)   - refers to a labeled step defined by (^label ...body)
+    // (^label ...body) - defines a labeled recursion target, then parses body
     else if (stream->next == '^') {
-      // The first ^ refers to the innermost [...], each further ^ goes one level out.
-      const EnclosingAlternation *target = enclosing_alternations;
-      while(1) {
-        if (!target) return TSQueryErrorSyntax;
-        stream_advance(stream);
-        if (stream->next != '^') break;
-        target = target->parent;
-      }
-      
-      // after ^^^, group must be closed (recursive nodes, can not have direct children)
-      stream_skip_whitespace(stream);
-      if (stream->next != ')') return TSQueryErrorSyntax;
       stream_advance(stream);
 
-      // Emit a dead-end step that jumps backward to the alternation start.
-      QueryStep rec_step = query_step__new(0, depth, false);
-      rec_step.is_dead_end = true;
-      rec_step.alternative_index = target->start_step_index;
-      array_push(&self->steps, rec_step);
+      if (stream->next == '^' || !stream_is_ident_start(stream)) {
+        // Anonymous back-reference: (^), (^^), (^^^), etc.
+        // Walk the entry-point stack, skipping labeled entries (only
+        // anonymous alternation entries count for De Bruijn indexing).
+        const EntryPoint *target = entry_points;
+        while (target && target->name) target = target->parent;
+        if (!target) return TSQueryErrorSyntax;
+        while (stream->next == '^') {
+          stream_advance(stream);
+          target = target->parent;
+          while (target && target->name) target = target->parent;
+          if (!target) return TSQueryErrorSyntax;
+        }
 
+        stream_skip_whitespace(stream);
+        if (stream->next != ')') return TSQueryErrorSyntax;
+        stream_advance(stream);
+
+        // Emit pass-through + dead-end pair, same as labeled refs.
+        // When this reference is a bare branch in [...], the pass-through
+        // receives the alternation link and the dead-end keeps its
+        // recursion target.
+        QueryStep pass_step = query_step__new(0, depth, false);
+        pass_step.is_pass_through = true;
+        array_push(&self->steps, pass_step);
+        QueryStep rec_step = query_step__new(0, depth, false);
+        rec_step.is_dead_end = true;
+        rec_step.alternative_index = target->start_step_index;
+        array_push(&self->steps, rec_step);
+      } else {
+        // Labeled: (^label) or (^label ...body).
+        // Scan the label name.
+        const char *label_name = stream->input;
+        stream_scan_identifier(stream);
+        uint32_t label_length = (uint32_t)(stream->input - label_name);
+        stream_skip_whitespace(stream);
+
+        if (stream->next == ')') {
+          // (^label) - labeled back-reference.
+          stream_advance(stream);
+
+          // Walk the entry-point stack to find the label.
+          const EntryPoint *target = entry_points;
+          while (target) {
+            if (target->name &&
+                target->name_length == label_length &&
+                !strncmp(target->name, label_name, label_length))
+              break;
+            target = target->parent;
+          }
+          if (!target) return TSQueryErrorSyntax;
+
+          // Emit pass-through + dead-end pair.
+          QueryStep pass_step = query_step__new(0, depth, false);
+          pass_step.is_pass_through = true;
+          array_push(&self->steps, pass_step);
+          QueryStep rec_step = query_step__new(0, depth, false);
+          rec_step.is_dead_end = true;
+          rec_step.alternative_index = target->start_step_index;
+          array_push(&self->steps, rec_step);
+        } else {
+          // (^label ...body) - labeled step definition.
+          // Push a labeled entry point onto the stack.
+          EntryPoint label_entry = {
+            .start_step_index = self->steps.size,
+            .name = label_name,
+            .name_length = label_length,
+            .parent = entry_points,
+          };
+
+          // Parse the body - one or more child patterns until ')'.
+          CaptureQuantifiers child_capture_quantifiers = capture_quantifiers_new();
+          bool child_is_immediate = false;
+          for (;;) {
+            if (stream->next == '.') {
+              child_is_immediate = true;
+              stream_advance(stream);
+              stream_skip_whitespace(stream);
+            }
+            TSQueryError e = ts_query__parse_pattern(
+              self,
+              stream,
+              depth,
+              child_is_immediate,
+              &child_capture_quantifiers,
+              &label_entry
+            );
+            if (e == PARENT_DONE) {
+              if (stream->next == ')') {
+                stream_advance(stream);
+                break;
+              }
+              e = TSQueryErrorSyntax;
+            }
+            if (e) {
+              capture_quantifiers_delete(&child_capture_quantifiers);
+              return e;
+            }
+
+            capture_quantifiers_add_all(capture_quantifiers, &child_capture_quantifiers);
+            capture_quantifiers_clear(&child_capture_quantifiers);
+            child_is_immediate = false;
+          }
+          capture_quantifiers_delete(&child_capture_quantifiers);
+          // label_entry goes out of scope here - label is no longer visible.
+        }
+      }
     }
 
     // Otherwise, this parenthesis is the start of a named node.
@@ -2735,7 +2846,7 @@ static TSQueryError ts_query__parse_pattern(
           depth + 1,
           child_is_immediate,
           &child_capture_quantifiers,
-          enclosing_alternations
+          entry_points
         );
         // In the event we only parsed a predicate, meaning no new steps were added,
         // then subtract one so we're not indexing past the end of the array
@@ -2870,7 +2981,7 @@ static TSQueryError ts_query__parse_pattern(
       depth,
       is_immediate,
       &field_capture_quantifiers,
-      enclosing_alternations
+      entry_points
     );
     if (e) {
       capture_quantifiers_delete(&field_capture_quantifiers);
@@ -2961,14 +3072,20 @@ static TSQueryError ts_query__parse_pattern(
   switch (quantifier) {
     case TSQuantifierOneOrMore:
       repeat_step = query_step__new(WILDCARD_SYMBOL, depth, false);
-      repeat_step.is_inside_alternation = (enclosing_alternations != NULL);
+      repeat_step.is_inside_alternation = false;
+      for (const EntryPoint *ep = entry_points; ep; ep = ep->parent) {
+        if (!ep->name) { repeat_step.is_inside_alternation = true; break; }
+      }
       repeat_step.alternative_index = starting_step_index;
       repeat_step.is_pass_through = true;
       array_push(&self->steps, repeat_step);
       break;
     case TSQuantifierZeroOrMore:
       repeat_step = query_step__new(WILDCARD_SYMBOL, depth, false);
-      repeat_step.is_inside_alternation = (enclosing_alternations != NULL);
+      repeat_step.is_inside_alternation = false;
+      for (const EntryPoint *ep = entry_points; ep; ep = ep->parent) {
+        if (!ep->name) { repeat_step.is_inside_alternation = true; break; }
+      }
       repeat_step.alternative_index = starting_step_index;
       repeat_step.is_pass_through = true;
       array_push(&self->steps, repeat_step);
@@ -4346,6 +4463,14 @@ static inline bool ts_query_cursor__advance(
               child_step = array_get(&self->query->steps, child_state->step_index);
             }
 
+            // Skip bare pass-through steps that have no alternation link
+            // (labeled ref outside an alternation).  Inside alternations,
+            // pass-throughs have alternative_index set and are handled below.
+            while (child_step->is_pass_through && child_step->alternative_index == NONE) {
+              child_state->step_index++;
+              child_step = array_get(&self->query->steps, child_state->step_index);
+            }
+
             if (child_step->alternative_index != NONE) {
               // A "dead-end" step exists only to add a non-sequential jump into the step sequence,
               // via its alternative index. When a state reaches a dead-end step, it jumps straight
@@ -4357,6 +4482,9 @@ static inline bool ts_query_cursor__advance(
                   // align with the current tree position.
                   QueryStep *target_step = array_get(&self->query->steps, child_step->alternative_index);
                   child_state->start_depth += child_step->depth - target_step->depth;
+                  // The jump enters a new scope - clear seeking_immediate_match
+                  // so the target step can match any sibling, not just the first.
+                  child_state->seeking_immediate_match = false;
                 }
                 child_state->step_index = child_step->alternative_index;
                 k--;
@@ -4385,7 +4513,16 @@ static inline bool ts_query_cursor__advance(
                 copy_count++;
                 copy->step_index = child_step->alternative_index;
                 if (child_step->is_pass_through) {
-                  copy->seeking_immediate_match = true;
+                  // For quantifier pass-throughs, the copy should only match
+                  // the immediate next sibling.  For labeled-ref pass-throughs
+                  // (where the next step is a backward dead-end goto), don't
+                  // restrict - the target scope will match any sibling.
+                  QueryStep *after_pass = array_get(
+                    &self->query->steps, child_state->step_index);
+                  if (!after_pass->is_dead_end ||
+                      after_pass->alternative_index >= child_state->step_index) {
+                    copy->seeking_immediate_match = true;
+                  }
                 }
               }
             }

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -72,6 +72,16 @@ typedef struct {
  *    step, so this splitting is an iterative process.
  * - `is_dead_end` - Indicates that this state cannot be passed directly, and
  *    exists only in order to redirect to an alternative index, with no splitting.
+ *    When the alternative_index points *backward* (to a lower step index), the
+ *    dead-end represents a recursive back-reference written as `(^)` in the query
+ *    language. This causes the step machine to loop back to the start of an
+ *    enclosing `[...]` alternation, enabling descent to arbitrary depth. Multiple
+ *    carets `(^^)` refer to successively outer alternations (De Bruijn indices).
+ *    Recursive references must appear in tail position - they are the last step
+ *    in their branch, with no subsequent siblings or children. On the execution
+ *    side, a backward jump adjusts `start_depth` by the difference between the
+ *    dead-end step's depth and the target step's depth, so that compile-time
+ *    depths remain aligned with the runtime tree position as recursion deepens.
  * - `is_pass_through` - Indicates that state has no matching logic of its own,
  *    and exists only to split a state. One copy of the state advances immediately
  *    to the next step, and one moves to the alternative step.
@@ -111,6 +121,16 @@ typedef struct {
   bool parent_pattern_guaranteed: 1;
   bool is_missing: 1;
 } QueryStep;
+
+/*
+ * EnclosingAlternation - A singly-linked list tracking the start step indices
+ * of enclosing [...] alternations during query parsing. Used to resolve (^)
+ * recursive back-references to the correct alternation level.
+ */
+typedef struct EnclosingAlternation {
+  uint32_t start_step_index;
+  const struct EnclosingAlternation *parent;
+} EnclosingAlternation;
 
 /*
  * Slice - A slice of an external array. Within a query, capture names,
@@ -1421,7 +1441,12 @@ static void ts_query__perform_analysis(
             // If the pattern is finished or hypothetical parent node is complete, then
             // record that matching can terminate at this step of the pattern. Otherwise,
             // add this state to the list of states to process on the next iteration.
-            if (!next_step->is_dead_end) {
+            // Backward-pointing dead-ends are recursive (^) references - treat them as
+            // successful terminations since the recursion always has a base case.
+            if (next_step->is_dead_end && next_step->alternative_index != NONE &&
+                next_step->alternative_index < next_state.step_index) {
+              array_insert_sorted_by(&analysis->finished_parent_symbols, , state->root_symbol);
+            } else if (!next_step->is_dead_end) {
               bool did_finish_pattern = array_get(&self->steps, next_state.step_index)->depth != step->depth;
               if (did_finish_pattern) {
                 array_insert_sorted_by(&analysis->finished_parent_symbols, , state->root_symbol);
@@ -2223,8 +2248,8 @@ static TSQueryError ts_query__parse_pattern(
   Stream *stream,
   uint32_t depth,
   bool is_immediate,
-  bool is_inside_alternation,
-  CaptureQuantifiers *capture_quantifiers
+  CaptureQuantifiers *capture_quantifiers,
+  const EnclosingAlternation *enclosing_alternations
 ) {
   if (stream->next == 0) return TSQueryErrorSyntax;
   if (stream->next == ')' || stream->next == ']') return PARENT_DONE;
@@ -2250,6 +2275,10 @@ static TSQueryError ts_query__parse_pattern(
     // Parse each branch, and add a placeholder step in between the branches.
     Array(uint32_t) branch_step_indices = array_new();
     CaptureQuantifiers branch_capture_quantifiers = capture_quantifiers_new();
+    EnclosingAlternation alt_entry = {
+      .start_step_index = self->steps.size,
+      .parent = enclosing_alternations,
+    };
     for (;;) {
       uint32_t start_index = self->steps.size;
       TSQueryError e = ts_query__parse_pattern(
@@ -2257,8 +2286,8 @@ static TSQueryError ts_query__parse_pattern(
         stream,
         depth,
         is_immediate,
-        true,
-        &branch_capture_quantifiers
+        &branch_capture_quantifiers,
+        &alt_entry
       );
 
       if (e == PARENT_DONE) {
@@ -2285,6 +2314,39 @@ static TSQueryError ts_query__parse_pattern(
       capture_quantifiers_clear(&branch_capture_quantifiers);
     }
     (void)array_pop(&self->steps);
+
+    // Validate recursive branches:
+    // 1. At least one branch must be a non-recursive base case.
+    // 2. Recursive branches must contain at least one node before (^),
+    //    otherwise they loop without consuming input.
+    {
+      bool has_base_case = false;
+      for (unsigned i = 0; i < branch_step_indices.size; i++) {
+        uint32_t branch_start = *array_get(&branch_step_indices, i);
+        uint32_t branch_end = (i + 1 < branch_step_indices.size)
+          ? *array_get(&branch_step_indices, i + 1) - 1
+          : self->steps.size;
+        QueryStep *last_step = array_get(&self->steps, branch_end - 1);
+        bool branch_is_recursive = last_step->is_dead_end &&
+          last_step->alternative_index < alt_entry.start_step_index + 1;
+        if (branch_is_recursive) {
+          // A recursive branch that is just (^) with no preceding node
+          // would loop forever without descending into any child.
+          if (branch_end - branch_start <= 1) {
+            capture_quantifiers_delete(&branch_capture_quantifiers);
+            array_delete(&branch_step_indices);
+            return TSQueryErrorStructure;
+          }
+        } else {
+          has_base_case = true;
+        }
+      }
+      if (!has_base_case) {
+        capture_quantifiers_delete(&branch_capture_quantifiers);
+        array_delete(&branch_step_indices);
+        return TSQueryErrorStructure;
+      }
+    }
 
     // For all of the branches except for the last one, add the subsequent branch as an
     // alternative, and link the end of the branch to the current end of the steps.
@@ -2337,10 +2399,11 @@ static TSQueryError ts_query__parse_pattern(
     array_delete(&branch_step_indices);
   }
 
-  // An open parenthesis can be the start of three possible constructs:
+  // An open parenthesis can be the start of four possible constructs:
   // * A grouped sequence
   // * A predicate
   // * A named node
+  // * A parent pointer (recursion)
   else if (stream->next == '(') {
     stream_advance(stream);
     stream_skip_whitespace(stream);
@@ -2360,8 +2423,8 @@ static TSQueryError ts_query__parse_pattern(
           stream,
           depth,
           child_is_immediate,
-          is_inside_alternation,
-          &child_capture_quantifiers
+          &child_capture_quantifiers,
+          enclosing_alternations
         );
         if (e == PARENT_DONE) {
           if (stream->next == ')') {
@@ -2387,6 +2450,31 @@ static TSQueryError ts_query__parse_pattern(
     else if (stream->next == '.' || stream->next == '#') {
       stream_advance(stream);
       return ts_query__parse_predicate(self, stream);
+    }
+
+    // A caret indicates a recursive back-reference to an enclosing alternation.
+    // (^) refers to the immediately enclosing [...], (^^) to the next outer, etc.
+    else if (stream->next == '^') {
+      // The first ^ refers to the innermost [...], each further ^ goes one level out.
+      const EnclosingAlternation *target = enclosing_alternations;
+      while(1) {
+        if (!target) return TSQueryErrorSyntax;
+        stream_advance(stream);
+        if (stream->next != '^') break;
+        target = target->parent;
+      }
+      
+      // after ^^^, group must be closed (recursive nodes, can not have direct children)
+      stream_skip_whitespace(stream);
+      if (stream->next != ')') return TSQueryErrorSyntax;
+      stream_advance(stream);
+
+      // Emit a dead-end step that jumps backward to the alternation start.
+      QueryStep rec_step = query_step__new(0, depth, false);
+      rec_step.is_dead_end = true;
+      rec_step.alternative_index = target->start_step_index;
+      array_push(&self->steps, rec_step);
+
     }
 
     // Otherwise, this parenthesis is the start of a named node.
@@ -2599,8 +2687,8 @@ static TSQueryError ts_query__parse_pattern(
           stream,
           depth + 1,
           child_is_immediate,
-          is_inside_alternation,
-          &child_capture_quantifiers
+          &child_capture_quantifiers,
+          enclosing_alternations
         );
         // In the event we only parsed a predicate, meaning no new steps were added,
         // then subtract one so we're not indexing past the end of the array
@@ -2711,8 +2799,8 @@ static TSQueryError ts_query__parse_pattern(
       stream,
       depth,
       is_immediate,
-      is_inside_alternation,
-      &field_capture_quantifiers
+      &field_capture_quantifiers,
+      enclosing_alternations
     );
     if (e) {
       capture_quantifiers_delete(&field_capture_quantifiers);
@@ -2830,14 +2918,14 @@ static TSQueryError ts_query__parse_pattern(
   switch (quantifier) {
     case TSQuantifierOneOrMore:
       repeat_step = query_step__new(WILDCARD_SYMBOL, depth, false);
-      repeat_step.is_inside_alternation = is_inside_alternation;
+      repeat_step.is_inside_alternation = (enclosing_alternations != NULL);
       repeat_step.alternative_index = starting_step_index;
       repeat_step.is_pass_through = true;
       array_push(&self->steps, repeat_step);
       break;
     case TSQuantifierZeroOrMore:
       repeat_step = query_step__new(WILDCARD_SYMBOL, depth, false);
-      repeat_step.is_inside_alternation = is_inside_alternation;
+      repeat_step.is_inside_alternation = (enclosing_alternations != NULL);
       repeat_step.alternative_index = starting_step_index;
       repeat_step.is_pass_through = true;
       array_push(&self->steps, repeat_step);
@@ -2916,7 +3004,7 @@ TSQuery *ts_query_new(
       .is_non_local = false,
     }));
     CaptureQuantifiers capture_quantifiers = capture_quantifiers_new();
-    *error_type = ts_query__parse_pattern(self, &stream, 0, false, false, &capture_quantifiers);
+    *error_type = ts_query__parse_pattern(self, &stream, 0, false, &capture_quantifiers, NULL);
     array_push(&self->steps, query_step__new(0, PATTERN_DONE_MARKER, false));
 
     QueryPattern *pattern = array_back(&self->patterns);
@@ -4183,7 +4271,7 @@ static inline bool ts_query_cursor__advance(
 
           // If this state's next step has an alternative step, then copy the state in order
           // to pursue both alternatives. The alternative step itself may have an alternative,
-          // so this is an interactive process.
+          // so this is an iterative process.
           unsigned end_index = j + 1;
           for (unsigned k = j; k < end_index; k++) {
             QueryState *child_state = array_get(&self->states, k);
@@ -4193,6 +4281,13 @@ static inline bool ts_query_cursor__advance(
               // via its alternative index. When a state reaches a dead-end step, it jumps straight
               // to the step's alternative.
               if (child_step->is_dead_end) {
+                // A backward-pointing dead-end is a recursive back-reference (^).
+                // Adjust start_depth so the target steps' compile-time depths
+                // align with the current tree position.
+                if (child_step->alternative_index < child_state->step_index) {
+                  QueryStep *target_step = array_get(&self->query->steps, child_step->alternative_index);
+                  child_state->start_depth += child_step->depth - target_step->depth;
+                }
                 child_state->step_index = child_step->alternative_index;
                 k--;
                 continue;

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -2288,14 +2288,49 @@ static TSQueryError ts_query__parse_pattern(
 
     // For all of the branches except for the last one, add the subsequent branch as an
     // alternative, and link the end of the branch to the current end of the steps.
+    // Also detect if any branch has an optional quantifier (? or *), which means
+    // the alternation as a whole can match zero nodes.
+    bool any_branch_optional = false;
     for (unsigned i = 0; i < branch_step_indices.size - 1; i++) {
       uint32_t step_index = *array_get(&branch_step_indices, i);
       uint32_t next_step_index = *array_get(&branch_step_indices, i + 1);
       QueryStep *start_step = array_get(&self->steps, step_index);
       QueryStep *end_step = array_get(&self->steps, next_step_index - 1);
+
+      // If the step already has an alternative_index, it was set by a ? or *
+      // quantifier (pointing forward to skip past the branch).  Alternation
+      // linking is about to overwrite it, so record that this branch was optional.
+      if (start_step->alternative_index != NONE)
+        any_branch_optional = true;
+
       start_step->alternative_index = next_step_index;
       end_step->alternative_index = self->steps.size;
       end_step->is_dead_end = true;
+    }
+
+    // Check the last branch too - its ? or * is not overwritten by linking,
+    // but we still want to know if it was optional.
+    {
+      uint32_t last_start = *array_get(&branch_step_indices,
+                                        branch_step_indices.size - 1);
+      QueryStep *last_step = array_get(&self->steps, last_start);
+      if (last_step->alternative_index != NONE)
+        any_branch_optional = true;
+    }
+
+    // If any branch was optional (? or *), the whole alternation can match
+    // zero nodes.  Ensure the last branch's alt chain ends with a skip past
+    // the alternation, so that when all branches fail, the match can still
+    // succeed with zero consumed nodes.
+    if (any_branch_optional) {
+      uint32_t last_start = *array_get(&branch_step_indices,
+                                        branch_step_indices.size - 1);
+      QueryStep *step = array_get(&self->steps, last_start);
+      while (step->alternative_index != NONE
+             && step->alternative_index < self->steps.size) {
+        step = array_get(&self->steps, step->alternative_index);
+      }
+      step->alternative_index = self->steps.size;
     }
 
     capture_quantifiers_delete(&branch_capture_quantifiers);


### PR DESCRIPTION
Introduce "(^)"-expressions inside "[...]"-alternations to express recursive descent to arbitrary tree depth. Allows matching deeply nested elements without specifying each possible nesting alternative.

I need a feature like this to do complex pattern detection (on unpreprocessed C-code in a code-checker-tool I'm writing for work). Without it, I'd have to write many nested queries for each of my cases and it almost defeats the purpose of having a powerful query-language.

example recursive query:
```query
    (function_definition
        body: (compound_statement [
            (if_statement consequence: (^))
            (if_statement consequence: (compound_statement (^)))
            (return_statement) @ret
        ])
    ) @func
```

-> matches function definitions and their "return"s if they are in the "consequence:"-lineage of an arbitrarily nested if-structure.

example syntax data:
```c
    int shallow(void) {           // <- [0].func
        return 1;                 // <- [0].ret
    }
    int one_deep(int x) {         // <- [1]func, [2].func
        if (x) { return 1; }      // <- [2].ret
        return 0;                 // <- [1].ret
    }
    int two_deep(int x, int y) {  // <- [3].func, [4].func, [5].func
        if (x) {
            if (y) { return 2; }  // <- [5].ret
            return 1;             // <- [4].ret
        }
        return 0;                 // <- [3].ret
    }
```

Each (^) jumps back to the enclosing [...], retrying all alternatives one level deeper. (^^) refers to the next outer alternation (De Bruijn indices), enabling multi-state recursive patterns.

The implementation reuses the existing dead-end step mechanism but with backward-pointing alternative_index. No new fields on QueryStep or QueryState — only a small linked list during parsing to track enclosing [...] positions.

Parsing:
* new (^) branch in the "("-dispatch chain
* validation that recursive branches consume input and a base case exists.

Analysis:
* backward dead-ends treated as successful terminations.

Execution:
* backward jump adjusts start_depth to keep compile-time step depths aligned with runtime tree position.