### PR TITLE
fix(loader): don't discard CC wrapper command specified in `CC` variable

### DIFF
--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -1236,11 +1236,7 @@ impl Loader {
         }
 
         let compiler = cc_config.get_compiler();
-        let mut command = Command::new(compiler.path());
-        command.args(compiler.args());
-        for (key, value) in compiler.env() {
-            command.env(key, value);
-        }
+        let mut command = compiler.to_command();
 
         let output_path = config.output_path.as_ref().unwrap();
 

--- a/docs/src/cli/build.md
+++ b/docs/src/cli/build.md
@@ -8,6 +8,10 @@ tree-sitter build [OPTIONS] [PATH] # Aliases: b
 ```
 
 You can change the compiler executable via the `CC` environment variable and add extra flags via `CFLAGS`.
+The `CC` variable can include a compiler wrapper (for example, `sccache cc`). Common wrappers such as `ccache`,
+`distcc`, `sccache`, `icecc`, `cachepot`, and `buildcache` are recognized automatically. If you use a custom wrapper,
+set `CC_KNOWN_WRAPPER_CUSTOM` to the wrapper executable name used in `CC` (for example, `CC="my-wrapper clang"` with
+`CC_KNOWN_WRAPPER_CUSTOM=my-wrapper`).
 For macOS or iOS, you can set `MACOSX_DEPLOYMENT_TARGET` or `IPHONEOS_DEPLOYMENT_TARGET` respectively to define the
 minimum supported version.
 


### PR DESCRIPTION
`cc::Tool::path()` returns the C compiler itself, not the wrapper command specified in the `CC` environment variable.
This PR changes the code to use `cc::Tool::get_command()` instead, ensuring that if a wrapper command is set, it is used instead of just the compiler.