### PR TITLE
fix(web): map Node-only specifiers to false via browser field

### DIFF
--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -43,6 +43,10 @@
     },
     "./debug/web-tree-sitter.wasm": "./debug/web-tree-sitter.wasm"
   },
+  "browser": {
+    "fs/promises": false,
+    "module": false
+  },
   "types": "web-tree-sitter.d.ts",
   "keywords": [
     "incremental",

--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -43,6 +43,11 @@
     },
     "./debug/web-tree-sitter.wasm": "./debug/web-tree-sitter.wasm"
   },
+  "browser": {
+    "fs": false,
+    "fs/promises": false,
+    "module": false
+  },
   "types": "web-tree-sitter.d.ts",
   "keywords": [
     "incremental",


### PR DESCRIPTION
## Summary

- Adds a top-level `"browser"` field in `lib/binding_web/package.json` mapping `fs/promises` and `module` to `false`.
- Fixes #5545

The `"browser"` field tells bundlers to substitute empty stubs for these specifiers when targeting the browser.

### Other Node references audited

- `require("fs")`, `require("path")`, `require("url")` call a local `var require = createRequire(import.meta.url)` that's hoisted inside `Module2()`. esbuild and webpack both correctly resolve these as local-variable calls and leave them untouched.

## Test plan

Claude reproduced the issue's exact esbuild repro against the published `web-tree-sitter@0.26.8` artifact, then re-ran with the patched `package.json`, and it succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)