### PR TITLE
fix: resolve #1309 — Provide documentation for graphviz output

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -28,6 +28,7 @@
 - [Implementation](./5-implementation.md)
 - [Contributing](./6-contributing.md)
 - [Playground](./7-playground.md)
+- [Debugging](./8-debugging.md)
 
 # Reference Guide
 


### PR DESCRIPTION
## Summary

The new page must be referenced from SUMMARY.md so mdBook includes it in the built site. Without this entry the page will not appear in navigation or be built

Fixes #1309

## Changes

- `docs/src/SUMMARY.md`

## Why

`docs/src/SUMMARY.md`: The new page must be referenced from SUMMARY.md so mdBook includes it in the built site. Without this entry the page will not appear in navigation or be built.
