### PR TITLE
fix(lib): use correct TREE_SITTER_HIDE_SYMBOLS macro name in alloc.h

### DIFF
--- a/lib/src/alloc.h
+++ b/lib/src/alloc.h
@@ -9,7 +9,7 @@ extern "C" {
 #include <stdio.h>
 #include <stdlib.h>
 
-#if defined(TREE_SITTER_HIDDEN_SYMBOLS) || defined(_WIN32)
+#if defined(TREE_SITTER_HIDE_SYMBOLS) || defined(_WIN32)
 #define TS_PUBLIC
 #else
 #define TS_PUBLIC __attribute__((visibility("default")))


### PR DESCRIPTION
The `alloc.h` header checked for `TREE_SITTER_HIDDEN_SYMBOLS`, but the canonical macro name used everywhere else (`api.h`, `render.rs`, `setup.py`) is `TREE_SITTER_HIDE_SYMBOLS`. This mismatch meant that defining `TREE_SITTER_HIDE_SYMBOLS` (as the Python binding build does) would not actually hide the allocator symbols in `alloc.h`.

Fixes #5625