### PR TITLE
docs: update WASM build requirements for wasi-sdk

### DIFF
--- a/lib/binding_web/README.md
+++ b/lib/binding_web/README.md
@@ -174,7 +174,9 @@ For example, you can download the JavaScript `.wasm` file from the tree-sitter-j
 You can also generate the `.wasm` file for your desired grammar. Shown below is an example of how to generate the `.wasm`
 file for the JavaScript grammar.
 
-**IMPORTANT**: [Emscripten][emscripten], [Docker][docker], or [Podman][podman] need to be installed.
+> [!NOTE]
+> Since v0.26.1, `tree-sitter build --wasm` uses [wasi-sdk][] and will automatically download it on first use.
+> No additional tools need to be installed.
 
 First install `tree-sitter-cli`, and the tree-sitter language for which to generate `.wasm`
 (`tree-sitter-javascript` in this example):
@@ -263,3 +265,4 @@ following to your webpack config:
 [node bindings]: https://github.com/tree-sitter/node-tree-sitter
 [npm module]: https://www.npmjs.com/package/web-tree-sitter
 [podman]: https://podman.io
+[wasi-sdk]: https://github.com/WebAssembly/wasi-sdk


### PR DESCRIPTION
## Summary

Since v0.26.1, `tree-sitter build --wasm` uses wasi-sdk instead of Emscripten (#4393). The CLI automatically downloads wasi-sdk on first use, so Emscripten, Docker, and Podman are no longer prerequisites.

The web binding README (`lib/binding_web/README.md`) still says:

> **IMPORTANT**: Emscripten, Docker, or Podman need to be installed.

This PR replaces that note with accurate information about the wasi-sdk auto-download behavior and adds a `[wasi-sdk]` reference link.

## Changes

- Replace the outdated Emscripten/Docker/Podman requirement with a note about wasi-sdk auto-download
- Add `[wasi-sdk]` link definition pointing to the wasi-sdk repository