### PR TITLE
fix: update broken link to Parser.Language in template

### DIFF
--- a/crates/cli/src/templates/index.d.ts
+++ b/crates/cli/src/templates/index.d.ts
@@ -21,7 +21,7 @@ type NodeInfo =
 /**
  * The tree-sitter language object for this grammar.
  *
- * @see {@linkcode https://tree-sitter.github.io/node-tree-sitter/interfaces/Parser.Language.html Parser.Language}
+ * @see {@linkcode https://tree-sitter.github.io/node-tree-sitter/interfaces/Language.html Parser.Language}
  *
  * @example
  * import Parser from "tree-sitter";


### PR DESCRIPTION
The link `https://tree-sitter.github.io/node-tree-sitter/interfaces/Parser.Language.html` returns a 404 error.

In the current typedoc output, the Language interface is at `/interfaces/Language.html` (without the `Parser.` prefix), as the documentation flattens namespace members.

Fixes #5525