### PR TITLE
fix(cli): account for process versions > 5 in the parse command's pretty debug output.

### DIFF
--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -310,13 +310,13 @@ pub fn parse_file_at_path(
                 }
                 writeln!(&mut io::stderr(), "{message}").unwrap();
             } else {
+                #[rustfmt::skip]
                 let colors = &[
-                    AnsiColor::White,
-                    AnsiColor::Red,
-                    AnsiColor::Blue,
-                    AnsiColor::Green,
-                    AnsiColor::Cyan,
-                    AnsiColor::Yellow,
+                    AnsiColor::White, AnsiColor::Red, AnsiColor::Blue, AnsiColor::Green,
+                    AnsiColor::Cyan, AnsiColor::Yellow, AnsiColor::Magenta,
+                    AnsiColor::BrightWhite, AnsiColor::BrightRed, AnsiColor::BrightBlue,
+                    AnsiColor::BrightGreen, AnsiColor::BrightCyan, AnsiColor::BrightYellow,
+                    AnsiColor::BrightMagenta,
                 ];
                 if message.starts_with("process version:") {
                     let comma_idx = message.find(',').unwrap();
@@ -325,7 +325,7 @@ pub fn parse_file_at_path(
                         .unwrap();
                 }
                 let color = if use_color {
-                    Some(colors[curr_version])
+                    Some(colors[curr_version % colors.len()])
                 } else {
                     None
                 };


### PR DESCRIPTION
## The Problem

The initial implementation of `--debug pretty` assumed process version was bounded by `MAX_VERSION_COUNT`:

https://github.com/tree-sitter/tree-sitter/blob/8d737aa238084f9a51f1e97c195a362419beee8d/lib/src/parser.c#L77

However, we also have to account for `MAX_VERSION_COUNT_OVERFLOW` as well as `halted_version_count`. In practice, the version count shouldn't exceed `MAX_VERSION_COUNT` by much, but technically it's unbounded  due to `halted_version_count`.

### Reproduction

Within the root directory of the [`tree-sitter-elixir`](https://github.com/elixir-lang/tree-sitter-elixir) grammar: 

`tree-sitter parse --debug pretty test/highlight/anonymous.ex`:

<img width="1603" height="971" alt="image" src="https://github.com/user-attachments/assets/7d01b18d-cbc6-4fef-a293-241275dac144" />

With the fix:

<img width="643" height="971" alt="image" src="https://github.com/user-attachments/assets/793fca8a-727c-4872-98b8-b10772cebf26" />
(and so on)

## The Solution

The fix is simple, just modulo-wrap the index into the `colors` array so it can't read OOB. I opted to add some more colors to this array so that we don't re-use colors between different process versions for the common case as well. Colors 1-7 are matched by their "bright" variants in colors 8-14.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

I used claude code to find a reproducer while working on another task, as #5568 did not provide one. 

- Closes #5568