### PR TITLE
fix(lib): Consider subtree lookahead bytes when determining whether the parser can reuse a node.

### DIFF
--- a/crates/cli/src/tests/tree_test.rs
+++ b/crates/cli/src/tests/tree_test.rs
@@ -795,3 +795,44 @@ fn get_changed_ranges(
     *tree = new_tree;
     result
 }
+
+// Regression test for an incremental reparse bug where an external
+// scanner's choice depends on lexer->eof() (and thus on the parser's
+// current included ranges). The cached token at byte 0 was emitted when
+// the included range stopped just after the opener. Widening the range
+// to include a later matching delimiter must invalidate that cached
+// token so the scanner re-runs and emits the open form instead of the
+// unclosed form.
+#[test]
+fn test_reuse_invalidates_scanner_token_when_included_range_expands() {
+    let language = get_test_fixture_language("external_lookahead_eof_boundary");
+    let mut parser = Parser::new();
+    parser.set_language(&language).unwrap();
+
+    let source = "``";
+
+    parser
+        .set_included_ranges(&[Range {
+            start_byte: 0,
+            end_byte: 1,
+            start_point: Point::new(0, 0),
+            end_point: Point::new(0, 1),
+        }])
+        .unwrap();
+    let tree1 = parser.parse(source, None).unwrap();
+    assert_eq!(tree1.root_node().to_sexp(), "(document (unclosed_delim))");
+
+    parser
+        .set_included_ranges(&[Range {
+            start_byte: 0,
+            end_byte: 2,
+            start_point: Point::new(0, 0),
+            end_point: Point::new(0, 2),
+        }])
+        .unwrap();
+    let tree2 = parser.parse(source, Some(&tree1)).unwrap();
+    assert_eq!(
+        tree2.root_node().to_sexp(),
+        "(document (span (open_delim) (close_delim)))"
+    );
+}

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -795,7 +795,13 @@ static Subtree ts_parser__reuse_node(
       reason = "is_missing";
     } else if (ts_subtree_is_fragile(result)) {
       reason = "is_fragile";
-    } else if (ts_parser__has_included_range_difference(self, byte_offset, end_byte_offset)) {
+    } else if (ts_parser__has_included_range_difference(
+                 self,
+                 byte_offset,
+                 ts_subtree_is_eof(result)
+                   ? end_byte_offset
+                   : end_byte_offset + ts_subtree_lookahead_bytes(result)
+               )) {
       reason = "contains_different_included_range";
     }
 

--- a/test/fixtures/test_grammars/external_lookahead_eof_boundary/corpus.txt
+++ b/test/fixtures/test_grammars/external_lookahead_eof_boundary/corpus.txt
@@ -1,0 +1,13 @@
+=====================
+opened and closed span
+=====================
+``
+---
+(document (span (open_delim) (close_delim)))
+
+==================
+unclosed delimiter
+==================
+`
+---
+(document (unclosed_delim))

--- a/test/fixtures/test_grammars/external_lookahead_eof_boundary/grammar.js
+++ b/test/fixtures/test_grammars/external_lookahead_eof_boundary/grammar.js
@@ -1,0 +1,15 @@
+// External scanner whose token choice depends on `lexer->eof()`: at a
+// '`' it peeks past mark_end for a matching close, emitting open_delim
+// if one is found or unclosed_delim if eof is reached first. Inside an
+// open span the same '`' is emitted as close_delim.
+
+export default grammar({
+    name: 'external_lookahead_eof_boundary',
+
+    externals: $ => [$.open_delim, $.close_delim, $.unclosed_delim],
+
+    rules: {
+        document: $ => repeat(choice($.span, $.unclosed_delim)),
+        span: $ => seq($.open_delim, $.close_delim),
+    }
+});

--- a/test/fixtures/test_grammars/external_lookahead_eof_boundary/scanner.c
+++ b/test/fixtures/test_grammars/external_lookahead_eof_boundary/scanner.c
@@ -1,0 +1,54 @@
+#include "tree_sitter/parser.h"
+
+enum {
+    OPEN_DELIM,
+    CLOSE_DELIM,
+    UNCLOSED_DELIM,
+};
+
+void *tree_sitter_external_lookahead_eof_boundary_external_scanner_create(void) { return NULL; }
+
+void tree_sitter_external_lookahead_eof_boundary_external_scanner_destroy(void *payload) {}
+
+unsigned tree_sitter_external_lookahead_eof_boundary_external_scanner_serialize(
+    void *payload, char *buffer
+) {
+    return 0;
+}
+
+void tree_sitter_external_lookahead_eof_boundary_external_scanner_deserialize(
+    void *payload, const char *buffer, unsigned length
+) {}
+
+bool tree_sitter_external_lookahead_eof_boundary_external_scanner_scan(
+    void *payload, TSLexer *lexer, const bool *valid_symbols
+) {
+    if (lexer->lookahead != '`') return false;
+
+    lexer->advance(lexer, false);
+    lexer->mark_end(lexer);
+
+    // Mid-span: emit the closer.
+    if (valid_symbols[CLOSE_DELIM]) {
+        lexer->result_symbol = CLOSE_DELIM;
+        return true;
+    }
+
+    // At an opener: peek past mark_end for a matching '`'. The eof()
+    // probe makes the result depend on the current included ranges.
+    if (valid_symbols[OPEN_DELIM]) {
+        while (!lexer->eof(lexer)) {
+            if (lexer->lookahead == '`') {
+                lexer->result_symbol = OPEN_DELIM;
+                return true;
+            }
+            lexer->advance(lexer, false);
+        }
+        if (valid_symbols[UNCLOSED_DELIM]) {
+            lexer->result_symbol = UNCLOSED_DELIM;
+            return true;
+        }
+    }
+
+    return false;
+}


### PR DESCRIPTION
### The Problem

A cached external-scanner token whose lookahead reached the previous range boundary can be incorrectly reused, producing a tree that diverges from a fresh parse of the same buffer.

Stepping through the failing edit from #5636 ("`c \n" -> "`c `\n"):

  1. Before the edit, the inline included range was [0..2). The ` at byte 0 produced an UNCLOSED_SPAN token: size = 1, lookahead_bytes = 1 (the scanner advanced to byte 2 looking for a close, then lexer->eof() returned true).
  2. The text edit at byte 3 propagates through ts_subtree_edit. Its existing lookahead-aware check (subtree.c:734) correctly leaves the cached UNCLOSED_SPAN alone, since the edit is past its lookahead window.
  3. The reparse sets the inline included range to [0..4). ts_range_array_get_changed_ranges produces a diff of [2..4).
  4. ts_parser__reuse_node evaluates the cached UNCLOSED_SPAN and calls ts_parser__has_included_range_difference(self, byte_offset, end_byte_offset) with (0, 1). The intersection check asks "does [2..4) overlap [0..1)?" The answer is no, so the token is reused unchanged.

Step 4 is the bug. The cached token's content spans bytes [0..1), but its validity depends on bytes [0..2), because the scanner's lexer->eof() probe at byte 2 was a real decision input. The check ignores lookahead_bytes entirely.

### The Solution

Include lookahead_bytes in the range passed to `ts_parser__has_included_range_difference`. Now the markdown case checks [2..4) against [0..2), finds an intersection, and rejects the cached token. The scanner re-runs at byte 0, sees the matching ` at byte 3 before eof(), and emits the open/close pair - producing the expected code_span.

- Closes #5636

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

Used Claude 4.7 Opus to investigate the issue and decide where the fix should be made.

<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->