### PR TITLE
perf(cli): misc. improvements

### DIFF
--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -437,7 +437,7 @@ pub fn parse_file_at_path(
     let parse_duration = parse_time.elapsed();
 
     let stdout = io::stdout();
-    let mut stdout = stdout.lock();
+    let mut stdout = io::BufWriter::with_capacity(64 * 1024, stdout.lock());
 
     if let Some(mut tree) = tree {
         if opts.debug_graph && !opts.edits.is_empty() {
@@ -514,7 +514,7 @@ pub fn parse_file_at_path(
                 }
             }
             cursor.reset(tree.root_node());
-            println!();
+            writeln!(&mut stdout)?;
         }
 
         if opts.output == ParseOutput::Cst {

--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -585,11 +585,11 @@ pub fn parse_file_at_path(
                         }
                         let start = node.start_position();
                         let end = node.end_position();
-                        write!(&mut stdout, " srow=\"{}\"", start.row)?;
-                        write!(&mut stdout, " scol=\"{}\"", start.column)?;
-                        write!(&mut stdout, " erow=\"{}\"", end.row)?;
-                        write!(&mut stdout, " ecol=\"{}\"", end.column)?;
-                        write!(&mut stdout, ">")?;
+                        write!(
+                            &mut stdout,
+                            " srow=\"{}\" scol=\"{}\" erow=\"{}\" ecol=\"{}\">",
+                            start.row, start.column, end.row, end.column
+                        )?;
                         tags.push(node.kind());
                         needs_newline = true;
                     }

--- a/crates/cli/src/query.rs
+++ b/crates/cli/src/query.rs
@@ -37,7 +37,7 @@ pub fn query_file_at_path(
     test_summary: Option<&mut TestSummary>,
 ) -> Result<()> {
     let stdout = io::stdout();
-    let mut stdout = stdout.lock();
+    let mut stdout = io::BufWriter::with_capacity(64 * 1024, stdout.lock());
 
     let query_source = fs::read_to_string(query_path)
         .with_context(|| format!("Error reading query file {}", query_path.display()))?;

--- a/crates/cli/src/test.rs
+++ b/crates/cli/src/test.rs
@@ -888,13 +888,14 @@ fn run_tests(
                 let tree = parser.parse(&input, None).unwrap();
                 let parse_rate = {
                     let parse_time = start.elapsed();
-                    let true_parse_rate = tree.root_node().byte_range().len() as f64
-                        / (parse_time.as_nanos() as f64 / 1_000_000.0);
+                    let byte_len = tree.root_node().byte_range().len();
+                    let true_parse_rate =
+                        byte_len as f64 / (parse_time.as_nanos() as f64 / 1_000_000.0);
                     let adj_parse_rate = adjusted_parse_rate(&tree, parse_time);
 
                     test_summary.parse_stats.total_parses += 1;
                     test_summary.parse_stats.total_duration += parse_time;
-                    test_summary.parse_stats.total_bytes += tree.root_node().byte_range().len();
+                    test_summary.parse_stats.total_bytes += byte_len;
 
                     Some((true_parse_rate, adj_parse_rate))
                 };

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -3811,11 +3811,11 @@ impl fmt::Display for QueryError {
 #[must_use]
 pub fn format_sexp(sexp: &str, initial_indent_level: usize) -> String {
     let mut indent_level = initial_indent_level;
-    let mut formatted = String::new();
+    let mut formatted = String::with_capacity(sexp.len());
     let mut has_field = false;
 
     let mut c_iter = sexp.chars().peekable();
-    let mut s = String::with_capacity(sexp.len());
+    let mut scratch = String::with_capacity(sexp.len());
     let mut quote = '\0';
     let mut saw_paren = false;
     let mut did_last = false;
@@ -3861,12 +3861,12 @@ pub fn format_sexp(sexp: &str, initial_indent_level: usize) -> String {
         Some(())
     };
 
-    while fetch_next_str(&mut s).is_some() {
-        if s.is_empty() && indent_level > 0 {
+    while fetch_next_str(&mut scratch).is_some() {
+        if scratch.is_empty() && indent_level > 0 {
             // ")"
             indent_level -= 1;
             write!(formatted, ")").unwrap();
-        } else if s.starts_with('(') {
+        } else if scratch.starts_with('(') {
             if has_field {
                 has_field = false;
             } else {
@@ -3880,27 +3880,27 @@ pub fn format_sexp(sexp: &str, initial_indent_level: usize) -> String {
             }
 
             // "(node_name"
-            write!(formatted, "{s}").unwrap();
+            write!(formatted, "{scratch}").unwrap();
 
             // "(MISSING node_name" or "(UNEXPECTED 'x'"
-            if s.starts_with("(MISSING") || s.starts_with("(UNEXPECTED") {
-                fetch_next_str(&mut s).unwrap();
-                if s.is_empty() {
+            if scratch.starts_with("(MISSING") || scratch.starts_with("(UNEXPECTED") {
+                fetch_next_str(&mut scratch).unwrap();
+                if scratch.is_empty() {
                     while indent_level > 0 {
                         indent_level -= 1;
                         write!(formatted, ")").unwrap();
                     }
                 } else {
-                    write!(formatted, " {s}").unwrap();
+                    write!(formatted, " {scratch}").unwrap();
                 }
             }
-        } else if s.ends_with(':') {
+        } else if scratch.ends_with(':') {
             // "field:"
             writeln!(formatted).unwrap();
             for _ in 0..indent_level {
                 write!(formatted, "  ").unwrap();
             }
-            write!(formatted, "{s} ").unwrap();
+            write!(formatted, "{scratch} ").unwrap();
             has_field = true;
             indent_level += 1;
         }


### PR DESCRIPTION
A few small perf changes for the cli. The buffering change doesn't really shine unless the result is being piped to a file. For example, when parsing `test/fixtures/grammars/javascript/examples/jquery.js`, both builds take ~73ms. When piping to a file however, this branch takes ~30ms while the current master branch takes ~60ms. This suggests terminal rendering is dominating when results are being printed, but this is still a nice to have for larger files.