### PR TITLE
fix(test): make lookahead iterator test order-independent

### DIFF
--- a/crates/cli/src/tests/language_test.rs
+++ b/crates/cli/src/tests/language_test.rs
@@ -27,20 +27,25 @@ fn test_lookahead_iterator() {
     assert_eq!(cursor.node().grammar_name(), "identifier");
     assert_ne!(cursor.node().grammar_id(), cursor.node().kind_id());
 
-    let expected_symbols = ["//", "/*", "identifier", "line_comment", "block_comment"];
+    let expected_symbols = ["/*", "//", "block_comment", "identifier", "line_comment"];
+
     let mut lookahead = language.lookahead_iterator(next_state).unwrap();
     assert_eq!(*lookahead.language(), language);
-    assert!(lookahead.iter_names().eq(expected_symbols));
+    let mut actual = lookahead.iter_names().collect::<Vec<_>>();
+    actual.sort_unstable();
+    assert_eq!(actual, expected_symbols);
 
     lookahead.reset_state(next_state);
-    assert!(lookahead.iter_names().eq(expected_symbols));
+    let mut actual = lookahead.iter_names().collect::<Vec<_>>();
+    actual.sort_unstable();
+    assert_eq!(actual, expected_symbols);
 
     lookahead.reset(&language, next_state);
-    assert!(
-        lookahead
-            .map(|s| language.node_kind_for_id(s).unwrap())
-            .eq(expected_symbols)
-    );
+    let mut actual = lookahead
+        .map(|s| language.node_kind_for_id(s).unwrap())
+        .collect::<Vec<_>>();
+    actual.sort_unstable();
+    assert_eq!(actual, expected_symbols);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- stop assuming a specific iteration order in `test_lookahead_iterator`
- sort the collected symbol names before comparison so the test only checks the documented set of valid symbols

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

Used GitHub Copilot Chat / OpenCode to inspect the larger unmerged CSR branch, identify this test-only fix as a standalone change, and help prepare this isolated PR. The final patch here is limited to the lookahead iterator test.