### PR TITLE
generate: preserve word-token transitions when pruning keyword completions

### DIFF
--- a/crates/generate/src/build_tables.rs
+++ b/crates/generate/src/build_tables.rs
@@ -321,18 +321,6 @@ fn populate_external_lex_states(parse_table: &mut ParseTable, syntax_grammar: &S
     }
 }
 
-/// Returns `(promoted_keywords, leaked_keywords)`.
-///
-/// `promoted_keywords` are the keyword candidates that pass every filter and
-/// are extracted by the runtime word-extraction path via `ts_lex_keywords`.
-///
-/// `leaked_keywords` are candidates that were dropped here (either because
-/// another candidate matches the same string, or because substituting the
-/// word token would introduce new lexical conflicts) and therefore remain in
-/// the main `ts_lex` table. They are the keywords whose word-boundary
-/// behavior cannot rely on the runtime word-extraction path and which must
-/// be considered by `LexTableBuilder` when deciding whether to keep a
-/// pruned word-token continuation transition.
 fn identify_keywords(
     lexical_grammar: &LexicalGrammar,
     parse_table: &ParseTable,

--- a/crates/generate/src/build_tables.rs
+++ b/crates/generate/src/build_tables.rs
@@ -58,7 +58,7 @@ pub fn build_tables(
     )?;
     let token_conflict_map = TokenConflictMap::new(lexical_grammar, following_tokens);
     let coincident_token_index = CoincidentTokenIndex::new(&parse_table, lexical_grammar);
-    let keywords = identify_keywords(
+    let (keywords, leaked_keywords) = identify_keywords(
         lexical_grammar,
         &parse_table,
         syntax_grammar.word_token,
@@ -88,6 +88,7 @@ pub fn build_tables(
         syntax_grammar,
         lexical_grammar,
         &keywords,
+        &leaked_keywords,
         &coincident_token_index,
         &token_conflict_map,
     );
@@ -320,15 +321,27 @@ fn populate_external_lex_states(parse_table: &mut ParseTable, syntax_grammar: &S
     }
 }
 
+/// Returns `(promoted_keywords, leaked_keywords)`.
+///
+/// `promoted_keywords` are the keyword candidates that pass every filter and
+/// are extracted by the runtime word-extraction path via `ts_lex_keywords`.
+///
+/// `leaked_keywords` are candidates that were dropped here (either because
+/// another candidate matches the same string, or because substituting the
+/// word token would introduce new lexical conflicts) and therefore remain in
+/// the main `ts_lex` table. They are the keywords whose word-boundary
+/// behavior cannot rely on the runtime word-extraction path and which must
+/// be considered by `LexTableBuilder` when deciding whether to keep a
+/// pruned word-token continuation transition.
 fn identify_keywords(
     lexical_grammar: &LexicalGrammar,
     parse_table: &ParseTable,
     word_token: Option<Symbol>,
     token_conflict_map: &TokenConflictMap,
     coincident_token_index: &CoincidentTokenIndex,
-) -> TokenSet {
+) -> (TokenSet, TokenSet) {
     if word_token.is_none() {
-        return TokenSet::new();
+        return (TokenSet::new(), TokenSet::new());
     }
 
     let word_token = word_token.unwrap();
@@ -358,6 +371,7 @@ fn identify_keywords(
         .collect::<TokenSet>();
 
     // Exclude keyword candidates that shadow another keyword candidate.
+    let mut leaked_keywords = TokenSet::new();
     let keywords = keyword_candidates
         .iter()
         .filter(|token| {
@@ -370,6 +384,7 @@ fn identify_keywords(
                         lexical_grammar.variables[token.index].name,
                         lexical_grammar.variables[other_token.index].name
                     );
+                    leaked_keywords.insert(*token);
                     return false;
                 }
             }
@@ -380,7 +395,7 @@ fn identify_keywords(
     // Exclude keyword candidates for which substituting the keyword capture
     // token would introduce new lexical conflicts with other tokens.
 
-    keywords
+    let promoted = keywords
         .iter()
         .filter(|token| {
             for other_index in 0..lexical_grammar.variables.len() {
@@ -413,6 +428,7 @@ fn identify_keywords(
                         lexical_grammar.variables[token.index].name,
                         lexical_grammar.variables[other_index].name
                     );
+                    leaked_keywords.insert(*token);
                     return false;
                 }
             }
@@ -423,7 +439,9 @@ fn identify_keywords(
             );
             true
         })
-        .collect()
+        .collect();
+
+    (promoted, leaked_keywords)
 }
 
 fn mark_fragile_tokens(parse_table: &mut ParseTable, token_conflict_map: &TokenConflictMap) {

--- a/crates/generate/src/build_tables/build_lex_table.rs
+++ b/crates/generate/src/build_tables/build_lex_table.rs
@@ -29,11 +29,15 @@ pub fn build_lex_table(
     syntax_grammar: &SyntaxGrammar,
     lexical_grammar: &LexicalGrammar,
     keywords: &TokenSet,
+    leaked_keywords: &TokenSet,
     coincident_token_index: &CoincidentTokenIndex,
     token_conflict_map: &TokenConflictMap,
 ) -> LexTables {
     let keyword_lex_table = if syntax_grammar.word_token.is_some() {
-        let mut builder = LexTableBuilder::new(lexical_grammar);
+        // The keyword lex table recognises keywords directly; it does not need
+        // the word-token continuation protection (word_token = None,
+        // leaked_keywords = empty).
+        let mut builder = LexTableBuilder::new(lexical_grammar, None, None);
         builder.add_state_for_tokens(keywords);
         builder.table
     } else {
@@ -81,7 +85,11 @@ pub fn build_lex_table(
         }
     }
 
-    let mut builder = LexTableBuilder::new(lexical_grammar);
+    let mut builder = LexTableBuilder::new(
+        lexical_grammar,
+        syntax_grammar.word_token,
+        Some(leaked_keywords),
+    );
     for (tokens, parse_state_ids) in parse_state_ids_by_token_set {
         let lex_state_id = builder.add_state_for_tokens(&tokens);
         for id in parse_state_ids {
@@ -142,16 +150,37 @@ struct LexTableBuilder<'a> {
     table: LexTable,
     state_queue: VecDeque<QueueEntry>,
     state_ids_by_nfa_state_set: FxHashMap<(Vec<u32>, bool), usize>,
+    /// The word token (identifier), if any. Used together with
+    /// `leaked_keywords` to decide when to keep a word-token continuation
+    /// transition that would otherwise be pruned by a higher-precedence
+    /// keyword completion.
+    word_token: Option<Symbol>,
+    /// Keyword candidates that `identify_keywords` excluded from
+    /// `ts_lex_keywords` and that therefore remain in the main `ts_lex`
+    /// table. For these tokens the runtime word-extraction path is not
+    /// available, so a pruned word-token continuation transition at the
+    /// keyword completion would lose the identifier reading. When the
+    /// completed token is in this set and the pruned transition leads to
+    /// the word token, the transition is kept so the DFA can fall through
+    /// to the longer identifier match. `None` (only used by the keyword
+    /// lex table) disables the rescue entirely.
+    leaked_keywords: Option<&'a TokenSet>,
 }
 
 impl<'a> LexTableBuilder<'a> {
-    fn new(lexical_grammar: &'a LexicalGrammar) -> Self {
+    fn new(
+        lexical_grammar: &'a LexicalGrammar,
+        word_token: Option<Symbol>,
+        leaked_keywords: Option<&'a TokenSet>,
+    ) -> Self {
         Self {
             lexical_grammar,
             cursor: NfaCursor::new(&lexical_grammar.nfa, vec![]),
             table: LexTable::default(),
             state_queue: VecDeque::new(),
             state_ids_by_nfa_state_set: FxHashMap::default(),
+            word_token,
+            leaked_keywords,
         }
     }
 
@@ -258,7 +287,44 @@ impl<'a> LexTableBuilder<'a> {
                     has_sep,
                 )
             {
-                continue;
+                // Leaked-keyword word-boundary rescue.
+                //
+                // If the completed token is a keyword candidate that
+                // `identify_keywords` excluded from `ts_lex_keywords` (so it
+                // remains in main `ts_lex`), the runtime word-extraction
+                // path is not available for it. In that case the lexer must
+                // still be able to follow a longer word-token (identifier)
+                // continuation out of the keyword-completion state, or
+                // strings like `nextgame` (which starts with the leaked
+                // keyword `NE`) get split at the keyword boundary because
+                // the identifier continuation branch is dropped here.
+                //
+                // For promoted keywords (in `ts_lex_keywords`) and for
+                // grammars without a word token, this rescue does not fire
+                // and pruning proceeds as before, so positive-precedence
+                // alphabetic tokens that are not keyword candidates still
+                // beat the word token as the grammar author intended.
+                let rescue = match (self.word_token, self.leaked_keywords) {
+                    (Some(wt), Some(leaked))
+                        if leaked.contains(&Symbol::terminal(completed_id)) =>
+                    {
+                        let leads_to_word_token = self
+                            .lexical_grammar
+                            .variable_indices_for_nfa_states(&transition.states)
+                            .any(|i| i == wt.index);
+                        if leads_to_word_token {
+                            debug!(
+                                "Lex - keep word-token transition out of leaked keyword {}",
+                                self.lexical_grammar.variables[completed_id].name,
+                            );
+                        }
+                        leads_to_word_token
+                    }
+                    _ => false,
+                };
+                if !rescue {
+                    continue;
+                }
             }
 
             let (next_state_id, _) =

--- a/crates/generate/src/build_tables/build_lex_table.rs
+++ b/crates/generate/src/build_tables/build_lex_table.rs
@@ -34,9 +34,6 @@ pub fn build_lex_table(
     token_conflict_map: &TokenConflictMap,
 ) -> LexTables {
     let keyword_lex_table = if syntax_grammar.word_token.is_some() {
-        // The keyword lex table recognises keywords directly; it does not need
-        // the word-token continuation protection (word_token = None,
-        // leaked_keywords = empty).
         let mut builder = LexTableBuilder::new(lexical_grammar, None, None);
         builder.add_state_for_tokens(keywords);
         builder.table
@@ -150,20 +147,7 @@ struct LexTableBuilder<'a> {
     table: LexTable,
     state_queue: VecDeque<QueueEntry>,
     state_ids_by_nfa_state_set: FxHashMap<(Vec<u32>, bool), usize>,
-    /// The word token (identifier), if any. Used together with
-    /// `leaked_keywords` to decide when to keep a word-token continuation
-    /// transition that would otherwise be pruned by a higher-precedence
-    /// keyword completion.
     word_token: Option<Symbol>,
-    /// Keyword candidates that `identify_keywords` excluded from
-    /// `ts_lex_keywords` and that therefore remain in the main `ts_lex`
-    /// table. For these tokens the runtime word-extraction path is not
-    /// available, so a pruned word-token continuation transition at the
-    /// keyword completion would lose the identifier reading. When the
-    /// completed token is in this set and the pruned transition leads to
-    /// the word token, the transition is kept so the DFA can fall through
-    /// to the longer identifier match. `None` (only used by the keyword
-    /// lex table) disables the rescue entirely.
     leaked_keywords: Option<&'a TokenSet>,
 }
 
@@ -287,23 +271,6 @@ impl<'a> LexTableBuilder<'a> {
                     has_sep,
                 )
             {
-                // Leaked-keyword word-boundary rescue.
-                //
-                // If the completed token is a keyword candidate that
-                // `identify_keywords` excluded from `ts_lex_keywords` (so it
-                // remains in main `ts_lex`), the runtime word-extraction
-                // path is not available for it. In that case the lexer must
-                // still be able to follow a longer word-token (identifier)
-                // continuation out of the keyword-completion state, or
-                // strings like `nextgame` (which starts with the leaked
-                // keyword `NE`) get split at the keyword boundary because
-                // the identifier continuation branch is dropped here.
-                //
-                // For promoted keywords (in `ts_lex_keywords`) and for
-                // grammars without a word token, this rescue does not fire
-                // and pruning proceeds as before, so positive-precedence
-                // alphabetic tokens that are not keyword candidates still
-                // beat the word token as the grammar author intended.
                 let rescue = match (self.word_token, self.leaked_keywords) {
                     (Some(wt), Some(leaked))
                         if leaked.contains(&Symbol::terminal(completed_id)) =>

--- a/test/fixtures/test_grammars/word_token_leaked_keyword/corpus.txt
+++ b/test/fixtures/test_grammars/word_token_leaked_keyword/corpus.txt
@@ -80,3 +80,26 @@ neqv-;
 
 (source_file
   (neqv_ext))
+
+================================================================
+High-Precedence Companion Wins At Word Boundary
+================================================================
+
+kw-;
+
+---
+
+(source_file
+  (kw_hi))
+
+================================================================
+High-Precedence Companion Wins Over Identifier (Continuation Pruned)
+================================================================
+
+kw-base;
+
+---
+
+(source_file
+  (kw_hi)
+  (identifier))

--- a/test/fixtures/test_grammars/word_token_leaked_keyword/corpus.txt
+++ b/test/fixtures/test_grammars/word_token_leaked_keyword/corpus.txt
@@ -58,3 +58,25 @@ hello;
 
 (source_file
   (identifier))
+
+================================================================
+Hyphenated Identifier Starting With NEQV Not Split (Regression)
+================================================================
+
+neqv-base;
+
+---
+
+(source_file
+  (identifier))
+
+================================================================
+NEQV Companion Operator Wins In Operator Position (Regression)
+================================================================
+
+neqv-;
+
+---
+
+(source_file
+  (neqv_ext))

--- a/test/fixtures/test_grammars/word_token_leaked_keyword/corpus.txt
+++ b/test/fixtures/test_grammars/word_token_leaked_keyword/corpus.txt
@@ -1,0 +1,60 @@
+================================================================
+Identifier Starting With NEQV Keyword Not Split (Bug Reproduction)
+================================================================
+
+neqvbase;
+
+---
+
+(source_file
+  (identifier))
+
+================================================================
+Identifier Starting With NEQV Adjacent To Operator (Bug Reproduction)
+================================================================
+
+neqvbase neqv other;
+
+---
+
+(source_file
+  (binary_expr
+    (identifier)
+    (neqv_op)
+    (identifier)))
+
+================================================================
+NEQV Keyword Recognised Standalone
+================================================================
+
+neqv;
+
+---
+
+(source_file
+  (neqv_op))
+
+================================================================
+NEQV Keyword In Binary Expression
+================================================================
+
+x neqv y;
+
+---
+
+(source_file
+  (binary_expr
+    (identifier)
+    (neqv_op)
+    (identifier)))
+
+================================================================
+Plain Identifier Unaffected
+================================================================
+
+hello;
+
+---
+
+(source_file
+  (identifier))

--- a/test/fixtures/test_grammars/word_token_leaked_keyword/grammar.js
+++ b/test/fixtures/test_grammars/word_token_leaked_keyword/grammar.js
@@ -58,15 +58,10 @@
  *   word-token NFA variable; if it does, the transition is KEPT.  Applied
  *   only to the main lex table (word_token = Some(identifier)).
  *
- * @author Chris Fanning
- * @license MIT
  */
 
-/// <reference types="tree-sitter-cli/dsl" />
-// @ts-check
-
 export default grammar({
-  name: "pruning",
+  name: "word_token_leaked_keyword",
 
   // word: declaration is required:
   //   1. It enables the keyword extraction mechanism (ts_lex_keywords).
@@ -111,7 +106,7 @@ export default grammar({
     // Keyword with positive precedence (prec=1 > 0 of identifier Advance states).
     // This satisfies prefer_transition(t.prec=0 < completed=1) == false,
     // causing the identifier-continuation to be dropped from the DFA.
-    neqv_op: $ => token(prec(1, /[nN][eE][qQ][vV]/)),
+    neqv_op: $ => token(prec(1, /neqv/)),
 
     // Compound-assignment operator: same prefix as neqv_op, then ":=".
     // Critical properties:
@@ -126,7 +121,7 @@ export default grammar({
     //   * Appears in operator position where identifier is NOT valid,
     //     so the fast-path ("identifier already valid everywhere") does not
     //     skip the conflict check.
-    neqv_assign: $ => token(prec(0, /[nN][eE][qQ][vV]:=/)),
+    neqv_assign: $ => token(prec(0, /neqv:=/)),
 
     // Word token.
     identifier: $ => /[a-zA-Z]\w*/,

--- a/test/fixtures/test_grammars/word_token_leaked_keyword/grammar.js
+++ b/test/fixtures/test_grammars/word_token_leaked_keyword/grammar.js
@@ -1,0 +1,134 @@
+/**
+ * @file Minimal reproduction of tree-sitter build_lex_table.rs word-token
+ *       transition pruning bug.
+ *
+ * TRIGGER CONDITIONS (all three required):
+ *
+ *   1. Grammar declares `word: $ => $.identifier`.
+ *   2. A keyword token (neqv_op) uses explicit positive precedence via
+ *      `token(prec(N, pattern))` with N > 0.
+ *   3. A companion "compound-assignment" token exists whose pattern STARTS
+ *      with the same characters as the keyword but continues past the keyword
+ *      completion point (e.g. "neqv:=" vs "neqv").  The companion token must
+ *      be a non-keyword-candidate (it matches strings that `identifier` does
+ *      not: "neqv:=" is not a valid identifier).
+ *
+ * MECHANISM: why neqv_op stays in ts_lex instead of ts_lex_keywords
+ *
+ *   `identify_keywords` (build_tables.rs) runs a final filter that excludes
+ *   keyword candidates for which substituting the word token (identifier)
+ *   would introduce new lexical conflicts.  The filter tests each non-keyword
+ *   token X:
+ *
+ *   Step A: find states where `neqv_op` and X coexist.  In this grammar,
+ *           after a complete LHS `_expression`, both `neqv_op` (binary
+ *           operator) and `neqv_assign` (compound assignment) are valid
+ *           lookaheads, but `identifier` is NOT.
+ *
+ *   Step B: because identifier is not valid in those states, the "no new
+ *           conflicts" fast-path does not apply.
+ *
+ *   Step C: compare conflict status of `neqv_op` vs `identifier` vs X:
+ *
+ *     status_matrix[neqv_op, neqv_assign]:
+ *       At "neqv" completion (prec=1), the `:` advance for neqv_assign has
+ *       prec=0 < 1.  prefer_transition() returns FALSE.  MATCHES_PREFIX set.
+ *
+ *     status_matrix[identifier, neqv_assign]:
+ *       At "neqv" completion (prec=0), the `:` advance for neqv_assign has
+ *       prec=0 == 0.  prefer_transition() returns TRUE.  DOES_MATCH_CONTIN-
+ *       UATION is set on neqv_assign side, not on identifier side.
+ *       status_matrix[identifier, neqv_assign] stays EMPTY.
+ *
+ *     MATCHES_PREFIX != EMPTY
+ *     has_same_conflict_status(neqv_op, identifier, neqv_assign) == false
+ *     neqv_op is EXCLUDED from keywords and stays in ts_lex.
+ *
+ * DFA BUG: once neqv_op is in ts_lex
+ *
+ *   In the DFA state after reading "neqv", neqv_op is COMPLETE (prec=1) and
+ *   the identifier continuation transition (prec=0 Advance states) is also
+ *   present.  populate_state() calls
+ *     prefer_transition(t.prec=0, completed_precedence=1)
+ *   0 < 1 returns false, so the identifier-continuation branch is DROPPED.
+ *   Input "neqvbase" is lexed as neqv_op("neqv") + identifier("base")
+ *   instead of the correct identifier("neqvbase").
+ *
+ * FIX: populate_state() checks whether the pruned transition leads to the
+ *   word-token NFA variable; if it does, the transition is KEPT.  Applied
+ *   only to the main lex table (word_token = Some(identifier)).
+ *
+ * @author Chris Fanning
+ * @license MIT
+ */
+
+/// <reference types="tree-sitter-cli/dsl" />
+// @ts-check
+
+export default grammar({
+  name: "pruning",
+
+  // word: declaration is required:
+  //   1. It enables the keyword extraction mechanism (ts_lex_keywords).
+  //   2. The fix sets word_token = Some(identifier), which is only possible
+  //      when a word token is declared.
+  word: $ => $.identifier,
+
+  rules: {
+    source_file: $ => repeat($._statement),
+
+    // Three statement forms:
+    //   expression-statement:   expr ;
+    //   standalone-keyword:     neqv_op ;  <-- puts neqv_op and identifier
+    //                                          in the SAME initial parse
+    //                                          state.  The generator creates
+    //                                          a shared lex_state with both
+    //                                          the neqv-specific prefix path
+    //                                          AND the general identifier
+    //                                          path.  This is where the DFA
+    //                                          bug manifests: state 8 accepts
+    //                                          neqv_op with no identifier
+    //                                          continuation.
+    //   compound-assignment:    expr  neqv_assign  expr ;
+    //                                      <-- keeps neqv_op in ts_lex via
+    //                                          the identify_keywords exclusion
+    //                                          (conflict-status asymmetry).
+    _statement: $ => choice(
+      seq($._expression, ";"),
+      seq($.neqv_op, ";"),
+      seq($._expression, $.neqv_assign, $._expression, ";"),
+    ),
+
+    _expression: $ => choice(
+      $.identifier,
+      $.binary_expr,
+    ),
+
+    binary_expr: $ => prec.left(1,
+      seq($._expression, $.neqv_op, $._expression),
+    ),
+
+    // Keyword with positive precedence (prec=1 > 0 of identifier Advance states).
+    // This satisfies prefer_transition(t.prec=0 < completed=1) == false,
+    // causing the identifier-continuation to be dropped from the DFA.
+    neqv_op: $ => token(prec(1, /[nN][eE][qQ][vV]/)),
+
+    // Compound-assignment operator: same prefix as neqv_op, then ":=".
+    // Critical properties:
+    //   * NOT a keyword candidate: "neqv:=" is not in identifier's language,
+    //     so does_match_different_string(neqv_assign, identifier) = true.
+    //   * Creates the conflict-status asymmetry between neqv_op and identifier:
+    //       neqv_op  (prec=1) vs neqv_assign: MATCHES_PREFIX
+    //       identifier (prec=0) vs neqv_assign: EMPTY (continuation goes to
+    //         neqv_assign side, not identifier side)
+    //     has_same_conflict_status(neqv_op, identifier, neqv_assign) == false
+    //     forces neqv_op out of keywords and into ts_lex.
+    //   * Appears in operator position where identifier is NOT valid,
+    //     so the fast-path ("identifier already valid everywhere") does not
+    //     skip the conflict check.
+    neqv_assign: $ => token(prec(0, /[nN][eE][qQ][vV]:=/)),
+
+    // Word token.
+    identifier: $ => /[a-zA-Z]\w*/,
+  },
+});

--- a/test/fixtures/test_grammars/word_token_leaked_keyword/grammar.js
+++ b/test/fixtures/test_grammars/word_token_leaked_keyword/grammar.js
@@ -72,7 +72,7 @@ export default grammar({
   rules: {
     source_file: $ => repeat($._statement),
 
-    // Three statement forms:
+    // Six statement forms:
     //   expression-statement:   expr ;
     //   standalone-keyword:     neqv_op ;  <-- puts neqv_op and identifier
     //                                          in the SAME initial parse
@@ -92,11 +92,21 @@ export default grammar({
     //                                      <-- keeps neqv_op in ts_lex via
     //                                          the identify_keywords exclusion
     //                                          (conflict-status asymmetry).
+    //   standalone-hi-companion: kw_hi ;  <-- kw_hi uses prec=1; demonstrates
+    //                                          that the token wins at the
+    //                                          "kw-" completion point.
+    //   prefix-hi-companion:    kw_hi expr ;
+    //                                      <-- kw_hi wins even when word
+    //                                          characters follow the hyphen
+    //                                          (identifier continuation pruned,
+    //                                          rescue does not fire).
     _statement: $ => choice(
       seq($._expression, ";"),
       seq($.neqv_op, ";"),
       seq($.neqv_ext, ";"),
       seq($._expression, $.neqv_ext, $._expression, ";"),
+      seq($.kw_hi, ";"),
+      seq($.kw_hi, $._expression, ";"),
     ),
 
     _expression: $ => choice(
@@ -129,9 +139,32 @@ export default grammar({
     //     skip the conflict check.
     neqv_ext: $ => token(prec(0, /neqv-/)),
 
+    // High-precedence companion: demonstrates the intentional-priority case.
+    // Unlike neqv_ext (prec=0 == identifier prec=0), kw_hi uses prec=1:
+    //   * At "kw-" completion: prefer_transition(t.prec=0, completed_prec=1)
+    //     == false, so the identifier word-char continuation IS pruned.
+    //   * The rescue in populate_state does NOT fire: kw_hi is not a keyword
+    //     candidate and is never placed in leaked_keywords.
+    //   * Result: kw_hi wins at "kw-" even when word characters follow,
+    //     unlike neqv_ext where equal precedence lets identifier continue.
+    kw_hi: $ => token(prec(1, /kw-/)),
+
     // Word token.  Internal hyphens are allowed (e.g. "neqv-base" is a
-    // valid identifier), but a trailing hyphen is not, so "neqv-" alone
-    // cannot be an identifier and neqv_ext wins there unambiguously.
+    // valid identifier), but a trailing hyphen is not.
+    //
+    // Disambiguation at the "neqv-" DFA state depends on TWO properties:
+    //
+    //   1. Equal precedence (prec=0 on both neqv_ext and identifier):
+    //      prefer_transition(t.prec=0, completed_prec=0) returns TRUE, so
+    //      the identifier word-char continuation is NOT pruned after neqv_ext
+    //      completes.  If neqv_ext were prec(2), prefer_transition(0, 2)
+    //      would be false and "neqv-base" would be lexed as
+    //      neqv_ext("neqv-") + identifier("base").
+    //
+    //   2. No trailing hyphen in identifier:
+    //      When ";" follows "neqv-", identifier cannot complete (the
+    //      (-\w+)* group requires at least one word character after "-"),
+    //      so neqv_ext is the only complete token and wins unambiguously.
     identifier: $ => /[a-zA-Z]\w*(-\w+)*/
   },
 });

--- a/test/fixtures/test_grammars/word_token_leaked_keyword/grammar.js
+++ b/test/fixtures/test_grammars/word_token_leaked_keyword/grammar.js
@@ -7,11 +7,11 @@
  *   1. Grammar declares `word: $ => $.identifier`.
  *   2. A keyword token (neqv_op) uses explicit positive precedence via
  *      `token(prec(N, pattern))` with N > 0.
- *   3. A companion "compound-assignment" token exists whose pattern STARTS
- *      with the same characters as the keyword but continues past the keyword
- *      completion point (e.g. "neqv:=" vs "neqv").  The companion token must
- *      be a non-keyword-candidate (it matches strings that `identifier` does
- *      not: "neqv:=" is not a valid identifier).
+ *   3. A companion operator token exists whose pattern STARTS with the same
+ *      characters as the keyword but continues past the keyword completion
+ *      point (e.g. "neqv-" vs "neqv").  The companion token must be a
+ *      non-keyword-candidate (it matches strings that `identifier` does not:
+ *      bare "neqv-" cannot be an identifier because it ends with a hyphen).
  *
  * MECHANISM: why neqv_op stays in ts_lex instead of ts_lex_keywords
  *
@@ -22,7 +22,7 @@
  *
  *   Step A: find states where `neqv_op` and X coexist.  In this grammar,
  *           after a complete LHS `_expression`, both `neqv_op` (binary
- *           operator) and `neqv_assign` (compound assignment) are valid
+ *           operator) and `neqv_ext` (companion operator) are valid
  *           lookaheads, but `identifier` is NOT.
  *
  *   Step B: because identifier is not valid in those states, the "no new
@@ -30,18 +30,18 @@
  *
  *   Step C: compare conflict status of `neqv_op` vs `identifier` vs X:
  *
- *     status_matrix[neqv_op, neqv_assign]:
- *       At "neqv" completion (prec=1), the `:` advance for neqv_assign has
+ *     status_matrix[neqv_op, neqv_ext]:
+ *       At "neqv" completion (prec=1), the `-` advance for neqv_ext has
  *       prec=0 < 1.  prefer_transition() returns FALSE.  MATCHES_PREFIX set.
  *
- *     status_matrix[identifier, neqv_assign]:
- *       At "neqv" completion (prec=0), the `:` advance for neqv_assign has
+ *     status_matrix[identifier, neqv_ext]:
+ *       At "neqv" completion (prec=0), the `-` advance for neqv_ext has
  *       prec=0 == 0.  prefer_transition() returns TRUE.  DOES_MATCH_CONTIN-
- *       UATION is set on neqv_assign side, not on identifier side.
- *       status_matrix[identifier, neqv_assign] stays EMPTY.
+ *       UATION is set on neqv_ext side, not on identifier side.
+ *       status_matrix[identifier, neqv_ext] stays EMPTY.
  *
  *     MATCHES_PREFIX != EMPTY
- *     has_same_conflict_status(neqv_op, identifier, neqv_assign) == false
+ *     has_same_conflict_status(neqv_op, identifier, neqv_ext) == false
  *     neqv_op is EXCLUDED from keywords and stays in ts_lex.
  *
  * DFA BUG: once neqv_op is in ts_lex
@@ -84,14 +84,19 @@ export default grammar({
     //                                          bug manifests: state 8 accepts
     //                                          neqv_op with no identifier
     //                                          continuation.
-    //   compound-assignment:    expr  neqv_assign  expr ;
+    //   standalone-companion:   neqv_ext ;  <-- puts neqv_ext and identifier
+    //                                          in the SAME initial parse state,
+    //                                          allowing the regression tests
+    //                                          below to exercise the boundary.
+    //   binary-with-companion:  expr  neqv_ext  expr ;
     //                                      <-- keeps neqv_op in ts_lex via
     //                                          the identify_keywords exclusion
     //                                          (conflict-status asymmetry).
     _statement: $ => choice(
       seq($._expression, ";"),
       seq($.neqv_op, ";"),
-      seq($._expression, $.neqv_assign, $._expression, ";"),
+      seq($.neqv_ext, ";"),
+      seq($._expression, $.neqv_ext, $._expression, ";"),
     ),
 
     _expression: $ => choice(
@@ -108,22 +113,25 @@ export default grammar({
     // causing the identifier-continuation to be dropped from the DFA.
     neqv_op: $ => token(prec(1, /neqv/)),
 
-    // Compound-assignment operator: same prefix as neqv_op, then ":=".
+    // Companion operator: same prefix as neqv_op, then a hyphen.
     // Critical properties:
-    //   * NOT a keyword candidate: "neqv:=" is not in identifier's language,
-    //     so does_match_different_string(neqv_assign, identifier) = true.
+    //   * NOT a keyword candidate: "neqv-" is not in identifier's language
+    //     (identifiers cannot end with a hyphen), so
+    //     does_match_different_string(neqv_ext, identifier) = true.
     //   * Creates the conflict-status asymmetry between neqv_op and identifier:
-    //       neqv_op  (prec=1) vs neqv_assign: MATCHES_PREFIX
-    //       identifier (prec=0) vs neqv_assign: EMPTY (continuation goes to
-    //         neqv_assign side, not identifier side)
-    //     has_same_conflict_status(neqv_op, identifier, neqv_assign) == false
+    //       neqv_op  (prec=1) vs neqv_ext: MATCHES_PREFIX
+    //       identifier (prec=0) vs neqv_ext: EMPTY (continuation goes to
+    //         neqv_ext side, not identifier side)
+    //     has_same_conflict_status(neqv_op, identifier, neqv_ext) == false
     //     forces neqv_op out of keywords and into ts_lex.
     //   * Appears in operator position where identifier is NOT valid,
     //     so the fast-path ("identifier already valid everywhere") does not
     //     skip the conflict check.
-    neqv_assign: $ => token(prec(0, /neqv:=/)),
+    neqv_ext: $ => token(prec(0, /neqv-/)),
 
-    // Word token.
-    identifier: $ => /[a-zA-Z]\w*/,
+    // Word token.  Internal hyphens are allowed (e.g. "neqv-base" is a
+    // valid identifier), but a trailing hyphen is not, so "neqv-" alone
+    // cannot be an identifier and neqv_ext wins there unambiguously.
+    identifier: $ => /[a-zA-Z]\w*(-\w+)*/
   },
 });


### PR DESCRIPTION
I believe this behavior is a bug and am proposing a correction. It was encountered during a grammar development that triggered the issue. AI was used to help identify and correct the issue. The workaround without this
PR is to implement a scanner. It is fairly complex, both (what I believe to be) the error and the fix. Understanding might be best if you start with the test grammar and corpus and compare with and without the PR.

Problem:
When a grammar declares 'word: $ => $.identifier' tree-sitter promotes certain keyword tokens to a separate 'ts_lex_keywords' table so the runtime can use word-boundary checks to distinguish them from identifiers. However, some keyword candidates fail the promotion filter. For example, a token whose lexical conflict status differs from the plain identifier and they "leak" back into the main 'ts_lex' table. Before this fix, those leaked keywords caused a silent correctness bug. Any identifier that started with the leaked keyword's text (e.g. in our test grammar and corpus 'neqvbase' starts with 'neqv') was incorrectly split at the keyword boundary instead of being recognized as a single identifier.

During lexer DFA construction (build_lex_table.rs, 'populate_state'), when a token reaches a completion state with precedence N, any NFA transitions that represent continuing to read more characters are suppressed via 'prefer_transition(transition.prec, N)' if the transition's precedence is lower. This is correct and intentional for tokens in 'ts_lex_keywords', because the runtime will re-examine the completed text against the word token using word-boundary rules. But for leaked keywords (those that 'identify_keywords' excluded and remain only in 'ts_lex' with no runtime word-boundary safety net) the suppression is wrong. Once the DFA drops the identifier continuation branch, there is no second chance to recover the full identifier, and the parser silently accepts the shorter keyword match.

Fix:
'populate_state' now checks a 'leaked_keywords: Option<&TokenSet>' parameter (supplied only for the main lex table 'None' for 'ts_lex_keywords') before discarding a transition. If the completed token is in 'leaked_keywords' and the suppressed transition leads to an NFA state belonging to the word token, the transition is rescued and kept. Leaked keywords never go through the runtime word/boundary path, so there is no double counting. Promoted keywords and grammars without a word token are unaffected. A new 'word_token_leaked_keyword' fixture grammar and nine corpus tests cover the exact failure mode and the boundary cases introduced by the fix. 
