### PR TITLE
Fix wasm loading of languages w/ multiple reserved word sets

### DIFF
--- a/crates/cli/src/tests/wasm_language_test.rs
+++ b/crates/cli/src/tests/wasm_language_test.rs
@@ -315,6 +315,55 @@ fn test_load_wasm_errors() {
 }
 
 #[test]
+fn test_load_wasm_language_with_reserved_words() {
+    // This test exercises a grammar with multiple reserved word sets loaded via WASM.
+    allocations::record(|| {
+        let store = WasmStore::new(&ENGINE).unwrap();
+        let language = get_test_fixture_language_wasm("reserved_words");
+
+        let mut parser = Parser::new();
+        parser.set_wasm_store(store).unwrap();
+        parser.set_language(&language).unwrap();
+
+        // "if" and "while" are globally reserved, so using them as identifiers
+        // should produce an error recovery.
+        let tree = parser
+            .parse("var a =\n\nif (something) {\n  c();\n}", None)
+            .unwrap();
+        assert_eq!(
+            tree.root_node().to_sexp(),
+            concat!(
+                "(program ",
+                "(ERROR (identifier)) ",
+                "(if_statement (parenthesized_expression (identifier)) ",
+                "(block (expression_statement (call_expression (identifier))))))",
+            )
+        );
+
+        // "if" and "while" are NOT reserved in the 'property' context, so they
+        // can appear as object keys without error.
+        let tree = parser
+            .parse("var x = {\n  if: a,\n  while: b,\n};", None)
+            .unwrap();
+        assert_eq!(
+            tree.root_node().to_sexp(),
+            concat!(
+                "(program (var_declaration (identifier) (object ",
+                "(pair (identifier) (identifier)) (pair (identifier) (identifier)))))"
+            )
+        );
+
+        // "var" IS reserved in the 'property' context, so using it as a property
+        // key triggers error recovery.
+        let tree = parser.parse("var x = {\nvar y = z;", None).unwrap();
+        assert_eq!(
+            tree.root_node().to_sexp(),
+            "(program (ERROR (identifier)) (var_declaration (identifier) (identifier)))"
+        );
+    });
+}
+
+#[test]
 fn test_wasm_oom() {
     allocations::record(|| {
         let mut store = WasmStore::new(&ENGINE).unwrap();

--- a/lib/src/wasm_store.c
+++ b/lib/src/wasm_store.c
@@ -1406,11 +1406,24 @@ const TSLanguage *ts_wasm_store_load_language(
 
   if (language->abi_version >= LANGUAGE_VERSION_WITH_RESERVED_WORDS) {
     language->name = copy_string(memory, wasm_language.name);
-    language->reserved_words = copy(
-        &memory[wasm_language.reserved_words],
-        wasm_language.max_reserved_word_set_size * sizeof(TSSymbol)
-    );
     language->max_reserved_word_set_size = wasm_language.max_reserved_word_set_size;
+
+    // Determine the number of reserved word sets by finding the maximum
+    // reserved_word_set_id across all lex modes.
+    uint16_t max_reserved_word_set_id = 0;
+    for (uint32_t i = 0; i < wasm_language.state_count; i++) {
+      uint16_t id = language->lex_modes[i].reserved_word_set_id;
+      if (id > max_reserved_word_set_id) max_reserved_word_set_id = id;
+    }
+
+    if (max_reserved_word_set_id > 0 && language->max_reserved_word_set_size > 0) {
+      uint32_t reserved_word_count =
+        (max_reserved_word_set_id + 1) * language->max_reserved_word_set_size;
+      language->reserved_words = copy(
+          &memory[wasm_language.reserved_words],
+          reserved_word_count * sizeof(TSSymbol)
+      );
+    }
   }
 
   if (language->external_token_count > 0) {


### PR DESCRIPTION
Previously, languages with multiple reserved word sets were not handled properly when loaded from WASM. This would cause crashes during lexing.