### PR TITLE
refactor(.github): quality: Missing await and unchecked array access in

### DIFF
--- a/.github/scripts/close_unresponsive.js
+++ b/.github/scripts/close_unresponsive.js
@@ -32,6 +32,9 @@ module.exports = async ({ github, context }) => {
     );
 
     const latest_response_label = events[events.length - 1];
+    if (!latest_response_label) {
+      continue;
+    }
 
     const created_at = new Date(latest_response_label.created_at);
     const now = new Date();
@@ -39,7 +42,7 @@ module.exports = async ({ github, context }) => {
     const diffDays = diff / (1000 * 60 * 60 * 24);
 
     if (diffDays > numberOfDaysLimit) {
-      github.rest.issues.update({
+      await github.rest.issues.update({
         owner: owner,
         repo: repo,
         issue_number: number,
@@ -47,7 +50,7 @@ module.exports = async ({ github, context }) => {
         state: "closed",
       });
 
-      github.rest.issues.createComment({
+      await github.rest.issues.createComment({
         owner: owner,
         repo: repo,
         issue_number: number,


### PR DESCRIPTION
## Summary

Add `await` to both API calls and guard against an empty `events` array (e.g. `if (events.length === 0) continue;`) before reading the last element.

## Root Cause

Inside the loop, github.rest.issues.update and github.rest.issues.createComment are called without `await`, so failures become unhandled promise rejections and ordering is not guaranteed. Additionally, `events[events.length - 1]` is accessed without checking that `events` is non-empty; if the timeli

## Changes

- `.github/scripts/close_unresponsive.js` — update implementation

## Why

Keeps the change minimal and consistent with the existing .github/scripts layout.

## Risk

MEDIUM. CodeQuality (1 files, ~61 lines)
