### PR TITLE
fix(cli): omit Node fields from package.json when bindings disabled

### DIFF
--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -78,6 +78,7 @@ const TAGS_QUERY_PATH_PLACEHOLDER: &str = "TAGS_QUERY_PATH";
 
 const GRAMMAR_JS_TEMPLATE: &str = include_str!("./templates/grammar.js");
 const PACKAGE_JSON_TEMPLATE: &str = include_str!("./templates/package.json");
+const PACKAGE_JSON_NO_NODE_TEMPLATE: &str = include_str!("./templates/package_no_node.json");
 const GITIGNORE_TEMPLATE: &str = include_str!("./templates/gitignore");
 const GITATTRIBUTES_TEMPLATE: &str = include_str!("./templates/gitattributes");
 const EDITORCONFIG_TEMPLATE: &str = include_str!("./templates/.editorconfig");
@@ -350,7 +351,7 @@ pub fn generate_grammar_files(
 
     let bindings_dir = repo_path.join("bindings");
 
-    generate_common_files(&ctx, &generate_opts)?;
+    generate_common_files(&ctx, &generate_opts, tree_sitter_config.bindings.node)?;
 
     if tree_sitter_config.bindings.rust {
         generate_rust_bindings(&ctx, &generate_opts, &bindings_dir)?;
@@ -380,20 +381,29 @@ pub fn generate_grammar_files(
     Ok(())
 }
 
-fn generate_common_files(ctx: &InitContext, opts: &GenerateOpts) -> Result<()> {
+fn generate_common_files(
+    ctx: &InitContext,
+    opts: &GenerateOpts,
+    node_bindings: bool,
+) -> Result<()> {
     // Create package.json
+    let package_json_template = if node_bindings {
+        PACKAGE_JSON_TEMPLATE
+    } else {
+        PACKAGE_JSON_NO_NODE_TEMPLATE
+    };
     missing_path_else(
         ctx.repo_path.join("package.json"),
         ctx.allow_update,
         |path| {
             generate_file(
                 path,
-                PACKAGE_JSON_TEMPLATE,
+                package_json_template,
                 ctx.dashed_language_name.as_str(),
                 opts,
             )
         },
-        update_package_json,
+        |path| update_package_json(path, node_bindings),
     )?;
 
     // Do not create a grammar.js file in a repo with multiple language configs
@@ -836,8 +846,62 @@ fn generate_java_bindings(
     Ok(())
 }
 
-fn update_package_json(path: &Path) -> Result<()> {
-    let mut contents = fs::read_to_string(path)?
+fn update_package_json(path: &Path, node_bindings: bool) -> Result<()> {
+    let mut contents = fs::read_to_string(path)?;
+    if !node_bindings && contents.contains("node-gyp-build") {
+        info!("Removing Node binding fields from package.json");
+        contents = contents
+            .replace("    \"install\": \"node-gyp-build\",\n", "")
+            .replace("  \"main\": \"bindings/node\",\n", "")
+            .replace("  \"types\": \"bindings/node\",\n", "")
+            .replace("    \"binding.gyp\",\n", "")
+            .replace("    \"prebuilds/**\",\n", "")
+            .replace("    \"bindings/node/*\",\n", "")
+            .replace("    \"*.wasm\"\n", "")
+            .replace(
+                indoc! {r#"
+  "dependencies": {
+    "node-addon-api": "^8.5.0",
+    "node-gyp-build": "^4.8.4"
+  },
+"#},
+                "",
+            )
+            .replace(
+                indoc! {r#"
+    "prebuildify": "^6.0.1",
+"#},
+                "",
+            )
+            .replace("    \"tree-sitter\": \"^0.25.0\",\n", "")
+            .replace(
+                indoc! {r#"
+  "peerDependencies": {
+    "tree-sitter": "^0.25.0"
+  },
+  "peerDependenciesMeta": {
+    "tree-sitter": {
+      "optional": true
+    }
+  },
+"#},
+                "",
+            )
+            .replace("    \"test\": \"node --test bindings/node/*_test.js\"\n", "");
+        if !contents.contains("\"private\"") {
+            contents = contents.replace(
+                "  \"keywords\": [",
+                "  \"private\": true,\n  \"keywords\": [",
+            );
+        }
+        if !contents.contains("tree-sitter-cli") {
+            let dev_deps = format!(
+                "  \"devDependencies\": {{\n    \"tree-sitter-cli\": \"^{CLI_VERSION}\",\n",
+            );
+            contents = contents.replace("  \"devDependencies\": {", &dev_deps);
+        }
+    }
+    let mut contents = contents
         .replace(
             r#""node-addon-api": "^8.3.1""#,
             r#""node-addon-api": "^8.5.0""#,

--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -1715,3 +1715,17 @@ where
         Ok(PathState::Exists(path))
     }
 }
+
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+
+    #[test]
+    fn package_json_templates_match_node_bindings() {
+        assert!(PACKAGE_JSON_TEMPLATE.contains("node-gyp-build"));
+        assert!(PACKAGE_JSON_TEMPLATE.contains("binding.gyp"));
+        assert!(!PACKAGE_JSON_NO_NODE_TEMPLATE.contains("node-gyp-build"));
+        assert!(!PACKAGE_JSON_NO_NODE_TEMPLATE.contains("binding.gyp"));
+        assert!(PACKAGE_JSON_NO_NODE_TEMPLATE.contains("tree-sitter-cli"));
+    }
+}

--- a/crates/cli/src/templates/package_no_node.json
+++ b/crates/cli/src/templates/package_no_node.json
@@ -1,0 +1,27 @@
+{
+  "name": "tree-sitter-PARSER_NAME",
+  "version": "PARSER_VERSION",
+  "description": "PARSER_DESCRIPTION",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+PARSER_URL.git"
+  },
+  "funding": "FUNDING_URL",
+  "license": "PARSER_LICENSE",
+  "author": {
+    "name": "PARSER_AUTHOR_NAME",
+    "email": "PARSER_AUTHOR_EMAIL",
+    "url": "PARSER_AUTHOR_URL"
+  },
+  "keywords": [
+    "incremental",
+    "parsing",
+    "tree-sitter",
+    "LOWER_PARSER_NAME"
+  ],
+  "devDependencies": {
+    "tree-sitter-cli": "^CLI_VERSION"
+  },
+  "private": true
+}

--- a/docs/src/creating-parsers/1-getting-started.md
+++ b/docs/src/creating-parsers/1-getting-started.md
@@ -118,8 +118,9 @@ This should print the following:
 You now have a working parser.
 
 Finally, look back at the [triple-slash][] and [`@ts-check`][ts-check] comments in `grammar.js`; these tell your editor
-to provide documentation and type information as you edit your grammar. For these to work, you must download Tree-sitter's
-TypeScript API from npm into a `node_modules` directory in your project:
+to provide documentation and type information as you edit your grammar. For these to work, install the `tree-sitter-cli`
+npm package into a `node_modules` directory in your project (this works even when `tree-sitter init` did not generate
+Node.js bindings):
 
 ```sh
 npm install # or your package manager of choice


### PR DESCRIPTION
## Summary

When `tree-sitter init` is run without Node bindings, the generated `package.json` still referenced `binding.gyp` and ran `node-gyp-build` on `npm install`, causing failures described in #5430.

- Add a minimal `package_no_node.json` template (only `tree-sitter-cli` for grammar.js types).
- Select the template based on `tree-sitter.json` `bindings.node`.
- On `init --update`, strip Node-only fields when Node bindings are disabled.

Fixes #5430

## Test plan

- [x] `cargo check -p tree-sitter-cli`
- [ ] `tree-sitter init` with only Rust bindings → `npm install` succeeds
- [ ] `tree-sitter init` with Node bindings → unchanged full `package.json`