### PR TITLE
NULL check for length before dereferencing it.

### DIFF
--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -783,7 +783,7 @@ static const char *symbol_table_name_for_id(
   uint32_t *length
 ) {
   Slice slice = *(array_get(&self->slices,id));
-  *length = slice.length;
+  if (length != NULL) *length = slice.length;
   return array_get(&self->characters, slice.offset);
 }
 


### PR DESCRIPTION
Caller can pass NULL if they don't want to use length. And if they accidentally do check if it is NULL without having to dereference a NULL pointer. 
