### PR TITLE
ci(actions): bump actions/cache to v5

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -10,7 +10,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       id: cache
       with:
         path: |


### PR DESCRIPTION
Apparently dependabot doesn't cover the actions/cache/action.yml.

(Stop GHA screaming about Node 20.)