### PR TITLE
fix(wasm): load supertype tables for ABI 15 grammars

### DIFF
--- a/lib/src/wasm_store.c
+++ b/lib/src/wasm_store.c
@@ -1325,7 +1325,7 @@ const TSLanguage *ts_wasm_store_load_language(
   }
 
   bool has_supertypes =
-    wasm_language.abi_version > LANGUAGE_VERSION_WITH_RESERVED_WORDS &&
+    wasm_language.abi_version >= LANGUAGE_VERSION_WITH_RESERVED_WORDS &&
     wasm_language.supertype_count > 0;
 
   int32_t addresses[] = {


### PR DESCRIPTION
### Problem

Query construction can crash when grammars that use supertypes, are compiled with ABI version 15, and are loaded via Wasm.

### Background

Supertypes were introduced in ABI version 15, the same ABI version that introduced reserved words. Methods that access a language's supertypes check that the grammar's ABI version is greater than **or equal to** 15.

But when loading a language via Wasm, we were neglecting to load supertype data unless the language's abi version was strictly greater than 15.

Switching the check to `>=` matches the convention used everywhere else for `LANGUAGE_VERSION_WITH_RESERVED_WORDS` and fixes the crash.

This was observed as a SIGSEGV in `ts_language_subtypes` reaching users via Zed loading tree-sitter grammars compiled to Wasm.

### AI Use

I found this bug by showing Claude Opus 4.7 the crash backtrace and directing it to inspect `ts_wasm_store_load_language`, since that Wasm loading logic has been problematic in the past.