### PR TITLE
refactor(cli): better colored printing

### DIFF
--- a/crates/cli/src/logger.rs
+++ b/crates/cli/src/logger.rs
@@ -1,12 +1,8 @@
 use std::io::Write;
 
-use anstyle::{AnsiColor, Color, Style};
 use log::{Level, LevelFilter, Log, Metadata, Record};
 
-pub fn paint(color: Option<impl Into<Color>>, text: &str) -> String {
-    let style = Style::new().fg_color(color.map(Into::into));
-    format!("{style}{text}{style:#}")
-}
+use crate::paint::{Paint, RED, YELLOW};
 
 struct Logger;
 
@@ -17,16 +13,8 @@ impl Log for Logger {
 
     fn log(&self, record: &Record) {
         match record.level() {
-            Level::Error => eprintln!(
-                "{} {}",
-                paint(Some(AnsiColor::Red), "Error:"),
-                record.args()
-            ),
-            Level::Warn => eprintln!(
-                "{} {}",
-                paint(Some(AnsiColor::Yellow), "Warning:"),
-                record.args()
-            ),
+            Level::Error => eprintln!("{} {}", Paint(RED, "Error:"), record.args()),
+            Level::Warn => eprintln!("{} {}", Paint(YELLOW, "Warning:"), record.args()),
             Level::Info | Level::Debug => eprintln!("{}", record.args()),
             Level::Trace => eprintln!(
                 "[{}] {}",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -22,7 +22,7 @@ use tree_sitter_cli::{
     highlight::{self, HighlightOptions},
     init::{JsonConfigOpts, TREE_SITTER_JSON_SCHEMA, generate_grammar_files},
     input::{CliInput, get_input, get_tmp_source_file},
-    logger,
+    logger, paint,
     parse::{self, ParseDebugType, ParseFileOptions, ParseOutput, ParseTheme},
     playground,
     query::{self, QueryFileOptions},
@@ -1044,7 +1044,6 @@ impl Build {
 impl Parse {
     fn run(self, mut loader: loader::Loader, current_dir: &Path) -> Result<()> {
         let config = Config::load(self.config_path)?;
-        let color = env::var("NO_COLOR").map_or(true, |v| v != "1");
         let json_summary = if self.json {
             warn!("--json is deprecated, use --json-summary instead");
             true
@@ -1063,7 +1062,7 @@ impl Parse {
             ParseOutput::Normal
         };
 
-        let parse_theme = if color {
+        let parse_theme = if paint::color_enabled() {
             config
                 .get::<parse::Config>()
                 .with_context(|| "Failed to parse CST theme")?
@@ -1300,7 +1299,6 @@ fn check_test(
 impl Test {
     fn run(self, mut loader: loader::Loader, current_dir: &Path) -> Result<()> {
         let config = Config::load(self.config_path)?;
-        let color = env::var("NO_COLOR").map_or(true, |v| v != "1");
         let stat = self.stat.unwrap_or_default();
 
         loader.debug_build(self.debug_build);
@@ -1342,13 +1340,8 @@ impl Test {
         parser.set_language(language)?;
 
         let test_dir = current_dir.join("test");
-        let mut test_summary = TestSummary::new(
-            color,
-            stat,
-            self.update,
-            self.overview_only,
-            self.json_summary,
-        );
+        let mut test_summary =
+            TestSummary::new(stat, self.update, self.overview_only, self.json_summary);
 
         // Run the corpus tests. Look for them in `test/corpus`.
         let test_corpus_dir = test_dir.join("corpus");
@@ -1363,7 +1356,6 @@ impl Test {
                 update: self.update,
                 open_log: self.open_log,
                 languages: languages.iter().map(|(l, n)| (n.as_str(), l)).collect(),
-                color,
                 show_fields: self.show_fields,
                 overview_only: self.overview_only,
             };

--- a/crates/cli/src/paint.rs
+++ b/crates/cli/src/paint.rs
@@ -12,7 +12,7 @@ pub fn color_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("NO_COLOR").is_none_or(|v| v.is_empty()))
 }
 
-pub fn paint_opt<T>(color: Option<impl Into<Color>>, text: T) -> Paint<T> {
+pub fn paint<T>(color: Option<impl Into<Color>>, text: T) -> Paint<T> {
     Paint(Style::new().fg_color(color.map(Into::into)), text)
 }
 

--- a/crates/cli/src/paint.rs
+++ b/crates/cli/src/paint.rs
@@ -1,0 +1,27 @@
+use anstyle::{AnsiColor, Color, Style};
+
+pub const RED: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Red)));
+pub const YELLOW: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Yellow)));
+
+/// Wraps a `Display` value with a style; emits ANSI codes only when
+/// [`color_enabled`] is true.
+pub struct Paint<T>(pub Style, pub T);
+
+pub fn color_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("NO_COLOR").is_none_or(|v| v.is_empty()))
+}
+
+pub fn paint_opt<T>(color: Option<impl Into<Color>>, text: T) -> Paint<T> {
+    Paint(Style::new().fg_color(color.map(Into::into)), text)
+}
+
+impl<T: std::fmt::Display> std::fmt::Display for Paint<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if color_enabled() {
+            write!(f, "{}{}{:#}", self.0, self.1, self.0)
+        } else {
+            self.1.fmt(f)
+        }
+    }
+}

--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -18,7 +18,7 @@ use tree_sitter::{
     ffi,
 };
 
-use crate::{fuzz::edits::Edit, paint::paint_opt, util};
+use crate::{fuzz::edits::Edit, paint::paint, util};
 
 #[derive(Debug, Default, Serialize, JsonSchema)]
 pub struct Stats {
@@ -325,7 +325,7 @@ pub fn parse_file_at_path(
                 }
                 let color = Some(colors[curr_version % colors.len()]);
                 let prefix = if log_type == LogType::Lex { "  " } else { "" };
-                writeln!(&mut io::stderr(), "{prefix}{}", paint_opt(color, message)).unwrap();
+                writeln!(&mut io::stderr(), "{prefix}{}", paint(color, message)).unwrap();
             }
         })));
     }
@@ -819,19 +819,19 @@ pub fn render_cst<'a, 'b: 'a>(
     Ok(())
 }
 
-fn render_node_text(source: &str) -> String {
-    source
-        .chars()
-        .fold(String::with_capacity(source.len()), |mut acc, c| {
-            if let Some(esc) = escape_invisible(c) {
-                acc.push_str(esc);
-            } else if let Some(esc) = escape_delimiter(c) {
-                acc.push_str(esc);
-            } else {
-                acc.push(c);
+struct CstNodeText<'a>(&'a str);
+
+impl std::fmt::Display for CstNodeText<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use std::fmt::Write as _;
+        for c in self.0.chars() {
+            match escape_invisible(c).or_else(|| escape_delimiter(c)) {
+                Some(esc) => f.write_str(esc)?,
+                None => f.write_char(c)?,
             }
-            acc
-        })
+        }
+        Ok(())
+    }
 }
 
 fn write_node_text(
@@ -854,9 +854,9 @@ fn write_node_text(
         write!(
             out,
             "{}{}{}",
-            paint_opt(quote_color, &String::from(quote)),
-            paint_opt(color, &render_node_text(source)),
-            paint_opt(quote_color, &String::from(quote)),
+            paint(quote_color, quote),
+            paint(color, CstNodeText(source)),
+            paint(quote_color, quote),
         )?;
     } else {
         let multiline = source.contains('\n');
@@ -875,24 +875,34 @@ fn write_node_text(
                 } else {
                     0
                 };
-            let formatted_line = render_line_feed(line, opts);
+            if multiline {
+                writeln!(out)?;
+                if !opts.no_ranges {
+                    write!(
+                        out,
+                        "{}",
+                        CstNodeRange {
+                            opts,
+                            has_field_name: cursor.field_name().is_some(),
+                            is_named,
+                            is_multiline: true,
+                            total_width,
+                            range: node_range,
+                        }
+                    )?;
+                }
+                for _ in 0..=indent_level {
+                    write!(out, "  ")?;
+                }
+            } else {
+                write!(out, " ")?;
+            }
             write!(
                 out,
-                "{}{}{}{}{}{}",
-                if multiline { "\n" } else { " " },
-                if multiline && !opts.no_ranges {
-                    render_node_range(opts, cursor, is_named, true, total_width, node_range)
-                } else {
-                    String::new()
-                },
-                if multiline {
-                    "  ".repeat(indent_level + 1)
-                } else {
-                    String::new()
-                },
-                paint_opt(quote_color, &String::from(quote)),
-                paint_opt(color, &render_node_text(&formatted_line)),
-                paint_opt(quote_color, &String::from(quote)),
+                "{}{}{}",
+                paint(quote_color, quote),
+                paint(color, CstLineFeed { source: line, opts }),
+                paint(quote_color, quote),
             )?;
         }
     }
@@ -900,50 +910,65 @@ fn write_node_text(
     Ok(())
 }
 
-fn render_line_feed(source: &str, opts: &ParseFileOptions) -> String {
-    #[cfg(windows)]
-    let lf = "\r\n";
-    #[cfg(not(windows))]
-    let lf = "\n";
-    source.replace(lf, &paint_opt(opts.parse_theme.line_feed, lf).to_string())
+struct CstLineFeed<'src, 'opt> {
+    source: &'src str,
+    opts: &'src ParseFileOptions<'opt>,
 }
 
-fn render_node_range(
-    opts: &ParseFileOptions,
-    cursor: &TreeCursor,
+impl std::fmt::Display for CstLineFeed<'_, '_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[cfg(windows)]
+        let lf = "\r\n";
+        #[cfg(not(windows))]
+        let lf = "\n";
+        let painted = paint(self.opts.parse_theme.line_feed, CstNodeText(lf));
+        let mut parts = self.source.split(lf);
+        if let Some(first) = parts.next() {
+            write!(f, "{}", CstNodeText(first))?;
+        }
+        for part in parts {
+            write!(f, "{painted}{}", CstNodeText(part))?;
+        }
+        Ok(())
+    }
+}
+
+struct CstNodeRange<'src, 'opt> {
+    opts: &'src ParseFileOptions<'opt>,
+    has_field_name: bool,
     is_named: bool,
     is_multiline: bool,
     total_width: usize,
     range: Range,
-) -> String {
-    let has_field_name = cursor.field_name().is_some();
-    let range_color = if is_named && !is_multiline && !has_field_name {
-        opts.parse_theme.row_color_named
-    } else {
-        opts.parse_theme.row_color
-    };
+}
 
-    let remaining_width_start = (total_width
-        - (range.start_point.row as f64).log10() as usize
-        - (range.start_point.column as f64).log10() as usize)
-        .max(1);
-    let remaining_width_end = (total_width
-        - (range.end_point.row as f64).log10() as usize
-        - (range.end_point.column as f64).log10() as usize)
-        .max(1);
-    paint_opt(
-        range_color,
-        format!(
-            "{}:{}{:remaining_width_start$}- {}:{}{:remaining_width_end$}",
-            range.start_point.row,
-            range.start_point.column,
-            ' ',
-            range.end_point.row,
-            range.end_point.column,
-            ' ',
-        ),
-    )
-    .to_string()
+impl std::fmt::Display for CstNodeRange<'_, '_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let start = self.range.start_point;
+        let end = self.range.end_point;
+        let range_color = if self.is_named && !self.is_multiline && !self.has_field_name {
+            self.opts.parse_theme.row_color_named
+        } else {
+            self.opts.parse_theme.row_color
+        };
+        let remaining_width = |row: usize, col: usize| {
+            (self.total_width - (row as f64).log10() as usize - (col as f64).log10() as usize)
+                .max(1)
+        };
+        let remaining_width_start = remaining_width(start.row, start.column);
+        let remaining_width_end = remaining_width(end.row, end.column);
+        write!(
+            f,
+            "{}",
+            paint(
+                range_color,
+                format_args!(
+                    "{}:{}{:remaining_width_start$}- {}:{}{:remaining_width_end$}",
+                    start.row, start.column, ' ', end.row, end.column, ' ',
+                ),
+            )
+        )
+    }
 }
 
 fn cst_render_node(
@@ -961,7 +986,14 @@ fn cst_render_node(
         write!(
             out,
             "{}",
-            render_node_range(opts, cursor, is_named, false, total_width, node.range())
+            CstNodeRange {
+                opts,
+                has_field_name: cursor.field_name().is_some(),
+                is_named,
+                is_multiline: false,
+                total_width,
+                range: node.range(),
+            }
         )?;
     }
     write!(
@@ -979,12 +1011,12 @@ fn cst_render_node(
             write!(
                 out,
                 "{}",
-                paint_opt(opts.parse_theme.field, &format!("{field_name}: "))
+                paint(opts.parse_theme.field, format_args!("{field_name}: "))
             )?;
         }
 
         if node.has_error() || node.is_error() {
-            write!(out, "{}", paint_opt(opts.parse_theme.error, "•"))?;
+            write!(out, "{}", paint(opts.parse_theme.error, "•"))?;
         }
 
         let kind_color = if node.is_error() {
@@ -994,7 +1026,7 @@ fn cst_render_node(
         } else {
             opts.parse_theme.node_kind
         };
-        write!(out, "{}", paint_opt(kind_color, node.kind()))?;
+        write!(out, "{}", paint(kind_color, node.kind()))?;
 
         if node.child_count() == 0 {
             // Node text from a pattern or external scanner
@@ -1009,12 +1041,8 @@ fn cst_render_node(
             )?;
         }
     } else if node.is_missing() {
-        write!(out, "{}: ", paint_opt(opts.parse_theme.missing, "MISSING"))?;
-        write!(
-            out,
-            "\"{}\"",
-            paint_opt(opts.parse_theme.missing, node.kind())
-        )?;
+        write!(out, "{}: ", paint(opts.parse_theme.missing, "MISSING"))?;
+        write!(out, "\"{}\"", paint(opts.parse_theme.missing, node.kind()))?;
     } else {
         // Terminal literals, like "fn"
         write_node_text(

--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -18,7 +18,7 @@ use tree_sitter::{
     ffi,
 };
 
-use crate::{fuzz::edits::Edit, logger::paint, util};
+use crate::{fuzz::edits::Edit, paint::paint_opt, util};
 
 #[derive(Debug, Default, Serialize, JsonSchema)]
 pub struct Stats {
@@ -301,7 +301,6 @@ pub fn parse_file_at_path(
     // Log to stderr if `--debug` was passed
     else if opts.debug != ParseDebugType::Quiet {
         let mut curr_version: usize = 0;
-        let use_color = std::env::var("NO_COLOR").map_or(true, |v| v != "1");
         let debug = opts.debug;
         parser.set_logger(Some(Box::new(move |log_type, message| {
             if debug == ParseDebugType::Normal {
@@ -324,18 +323,9 @@ pub fn parse_file_at_path(
                         .parse()
                         .unwrap();
                 }
-                let color = if use_color {
-                    Some(colors[curr_version % colors.len()])
-                } else {
-                    None
-                };
-                let mut out = if log_type == LogType::Lex {
-                    "  ".to_string()
-                } else {
-                    String::new()
-                };
-                out += &paint(color, message);
-                writeln!(&mut io::stderr(), "{out}").unwrap();
+                let color = Some(colors[curr_version % colors.len()]);
+                let prefix = if log_type == LogType::Lex { "  " } else { "" };
+                writeln!(&mut io::stderr(), "{prefix}{}", paint_opt(color, message)).unwrap();
             }
         })));
     }
@@ -864,9 +854,9 @@ fn write_node_text(
         write!(
             out,
             "{}{}{}",
-            paint(quote_color, &String::from(quote)),
-            paint(color, &render_node_text(source)),
-            paint(quote_color, &String::from(quote)),
+            paint_opt(quote_color, &String::from(quote)),
+            paint_opt(color, &render_node_text(source)),
+            paint_opt(quote_color, &String::from(quote)),
         )?;
     } else {
         let multiline = source.contains('\n');
@@ -900,9 +890,9 @@ fn write_node_text(
                 } else {
                     String::new()
                 },
-                paint(quote_color, &String::from(quote)),
-                paint(color, &render_node_text(&formatted_line)),
-                paint(quote_color, &String::from(quote)),
+                paint_opt(quote_color, &String::from(quote)),
+                paint_opt(color, &render_node_text(&formatted_line)),
+                paint_opt(quote_color, &String::from(quote)),
             )?;
         }
     }
@@ -911,11 +901,11 @@ fn write_node_text(
 }
 
 fn render_line_feed(source: &str, opts: &ParseFileOptions) -> String {
-    if cfg!(windows) {
-        source.replace("\r\n", &paint(opts.parse_theme.line_feed, "\r\n"))
-    } else {
-        source.replace('\n', &paint(opts.parse_theme.line_feed, "\n"))
-    }
+    #[cfg(windows)]
+    let lf = "\r\n";
+    #[cfg(not(windows))]
+    let lf = "\n";
+    source.replace(lf, &paint_opt(opts.parse_theme.line_feed, lf).to_string())
 }
 
 fn render_node_range(
@@ -941,9 +931,9 @@ fn render_node_range(
         - (range.end_point.row as f64).log10() as usize
         - (range.end_point.column as f64).log10() as usize)
         .max(1);
-    paint(
+    paint_opt(
         range_color,
-        &format!(
+        format!(
             "{}:{}{:remaining_width_start$}- {}:{}{:remaining_width_end$}",
             range.start_point.row,
             range.start_point.column,
@@ -953,6 +943,7 @@ fn render_node_range(
             ' ',
         ),
     )
+    .to_string()
 }
 
 fn cst_render_node(
@@ -988,12 +979,12 @@ fn cst_render_node(
             write!(
                 out,
                 "{}",
-                paint(opts.parse_theme.field, &format!("{field_name}: "))
+                paint_opt(opts.parse_theme.field, &format!("{field_name}: "))
             )?;
         }
 
         if node.has_error() || node.is_error() {
-            write!(out, "{}", paint(opts.parse_theme.error, "•"))?;
+            write!(out, "{}", paint_opt(opts.parse_theme.error, "•"))?;
         }
 
         let kind_color = if node.is_error() {
@@ -1003,7 +994,7 @@ fn cst_render_node(
         } else {
             opts.parse_theme.node_kind
         };
-        write!(out, "{}", paint(kind_color, node.kind()))?;
+        write!(out, "{}", paint_opt(kind_color, node.kind()))?;
 
         if node.child_count() == 0 {
             // Node text from a pattern or external scanner
@@ -1018,8 +1009,12 @@ fn cst_render_node(
             )?;
         }
     } else if node.is_missing() {
-        write!(out, "{}: ", paint(opts.parse_theme.missing, "MISSING"))?;
-        write!(out, "\"{}\"", paint(opts.parse_theme.missing, node.kind()))?;
+        write!(out, "{}: ", paint_opt(opts.parse_theme.missing, "MISSING"))?;
+        write!(
+            out,
+            "\"{}\"",
+            paint_opt(opts.parse_theme.missing, node.kind())
+        )?;
     } else {
         // Terminal literals, like "fn"
         write_node_text(

--- a/crates/cli/src/test.rs
+++ b/crates/cli/src/test.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::BTreeMap,
     ffi::OsStr,
-    fmt::Display as _,
+    fmt::{Display as _, Write as _},
     fs,
     io::{self, Write},
     path::{Path, PathBuf},
@@ -23,7 +23,7 @@ use walkdir::WalkDir;
 
 use super::util;
 use crate::{
-    logger::paint,
+    paint::{color_enabled, paint_opt},
     parse::{
         ParseDebugType, ParseFileOptions, ParseOutput, ParseStats, ParseTheme, Stats, render_cst,
     },
@@ -169,7 +169,6 @@ pub struct TestOptions<'a> {
     pub update: bool,
     pub open_log: bool,
     pub languages: BTreeMap<&'a str, &'a Language>,
-    pub color: bool,
     pub show_fields: bool,
     pub overview_only: bool,
 }
@@ -208,9 +207,6 @@ pub struct TestSummary {
     // Options passed in from the CLI which control how the summary is displayed
     #[schemars(skip)]
     #[serde(skip)]
-    pub color: bool,
-    #[schemars(skip)]
-    #[serde(skip)]
     pub overview_only: bool,
     #[schemars(skip)]
     #[serde(skip)]
@@ -222,19 +218,13 @@ pub struct TestSummary {
 
 impl TestSummary {
     #[must_use]
-    #[expect(
-        clippy::fn_params_excessive_bools,
-        reason = "these map directly to CLI flags"
-    )]
     pub fn new(
-        color: bool,
         stat_display: TestStats,
         parse_update: bool,
         overview_only: bool,
         json_summary: bool,
     ) -> Self {
         Self {
-            color,
             parse_stat_display: stat_display,
             update: parse_update,
             overview_only,
@@ -498,11 +488,15 @@ impl TestSummary {
                             };
                             // 3 standard deviations below the mean, aka the "Empirical Rule"
                             if *adj_rate < 3.0f64.mul_add(-std_dev, avg) {
-                                stats += &paint(
-                                    self.color.then_some(AnsiColor::Yellow),
-                                    &format!(
-                                        " -- Warning: Slow parse rate ({true_rate:.3} bytes/ms)"
-                                    ),
+                                let _ = write!(
+                                    stats,
+                                    "{}",
+                                    paint_opt(
+                                        Some(AnsiColor::Yellow),
+                                        format!(
+                                            " -- Warning: Slow parse rate ({true_rate:.3} bytes/ms)"
+                                        ),
+                                    )
                                 );
                             }
                             stats
@@ -511,7 +505,7 @@ impl TestSummary {
                     writeln!(
                         f,
                         "{test_num:>3}. {result_char} {}{stat_display}",
-                        paint(self.color.then_some(color), &entry.name),
+                        paint_opt(Some(color), &entry.name),
                     )?;
                 }
                 TestInfo::AssertionTest { .. } => unreachable!(),
@@ -548,7 +542,7 @@ impl TestSummary {
                 )?;
             }
 
-            if self.color {
+            if color_enabled() {
                 DiffKey.fmt(f)?;
             }
             for (
@@ -569,25 +563,16 @@ impl TestSummary {
                     } else {
                         &format_sexp(actual, 2)
                     };
-                    writeln!(
-                        f,
-                        "  {}",
-                        paint(self.color.then_some(AnsiColor::Red), actual)
-                    )?;
+                    writeln!(f, "  {}", paint_opt(Some(AnsiColor::Red), actual))?;
                 } else {
                     writeln!(f, "\n  {}. {name}:", i + 1)?;
                     if *is_cst {
-                        writeln!(
-                            f,
-                            "{}",
-                            TestDiff::new(actual, expected).with_color(self.color)
-                        )?;
+                        writeln!(f, "{}", TestDiff::new(actual, expected))?;
                     } else {
                         writeln!(
                             f,
                             "{}",
                             TestDiff::new(&format_sexp(actual, 2), &format_sexp(expected, 2))
-                                .with_color(self.color,)
                         )?;
                     }
                 }
@@ -616,14 +601,14 @@ impl std::fmt::Display for TestSummary {
                                 f,
                                 "{:>3}. ✓ {} ({assertion_count} assertions)",
                                 test_num,
-                                paint(self.color.then_some(AnsiColor::Green), &entry.name)
+                                paint_opt(Some(AnsiColor::Green), &entry.name)
                             )?,
                             TestOutcome::AssertionFailed { error } => {
                                 writeln!(
                                     f,
                                     "{:>3}. ✗ {}",
                                     test_num,
-                                    paint(self.color.then_some(AnsiColor::Red), &entry.name)
+                                    paint_opt(Some(AnsiColor::Red), &entry.name)
                                 )?;
                                 writeln!(f, "{}  {error}", "  ".repeat(depth + 1))?;
                             }
@@ -725,8 +710,8 @@ impl std::fmt::Display for DiffKey {
         write!(
             f,
             "\ncorrect / {} / {}",
-            paint(Some(AnsiColor::Green), "expected"),
-            paint(Some(AnsiColor::Red), "unexpected")
+            paint_opt(Some(AnsiColor::Green), "expected"),
+            paint_opt(Some(AnsiColor::Red), "unexpected")
         )?;
         Ok(())
     }
@@ -742,23 +727,12 @@ impl DiffKey {
 pub struct TestDiff<'a> {
     pub actual: &'a str,
     pub expected: &'a str,
-    pub color: bool,
 }
 
 impl<'a> TestDiff<'a> {
     #[must_use]
     pub const fn new(actual: &'a str, expected: &'a str) -> Self {
-        Self {
-            actual,
-            expected,
-            color: true,
-        }
-    }
-
-    #[must_use]
-    pub const fn with_color(mut self, color: bool) -> Self {
-        self.color = color;
-        self
+        Self { actual, expected }
     }
 }
 
@@ -768,18 +742,18 @@ impl std::fmt::Display for TestDiff<'_> {
         for diff in diff.iter_all_changes() {
             match diff.tag() {
                 ChangeTag::Equal => {
-                    if self.color {
+                    if color_enabled() {
                         write!(f, "{diff}")?;
                     } else {
                         write!(f, " {diff}")?;
                     }
                 }
                 ChangeTag::Insert => {
-                    if self.color {
+                    if color_enabled() {
                         write!(
                             f,
                             "{}",
-                            paint(Some(AnsiColor::Green), diff.as_str().unwrap())
+                            paint_opt(Some(AnsiColor::Green), diff.as_str().unwrap())
                         )?;
                     } else {
                         write!(f, "+{diff}")?;
@@ -789,8 +763,12 @@ impl std::fmt::Display for TestDiff<'_> {
                     }
                 }
                 ChangeTag::Delete => {
-                    if self.color {
-                        write!(f, "{}", paint(Some(AnsiColor::Red), diff.as_str().unwrap()))?;
+                    if color_enabled() {
+                        write!(
+                            f,
+                            "{}",
+                            paint_opt(Some(AnsiColor::Red), diff.as_str().unwrap())
+                        )?;
                     } else {
                         write!(f, "-{diff}")?;
                     }
@@ -2329,7 +2307,6 @@ Test with cst marker
             update: false,
             open_log: false,
             languages,
-            color: true,
             show_fields: false,
             overview_only: false,
         }
@@ -2356,7 +2333,7 @@ Test with cst marker
             }],
         };
 
-        let mut test_summary = TestSummary::new(true, TestStats::All, false, false, false);
+        let mut test_summary = TestSummary::new(TestStats::All, false, false, false);
         let mut corrected_entries = Vec::new();
         run_tests(
             &mut parser,
@@ -2486,7 +2463,7 @@ Test with cst marker
             ],
         };
 
-        let mut test_summary = TestSummary::new(true, TestStats::All, false, false, false);
+        let mut test_summary = TestSummary::new(TestStats::All, false, false, false);
         let mut corrected_entries = Vec::new();
         run_tests(
             &mut parser,

--- a/crates/cli/src/test.rs
+++ b/crates/cli/src/test.rs
@@ -23,7 +23,7 @@ use walkdir::WalkDir;
 
 use super::util;
 use crate::{
-    paint::{color_enabled, paint_opt},
+    paint::{color_enabled, paint},
     parse::{
         ParseDebugType, ParseFileOptions, ParseOutput, ParseStats, ParseTheme, Stats, render_cst,
     },
@@ -491,9 +491,9 @@ impl TestSummary {
                                 let _ = write!(
                                     stats,
                                     "{}",
-                                    paint_opt(
+                                    paint(
                                         Some(AnsiColor::Yellow),
-                                        format!(
+                                        format_args!(
                                             " -- Warning: Slow parse rate ({true_rate:.3} bytes/ms)"
                                         ),
                                     )
@@ -505,7 +505,7 @@ impl TestSummary {
                     writeln!(
                         f,
                         "{test_num:>3}. {result_char} {}{stat_display}",
-                        paint_opt(Some(color), &entry.name),
+                        paint(Some(color), &entry.name),
                     )?;
                 }
                 TestInfo::AssertionTest { .. } => unreachable!(),
@@ -563,7 +563,7 @@ impl TestSummary {
                     } else {
                         &format_sexp(actual, 2)
                     };
-                    writeln!(f, "  {}", paint_opt(Some(AnsiColor::Red), actual))?;
+                    writeln!(f, "  {}", paint(Some(AnsiColor::Red), actual))?;
                 } else {
                     writeln!(f, "\n  {}. {name}:", i + 1)?;
                     if *is_cst {
@@ -601,14 +601,14 @@ impl std::fmt::Display for TestSummary {
                                 f,
                                 "{:>3}. ✓ {} ({assertion_count} assertions)",
                                 test_num,
-                                paint_opt(Some(AnsiColor::Green), &entry.name)
+                                paint(Some(AnsiColor::Green), &entry.name)
                             )?,
                             TestOutcome::AssertionFailed { error } => {
                                 writeln!(
                                     f,
                                     "{:>3}. ✗ {}",
                                     test_num,
-                                    paint_opt(Some(AnsiColor::Red), &entry.name)
+                                    paint(Some(AnsiColor::Red), &entry.name)
                                 )?;
                                 writeln!(f, "{}  {error}", "  ".repeat(depth + 1))?;
                             }
@@ -710,8 +710,8 @@ impl std::fmt::Display for DiffKey {
         write!(
             f,
             "\ncorrect / {} / {}",
-            paint_opt(Some(AnsiColor::Green), "expected"),
-            paint_opt(Some(AnsiColor::Red), "unexpected")
+            paint(Some(AnsiColor::Green), "expected"),
+            paint(Some(AnsiColor::Red), "unexpected")
         )?;
         Ok(())
     }
@@ -753,7 +753,7 @@ impl std::fmt::Display for TestDiff<'_> {
                         write!(
                             f,
                             "{}",
-                            paint_opt(Some(AnsiColor::Green), diff.as_str().unwrap())
+                            paint(Some(AnsiColor::Green), diff.as_str().unwrap())
                         )?;
                     } else {
                         write!(f, "+{diff}")?;
@@ -764,11 +764,7 @@ impl std::fmt::Display for TestDiff<'_> {
                 }
                 ChangeTag::Delete => {
                     if color_enabled() {
-                        write!(
-                            f,
-                            "{}",
-                            paint_opt(Some(AnsiColor::Red), diff.as_str().unwrap())
-                        )?;
+                        write!(f, "{}", paint(Some(AnsiColor::Red), diff.as_str().unwrap()))?;
                     } else {
                         write!(f, "-{diff}")?;
                     }

--- a/crates/cli/src/tree_sitter_cli.rs
+++ b/crates/cli/src/tree_sitter_cli.rs
@@ -5,6 +5,7 @@ pub mod highlight;
 pub mod init;
 pub mod input;
 pub mod logger;
+pub mod paint;
 pub mod parse;
 pub mod playground;
 pub mod query;


### PR DESCRIPTION
I've been working on a couple new tree-sitter features and other side projects and have settled on this painting abstraction as a strict improvement over our current `paint` function. This new wrapper struct leads to generally clearer code (imo), and avoids needless temporary `String` allocations.

The first commit in this PR also corrects our handling of the `NO_COLOR` environment variable, matching the spec.

With these changes, CST rendering sees a 20-30% boost in throughput for large files.