### PR TITLE
fix(dsl): update GrammarSchema type to match actual grammar() return value

### DIFF
--- a/crates/cli/npm/dsl.d.ts
+++ b/crates/cli/npm/dsl.d.ts
@@ -180,10 +180,27 @@ interface Grammar<
   >;
 }
 
+/**
+ * The actual output structure returned by the `grammar` function.
+ * This differs from the input Grammar interface:
+ * - The entire structure is nested under a `grammar` key
+ * - All callback functions are replaced with their return values
+ * - Optional fields become required with default empty values
+ */
 type GrammarSchema<RuleName extends string> = {
-  [K in keyof Grammar<RuleName>]: K extends 'rules'
-  ? Record<RuleName, Rule>
-  : Grammar<RuleName>[K];
+  grammar: {
+    name: string;
+    rules: Record<RuleName, Rule>;
+    precedences: RuleOrLiteral[][];
+    conflicts: RuleOrLiteral[][];
+    externals: RuleOrLiteral[];
+    extras: RuleOrLiteral[];
+    inline: RuleOrLiteral[];
+    supertypes: RuleOrLiteral[];
+    word: RuleOrLiteral | undefined;
+    inherits: unknown | undefined;
+    reserved: Record<string, RuleOrLiteral[]>;
+  };
 };
 
 /**


### PR DESCRIPTION
## Summary
Update the `GrammarSchema` TypeScript type to accurately reflect the actual structure returned by the `grammar()` function.

## Problem
The `GrammarSchema` type did not match the actual data returned by `grammar()`:
- The return value is nested under a `grammar` key
- Callback functions (precedences, conflicts, etc.) are replaced with their return values
- Optional fields become required with default empty values

## Solution
Updated `GrammarSchema` to correctly type the nested output structure with evaluated callbacks.

## Before
```ts
type GrammarSchema = {
  name: string;
  rules: Record<RuleName, Rule>;
  precedences?: (...) => RuleOrLiteral[][];
  // etc.
}
```

## After
```ts
type GrammarSchema = {
  grammar: {
    name: string;
    rules: Record<RuleName, Rule>;
    precedences: RuleOrLiteral[][];
    conflicts: RuleOrLiteral[][];
    externals: RuleOrLiteral[];
    extras: RuleOrLiteral[];
    inline: RuleOrLiteral[];
    supertypes: RuleOrLiteral[];
    word: RuleOrLiteral | undefined;
    inherits: unknown | undefined;
    reserved: Record<string, RuleOrLiteral[]>;
  }
}
```

Fixes #5373