### PR TITLE
fix(cli): improve soundness of cst range calculation

### DIFF
--- a/crates/cli/src/parse.rs
+++ b/crates/cli/src/parse.rs
@@ -775,7 +775,11 @@ pub fn render_cst<'a, 'b: 'a>(
     let total_width = lossy_source_code
         .lines()
         .enumerate()
-        .map(|(row, col)| (row as f64).log10() as usize + (col.len() as f64).log10() as usize + 1)
+        .map(|(row, col)| {
+            row.checked_ilog10().unwrap_or(0) as usize
+                + col.len().checked_ilog10().unwrap_or(0) as usize
+                + 1
+        })
         .max()
         .unwrap_or(1);
     let mut indent_level = usize::from(!opts.no_ranges);
@@ -952,8 +956,11 @@ impl std::fmt::Display for CstNodeRange<'_, '_> {
             self.opts.parse_theme.row_color
         };
         let remaining_width = |row: usize, col: usize| {
-            (self.total_width - (row as f64).log10() as usize - (col as f64).log10() as usize)
-                .max(1)
+            (self
+                .total_width
+                .saturating_sub(row.checked_ilog10().unwrap_or(0) as usize)
+                .saturating_sub(col.checked_ilog10().unwrap_or(0) as usize))
+            .max(1)
         };
         let remaining_width_start = remaining_width(start.row, start.column);
         let remaining_width_end = remaining_width(end.row, end.column);


### PR DESCRIPTION
Small patch to address a `cast_sign_loss` clippy lint in the CST rendering logic. While most of the instances of this lint are false positives (for the code in _this_ repo), these instances are actually ones we should be fixed. At a later date, it may be worth it to look through our current allow list in `Cargo.toml` to see if any others are hiding legitimate issues.