### PR TITLE
fix(generate): pass default optimization level in `generate_parser_for_grammar`

### DIFF
--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -316,7 +316,7 @@ pub fn generate_parser_for_grammar(
         LANGUAGE_VERSION,
         semantic_version,
         None,
-        OptLevel::empty(),
+        OptLevel::default(),
     )?;
     Ok((input_grammar.name, parser.c_code))
 }


### PR DESCRIPTION
Passing `empty` here causes some grammars (i.e. tree-sitter-cpp) to fail to generate.