### PR TITLE
fix: rewrite `ts_subtree__write_to_string` iteratively

### DIFF
--- a/crates/cli/src/fuzz.rs
+++ b/crates/cli/src/fuzz.rs
@@ -65,7 +65,7 @@ pub fn new_seed() -> usize {
     int_env_var("TREE_SITTER_SEED").unwrap_or_else(|| {
         let mut rng = rand::rng();
         let seed = rng.random_range(0..=usize::MAX);
-        info!("Seed: {seed}");
+        eprintln!("fuzz seed: {seed}");
         seed
     })
 }

--- a/crates/cli/src/fuzz/corpus_test.rs
+++ b/crates/cli/src/fuzz/corpus_test.rs
@@ -3,8 +3,20 @@ use tree_sitter::{LogType, Node, Parser, Point, Range, Tree};
 use super::{LOG_ENABLED, LOG_GRAPH_ENABLED, scope_sequence::ScopeSequence};
 use crate::util;
 
-pub fn check_consistent_sizes(tree: &Tree, input: &[u8]) {
-    fn check(node: Node, line_offsets: &[usize]) {
+struct SizeCheckFrame<'a> {
+    node: Node<'a>,
+    end_byte: usize,
+    end_point: Point,
+    child_count: u32,
+    child_index: u32,
+    last_child_end_byte: usize,
+    last_child_end_point: Point,
+    some_child_has_changes: bool,
+    actual_named_child_count: usize,
+}
+
+impl SizeCheckFrame<'_> {
+    fn new<'a>(node: Node<'a>, line_offsets: &[usize]) -> SizeCheckFrame<'a> {
         let start_byte = node.start_byte();
         let end_byte = node.end_byte();
         let start_point = node.start_position();
@@ -18,37 +30,21 @@ pub fn check_consistent_sizes(tree: &Tree, input: &[u8]) {
         );
         assert_eq!(end_byte, line_offsets[end_point.row] + end_point.column);
 
-        let mut last_child_end_byte = start_byte;
-        let mut last_child_end_point = start_point;
-        let mut some_child_has_changes = false;
-        let mut actual_named_child_count = 0;
-        for i in 0..node.child_count() {
-            let child = node.child(i).unwrap();
-            assert!(child.start_byte() >= last_child_end_byte);
-            assert!(child.start_position() >= last_child_end_point);
-            check(child, line_offsets);
-            if child.has_changes() {
-                some_child_has_changes = true;
-            }
-            if child.is_named() {
-                actual_named_child_count += 1;
-            }
-            last_child_end_byte = child.end_byte();
-            last_child_end_point = child.end_position();
-        }
-
-        assert_eq!(actual_named_child_count, node.named_child_count());
-
-        if node.child_count() > 0 {
-            assert!(end_byte >= last_child_end_byte);
-            assert!(end_point >= last_child_end_point);
-        }
-
-        if some_child_has_changes {
-            assert!(node.has_changes());
+        SizeCheckFrame {
+            node,
+            end_byte,
+            end_point,
+            child_count: node.child_count(),
+            child_index: 0,
+            last_child_end_byte: start_byte,
+            last_child_end_point: start_point,
+            some_child_has_changes: false,
+            actual_named_child_count: 0,
         }
     }
+}
 
+pub fn check_consistent_sizes(tree: &Tree, input: &[u8]) {
     let mut line_offsets = vec![0];
     for (i, c) in input.iter().enumerate() {
         if *c == b'\n' {
@@ -56,7 +52,41 @@ pub fn check_consistent_sizes(tree: &Tree, input: &[u8]) {
         }
     }
 
-    check(tree.root_node(), &line_offsets);
+    let mut stack: Vec<SizeCheckFrame> = vec![SizeCheckFrame::new(tree.root_node(), &line_offsets)];
+    while let Some(top) = stack.last_mut() {
+        if top.child_index < top.child_count {
+            let i = top.child_index;
+            let child = top.node.child(i).unwrap();
+
+            assert!(child.start_byte() >= top.last_child_end_byte);
+            assert!(child.start_position() >= top.last_child_end_point);
+            if child.has_changes() {
+                top.some_child_has_changes = true;
+            }
+            if child.is_named() {
+                top.actual_named_child_count += 1;
+            }
+            top.last_child_end_byte = child.end_byte();
+            top.last_child_end_point = child.end_position();
+            top.child_index += 1;
+
+            stack.push(SizeCheckFrame::new(child, &line_offsets));
+            continue;
+        }
+
+        let frame = stack.pop().unwrap();
+        assert_eq!(
+            frame.actual_named_child_count,
+            frame.node.named_child_count()
+        );
+        if frame.child_count > 0 {
+            assert!(frame.end_byte >= frame.last_child_end_byte);
+            assert!(frame.end_point >= frame.last_child_end_point);
+        }
+        if frame.some_child_has_changes {
+            assert!(frame.node.has_changes());
+        }
+    }
 }
 
 pub fn check_changed_ranges(old_tree: &Tree, new_tree: &Tree, input: &[u8]) -> Result<(), String> {

--- a/lib/src/subtree.c
+++ b/lib/src/subtree.c
@@ -818,109 +818,158 @@ static size_t ts_subtree__write_char_to_string(char *str, size_t n, int32_t chr)
 
 static const char *const ROOT_FIELD = "__ROOT__";
 
+typedef struct {
+  Subtree subtree;
+  TSSymbol alias_symbol;
+  bool alias_is_named;
+  const char *field_name;
+  bool is_root;
+
+  bool pre_written;
+  bool is_visible;
+  uint32_t child_index;
+  uint32_t structural_child_index;
+  const TSSymbol *alias_sequence;
+  const TSFieldMapEntry *field_map;
+  const TSFieldMapEntry *field_map_end;
+} WriteToStringFrame;
+
 static size_t ts_subtree__write_to_string(
   Subtree self, char *string, size_t limit,
   const TSLanguage *language, bool include_all,
-  TSSymbol alias_symbol, bool alias_is_named, const char *field_name
+  TSSymbol root_alias_symbol, bool root_alias_is_named, const char *root_field_name
 ) {
-  if (!self.ptr) return snprintf(string, limit, "(NULL)");
-
   char *cursor = string;
   char **writer = (limit > 1) ? &cursor : &string;
-  bool is_root = field_name == ROOT_FIELD;
-  bool is_visible =
-    include_all ||
-    ts_subtree_missing(self) ||
-    (
-      alias_symbol
-        ? alias_is_named
-        : ts_subtree_visible(self) && ts_subtree_named(self)
-    );
 
-  if (is_visible) {
-    if (!is_root) {
-      cursor += snprintf(*writer, limit, " ");
-      if (field_name) {
-        cursor += snprintf(*writer, limit, "%s: ", field_name);
-      }
-    }
+  Array(WriteToStringFrame) stack = array_new();
+  array_push(&stack, ((WriteToStringFrame) {
+    .subtree = self,
+    .alias_symbol = root_alias_symbol,
+    .alias_is_named = root_alias_is_named,
+    .field_name = root_field_name,
+    .is_root = root_field_name == ROOT_FIELD,
+  }));
 
-    if (ts_subtree_is_error(self) && ts_subtree_child_count(self) == 0 && self.ptr->size.bytes > 0) {
-      cursor += snprintf(*writer, limit, "(UNEXPECTED ");
-      cursor += ts_subtree__write_char_to_string(*writer, limit, self.ptr->lookahead_char);
-    } else {
-      TSSymbol symbol = alias_symbol ? alias_symbol : ts_subtree_symbol(self);
-      const char *symbol_name = ts_language_symbol_name(language, symbol);
-      if (ts_subtree_missing(self)) {
-        cursor += snprintf(*writer, limit, "(MISSING ");
-        if (alias_is_named || ts_subtree_named(self)) {
-          cursor += snprintf(*writer, limit, "%s", symbol_name);
-        } else {
-          cursor += snprintf(*writer, limit, "\"%s\"", symbol_name);
+  while (stack.size) {
+    WriteToStringFrame *frame = array_back(&stack);
+    Subtree node = frame->subtree;
+
+    if (!node.ptr) {
+      if (!frame->is_root) {
+        cursor += snprintf(*writer, limit, " ");
+        if (frame->field_name) {
+          cursor += snprintf(*writer, limit, "%s: ", frame->field_name);
         }
-      } else {
-        cursor += snprintf(*writer, limit, "(%s", symbol_name);
       }
+      cursor += snprintf(*writer, limit, "(NULL)");
+      (void)array_pop(&stack);
+      continue;
     }
-  } else if (is_root) {
-    TSSymbol symbol = alias_symbol ? alias_symbol : ts_subtree_symbol(self);
-    const char *symbol_name = ts_language_symbol_name(language, symbol);
-    if (ts_subtree_child_count(self) > 0) {
-      cursor += snprintf(*writer, limit, "(%s", symbol_name);
-    } else if (ts_subtree_named(self)) {
-      cursor += snprintf(*writer, limit, "(%s)", symbol_name);
-    } else {
-      cursor += snprintf(*writer, limit, "(\"%s\")", symbol_name);
-    }
-  }
 
-  if (ts_subtree_child_count(self)) {
-    const TSSymbol *alias_sequence = ts_language_alias_sequence(language, self.ptr->production_id);
-    const TSFieldMapEntry *field_map, *field_map_end;
-    ts_language_field_map(
-      language,
-      self.ptr->production_id,
-      &field_map,
-      &field_map_end
-    );
-
-    uint32_t structural_child_index = 0;
-    for (uint32_t i = 0; i < self.ptr->child_count; i++) {
-      Subtree child = ts_subtree_children(self)[i];
-      if (ts_subtree_extra(child)) {
-        cursor += ts_subtree__write_to_string(
-          child, *writer, limit,
-          language, include_all,
-          0, false, NULL
+    if (!frame->pre_written) {
+      bool is_visible =
+        include_all ||
+        ts_subtree_missing(node) ||
+        (
+          frame->alias_symbol
+            ? frame->alias_is_named
+            : ts_subtree_visible(node) && ts_subtree_named(node)
         );
+
+      if (is_visible) {
+        if (!frame->is_root) {
+          cursor += snprintf(*writer, limit, " ");
+          if (frame->field_name) {
+            cursor += snprintf(*writer, limit, "%s: ", frame->field_name);
+          }
+        }
+
+        if (ts_subtree_is_error(node) && ts_subtree_child_count(node) == 0 && node.ptr->size.bytes > 0) {
+          cursor += snprintf(*writer, limit, "(UNEXPECTED ");
+          cursor += ts_subtree__write_char_to_string(*writer, limit, node.ptr->lookahead_char);
+        } else {
+          TSSymbol symbol = frame->alias_symbol ? frame->alias_symbol : ts_subtree_symbol(node);
+          const char *symbol_name = ts_language_symbol_name(language, symbol);
+          if (ts_subtree_missing(node)) {
+            cursor += snprintf(*writer, limit, "(MISSING ");
+            if (frame->alias_is_named || ts_subtree_named(node)) {
+              cursor += snprintf(*writer, limit, "%s", symbol_name);
+            } else {
+              cursor += snprintf(*writer, limit, "\"%s\"", symbol_name);
+            }
+          } else {
+            cursor += snprintf(*writer, limit, "(%s", symbol_name);
+          }
+        }
+      } else if (frame->is_root) {
+        TSSymbol symbol = frame->alias_symbol ? frame->alias_symbol : ts_subtree_symbol(node);
+        const char *symbol_name = ts_language_symbol_name(language, symbol);
+        if (ts_subtree_child_count(node) > 0) {
+          cursor += snprintf(*writer, limit, "(%s", symbol_name);
+        } else if (ts_subtree_named(node)) {
+          cursor += snprintf(*writer, limit, "(%s)", symbol_name);
+        } else {
+          cursor += snprintf(*writer, limit, "(\"%s\")", symbol_name);
+        }
+      }
+
+      if (ts_subtree_child_count(node)) {
+        frame->alias_sequence = ts_language_alias_sequence(language, node.ptr->production_id);
+        ts_language_field_map(
+          language,
+          node.ptr->production_id,
+          &frame->field_map,
+          &frame->field_map_end
+        );
+      }
+
+      frame->is_visible = is_visible;
+      frame->pre_written = true;
+    }
+
+    if (frame->child_index < ts_subtree_child_count(node)) {
+      Subtree child = ts_subtree_children(node)[frame->child_index];
+      WriteToStringFrame child_frame = {
+        .subtree = child,
+        .is_root = false,
+      };
+
+      if (ts_subtree_extra(child)) {
+        // Extra children carry no alias/field info.
       } else {
-        TSSymbol subtree_alias_symbol = alias_sequence
-          ? alias_sequence[structural_child_index]
+        TSSymbol subtree_alias_symbol = frame->alias_sequence
+          ? frame->alias_sequence[frame->structural_child_index]
           : 0;
         bool subtree_alias_is_named = subtree_alias_symbol
           ? ts_language_symbol_metadata(language, subtree_alias_symbol).named
           : false;
 
-        const char *child_field_name = is_visible ? NULL : field_name;
-        for (const TSFieldMapEntry *map = field_map; map < field_map_end; map++) {
-          if (!map->inherited && map->child_index == structural_child_index) {
+        const char *child_field_name = frame->is_visible ? NULL : frame->field_name;
+        for (const TSFieldMapEntry *map = frame->field_map; map < frame->field_map_end; map++) {
+          if (!map->inherited && map->child_index == frame->structural_child_index) {
             child_field_name = language->field_names[map->field_id];
             break;
           }
         }
 
-        cursor += ts_subtree__write_to_string(
-          child, *writer, limit,
-          language, include_all,
-          subtree_alias_symbol, subtree_alias_is_named, child_field_name
-        );
-        structural_child_index++;
+        child_frame.alias_symbol = subtree_alias_symbol;
+        child_frame.alias_is_named = subtree_alias_is_named;
+        child_frame.field_name = child_field_name;
+        frame->structural_child_index++;
       }
+
+      frame->child_index++;
+      // After this push, `frame` may be invalidated by a realloc.
+      array_push(&stack, child_frame);
+      continue;
     }
+
+    if (frame->is_visible) cursor += snprintf(*writer, limit, ")");
+    (void)array_pop(&stack);
   }
 
-  if (is_visible) cursor += snprintf(*writer, limit, ")");
-
+  array_delete(&stack);
   return cursor - string;
 }
 


### PR DESCRIPTION
### The Problem

Rare (but observed a couple times now) failures in CI similar to this: https://github.com/tree-sitter/tree-sitter/actions/runs/26349496040/job/77565123262?pr=5620. I believe I've narrowed down the issue to a stack overflow in the subtree printing logic, triggered by deeply nested trees.

### The Solution

A couple small fixes

- Unconditionally print the fuzz seed upon creation. Having this tied to the "info" log level means it wasn't printing in CI, which made the above-mentioned failure somewhat difficult to reproduce.

- Rewrite the recursive helper in `corpus_test.rs` to use an iterative approach rather than recursive.

- Apply the same recursive->iterative fix to `ts_subtree__write_to_string`. 

I verified this fix by adding the following test, with depth controlled by a `REPRO_DEPTH` environment variable:

```diff
diff --git a/crates/cli/src/tests/corpus_test.rs b/crates/cli/src/tests/corpus_test.rs
index 4c5898cd..7f25c159 100644
--- a/crates/cli/src/tests/corpus_test.rs
+++ b/crates/cli/src/tests/corpus_test.rs
@@ -114,6 +114,36 @@ fn test_corpus_for_tsx_language(seed: usize) {
     test_language_corpus("typescript", seed, None, Some("tsx"));
 }

+#[test]
+#[ignore = "manual regression check for stack overflow on deep parse trees; run with REPRO_DEPTH set"]
+fn repro_deep_tree_stack_overflow() {
+    let language = get_language("typescript/tsx");
+    let depth: usize = std::env::var("REPRO_DEPTH")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(20000);
+    let mut input = String::with_capacity(depth * 2 + 4);
+    for _ in 0..depth {
+        input.push('(');
+    }
+    input.push('x');
+    for _ in 0..depth {
+        input.push(')');
+    }
+    input.push(';');
+
+    let mut parser = Parser::new();
+    parser.set_language(&language).unwrap();
+    eprintln!("parsing depth {depth} ({} bytes)", input.len());
+    let tree = parser.parse(&input, None).unwrap();
+    eprintln!("calling to_sexp...");
+    let s = tree.root_node().to_sexp();
+    eprintln!("to_sexp produced {} bytes", s.len());
+    eprintln!("calling check_consistent_sizes...");
+    crate::fuzz::corpus_test::check_consistent_sizes(&tree, input.as_bytes());
+    eprintln!("done");
+}
+
 pub fn test_language_corpus(
     language_name: &str,
     start_seed: usize,
```

Both recursive->iterative transformations helped increase the depth necessary to trigger an overflow.

DISCLAIMER: Opening this PR early as a draft for visibility (and so I don't forget about it later). I need to give the C changes a through second look before I'm ok with this landing.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

I used Claude Opus 4.7 to help narrow down the cause of the failure in https://github.com/tree-sitter/tree-sitter/actions/runs/26349496040/job/77565123262?pr=5620 and rewrite the recursive functions.

<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
