### PR TITLE
feat(generate): derive `Deserialize` on `GenerateError` and all subtypes

### DIFF
--- a/crates/generate/src/build_tables/build_parse_table.rs
+++ b/crates/generate/src/build_tables/build_parse_table.rs
@@ -7,7 +7,7 @@ use std::{
 use indexmap::{IndexMap, map::Entry};
 use log::warn;
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::{
@@ -67,7 +67,7 @@ struct ParseTableBuilder<'a> {
 
 pub type BuildTableResult<T> = Result<T, ParseTableBuilderError>;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum ParseTableBuilderError {
     #[error("Unresolved conflict for symbol sequence:\n\n{0}")]
     Conflict(#[from] ConflictError),
@@ -81,7 +81,7 @@ pub enum ParseTableBuilderError {
     StateCount(usize),
 }
 
-#[derive(Default, Debug, Serialize, Error)]
+#[derive(Default, Debug, Serialize, Error, Deserialize)]
 pub struct ConflictError {
     pub symbol_sequence: Vec<String>,
     pub conflicting_lookahead: String,
@@ -89,7 +89,7 @@ pub struct ConflictError {
     pub possible_resolutions: Vec<Resolution>,
 }
 
-#[derive(Default, Debug, Serialize, Error)]
+#[derive(Default, Debug, Serialize, Error, Deserialize)]
 pub struct Interpretation {
     pub preceding_symbols: Vec<String>,
     pub variable_name: String,
@@ -101,14 +101,14 @@ pub struct Interpretation {
     pub associativity: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum Resolution {
     Precedence { symbols: Vec<String> },
     Associativity { symbols: Vec<String> },
     AddConflict { symbols: Vec<String> },
 }
 
-#[derive(Debug, Serialize, Error)]
+#[derive(Debug, Serialize, Deserialize, Error)]
 pub struct AmbiguousExtraError {
     pub parent_symbols: Vec<String>,
 }

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -12,9 +12,7 @@ use node_types::VariableInfo;
 use rules::{Alias, Symbol};
 #[cfg(feature = "load")]
 use semver::Version;
-#[cfg(feature = "load")]
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 mod bitvec;
@@ -68,7 +66,7 @@ pub const PARSER_HEADER: &str = include_str!("parser.h.inc");
 
 pub type GenerateResult<T> = Result<T, GenerateError>;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum GenerateError {
     #[error("Error with specified path -- {0}")]
     GrammarPath(String),
@@ -94,7 +92,7 @@ pub enum GenerateError {
     SuperTypeCycle(#[from] SuperTypeCycleError),
 }
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub struct IoError {
     pub error: String,
     pub path: Option<String>,
@@ -124,7 +122,7 @@ impl std::fmt::Display for IoError {
 pub type LoadGrammarFileResult<T> = Result<T, LoadGrammarError>;
 
 #[cfg(feature = "load")]
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum LoadGrammarError {
     #[error("Path to a grammar file with `.js` or `.json` extension is required")]
     InvalidPath,
@@ -137,7 +135,7 @@ pub enum LoadGrammarError {
 }
 
 #[cfg(feature = "load")]
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum ParseVersionError {
     #[error("{0}")]
     Version(String),
@@ -151,7 +149,7 @@ pub enum ParseVersionError {
 pub type JSResult<T> = Result<T, JSError>;
 
 #[cfg(feature = "load")]
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum JSError {
     #[error("Failed to run `{runtime}` -- {error}")]
     JSRuntimeSpawn { runtime: String, error: String },

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashMap;
 #[cfg(feature = "load")]
 use rustc_hash::FxHashSet;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::{
@@ -141,7 +141,7 @@ impl ChildQuantity {
 
 pub type VariableInfoResult<T> = Result<T, VariableInfoError>;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum VariableInfoError {
     #[error(
         "Grammar error: Supertype symbols must always have a single visible child, but `{0}` can have multiple"
@@ -453,7 +453,7 @@ pub fn get_supertype_symbol_map(
 #[cfg(feature = "load")]
 pub type SuperTypeCycleResult<T> = Result<T, SuperTypeCycleError>;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub struct SuperTypeCycleError {
     items: Vec<String>,
 }

--- a/crates/generate/src/parse_grammar.rs
+++ b/crates/generate/src/parse_grammar.rs
@@ -113,7 +113,7 @@ pub struct GrammarJSON {
 
 pub type ParseGrammarResult<T> = Result<T, ParseGrammarError>;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum ParseGrammarError {
     #[error("{0}")]
     Serialization(String),

--- a/crates/generate/src/prepare_grammar.rs
+++ b/crates/generate/src/prepare_grammar.rs
@@ -19,7 +19,7 @@ use indexmap::IndexMap;
 pub use intern_symbols::InternSymbolsError;
 pub use process_inlines::ProcessInlinesError;
 use rustc_hash::{FxHashMap, FxHashSet};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 pub use self::expand_tokens::expand_tokens;
@@ -77,7 +77,7 @@ impl<T, U> Default for IntermediateGrammar<T, U> {
 
 pub type PrepareGrammarResult<T> = Result<T, PrepareGrammarError>;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 #[error(transparent)]
 pub enum PrepareGrammarError {
     ValidatePrecedences(#[from] ValidatePrecedenceError),
@@ -91,14 +91,14 @@ pub enum PrepareGrammarError {
 
 pub type ValidatePrecedenceResult<T> = Result<T, ValidatePrecedenceError>;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 #[error(transparent)]
 pub enum ValidatePrecedenceError {
     Undeclared(#[from] UndeclaredPrecedenceError),
     Ordering(#[from] ConflictingPrecedenceOrderingError),
 }
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub struct IndirectRecursionError(pub Vec<String>);
 
 impl std::fmt::Display for IndirectRecursionError {
@@ -114,7 +114,7 @@ impl std::fmt::Display for IndirectRecursionError {
     }
 }
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub struct UndeclaredPrecedenceError {
     pub precedence: String,
     pub rule: String,
@@ -131,7 +131,7 @@ impl std::fmt::Display for UndeclaredPrecedenceError {
     }
 }
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub struct ConflictingPrecedenceOrderingError {
     pub precedence_1: String,
     pub precedence_2: String,

--- a/crates/generate/src/prepare_grammar/expand_tokens.rs
+++ b/crates/generate/src/prepare_grammar/expand_tokens.rs
@@ -2,7 +2,7 @@ use regex_syntax::{
     ParserBuilder,
     hir::{Class, Hir, HirKind},
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::ExtractedLexicalGrammar;
@@ -20,7 +20,7 @@ struct NfaBuilder {
 
 pub type ExpandTokensResult<T> = Result<T, ExpandTokensError>;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum ExpandTokensError {
     #[error(
         "The rule `{0}` matches the empty string.
@@ -35,7 +35,7 @@ unless they are used only as the grammar's start rule.
     ExpandRule(ExpandRuleError),
 }
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub struct ExpandTokensProcessingError {
     rule: String,
     error: ExpandRuleError,
@@ -139,7 +139,7 @@ pub fn expand_tokens(mut grammar: ExtractedLexicalGrammar) -> ExpandTokensResult
 
 pub type ExpandRuleResult<T> = Result<T, ExpandRuleError>;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum ExpandRuleError {
     #[error("Grammar error: Unexpected rule {0:?}")]
     UnexpectedRule(Rule),
@@ -151,7 +151,7 @@ pub enum ExpandRuleError {
 
 pub type ExpandRegexResult<T> = Result<T, ExpandRegexError>;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum ExpandRegexError {
     #[error("{0}")]
     Utf8(String),

--- a/crates/generate/src/prepare_grammar/extract_tokens.rs
+++ b/crates/generate/src/prepare_grammar/extract_tokens.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashMap;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::{ExtractedLexicalGrammar, ExtractedSyntaxGrammar, InternedGrammar};
@@ -11,7 +11,7 @@ use crate::{
 
 pub type ExtractTokensResult<T> = Result<T, ExtractTokensError>;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum ExtractTokensError {
     #[error(
         "The rule `{0}` contains an empty string.
@@ -33,7 +33,7 @@ unless they are used only as the grammar's start rule.
     NonTokenReservedWord(String),
 }
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub struct NonTerminalWordTokenError {
     pub symbol_name: String,
     pub conflicting_symbol_name: Option<String>,

--- a/crates/generate/src/prepare_grammar/flatten_grammar.rs
+++ b/crates/generate/src/prepare_grammar/flatten_grammar.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashMap;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::ExtractedSyntaxGrammar;
@@ -13,7 +13,7 @@ use crate::{
 
 pub type FlattenGrammarResult<T> = Result<T, FlattenGrammarError>;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum FlattenGrammarError {
     #[error("No such reserved word set: {0}")]
     NoReservedWordSet(String),

--- a/crates/generate/src/prepare_grammar/intern_symbols.rs
+++ b/crates/generate/src/prepare_grammar/intern_symbols.rs
@@ -1,5 +1,5 @@
 use log::warn;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::InternedGrammar;
@@ -10,7 +10,7 @@ use crate::{
 
 pub type InternSymbolsResult<T> = Result<T, InternSymbolsError>;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum InternSymbolsError {
     #[error("A grammar's start rule must be visible.")]
     HiddenStartRule,

--- a/crates/generate/src/prepare_grammar/process_inlines.rs
+++ b/crates/generate/src/prepare_grammar/process_inlines.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashMap;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
@@ -190,7 +190,7 @@ impl InlinedProductionMapBuilder {
 
 pub type ProcessInlinesResult<T> = Result<T, ProcessInlinesError>;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum ProcessInlinesError {
     #[error("External token `{0}` cannot be inlined")]
     ExternalToken(String),

--- a/crates/generate/src/render.rs
+++ b/crates/generate/src/render.rs
@@ -8,7 +8,7 @@ use std::{
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::LANGUAGE_VERSION;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::{
@@ -30,7 +30,7 @@ const ABI_VERSION_WITH_RESERVED_WORDS: usize = 15;
 
 pub type RenderResult<T> = Result<T, RenderError>;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum RenderError {
     #[error("Parse table action count {0} exceeds maximum value of {max}", max=u16::MAX)]
     ParseTable(usize),

--- a/crates/generate/src/rules.rs
+++ b/crates/generate/src/rules.rs
@@ -1,11 +1,11 @@
 use std::{collections::BTreeMap, fmt, hash::Hash};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::bitvec::{BitVec, SetBitsIter};
 use super::grammars::VariableType;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum SymbolType {
     External = 0,
     End = 1,
@@ -14,19 +14,19 @@ pub enum SymbolType {
     NonTerminal = 4,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum Associativity {
     Left,
     Right,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Alias {
     pub value: String,
     pub is_named: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default, Serialize, Deserialize)]
 pub enum Precedence {
     #[default]
     None,
@@ -36,7 +36,7 @@ pub enum Precedence {
 
 pub type AliasMap = BTreeMap<Symbol, Alias>;
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct MetadataParams {
     pub precedence: Precedence,
     pub dynamic_precedence: i32,
@@ -47,13 +47,13 @@ pub struct MetadataParams {
     pub field_name: Option<String>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Symbol {
     pub kind: SymbolType,
     pub index: usize,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Rule {
     Blank,
     String(String),


### PR DESCRIPTION
These types all derive `Serialize` already.

Allows for communication of errors across process boundaries, to be used in a future feature.