### PR TITLE
Generator panics in `node_types.rs` when supertype rule is replaced by external token wrapper

### DIFF
--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -677,6 +677,10 @@ pub fn generate_node_types_json(
             }
         }
     }
+    // Remove stale entries whose kind is not in the topological sort
+    // (e.g., when a supertype's subtypes have been replaced by external tokens).
+    subtype_map.retain(|(supertype, _)| sorted_kinds.contains(&supertype.kind));
+
     subtype_map.sort_by(|a, b| {
         let a_idx = sorted_kinds.iter().position(|n| n.eq(&a.0.kind)).unwrap();
         let b_idx = sorted_kinds.iter().position(|n| n.eq(&b.0.kind)).unwrap();


### PR DESCRIPTION
## Fix: prevent panic when supertype subtypes are replaced by external tokens

### Problem

`tree-sitter generate` panics when a grammar rule that was a supertype (`choice()` of named subtypes) is changed to a wrapper around a hidden external token, and the former subtype rules are removed:

```
thread 'main' panicked at crates/generate/src/node_types.rs:677:71:
called `Option::unwrap()` on a `None` value
```

### Cause

`subtype_map` retains entries referencing kinds that no longer exist in `sorted_kinds` (populated by topological sort). The `unwrap()` on `position()` panics when looking up these stale entries.

### Fix

Filter out stale `subtype_map` entries before sorting:

```rust
subtype_map.retain(|(supertype, _)| sorted_kinds.contains(&supertype.kind));
```

### Context

This arises when migrating a tree-sitter grammar to use an external scanner. A common pattern is replacing a supertype like:

```js
terminator: $ => choice($.period, $.question, $.trailing_off, ...),
period: $ => '.',
question: $ => '?',
trailing_off: $ => token('+...'),
```

with a single external token:

```js
externals: $ => [$._terminator_token],
terminator: $ => $._terminator_token,
```

The former subtype rules (`period`, `question`, `trailing_off`) are removed since they're no longer referenced. The generator crashes because the supertype bookkeeping still references them.

Does not reproduce in small grammars — requires ~300+ rules for the stale entries to accumulate. Discovered while adding a re2c external scanner to a 2,300-line CHAT transcription grammar.
