### PR TITLE
Allow building with the system wasmtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,6 +1995,7 @@ dependencies = [
  "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
+ "wasmtime",
  "wasmtime-c-api-impl",
 ]
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -30,9 +30,10 @@ harness = false
 name    = "benchmark"
 
 [features]
-default = [ "qjs-rt" ]
-qjs-rt  = [ "tree-sitter-generate/qjs-rt" ]
-wasm    = [ "tree-sitter/wasm", "tree-sitter-loader/wasm" ]
+default     = [ "qjs-rt" ]
+qjs-rt      = [ "tree-sitter-generate/qjs-rt" ]
+wasm        = [ "tree-sitter/wasm", "tree-sitter-loader/wasm" ]
+wasm-system = [ "tree-sitter/wasm-system", "tree-sitter-loader/wasm-system" ]
 
 [dependencies]
 ansi_colours.workspace          = true

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -229,7 +229,7 @@ struct Parse {
     #[arg(long, short = 'D')]
     pub debug_graph: bool,
     /// Compile parsers to Wasm instead of native dynamic libraries
-    #[arg(long, hide = cfg!(not(feature = "wasm")))]
+    #[arg(long, hide = cfg!(not(any(feature = "wasm", feature = "wasm-system"))))]
     pub wasm: bool,
     /// Output the parse data with graphviz dot
     #[arg(long = "dot")]
@@ -624,11 +624,11 @@ pub enum Shell {
 /// Complete `action` if the wasm feature is enabled, otherwise return an error
 macro_rules! checked_wasm {
     ($action:block) => {
-        #[cfg(feature = "wasm")]
+        #[cfg(any(feature = "wasm", feature = "wasm-system"))]
         {
             $action
         }
-        #[cfg(not(feature = "wasm"))]
+        #[cfg(not(any(feature = "wasm", feature = "wasm-system")))]
         {
             Err(anyhow!("--wasm flag specified, but this build of tree-sitter-cli does not include the wasm feature"))?;
         }

--- a/crates/cli/src/tests.rs
+++ b/crates/cli/src/tests.rs
@@ -14,7 +14,7 @@ mod test_tags_test;
 mod text_provider_test;
 mod tree_test;
 
-#[cfg(feature = "wasm")]
+#[cfg(any(feature = "wasm", feature = "wasm-system"))]
 mod wasm_language_test;
 
 use tree_sitter_generate::GenerateResult;

--- a/crates/cli/src/tests/helpers/dirs.rs
+++ b/crates/cli/src/tests/helpers/dirs.rs
@@ -21,7 +21,7 @@ pub static SCRATCH_BASE_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
     result
 });
 
-#[cfg(feature = "wasm")]
+#[cfg(any(feature = "wasm", feature = "wasm-system"))]
 pub static WASM_DIR: LazyLock<PathBuf> = LazyLock::new(|| ROOT_DIR.join("target").join("release"));
 
 pub static SCRATCH_DIR: LazyLock<PathBuf> = LazyLock::new(|| {

--- a/crates/cli/src/tests/helpers/fixtures.rs
+++ b/crates/cli/src/tests/helpers/fixtures.rs
@@ -28,7 +28,7 @@ static TEST_LOADER: LazyLock<Loader> = LazyLock::new(|| {
 // `src_dir/tree_sitter/` and observing a half-rewritten header.
 static WRITTEN_HEADER_DIRS: LazyLock<Mutex<HashSet<PathBuf>>> = LazyLock::new(Default::default);
 
-#[cfg(feature = "wasm")]
+#[cfg(any(feature = "wasm", feature = "wasm-system"))]
 pub static ENGINE: LazyLock<tree_sitter::wasmtime::Engine> = LazyLock::new(Default::default);
 
 pub fn test_loader() -> &'static Loader {
@@ -54,7 +54,7 @@ pub fn get_test_fixture_language(name: &str) -> Language {
     get_test_fixture_language_internal(name, false)
 }
 
-#[cfg(feature = "wasm")]
+#[cfg(any(feature = "wasm", feature = "wasm-system"))]
 pub fn get_test_fixture_language_wasm(name: &str) -> Language {
     get_test_fixture_language_internal(name, true)
 }
@@ -168,7 +168,7 @@ fn get_test_language_internal(
     config.name = name.to_string();
 
     if wasm {
-        #[cfg(feature = "wasm")]
+        #[cfg(any(feature = "wasm", feature = "wasm-system"))]
         {
             let mut loader = Loader::with_parser_lib_path(SCRATCH_DIR.clone());
             loader.use_wasm(&ENGINE);
@@ -177,7 +177,7 @@ fn get_test_language_internal(
             }
             loader.load_language_at_path_with_name(config).unwrap()
         }
-        #[cfg(not(feature = "wasm"))]
+        #[cfg(not(any(feature = "wasm", feature = "wasm-system")))]
         {
             unimplemented!("Wasm feature is not enabled")
         }

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -24,8 +24,9 @@ path = "src/loader.rs"
 workspace = true
 
 [features]
-default = [ "tree-sitter-highlight", "tree-sitter-tags" ]
-wasm    = [ "tree-sitter/wasm" ]
+default     = [ "tree-sitter-highlight", "tree-sitter-tags" ]
+wasm        = [ "tree-sitter/wasm" ]
+wasm-system = [ "tree-sitter/wasm-system" ]
 
 [dependencies]
 cc.workspace         = true

--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -31,7 +31,7 @@ use tree_sitter::Language;
 use tree_sitter::QueryError;
 #[cfg(feature = "tree-sitter-highlight")]
 use tree_sitter::QueryErrorKind;
-#[cfg(feature = "wasm")]
+#[cfg(any(feature = "wasm", feature = "wasm-system"))]
 use tree_sitter::WasmError;
 #[cfg(feature = "tree-sitter-highlight")]
 use tree_sitter_highlight::HighlightConfiguration;
@@ -130,7 +130,7 @@ pub enum LoaderError {
     WasmTool(#[from] WasmToolError),
     #[error("Unsupported platform for wasi-sdk")]
     WasiSDKPlatform,
-    #[cfg(feature = "wasm")]
+    #[cfg(any(feature = "wasm", feature = "wasm-system"))]
     #[error(transparent)]
     Wasm(#[from] WasmError),
     #[error("Failed to run wasi-sdk clang -- {0}")]
@@ -674,7 +674,7 @@ pub struct Loader {
     force_rebuild: bool,
     verbose: bool,
 
-    #[cfg(feature = "wasm")]
+    #[cfg(any(feature = "wasm", feature = "wasm-system"))]
     wasm_store: Mutex<Option<tree_sitter::WasmStore>>,
 }
 
@@ -823,7 +823,7 @@ impl Loader {
             force_rebuild: false,
             verbose: false,
 
-            #[cfg(feature = "wasm")]
+            #[cfg(any(feature = "wasm", feature = "wasm-system"))]
             wasm_store: Mutex::default(),
         }
     }
@@ -1107,7 +1107,7 @@ impl Loader {
         let output_path = config.output_path.unwrap_or_else(|| {
             let mut path = self.parser_lib_path.join(lib_name);
             path.set_extension(env::consts::DLL_EXTENSION);
-            #[cfg(feature = "wasm")]
+            #[cfg(any(feature = "wasm", feature = "wasm-system"))]
             if self.wasm_store.lock().unwrap().is_some() {
                 path.set_extension("wasm");
             }
@@ -1172,15 +1172,15 @@ impl Loader {
                 Some(_lock) => {
                     // We won the race, so compile with the lock.
                     let compile_wasm;
-                    #[cfg(feature = "wasm")]
+                    #[cfg(any(feature = "wasm", feature = "wasm-system"))]
                     {
                         compile_wasm = self.wasm_store.lock().unwrap().is_some();
                     }
-                    #[cfg(not(feature = "wasm"))]
+                    #[cfg(not(any(feature = "wasm", feature = "wasm-system")))]
                     {
                         compile_wasm = false;
                     };
-                    #[cfg(feature = "wasm")]
+                    #[cfg(any(feature = "wasm", feature = "wasm-system"))]
                     if compile_wasm {
                         self.compile_parser_to_wasm(
                             &config.name,
@@ -1206,7 +1206,7 @@ impl Loader {
             }
         }
 
-        #[cfg(feature = "wasm")]
+        #[cfg(any(feature = "wasm", feature = "wasm-system"))]
         if let Some(wasm_store) = self.wasm_store.lock().unwrap().as_mut() {
             let wasm_bytes = fs::read(&output_path)
                 .map_err(|e| LoaderError::IO(IoError::new(e, Some(output_path.as_path()))))?;
@@ -2034,8 +2034,8 @@ impl Loader {
         self.verbose = verbose;
     }
 
-    #[cfg(feature = "wasm")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "wasm")))]
+    #[cfg(any(feature = "wasm", feature = "wasm-system"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "wasm", feature = "wasm-system"))))]
     pub fn use_wasm(&mut self, engine: &tree_sitter::wasmtime::Engine) {
         *self.wasm_store.lock().unwrap() = Some(tree_sitter::WasmStore::new(engine).unwrap());
     }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -37,9 +37,10 @@ targets      = [ "x86_64-unknown-linux-gnu", "x86_64-pc-windows-gnu" ]
 workspace = true
 
 [features]
-default = [ "std" ]
-std     = [ "regex/std", "regex/perf" ]
-wasm    = [ "std", "wasmtime-c-api" ]
+default     = [ "std" ]
+std         = [ "regex/std", "regex/perf" ]
+wasm        = [ "std", "wasmtime-c-api" ]
+wasm-system = [ "std", "wasmtime" ]
 
 [dependencies]
 regex                          = { default-features = false, features = [ "unicode" ], version = "1.12.3" }
@@ -52,6 +53,12 @@ default-features = false
 features         = [ "cranelift", "gc-drc" ]
 optional         = true
 package          = "wasmtime-c-api-impl"
+
+[dependencies.wasmtime]
+version         = "36"
+default-features = false
+features        = [ "cranelift", "gc-drc" ]
+optional        = true
 
 [build-dependencies]
 bindgen              = { optional = true, version = "0.72.1" }

--- a/lib/binding_rust/build.rs
+++ b/lib/binding_rust/build.rs
@@ -16,11 +16,18 @@ fn main() {
     let mut config = cc::Build::new();
 
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_WASM");
-    if env::var("CARGO_FEATURE_WASM").is_ok() {
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_WASM_SYSTEM");
+    if env::var("CARGO_FEATURE_WASM").is_ok() || env::var("CARGO_FEATURE_WASM_SYSTEM").is_ok() {
         config
             .define("TREE_SITTER_FEATURE_WASM", "")
-            .define("static_assert(...)", "")
-            .include(env::var("DEP_WASMTIME_C_API_INCLUDE").unwrap());
+            .define("static_assert(...)", "");
+    }
+    if env::var("CARGO_FEATURE_WASM").is_ok() {
+        config.include(env::var("DEP_WASMTIME_C_API_INCLUDE").unwrap());
+    }
+    if env::var("CARGO_FEATURE_WASM_SYSTEM").is_ok() {
+        config.include("/usr/include");
+        println!("cargo:rustc-link-lib=wasmtime");
     }
 
     let manifest_path = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -30,10 +30,10 @@ use std::os::windows::io::AsRawHandle;
 pub use streaming_iterator::{StreamingIterator, StreamingIteratorMut};
 use tree_sitter_language::LanguageFn;
 
-#[cfg(feature = "wasm")]
+#[cfg(any(feature = "wasm", feature = "wasm-system"))]
 mod wasm_language;
-#[cfg(feature = "wasm")]
-#[cfg_attr(docsrs, doc(cfg(feature = "wasm")))]
+#[cfg(any(feature = "wasm", feature = "wasm-system"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "wasm", feature = "wasm-system"))))]
 pub use wasm_language::*;
 
 /// The latest ABI version that is supported by the current version of the
@@ -444,7 +444,7 @@ pub struct QueryCapture<'tree> {
 #[derive(Debug, PartialEq, Eq)]
 pub enum LanguageError {
     Version(usize),
-    #[cfg(feature = "wasm")]
+    #[cfg(any(feature = "wasm", feature = "wasm-system"))]
     Wasm,
 }
 
@@ -736,11 +736,11 @@ impl Parser {
         let version = language.abi_version();
         if (MIN_COMPATIBLE_LANGUAGE_VERSION..=LANGUAGE_VERSION).contains(&version) {
             #[cfg_attr(
-                not(feature = "wasm"),
+                not(any(feature = "wasm", feature = "wasm-system")),
                 expect(unused_variables, reason = "only used when wasm feature is enabled")
             )]
             let success = unsafe { ffi::ts_parser_set_language(self.0.as_ptr(), language.0) };
-            #[cfg(feature = "wasm")]
+            #[cfg(any(feature = "wasm", feature = "wasm-system"))]
             if !success {
                 return Err(LanguageError::Wasm);
             }
@@ -3773,7 +3773,7 @@ impl fmt::Display for LanguageError {
                     "Incompatible language version {version}. Expected minimum {MIN_COMPATIBLE_LANGUAGE_VERSION}, maximum {LANGUAGE_VERSION}",
                 )
             }
-            #[cfg(feature = "wasm")]
+            #[cfg(any(feature = "wasm", feature = "wasm-system"))]
             Self::Wasm => {
                 write!(f, "Failed to load the Wasm store.")
             }

--- a/lib/binding_rust/wasm_language.rs
+++ b/lib/binding_rust/wasm_language.rs
@@ -6,12 +6,17 @@ use std::{
     os::raw::c_char,
 };
 
+#[cfg(not(feature = "wasm-system"))]
 pub use wasmtime_c_api::wasmtime;
+
+#[cfg(feature = "wasm-system")]
+pub use wasmtime;
 
 use crate::{FREE_FN, Language, LanguageError, Parser, ffi};
 
 // Force Cargo to include wasmtime-c-api as a dependency of this crate,
 // even though it is only used by the C code.
+#[cfg(not(feature = "wasm-system"))]
 #[expect(unused, reason = "forces Cargo to link wasmtime-c-api")]
 fn use_wasmtime() {
     wasmtime_c_api::wasm_engine_new();


### PR DESCRIPTION
Allow compiling and linking the system wasmtime using the 'wasm-system' feature.

Have the existing 'wasm' feature and this new 'wasm-system' feature depend on a new '_wasm' feature, which gates all the portions of code which need to be enabled for wasm support.

The alternative to this was renaming the existing feature to 'wasm-bundled', and then making it and 'wasm-system' depend on a common 'wasm'. This is a bit cleaner, but would be a breaking change for all downstream consumers.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below:
  - _figuring out how the cargo-compiled wasmtime was being statically linked (i.e.: finding `DEP_WASMTIME_C_API_INCLUDE` and `fn use_wasmtime`)._