### PR TITLE
fix: resolve #2006 — Document libtreesitter ABI to allow other parser generators to target it

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -46,3 +46,4 @@
   - [Playground](./cli/playground.md)
   - [Dump Languages](./cli/dump-languages.md)
   - [Complete](./cli/complete.md)
+- [Parser ABI](./parser-abi.md)


### PR DESCRIPTION
## Summary

The new ABI reference page must be added to the mdBook `SUMMARY.md` so it is rendered into the documentation site and is discoverable. Without this entry the page will not appear in the built book

Fixes #2006

## Changes

- `docs/src/SUMMARY.md`

## Why

`docs/src/SUMMARY.md`: The new ABI reference page must be added to the mdBook `SUMMARY.md` so it is rendered into the documentation site and is discoverable. Without this entry the page will not appear in the built book.
