### PR TITLE
playground: set LANGUAGE_BASE_URL to "." to fix subfolder hosting

### DIFF
--- a/crates/cli/src/playground.html
+++ b/crates/cli/src/playground.html
@@ -470,7 +470,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/clusterize.js/0.19.0/clusterize.min.js"></script>
 
-    <script>LANGUAGE_BASE_URL = "";</script>
+    <script>LANGUAGE_BASE_URL = ".";</script>
     <script type="module" src="playground.js"></script>
     <script type="module">
       import * as TreeSitter from './web-tree-sitter.js';


### PR DESCRIPTION


Currently, the playground from `tree-sitter playground --export` would not work when hosted at a subfolder of the domain. This is because playground.js has this code:

      const url = `${LANGUAGE_BASE_URL}/tree-sitter-${newLanguageName}.wasm`;

With the empty string base URL, it would look for wasm at the root of the website and 404.

Github code search shows that this is an issue which lots of people have run into, and everyone has had to make their own workaround: https://github.com/search?q=%2FLANGUAGE_BASE_URL+%3D+%22%22%2F+-language%3AHTML&type=code

Related to https://github.com/tree-sitter/tree-sitter/issues/5230 and https://github.com/tree-sitter/tree-sitter/discussions/5232