### PR TITLE
Update the Dockerfile so it works with current source base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
-FROM rust:1.76-buster
+FROM rust:1.90-trixie
 
 WORKDIR /app
 
-RUN apt-get update
-RUN apt-get install -y nodejs
+RUN apt-get update && apt-get install -y \
+    clang \
+    cmake \
+    libclang-dev \
+    nodejs \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY . .
 
-CMD cargo test --all-features
+RUN cargo xtask fetch-fixtures
+RUN cargo xtask generate-fixtures
+
+CMD ["cargo", "xtask", "test"]
+


### PR DESCRIPTION
Update the Dockerfile so it works with current source base so that the resulting image is suitable for building and running tests against the current source base. The previous Dockerfile specified an image that didn't have the right versions of rust or nodejs for all the dependencies.