### PR TITLE
fix(generate): improve error message for nonterminals used in immediate token rule

### DIFF
--- a/crates/generate/src/parse_grammar.rs
+++ b/crates/generate/src/parse_grammar.rs
@@ -404,7 +404,7 @@ fn parse_rule(json: RuleJSON, is_token: bool) -> ParseGrammarResult<Rule> {
         }),
         RuleJSON::TOKEN { content } => parse_rule(*content, true).map(Rule::token),
         RuleJSON::IMMEDIATE_TOKEN { content } => {
-            parse_rule(*content, is_token).map(Rule::immediate_token)
+            parse_rule(*content, true).map(Rule::immediate_token)
         }
     }
 }


### PR DESCRIPTION
Fixes a typo from #4115 

