### PR TITLE
docs: fix typo in config update comment

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -901,7 +901,7 @@ impl Init {
 
             let new_config = format!("{}\n", serde_json::to_string_pretty(&json)?);
             // Write the re-serialized config back, as newly added optional boolean fields
-            // will be included with explicit `false`s rather than implict `null`s
+            // will be included with explicit `false`s rather than implicit `null`s
             if self.update && !old_config.trim().eq(new_config.trim()) {
                 info!("Updating tree-sitter.json");
                 fs::write(


### PR DESCRIPTION
## Summary

Fix a typo in the CLI comment that describes how optional boolean fields are rewritten.

## Related issue

N/A

## Guideline alignment

- CONTRIBUTING: https://github.com/tree-sitter/tree-sitter/blob/master/docs/src/6-contributing.md
- Base branch: `master`

## Validation

- Not run; comment-only change.
