### PR TITLE
Fix issues with queries matching a parent node with anchored children (siblings)

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -1594,6 +1594,38 @@ fn test_query_matches_with_leading_zero_or_more_repeated_leaf_nodes() {
 }
 
 #[test]
+fn test_matches_with_anchor_sibling_inside_parent() {
+    allocations::record(|| {
+        let language = get_language("rust");
+
+        let query = Query::new(
+            &language,
+            "
+            (source_file
+                (line_comment)
+                .
+                (function_item
+                    name: (identifier) @name)
+            )",
+        )
+        .unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "
+            // A
+            fn a() {}
+
+            // B
+            fn b() {}
+            ",
+            &[(0, vec![("name", "a")]), (0, vec![("name", "b")])],
+        );
+    });
+}
+
+#[test]
 fn test_query_matches_with_trailing_optional_nodes() {
     allocations::record(|| {
         let language = get_language("javascript");

--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -1626,6 +1626,41 @@ fn test_matches_with_anchor_sibling_inside_parent() {
 }
 
 #[test]
+fn test_matches_with_anchor_sibling_with_quantifier_captured_inside_parent() {
+    allocations::record(|| {
+        let language = get_language("rust");
+
+        let query = Query::new(
+            &language,
+            "
+            (source_file
+                (line_comment)+ @doc
+                .
+                (function_item
+                    name: (identifier) @name)
+            )",
+        )
+        .unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "
+            // A
+            fn a() {}
+
+            // B
+            fn b() {}
+            ",
+            &[
+                (0, vec![("doc", "// A"), ("name", "a")]),
+                (0, vec![("doc", "// B"), ("name", "b")]),
+            ],
+        );
+    });
+}
+
+#[test]
 fn test_query_matches_with_trailing_optional_nodes() {
     allocations::record(|| {
         let language = get_language("javascript");

--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -1626,6 +1626,38 @@ fn test_matches_with_anchor_sibling_inside_parent() {
 }
 
 #[test]
+fn test_matches_with_anchor_sibling_with_quantifier_inside_parent() {
+    allocations::record(|| {
+        let language = get_language("rust");
+
+        let query = Query::new(
+            &language,
+            "
+            (source_file
+                (line_comment)+
+                .
+                (function_item
+                    name: (identifier) @name)
+            )",
+        )
+        .unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "
+            // A
+            fn a() {}
+
+            // B
+            fn b() {}
+            ",
+            &[(0, vec![("name", "a")]), (0, vec![("name", "b")])],
+        );
+    });
+}
+
+#[test]
 fn test_matches_with_anchor_sibling_with_quantifier_captured_inside_parent() {
     allocations::record(|| {
         let language = get_language("rust");

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -3292,7 +3292,8 @@ bool ts_query__step_is_fallible(
   QueryStep *next_step = array_get(&self->steps, step_index + 1);
   return (
     next_step->depth != PATTERN_DONE_MARKER &&
-    next_step->depth > step->depth &&
+    (next_step->depth > step->depth ||
+        (next_step->depth == step->depth && next_step->is_immediate)) &&
     (!next_step->parent_pattern_guaranteed || step->symbol == WILDCARD_SYMBOL)
   );
 }

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -3287,9 +3287,14 @@ bool ts_query__step_is_fallible(
   const TSQuery *self,
   uint16_t step_index
 ) {
-  ts_assert((uint32_t)step_index + 1 < self->steps.size);
+  unsigned i = 1;
   QueryStep *step = array_get(&self->steps, step_index);
-  QueryStep *next_step = array_get(&self->steps, step_index + 1);
+  QueryStep *next_step;
+  do {
+    ts_assert((uint32_t)step_index + i < self->steps.size);
+    next_step = array_get(&self->steps, step_index + i);
+    i++;
+  } while (next_step->is_pass_through);
   return (
     next_step->depth != PATTERN_DONE_MARKER &&
     (next_step->depth > step->depth ||

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -4373,7 +4373,10 @@ static inline bool ts_query_cursor__advance(
               &right_contains_left
             );
             if (left_contains_right) {
-              if (state->step_index == other_state->step_index) {
+              if (
+                state->step_index == other_state->step_index &&
+                (other_state->seeking_immediate_match || !state->seeking_immediate_match)
+              ) {
                 LOG(
                   "  drop shorter state. pattern: %u, step_index: %u\n",
                   state->pattern_index,
@@ -4387,7 +4390,10 @@ static inline bool ts_query_cursor__advance(
               other_state->has_in_progress_alternatives = true;
             }
             if (right_contains_left) {
-              if (state->step_index == other_state->step_index) {
+              if (
+                state->step_index == other_state->step_index &&
+                (state->seeking_immediate_match || !other_state->seeking_immediate_match)
+              ) {
                 LOG(
                   "  drop shorter state. pattern: %u, step_index: %u\n",
                   state->pattern_index,


### PR DESCRIPTION
### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

I used claude.ai web interface for help with debugging and reasoning through debug logs, evaluating my approach and suggesting other directions to explore, and double-checking my code.

### Description
This PR fixes three issues for queries that match parent node with anchored children (siblings).

The first issue was that the check for fallible steps was only considering nodes with children, which resulted in no state split being made for anchored siblings (node1) . (node2). This prevented the query from matching beyond the first occurrence. The fix was to also consider the case where the next step is at the same depth and must be matched immediately after.

The second issue was that with this type of queries where in addition the first anchored sibling had a quantifier, the deduplication logic for states was being overly aggressive, causing the state split on the first capture (with the parent) to be dropped in favor of the loopback state. This resulted in not being able to match beyond the first occurrence. The fix was to prevent the deduplication logic to drop a state that is not seeking for an immediate match for one that is seeking for an immediate match, because the one that is not seeking for an immediate match still could match later nodes.

The third issue was that with this type of queries where in addition the first anchored sibling had a quantifier and wasn't captured, the check for fallible steps was skipping splitting the state, because the next node was a passthrough node (and not an `is_immediate` one like in the first issue). This again prevented the query from matching beyond the first occurrence. The fix was to skip the next steps in the check for fallibility while they are passthrough steps.

The third fix would close issue #4688 .