### PR TITLE
fix(cli): place generate artifacts next to grammar file rather than cwd

### DIFF
--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -251,6 +251,18 @@ where
             repo_path = path_buf;
             repo_path.join("grammar.js")
         } else {
+            // Given an _explicit_ path to an input file, derive the repo root from the
+            // conventional locations:
+            //     - grammar.js sits inside <root>/
+            //     - grammar.json sits inside <root>/src/
+            let repo_root = match path_buf.extension() {
+                Some(e) if e == "js" => path_buf.parent(),
+                Some(e) if e == "json" => path_buf.parent().and_then(Path::parent),
+                _ => None,
+            };
+            if let Some(root) = repo_root {
+                repo_path = root.to_path_buf();
+            }
             path_buf
         }
     } else {


### PR DESCRIPTION
### The Problem

This is some weird behavior from tree-sitter-cli that I don't *think* is intentional. If you run `tree-sitter generate path/to/grammar.js`, the generated `src` directory will get placed in the current working directory of the tree-sitter invocation, rather than next to `grammar.js`. This is a bit unintuitive and leaves artifacts in unexpected places.

### The Solution

Instead, if we provide an _explicit_ path to a grammar file, ensure the generated files are placed in the proper place.
