### PR TITLE
perf(bindings): defer importlib.resources import in python template

### DIFF
--- a/crates/cli/src/templates/__init__.py
+++ b/crates/cli/src/templates/__init__.py
@@ -1,11 +1,10 @@
 """PARSER_DESCRIPTION"""
 
-from importlib.resources import files as _files
-
 from ._binding import language
 
 
 def _get_query(name, file):
+    from importlib.resources import files as _files
     try:
         query = _files(f"{__package__}") / file
         globals()[name] = query.read_text()

--- a/crates/cli/src/templates/__init__.py
+++ b/crates/cli/src/templates/__init__.py
@@ -4,9 +4,9 @@ from ._binding import language
 
 
 def _get_query(name, file):
-    from importlib.resources import files as _files
+    from importlib.resources import files
     try:
-        query = _files(f"{__package__}") / file
+        query = files(f"{__package__}") / file
         globals()[name] = query.read_text()
     except FileNotFoundError:
         globals()[name] = None

--- a/crates/cli/src/templates/__init__.py
+++ b/crates/cli/src/templates/__init__.py
@@ -4,7 +4,10 @@ from ._binding import language
 
 
 def _get_query(name, file):
-    from importlib.resources import files
+    files = globals().get("_files")
+    if files is None:
+        from importlib.resources import files
+        globals()["_files"] = files
     try:
         query = files(f"{__package__}") / file
         globals()[name] = query.read_text()


### PR DESCRIPTION
Previously submitted as https://github.com/tree-sitter/tree-sitter-bash/pull/338

## Summary

I noticed on my machine that `import tree_sitter_bash` took ~170ms cold / ~50ms warm on CPython 3.14.

Moving `from importlib.resources import files as _files` from module top-level into `_get_query` (the only function that uses it) **reduces import time by ~97%**.

## Root cause

`python3 -X importtime -c "import tree_sitter_bash"` (trimmed):

```
import time:      1084 |       1084 |   tree_sitter_bash._binding
import time:       505 |      35355 |   importlib.resources       ← 35ms cumulative
import time:       725 |      37164 | tree_sitter_bash
```

`importlib.resources` transitively pulls in ~30 stdlib modules.

`_files` has exactly one caller: `_get_query`. And `_get_query` is only reached through `__getattr__` when a consumer accesses `HIGHLIGHTS_QUERY`.

## Fix

Move the import inside `_get_query`:

```python
def _get_query(name, file):
    from importlib.resources import files as _files
    query = _files(f"{__package__}.queries") / file
    globals()[name] = query.read_text()
    return globals()[name]
```

The existing `globals()[name] = ...` cache still works: `HIGHLIGHTS_QUERY` is populated on first access and becomes a normal module attribute afterward.

## Measurements

Python 3.14.4, darwin-arm64, M5 MacBook Pro. Five consecutive runs:

| | cold | warm (median of 4) |
|---|---|---|
| before | 172 ms | 51 ms |
| after | 3.6 ms | 1.4 ms |
| speedup | **~47×** | **~35×** |