### PR TITLE
fix(docs): explicitly warn against aliasing supertypes

### DIFF
--- a/docs/src/creating-parsers/3-writing-the-grammar.md
+++ b/docs/src/creating-parsers/3-writing-the-grammar.md
@@ -520,6 +520,13 @@ module.exports = grammar({
 Although supertype rules are hidden from the syntax tree, they can still be used in queries. See the chapter on
 [Query Syntax][query syntax] for more information.
 
+```admonish warning
+Aliasing a supertype rule makes the node in the alias match the supertype in
+name only and will not be treated as a supertype. For `alias($.foo, $.bar)` a
+query targeting `bar` will not transparently match the supertype's subtypes the
+way a query targeting `foo` would.
+```
+
 # Lexical Analysis
 
 Tree-sitter's parsing process is divided into two phases: parsing (which is described above) and [lexing][lexing] — the


### PR DESCRIPTION
Aliases work in name only, they don't automatically make an aliased rule a supertype.

I found a way to check this as part of the generate pipeline, but it requires a recursive walk over all rules in an `InputGrammar`. Furthermore, we're trying to move away from issuing warnings as part of the generate pipeline, as these typically serve more as noise to consumers rather than helpful hints to grammar authors. An upcoming feature will aim to move this kind of warning (and many others) to author-facing tooling better suited for it. 

- Closes #5270
