### PR TITLE
Documentation update to index.md

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -39,6 +39,7 @@ There are bindings that allow Tree-sitter to be used from the following language
 - [D](https://github.com/aminya/d-tree-sitter)
 - [Delphi](https://github.com/modersohn/delphi-tree-sitter)
 - [ELisp](https://www.gnu.org/software/emacs/manual/html_node/elisp/Parsing-Program-Source.html)
+- [F#](https://github.com/ionide/tree-sitter-fsharp)
 - [Go](https://github.com/alexaandru/go-tree-sitter-bare)
 - [Guile](https://github.com/Z572/guile-ts)
 - [Janet](https://github.com/sogaiu/janet-tree-sitter)


### PR DESCRIPTION
I've been testing the 0.3.0 version of the F# tree-sitter and that works very well.

### AI Policy

- [x] No AI used.
