### PR TITLE
Fix/case insensitive keyword extraction

### DIFF
--- a/crates/generate/src/build_tables.rs
+++ b/crates/generate/src/build_tables.rs
@@ -542,7 +542,7 @@ fn all_chars_are_alphabetical(cursor: &NfaCursor) -> bool {
         if is_sep {
             true
         } else {
-            chars.chars().all(|c| c.is_alphabetic() || c == '_')
+            chars.chars().all(|c| c.is_ascii_alphabetic() || c == '_')
         }
     })
 }

--- a/test/fixtures/test_grammars/keyword_extraction_case_insensitive/corpus.txt
+++ b/test/fixtures/test_grammars/keyword_extraction_case_insensitive/corpus.txt
@@ -1,0 +1,24 @@
+=====================================================
+Identifier prefixed with keyword should not split
+=====================================================
+
+count_foo
+
+---
+
+(expression
+  (variable))
+
+=====================================================
+Exact keyword match should be a unary command
+=====================================================
+
+count x
+
+---
+
+(expression
+  (unary_expression
+    (unary_command)
+    (expression
+      (variable))))

--- a/test/fixtures/test_grammars/keyword_extraction_case_insensitive/grammar.js
+++ b/test/fixtures/test_grammars/keyword_extraction_case_insensitive/grammar.js
@@ -1,0 +1,13 @@
+export default grammar({
+  name: "keyword_extraction_case_insensitive",
+
+  word: ($) => $.variable,
+
+  rules: {
+    expression: ($) => choice($.variable, $.unary_expression),
+    unary_expression: ($) => seq($.unary_command, $.expression),
+    variable: ($) => token(prec(1, /[a-zA-Z_][a-zA-Z0-9_]*/)),
+    unary_command: ($) =>
+      token(prec(2, choice(/count/i, /creatediarylink/i))),
+  },
+});


### PR DESCRIPTION
### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

I used claude to help navigate the codebase and understand how keyword extraction works. The root cause analysis and the fix are my own. I have also used the same to skim through the docs also referred old commits and PR for format references. 

### Problem

When case insensitive regular expressions are used for keywords, the regex engine expands them to include unicode case-folds. For example letter ‘k’ also matches the kelvin sign (U+212A). The function `all_chars_are_alphabetical` (ln 540-548) in `crates/generate/src/build_tables.rs` used `is_alphabetic()` which returns true for these unicode characters. Resulting the keyword shadowing logic to break in unexpected ways depending on which keywords were present.

### Fix

Changed `is_alphabetic()` to `is_ascii_alphabetic()` in `all_chars_are_alphabetical`. Keywords are always ASCII identifiers, so non-ASCII unicode case folds should never pass this check.

Fixes #5607

