### PR TITLE
Add `ts_query_copy` for cloning queries

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -4268,6 +4268,54 @@ fn test_query_disable_pattern() {
 }
 
 #[test]
+fn test_query_deep_clone() {
+    allocations::record(|| {
+        let language = get_language("javascript");
+        let query = Query::new(
+            &language,
+            "
+                (function_declaration
+                    name: (identifier) @name)
+                (function_declaration
+                    body: (statement_block) @body)
+            ",
+        )
+        .unwrap();
+
+        let mut clone = query.deep_clone();
+        clone.disable_pattern(1);
+
+        let source = "function foo() { return 1; }";
+        let mut parser = Parser::new();
+        parser.set_language(&language).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        let mut cursor = QueryCursor::new();
+
+        // The clone with pattern 1 disabled only produces the @name match.
+        let clone_matches = collect_matches(
+            cursor.matches(&clone, tree.root_node(), source.as_bytes()),
+            &clone,
+            source,
+        );
+        assert_eq!(clone_matches, &[(0, vec![("name", "foo")])]);
+
+        // The original is unaffected and still produces both @name and @body.
+        let original_matches = collect_matches(
+            cursor.matches(&query, tree.root_node(), source.as_bytes()),
+            &query,
+            source,
+        );
+        assert_eq!(
+            original_matches,
+            &[
+                (0, vec![("name", "foo")]),
+                (1, vec![("body", "{ return 1; }")]),
+            ]
+        );
+    });
+}
+
+#[test]
 fn test_query_alternative_predicate_prefix() {
     allocations::record(|| {
         let language = get_language("c");

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -597,6 +597,10 @@ unsafe extern "C" {
     pub fn ts_query_delete(self_: *mut TSQuery);
 }
 unsafe extern "C" {
+    #[doc = " Create a copy of a query."]
+    pub fn ts_query_copy(self_: *const TSQuery) -> *mut TSQuery;
+}
+unsafe extern "C" {
     #[doc = " Get the number of patterns, captures, or string literals in the query."]
     pub fn ts_query_pattern_count(self_: *const TSQuery) -> u32;
 }

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -2908,6 +2908,23 @@ impl Query {
         unsafe { ffi::ts_query_disable_pattern(self.ptr.as_ptr(), index as u32) }
     }
 
+    /// Create a deep copy of this query.
+    ///
+    /// Queries are shareable across threads and cursors without cloning. You
+    /// should only need this when you want an independent copy to mutate (e.g.
+    /// via [`disable_capture`][Query::disable_capture] or
+    /// [`disable_pattern`][Query::disable_pattern]).
+    #[doc(alias = "ts_query_copy")]
+    #[must_use]
+    pub fn deep_clone(&self) -> Self {
+        let ptr = unsafe { ffi::ts_query_copy(self.ptr.as_ptr()) };
+        // SAFETY: from_raw_parts re-derives all Rust-side fields from the C
+        // object. The source string is only used for predicate error row
+        // numbers. Since this is a copy of an already-valid query, it cannot
+        // return an error.
+        unsafe { Self::from_raw_parts(ptr, "").unwrap_unchecked() }
+    }
+
     /// Check if a given pattern within a query has a single root node.
     #[doc(alias = "ts_query_is_pattern_rooted")]
     #[must_use]

--- a/lib/binding_web/lib/exports.txt
+++ b/lib/binding_web/lib/exports.txt
@@ -65,6 +65,7 @@
 "ts_query_capture_count",
 "ts_query_capture_name_for_id",
 "ts_query_captures_wasm",
+"ts_query_copy",
 "ts_query_delete",
 "ts_query_matches_wasm",
 "ts_query_new",

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -924,6 +924,11 @@ TSQuery *ts_query_new(
 void ts_query_delete(TSQuery *self);
 
 /**
+ * Create a copy of a query.
+ */
+TSQuery *ts_query_copy(const TSQuery *self);
+
+/**
  * Get the number of patterns, captures, or string literals in the query.
  */
 uint32_t ts_query_pattern_count(const TSQuery *self);

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -3180,6 +3180,39 @@ void ts_query_delete(TSQuery *self) {
   }
 }
 
+TSQuery *ts_query_copy(const TSQuery *self) {
+  TSQuery *copy = ts_malloc(sizeof(TSQuery));
+  *copy = (TSQuery) {
+    .captures = symbol_table_new(),
+    .predicate_values = symbol_table_new(),
+    .language = ts_language_copy(self->language),
+    .wildcard_root_pattern_count = self->wildcard_root_pattern_count,
+  };
+
+  array_assign(&copy->steps, &self->steps);
+  array_assign(&copy->pattern_map, &self->pattern_map);
+  array_assign(&copy->predicate_steps, &self->predicate_steps);
+  array_assign(&copy->patterns, &self->patterns);
+  array_assign(&copy->step_offsets, &self->step_offsets);
+  array_assign(&copy->negated_fields, &self->negated_fields);
+  array_assign(&copy->string_buffer, &self->string_buffer);
+  array_assign(&copy->repeat_symbols_with_rootless_patterns, &self->repeat_symbols_with_rootless_patterns);
+  array_assign(&copy->captures.characters, &self->captures.characters);
+  array_assign(&copy->captures.slices, &self->captures.slices);
+  array_assign(&copy->predicate_values.characters, &self->predicate_values.characters);
+  array_assign(&copy->predicate_values.slices, &self->predicate_values.slices);
+
+  array_assign(&copy->capture_quantifiers, &self->capture_quantifiers);
+  for (uint32_t i = 0; i < copy->capture_quantifiers.size; i++) {
+    CaptureQuantifiers *dst = array_get(&copy->capture_quantifiers, i);
+    const CaptureQuantifiers *src = array_get(&self->capture_quantifiers, i);
+    *dst = capture_quantifiers_new();
+    array_assign(dst, src);
+  }
+
+  return copy;
+}
+
 uint32_t ts_query_pattern_count(const TSQuery *self) {
   return self->patterns.size;
 }


### PR DESCRIPTION
This allows implementing `Clone for Query` in Rust for example. It's a deep-copy of the entire query object. You may wish to clone a query if you use `ts_query_disable_capture`. One motivation is tags.scm code navigation queries. You may wish to have one query derived from tags.scm which covers definitions and one for references. References are typically significantly more common that definitions, so disabling those captures might save a a fair amount of work when only querying for definition symbols. Instead of initializing the same tags.scm query twice and then disabling, we can save work by cloning the already-built query.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
