### PR TITLE
fix(cli): highlight test did not properly check for spans on later rows

### DIFF
--- a/crates/cli/src/test_highlight.rs
+++ b/crates/cli/src/test_highlight.rs
@@ -151,7 +151,9 @@ pub fn iterate_assertions(
                 i += 1;
                 continue;
             }
-            if highlight.0.row >= position.row && highlight.0.column > end_column {
+            if (highlight.0.row > position.row)
+                || (highlight.0.row == position.row && highlight.0.column > end_column)
+            {
                 break;
             }
 

--- a/crates/cli/src/tests/test_highlight_test.rs
+++ b/crates/cli/src/tests/test_highlight_test.rs
@@ -242,3 +242,25 @@ fn test_assertions_across_multiple_rows() {
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 2);
 }
+
+#[test]
+fn test_assertion_should_not_match_highlight_on_later_row() {
+    // Test logic for early exit when highlight is on a later row than the assertion
+
+    let highlight_names = vec!["keyword".to_string()];
+
+    let assertions = vec![Assertion::new(0, 5, 3, false, String::from("keyword"))];
+
+    let highlights = vec![
+        (Utf8Point::new(1, 0), Utf8Point::new(1, 5), Highlight(0)), // wrong row
+    ];
+
+    let result = iterate_assertions(&assertions, &highlights, &highlight_names);
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().downcast::<Failure>().unwrap();
+    assert_eq!(err.row, 0);
+    assert_eq!(err.column, 7); // end_column
+    assert_eq!(err.expected_highlight, "keyword");
+    assert_eq!(err.actual_highlights, Vec::<String>::new());
+}


### PR DESCRIPTION
The early exit condition to skip remaining highlights was incorrectly checking the lexicographical order, which could lead to false passes if a highlight was on a later row with smaller column number.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->

I used Claude Code to review my change locally, has been a while since I wrote this, wanted "a second opinion" :), this is the follow up mentioned in #5097.