### PR TITLE
build(swift): use single-file amalgamation for SPM target (fixes #5523)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,10 +19,8 @@ let package = Package(
                         "src/unicode/README.md",
                         "src/unicode/LICENSE",
                         "src/wasm/stdlib-symbols.txt",
-                        "src/lib.c",
                 ],
-                sources: ["src"],
-                publicHeadersPath: "include",
+                sources: ["src/lib.c"],
                 cSettings: [
                         .headerSearchPath("src"),
                         .define("_POSIX_C_SOURCE", to: "200112L"),


### PR DESCRIPTION
Fixes #5523.

Reverts the `TreeSitter` SPM target to the 0.20-era amalgamation build style (`sources: ["src/lib.c"]`) so Swift consumers can import the module on Xcode 26.

## What changed

`Package.swift`, 3 lines:

- `sources: ["src"]` → `sources: ["src/lib.c"]`
- Drop `"src/lib.c"` from `exclude` (it's compiled now)
- Drop the explicit `publicHeadersPath: "include"` (same as the default)

Everything else is untouched. `lib/src/lib.c` already exists and `#include`s every other `.c` file in `lib/src/`, so the compiled library is byte-for-byte the same as before from the linker's perspective.

## Why

On Xcode 26 (Swift 6.3), the multi-file layout (`sources: ["src"]` + `publicHeadersPath: "include"`) produces a generated modulemap (`umbrella "include"`) that `clang @import TreeSitter` can resolve, but `swift import TreeSitter` sees as an empty module — every reference to `TSLanguage` / `TSInputEncoding` / etc fails with `Cannot find type ... in scope`. Full investigation and dumped evidence in #5523.

The 0.20-era single-source-file layout goes through a different SwiftPM code path and works on Xcode 26. Since `lib/src/lib.c` is already maintained as a working amalgamation include, reusing it is the smallest possible fix that restores Swift SPM support without touching any non-core build surface.

## Non-impact

- **C / Rust / WASM builds**: untouched. These do not read `Package.swift`.
- **`swift build` CLI**: still works (both layouts work there; only `xcodebuild` / Xcode UI on Xcode 26 is broken).
- **Older Xcode (16/17)**: continues to work. 0.20.x used this same layout for years.
- **Grammars / bindings repos**: no ABI change, no header change, no include-path change visible to consumers.

## Tested

- `xcodebuild -scheme <consumer>` on Xcode 26.4 (Build 17E192), Swift 6.3 — build succeeds, consumer can reference `TSLanguage` etc.
- `swift build` CLI — unchanged, still green.
