### PR TITLE
fix(loader): allow filenames with dots

### DIFF
--- a/crates/cli/src/tests/detect_language.rs
+++ b/crates/cli/src/tests/detect_language.rs
@@ -128,6 +128,52 @@ fn detect_language_by_double_barrel_file_extension() {
 }
 
 #[test]
+fn detect_language_with_dots_in_filename() {
+    let blade_dir = tree_sitter_dir(
+        r#"{
+  "grammars": [
+    {
+      "name": "blade",
+      "path": ".",
+      "scope": "source.blade",
+      "file-types": [
+        "blade.php"
+      ]
+    },
+    {
+      "name": "php",
+      "path": ".",
+      "scope": "source.php",
+      "file-types": [
+        "php"
+      ]
+    }
+  ],
+  "metadata": {
+    "version": "0.0.1"
+  }
+}
+"#,
+        "blade",
+    );
+
+    let mut loader = Loader::with_parser_lib_path(scratch_dir().to_path_buf());
+    let config = loader
+        .find_language_configurations_at_path(blade_dir.path(), false)
+        .unwrap();
+
+    // this is just to validate that we can read the tree-sitter.json correctly
+    assert_eq!(config[0].scope.as_ref().unwrap(), "source.blade");
+
+    let file_name = blade_dir.path().join("foo.bar.baz.blade.php");
+    fs::write(&file_name, "").unwrap();
+    assert_eq!(
+        get_lang_scope(&loader, &file_name),
+        Some("source.blade".into())
+    );
+}
+
+#[test]
 fn detect_language_without_filename() {
     let gitignore_dir = tree_sitter_dir(
         r#"{

--- a/crates/cli/src/tests/detect_language.rs
+++ b/crates/cli/src/tests/detect_language.rs
@@ -154,7 +154,7 @@ fn detect_language_with_dots_in_filename() {
   }
 }
 "#,
-        "blade",
+        "blade_dots",
     );
 
     let mut loader = Loader::with_parser_lib_path(scratch_dir().to_path_buf());

--- a/crates/cli/src/tests/detect_language.rs
+++ b/crates/cli/src/tests/detect_language.rs
@@ -141,7 +141,7 @@ fn detect_language_with_dots_in_filename() {
       ]
     },
     {
-      "name": "php",
+      "name": "php_dots",
       "path": ".",
       "scope": "source.php",
       "file-types": [

--- a/crates/cli/src/tests/detect_language.rs
+++ b/crates/cli/src/tests/detect_language.rs
@@ -133,7 +133,7 @@ fn detect_language_with_dots_in_filename() {
         r#"{
   "grammars": [
     {
-      "name": "blade",
+      "name": "blade_dots",
       "path": ".",
       "scope": "source.blade",
       "file-types": [

--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -958,8 +958,10 @@ impl Loader {
                     path = PathBuf::from(path.file_stem()?.to_os_string());
                 }
                 extensions.reverse();
-                self.language_configuration_ids_by_file_type
-                    .get(&extensions.join("."))
+                // Try all extension suffixes from coarser to finer and stop at the first match.
+                (0..extensions.len())
+                    .map(|i| extensions[i..].join("."))
+                    .find_map(|key| self.language_configuration_ids_by_file_type.get(&key))
             });
 
         if let Some(configuration_ids) = configuration_ids

--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -958,7 +958,8 @@ impl Loader {
                     path = PathBuf::from(path.file_stem()?.to_os_string());
                 }
                 extensions.reverse();
-                // Try all extension suffixes from coarser to finer and stop at the first match.
+                // Try longest extension suffixs first (e.g. "foo.bar.baz"->"bar.baz"->"baz"),
+                // stopping at the first match.
                 (0..extensions.len())
                     .map(|i| extensions[i..].join("."))
                     .find_map(|key| self.language_configuration_ids_by_file_type.get(&key))


### PR DESCRIPTION
Currently all dots/periods in a filename are considered an extension. This way you can match filenames like `foo.blade.php` with `blade.php` and not only `php`.

Though there are cases where filenames have dots and you still want to match on a suffix of the extension (or simply the last one).

This commit introduces best effort matching. It starts with the all dots being considered an extension and then gradually tries to match with less and less extensions.

Example: A filename `foo.bar.baz.blade.php` would try to find a match of these extensions in this order:

 - `bar.baz.blade.php`
 - `baz.blade.php`
 - `blade.php`
 - `php`

It stops on the first match, so if a grammar for `blade.php` is registered, it stops there and won't try `php`.