### PR TITLE
generate: avoid panicking when a supertype only has hidden external token children

### DIFF
--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -588,7 +588,13 @@ pub fn generate_node_types_json(
                 kind: node_type_json.kind.clone(),
                 named: true,
             };
-            subtype_map.push((supertype, subtypes.clone()));
+
+            // We only add to the subtype map if there are visible subtypes.
+            // A supertype may have zero subtypes if its children are all
+            // hidden (e.g., wrapping a hidden external token).
+            if !subtypes.is_empty() {
+                subtype_map.push((supertype, subtypes.clone()));
+            }
             node_type_json.subtypes = Some(subtypes);
         } else if !syntax_grammar.variables_to_inline.contains(&symbol) {
             // If a rule is aliased under multiple names, then its information
@@ -1258,6 +1264,49 @@ mod tests {
                 )
             }
         );
+    }
+
+    /// A supertype whose only child is a hidden external token
+    /// xgust not cause generation to panic. The subtype map must
+    /// skip entries with empty subtypes to avoid a lookup failure
+    /// in the topological sort.
+    #[test]
+    fn test_node_types_supertype_with_only_hidden_child() {
+        let node_types = get_node_types(&InputGrammar {
+            supertype_symbols: vec!["_type_a".to_string(), "_type_b".to_string()],
+            variables: vec![
+                Variable {
+                    name: "v1".to_string(),
+                    kind: VariableType::Named,
+                    rule: Rule::seq(vec![Rule::named("_type_a"), Rule::named("_type_b")]),
+                },
+                // Supertype A: a normal choice of named subtypes
+                Variable {
+                    name: "_type_a".to_string(),
+                    kind: VariableType::Hidden,
+                    rule: Rule::choice(vec![Rule::named("v2"), Rule::named("v3")]),
+                },
+                Variable {
+                    name: "v2".to_string(),
+                    kind: VariableType::Named,
+                    rule: Rule::string("x"),
+                },
+                Variable {
+                    name: "v3".to_string(),
+                    kind: VariableType::Named,
+                    rule: Rule::string("y"),
+                },
+                // Supertype B: a hidden external token with no subtypes
+                Variable {
+                    name: "_type_b".to_string(),
+                    kind: VariableType::Hidden,
+                    rule: Rule::external(0),
+                },
+            ],
+            external_tokens: vec![Rule::named("_hidden_ext")],
+            ..Default::default()
+        });
+        assert!(node_types.is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Fix: prevent panic when supertype wraps a hidden external token

Fixes #5462

Yes, I used an LLM, but I also manually looked at the changes and ran these commands myself with my own fingers to double check everything this time.

### Problem

`tree-sitter generate` panics when a supertype rule's only child is a hidden external token:

```
thread 'main' panicked at crates/generate/src/node_types.rs:677:71:
called `Option::unwrap()` on a `None` value
```

### Root Cause

`get_variable_info()` filters hidden children from supertype `children.types` (line ~366: `retain(child_type_is_visible)`). When the only child is a hidden external token, this leaves zero subtypes.

`generate_node_types_json()` then pushes `(supertype, [])` into `subtype_map` (line 587). The topological sort at line 660 adds no edges for this supertype, so its kind never enters `sorted_kinds`. The `sort_by` at line 682 panics when `position()` returns `None`.

### Fix

Skip pushing to `subtype_map` when subtypes is empty:

```rust
if !subtypes.is_empty() {
    subtype_map.push((supertype, subtypes.clone()));
}
```

A supertype with zero visible subtypes has no dependency ordering to compute, so excluding it from the sort is correct.

### Test

`test_node_types_supertype_with_only_hidden_child`: two supertypes, one with normal named subtypes, one wrapping a hidden external. Panics without the fix, passes with it. All 60 existing tests pass.

Without the fix:

```
cargo test -p tree-sitter-generate --features qjs-rt test_node_types_supertype_with_only_hidden_child
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.05s
     Running unittests src/generate.rs (target/debug/deps/tree_sitter_generate-7ae5e72afb297ba1)

running 1 test
test node_types::tests::test_node_types_supertype_with_only_hidden_child ... FAILED

failures:

---- node_types::tests::test_node_types_supertype_with_only_hidden_child stdout ----

thread 'node_types::tests::test_node_types_supertype_with_only_hidden_child' (25867235) panicked at crates/generate/src/node_types.rs:677:71:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    node_types::tests::test_node_types_supertype_with_only_hidden_child

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 59 filtered out; finished in 0.00s

error: test failed, to rerun pass `-p tree-sitter-generate --lib`
```