### PR TITLE
chore: enable install via `cargo binstall`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
           # When adding a new `target`:
           # 1. Define a new platform alias above
           # 2. Add a new record to the matrix map in `crates/cli/npm/install.js`
+          # 3. Consider adding the mapping at the end of 'crates/cli/Cargo.toml' for cargo-binstall support
           - { platform: linux-arm64     , target: aarch64-unknown-linux-gnu     , os: ubuntu-24.04-arm }
           - { platform: linux-arm       , target: armv7-unknown-linux-gnueabihf , os: ubuntu-24.04-arm }
           - { platform: linux-x64       , target: x86_64-unknown-linux-gnu      , os: ubuntu-24.04     }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -81,3 +81,36 @@ widestring             = "1.2.1"
 pretty_assertions.workspace = true
 tempfile.workspace          = true
 unindent.workspace          = true
+
+[package.metadata.binstall]
+pkg-fmt = "zip"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-linux-arm64{ archive-suffix }"
+
+[package.metadata.binstall.overrides.armv7-unknown-linux-gnueabihf]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-linux-arm{ archive-suffix }"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-linux-x64{ archive-suffix }"
+
+[package.metadata.binstall.overrides.i686-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-linux-x86{ archive-suffix }"
+
+[package.metadata.binstall.overrides.powerpc64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-linux-powerpc64{ archive-suffix }"
+
+[package.metadata.binstall.overrides.aarch64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-windows-arm64{ archive-suffix }"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-windows-x64{ archive-suffix }"
+
+[package.metadata.binstall.overrides.i686-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-windows-x86{ archive-suffix }"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-macos-arm64{ archive-suffix }"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-macos-x64{ archive-suffix }"

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -12,21 +12,15 @@ The Tree-sitter CLI allows you to develop, test, and use Tree-sitter grammars fr
 
 ### Installation
 
-You can install the `tree-sitter-cli` with `cargo`:
+You can install the `tree-sitter-cli` with `cargo-binstall`:
 
-```sh
-cargo install --locked tree-sitter-cli
-```
-
-or if you have `cargo-binstall`, you can avoid compiling the CLI from source:
 ```sh
 cargo binstall tree-sitter-cli
 ```
 
-or with `npm`:
-
+or you can build it from source:
 ```sh
-npm install tree-sitter-cli
+cargo install --locked tree-sitter-cli
 ```
 
 You can also download a pre-built binary for your platform from [the releases page].

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -18,6 +18,11 @@ You can install the `tree-sitter-cli` with `cargo`:
 cargo install --locked tree-sitter-cli
 ```
 
+or if you have `cargo-binstall`, you can avoid compiling the CLI from source:
+```sh
+cargo binstall tree-sitter-cli
+```
+
 or with `npm`:
 
 ```sh


### PR DESCRIPTION
Closes #4351.

To test this:
- check out this PR
- temporarily change the `version` field in the root `Cargo.toml` to a released version (such as `0.26.8`)
- run `cargo binstall tree-sitter-cli --manifest-path crates/cli/Cargo.toml --verbose --version 0.26.8` and see that it offers to install tree-sitter from a downloaded archive instead of compiling it from scratch

Of course the actual command will become simpler once this change is released: it should become simply `cargo binstall tree-sitter-cli`.

See [the docs of `cargo binstall`](https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md) for details about this configuration format. I first tried making a more compact configuration via statements such as `[package.metadata.binstall.overrides.'cfg(target_arch = "x86_64")']` to translate architectures independently from platforms but this format doesn't seem to get picked up on my side. The more verbose format I ended up with is arguably easier to maintain as it matches the CI configuration more explicitly.