### PR TITLE
fix(ci): include wasi-sdk and binaryen version files in fixture cache hash

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -22,5 +22,7 @@ runs:
           'lib/src/array.h',
           'lib/src/alloc.h',
           'lib/src/wasm/wasm-stdlib.h',
+          'crates/loader/wasi-sdk-version',
+          'crates/loader/binaryen-version',
           'test/fixtures/grammars/*/**/src/*.c',
           '.github/actions/cache/action.yml') }}


### PR DESCRIPTION
Realized this while looking at #5499 

Since these external tools are used to generate the wasm fixtures, they should be part of the fixture hash.