### PR TITLE
docs: add guidance on working with generated files (fixes #5269)

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -23,6 +23,7 @@
   - [External Scanners](./creating-parsers/4-external-scanners.md)
   - [Writing Tests](./creating-parsers/5-writing-tests.md)
   - [Publishing Parsers](./creating-parsers/6-publishing.md)
+  - [Generated Files](./creating-parsers/7-generated-files.md)
 - [Syntax Highlighting](./3-syntax-highlighting.md)
 - [Code Navigation](./4-code-navigation.md)
 - [Implementation](./5-implementation.md)

--- a/docs/src/creating-parsers/7-generated-files.md
+++ b/docs/src/creating-parsers/7-generated-files.md
@@ -1,0 +1,48 @@
+# Working with generated files
+
+Tree-sitter grammars produce generated artifacts such as `src/parser.c`, `src/grammar.json`,
+and `src/node-types.json`. Whether to commit these files is a project choice; both approaches
+are common.
+
+## Committing generated files
+
+**Pros**
+
+- Consumers can build without running `tree-sitter generate`.
+- CI and editor integrations see a stable parser snapshot.
+
+**Tips**
+
+- Regenerate in CI when `grammar.js` changes so pull requests stay in sync.
+- Use a `.gitattributes` merge driver for generated C to reduce painful merges:
+
+  ```gitattributes
+  src/parser.c merge=ours
+  ```
+
+  (Adjust the strategy to match your team's workflow.)
+
+## Ignoring generated files
+
+**Pros**
+
+- Smaller diffs when the grammar changes frequently.
+- No risk of committing a parser built with a mismatched CLI version.
+
+**Tips**
+
+- Document the required `tree-sitter` CLI version in `README.md`.
+- Run `tree-sitter generate` in your build script or CI before compiling.
+- Keep `grammar.json` and `node-types.json` under version control if downstream tools
+  depend on them, even when `parser.c` is gitignored.
+
+## Keeping JSON artifacts in sync
+
+If you commit `grammar.json` or `node-types.json`, regenerate them whenever the grammar
+changes. Mismatched JSON and C sources cause subtle bugs in tests, queries, and editor tooling.
+
+## Related commands
+
+- `tree-sitter generate` — refresh parser sources from `grammar.js`.
+- `tree-sitter test` — verify corpus tests against the current parser.
+- `tree-sitter init --update` — refresh scaffolding without overwriting custom files.


### PR DESCRIPTION
## Summary
- Add a creating-parsers guide on committing vs ignoring generated parser artifacts.
- Cover gitattributes merge tips and keeping JSON outputs in sync.

Fixes #5269