### PR TITLE
fix(cli): avoid infinite loop on unmatched highlight assertion

### DIFF
--- a/crates/cli/src/test_highlight.rs
+++ b/crates/cli/src/test_highlight.rs
@@ -174,6 +174,14 @@ pub fn iterate_assertions(
 
                 j += 1;
             }
+
+            // Here the inner loop has scanned every highlight that could match this
+            // assertion. If it fell through here (rather than breaking out of
+            // 'highlight_loop), then `i` was not advanced, so re-entering the outer
+            // loop would rescan the same highlights forever causing a hang. The scan
+            // is complete at this point, so we stop because a still-unmatched
+            // assertion is considered a failure.
+            break 'highlight_loop;
         }
 
         if !passed {

--- a/crates/cli/src/tests/test_highlight_test.rs
+++ b/crates/cli/src/tests/test_highlight_test.rs
@@ -4,7 +4,7 @@ use tree_sitter_highlight::{Highlight, Highlighter};
 use super::helpers::fixtures::{get_highlight_config, get_language, test_loader};
 use crate::{
     query_testing::{Assertion, Utf8Point, parse_position_comments},
-    test_highlight::get_highlight_positions,
+    test_highlight::{get_highlight_positions, iterate_assertions},
 };
 
 #[test]
@@ -67,4 +67,16 @@ fn test_highlight_test_with_basic_test() {
             (Utf8Point::new(8, 11), Utf8Point::new(8, 19), Highlight(2)), // "function"
         ]
     );
+}
+
+#[test]
+fn test_highlight_test_unmatched_assertion_fails_without_looping() {
+    // An assertion that matches neither the expected name nor the break
+    // condition must fail, not loop forever (tree-sitter/tree-sitter#5645).
+    let highlight_names = vec!["comment".to_string()];
+    let highlights = vec![(Utf8Point::new(0, 0), Utf8Point::new(0, 4), Highlight(0))];
+    let assertions = vec![Assertion::new(0, 0, 1, false, String::from("x"))];
+
+    let result = iterate_assertions(&assertions, &highlights, &highlight_names);
+    assert!(result.is_err());
 }


### PR DESCRIPTION
Fixes #5645

A non-matching highlight test never advanced to the outer loop resulting in the actual highlights buffer growing until the process ran out of memory. We now break once the inner scan is done so that the assertion fails cleanly.

### AI Policy

- [X] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [X] If AI tools were used: I have disclosed the tool and extent of usage below.

I used AI to develop a prototype to fix. Comments and all words are my own. Code is a mixture of my own and AI. Moreover, I used AI to help me learn what all the terms in tree-sitter mean like "highlight test". I also used AI to help me hunt down the root cause of the problem.