### PR TITLE
feat(generate): don't require `tree-sitter.json` for ABI 15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,9 +1655,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -2032,7 +2032,6 @@ dependencies = [
  "bitflags 2.11.0",
  "dunce",
  "indexmap",
- "indoc",
  "log",
  "pathdiff",
  "regex",

--- a/crates/generate/Cargo.toml
+++ b/crates/generate/Cargo.toml
@@ -28,7 +28,6 @@ qjs-rt  = [ "load", "rquickjs", "pathdiff" ]
 bitflags = "2.10.0"
 dunce = "1.0.5"
 indexmap.workspace = true
-indoc.workspace = true
 log.workspace = true
 pathdiff = { optional = true, version = "0.2.3" }
 regex.workspace = true

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -8,8 +8,6 @@ use std::{
 };
 
 use bitflags::bitflags;
-#[cfg(feature = "load")]
-use log::warn;
 use node_types::VariableInfo;
 use rules::{Alias, Symbol};
 #[cfg(feature = "load")]
@@ -228,7 +226,7 @@ pub fn generate_parser_in_directory<T, U, V>(
     repo_path: T,
     out_path: Option<U>,
     grammar_path: Option<V>,
-    mut abi_version: usize,
+    abi_version: usize,
     report_symbol_name: Option<&str>,
     js_runtime: Option<&str>,
     generate_parser: bool,
@@ -284,20 +282,6 @@ where
     }
 
     let semantic_version = read_grammar_version(&repo_path)?;
-
-    if semantic_version.is_none() && abi_version > ABI_VERSION_MIN {
-        warn!(
-            concat!(
-                "No `tree-sitter.json` file found in your grammar, ",
-                "this file is required to generate with ABI {}. ",
-                "Using ABI version {} instead.\n",
-                "This file can be set up with `tree-sitter init`. ",
-                "For more information, see https://tree-sitter.github.io/tree-sitter/cli/init."
-            ),
-            abi_version, ABI_VERSION_MIN
-        );
-        abi_version = ABI_VERSION_MIN;
-    }
 
     // Generate the parser and related files.
     let GeneratedParser {

--- a/crates/generate/src/render.rs
+++ b/crates/generate/src/render.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use crate::LANGUAGE_VERSION;
-use indoc::indoc;
 use serde::Serialize;
 use thiserror::Error;
 
@@ -109,6 +108,7 @@ struct LargeCharacterSetInfo {
     is_used: bool,
 }
 
+#[derive(Clone, Copy, Default)]
 struct Metadata {
     major: u8,
     minor: u8,
@@ -1658,15 +1658,7 @@ impl Generator {
                     .unwrap()
             );
 
-            let Some(metadata) = &self.metadata else {
-                panic!(
-                    indoc! {"
-                        Metadata is required to generate ABI version {}.
-                        This means that your grammar doesn't have a tree-sitter.json config file with an appropriate version field in the metadata table.
-                    "},
-                    self.abi_version
-                );
-            };
+            let metadata = self.metadata.unwrap_or_default();
 
             add_line!(self, ".metadata = {{");
             indent!(self);


### PR DESCRIPTION
Problem: Many parser projects (about 100 out of ~330 tracked by
nvim-treesitter) still do not contain a `tree-sitter.json` config file,
so `tree-sitter generate` refuses to generate ABI 15 parsers due to the
lack of version information. This prevents these parsers from profiting
from other improvements in ABI 15+ and will eventually make them
unusable when ABI 14 support is dropped.

Solution: Simply use a default version `0.0.0` if no `tree-sitter.json`
is found.

This will allow the `nvim-treesitter-generate` workflow to give much wider
coverage of the ABI 15 code path.

(Don't know why I didn't think of that initially 🤦 )