### PR TITLE
fix(generate): allow disabling `qjs-rt` feature from CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ webbrowser = "1.1.0"
 
 tree-sitter           = { path = "./lib", version = "0.27.0" }
 tree-sitter-config    = { path = "./crates/config", version = "0.27.0" }
-tree-sitter-generate  = { path = "./crates/generate", version = "0.27.0" }
+tree-sitter-generate  = { path = "./crates/generate", version = "0.27.0", default-features = false }
 tree-sitter-highlight = { path = "./crates/highlight", version = "0.27.0" }
 tree-sitter-loader    = { path = "./crates/loader", version = "0.27.0" }
 tree-sitter-tags      = { path = "./crates/tags", version = "0.27.0" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -68,7 +68,7 @@ webbrowser.workspace            = true
 
 tree-sitter.workspace           = true
 tree-sitter-config.workspace    = true
-tree-sitter-generate.workspace  = true
+tree-sitter-generate            = { workspace = true, features = ["load"] }
 tree-sitter-highlight.workspace = true
 tree-sitter-loader.workspace    = true
 tree-sitter-tags.workspace      = true

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use bitflags::bitflags;
+#[cfg(feature = "load")]
 use log::warn;
 use node_types::VariableInfo;
 use regex::{Regex, RegexBuilder};
@@ -109,6 +110,7 @@ pub struct IoError {
     pub path: Option<String>,
 }
 
+#[cfg(feature = "load")]
 impl IoError {
     fn new(error: &std::io::Error, path: Option<&Path>) -> Self {
         Self {

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -1,4 +1,6 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+#[cfg(feature = "load")]
+use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use serde::Serialize;
 use thiserror::Error;


### PR DESCRIPTION
### The Problem 

`rquickjs` (which requires `libclang`) was always pulled into `tree-sitter-cli` builds even with `--no-default-features`, and `tree-sitter-generate` failed to compile without its `load` feature.

### The Solution
  - Set `default-features = false` on the workspace-level `tree-sitter-generate` dependency so that `tree-sitter-cli`'s `qjs-rt` feature forwarding actually controls whether `rquickjs` is included.
  - Explicitly enable the `load` feature in `tree-sitter-cli`'s dependency on `tree-sitter-generate`, since the `tree-sitter-cli` uses `load`-gated APIs (`generate_parser_in_directory`, `load_grammar_file`, `write_file`) unconditionally.
  - Gate `IoError::new`, the `log::warn` import, and the `HashSet` imports  behind `#[cfg(feature = "load")]` so `tree-sitter-generate` compiles with any feature combination.

With this fix, `tree-sitter-generate` should build correctly with any feature combination. In addition, `tree-sitter-cli` now properly includes/excludes `rquickjs` according to the `qjs-rt` feature flag. I verified that `rquickjs` isn't included in the `tree-sitter-cli` for `--no-default-features` via ` cargo tree --no-default-features -p tree-sitter-cli | rg rquickjs`.

I've added the backport label to this PR, but this will likely have to be backported manually.

- Closes #5298