### PR TITLE
feat(generate): collect warnings as structured data

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -33,7 +33,7 @@ use tree_sitter_cli::{
     wasm,
 };
 use tree_sitter_config::Config;
-use tree_sitter_generate::OptLevel;
+use tree_sitter_generate::{Diagnostic, GenerateError, OptLevel};
 use tree_sitter_highlight::Highlighter;
 use tree_sitter_loader::{self as loader, Bindings, TreeSitterJSON};
 use tree_sitter_tags::TagsContext;
@@ -951,7 +951,8 @@ impl Generate {
             self.json_summary
         };
 
-        if let Err(err) = tree_sitter_generate::generate_parser_in_directory(
+        let mut diagnostics = Vec::new();
+        let result = tree_sitter_generate::generate_parser_in_directory(
             current_dir,
             self.output.as_deref(),
             self.grammar_path.as_deref(),
@@ -964,16 +965,33 @@ impl Generate {
             } else {
                 OptLevel::default()
             },
-        ) {
-            if json_summary {
-                eprintln!("{}", serde_json::to_string_pretty(&err)?);
+            &mut diagnostics,
+        );
+        if json_summary {
+            #[derive(serde::Serialize)]
+            struct Envelope<'a> {
+                diagnostics: &'a [Diagnostic],
+                error: Option<&'a GenerateError>,
+            }
+            let envelope = Envelope {
+                diagnostics: &diagnostics,
+                error: result.as_ref().err(),
+            };
+            eprintln!("{}", serde_json::to_string_pretty(&envelope)?);
+            if result.is_err() {
                 // Exit early to prevent errors from being printed a second time in the caller
                 std::process::exit(1);
-            } else {
+            }
+        } else {
+            for d in &diagnostics {
+                warn!("{d}");
+            }
+            if let Err(err) = result {
                 // Removes extra context associated with the error
                 Err(anyhow!(err.to_string())).with_context(|| "Error when generating parser")?;
             }
         }
+
         if self.build {
             warn!("--build is deprecated, use the `build` command");
             if let Some(path) = self.libdir {

--- a/crates/cli/src/tests.rs
+++ b/crates/cli/src/tests.rs
@@ -30,5 +30,9 @@ pub use helpers::fixtures::get_language;
 /// This is a simple wrapper around [`tree_sitter_generate::generate_parser_for_grammar`], because
 /// our tests do not need to pass in a version number, only the grammar JSON.
 fn generate_parser(grammar_json: &str) -> GenerateResult<(String, String)> {
-    tree_sitter_generate::generate_parser_for_grammar(grammar_json, Some((0, 0, 0)))
+    tree_sitter_generate::generate_parser_for_grammar(
+        grammar_json,
+        Some((0, 0, 0)),
+        &mut Vec::new(),
+    )
 }

--- a/crates/cli/src/tests/corpus_test.rs
+++ b/crates/cli/src/tests/corpus_test.rs
@@ -375,8 +375,11 @@ fn test_feature_corpus_files() {
                 )
             })
             .unwrap();
-        let generate_result =
-            tree_sitter_generate::generate_parser_for_grammar(&grammar_json, Some((0, 0, 0)));
+        let generate_result = tree_sitter_generate::generate_parser_for_grammar(
+            &grammar_json,
+            Some((0, 0, 0)),
+            &mut Vec::new(),
+        );
 
         if error_message_path.exists() {
             if EXAMPLE_INCLUDE.is_some() || EXAMPLE_EXCLUDE.is_some() {

--- a/crates/generate/src/build_tables.rs
+++ b/crates/generate/src/build_tables.rs
@@ -23,7 +23,7 @@ use self::{
     token_conflicts::TokenConflictMap,
 };
 use crate::{
-    OptLevel,
+    Diagnostic, OptLevel,
     grammars::{InlinedProductionMap, LexicalGrammar, SyntaxGrammar},
     nfa::{CharacterSet, NfaCursor},
     node_types::VariableInfo,
@@ -38,6 +38,10 @@ pub struct Tables {
     pub large_character_sets: Vec<(Option<Symbol>, CharacterSet)>,
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "all parameters are required for table building"
+)]
 pub fn build_tables(
     syntax_grammar: &SyntaxGrammar,
     lexical_grammar: &LexicalGrammar,
@@ -46,6 +50,7 @@ pub fn build_tables(
     inlines: &InlinedProductionMap,
     report_symbol_name: Option<&str>,
     optimizations: OptLevel,
+    diagnostics: &mut Vec<Diagnostic>,
 ) -> BuildTableResult<Tables> {
     let item_set_builder = ParseItemSetBuilder::new(syntax_grammar, lexical_grammar, inlines);
     let following_tokens =
@@ -55,6 +60,7 @@ pub fn build_tables(
         lexical_grammar,
         item_set_builder,
         variable_info,
+        diagnostics,
     )?;
     let token_conflict_map = TokenConflictMap::new(lexical_grammar, following_tokens);
     let coincident_token_index = CoincidentTokenIndex::new(&parse_table, lexical_grammar);

--- a/crates/generate/src/build_tables/build_parse_table.rs
+++ b/crates/generate/src/build_tables/build_parse_table.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use indexmap::{IndexMap, map::Entry};
-use log::warn;
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -15,6 +14,7 @@ use super::{
     item_set_builder::ParseItemSetBuilder,
 };
 use crate::{
+    Diagnostic,
     grammars::{LexicalGrammar, PrecedenceEntry, ReservedWordSetId, SyntaxGrammar, VariableType},
     node_types::VariableInfo,
     rules::{Associativity, Precedence, Symbol, SymbolType, TokenSet},
@@ -266,7 +266,10 @@ impl<'a> ParseTableBuilder<'a> {
         }
     }
 
-    fn build(mut self) -> BuildTableResult<(ParseTable, Vec<ParseStateInfo<'a>>)> {
+    fn build(
+        mut self,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> BuildTableResult<(ParseTable, Vec<ParseStateInfo<'a>>)> {
         // Ensure that the empty alias sequence has index 0.
         self.parse_table
             .production_infos
@@ -346,21 +349,13 @@ impl<'a> ParseTableBuilder<'a> {
         }
 
         if !self.actual_conflicts.is_empty() {
-            warn!(
-                "unnecessary conflicts:\n  {}",
-                &self
-                    .actual_conflicts
-                    .iter()
-                    .map(|conflict| {
-                        conflict
-                            .iter()
-                            .map(|symbol| format!("`{}`", self.symbol_name(symbol)))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n  ")
-            );
+            let mut conflicts = self
+                .actual_conflicts
+                .iter()
+                .map(|conf| conf.iter().map(|s| self.symbol_name(s)).collect())
+                .collect::<Vec<_>>();
+            conflicts.sort_unstable();
+            diagnostics.push(Diagnostic::UnnecessaryConflicts(conflicts));
         }
 
         Ok((self.parse_table, self.parse_state_info_by_id))
@@ -1147,6 +1142,7 @@ pub fn build_parse_table<'a>(
     lexical_grammar: &'a LexicalGrammar,
     item_set_builder: ParseItemSetBuilder<'a>,
     variable_info: &'a [VariableInfo],
+    diagnostics: &mut Vec<Diagnostic>,
 ) -> BuildTableResult<(ParseTable, Vec<ParseStateInfo<'a>>)> {
     ParseTableBuilder::new(
         syntax_grammar,
@@ -1154,5 +1150,5 @@ pub fn build_parse_table<'a>(
         item_set_builder,
         variable_info,
     )
-    .build()
+    .build(diagnostics)
 }

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -248,6 +248,62 @@ impl Default for OptLevel {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Diagnostic {
+    UnnecessaryConflicts(Vec<Vec<String>>),
+    UnaryChoice { name: Option<String> },
+    UnarySeq { name: Option<String> },
+    EmptyStringMatch(String),
+    UnsupportedRegexFlag { flag: char, pattern: String },
+}
+
+impl std::fmt::Display for Diagnostic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnnecessaryConflicts(conflicts) => {
+                writeln!(f, "unnecessary conflicts:")?;
+                for (i, conflict) in conflicts.iter().enumerate() {
+                    write!(f, "  ")?;
+                    for (j, symbol) in conflict.iter().enumerate() {
+                        write!(f, "`{symbol}`")?;
+                        if j < conflict.len() - 1 {
+                            write!(f, ", ")?;
+                        }
+                    }
+                    if i < conflicts.len() - 1 {
+                        writeln!(f)?;
+                    }
+                }
+            }
+            Self::UnaryChoice { name } => {
+                write!(
+                    f,
+                    "rule {} contains a `choice` rule with a single element. this is unnecessary.",
+                    name.as_deref().unwrap_or("<ANONYMOUS>")
+                )?;
+            }
+            Self::UnarySeq { name } => {
+                write!(
+                    f,
+                    "rule {} contains a `seq` rule with a single element. this is unnecessary.",
+                    name.as_deref().unwrap_or("<ANONYMOUS>")
+                )?;
+            }
+            Self::EmptyStringMatch(rule) => {
+                write!(
+                    f,
+                    "named extra rule `{rule}` matches the empty string. \
+                     inline this to avoid infinite loops while parsing.",
+                )?;
+            }
+            Self::UnsupportedRegexFlag { flag, pattern } => {
+                write!(f, "unsupported regex flag `{flag}` in pattern `{pattern}`")?;
+            }
+        }
+        Ok(())
+    }
+}
+
 #[cfg(feature = "load")]
 #[expect(
     clippy::too_many_arguments,
@@ -262,6 +318,7 @@ pub fn generate_parser_in_directory<T, U, V>(
     js_runtime: Option<&str>,
     generate_parser: bool,
     optimizations: OptLevel,
+    diagnostics: &mut Vec<Diagnostic>,
 ) -> GenerateResult<()>
 where
     T: Into<PathBuf>,
@@ -316,10 +373,11 @@ where
     }
 
     // If our job is only to generate `grammar.json` and not `parser.c`, stop here.
-    let input_grammar = parse_grammar(&grammar_json)?;
+    let input_grammar = parse_grammar(&grammar_json, diagnostics)?;
 
     if !generate_parser {
-        let node_types_json = generate_node_types_from_grammar(&input_grammar)?.node_types_json;
+        let node_types_json =
+            generate_node_types_from_grammar(&input_grammar, diagnostics)?.node_types_json;
         write_file(&src_path.join("node-types.json"), node_types_json)?;
         return Ok(());
     }
@@ -336,6 +394,7 @@ where
         semantic_version.map(|v| (v.major as u8, v.minor as u8, v.patch as u8)),
         report_symbol_name,
         optimizations,
+        diagnostics,
     )?;
 
     write_file(&src_path.join("parser.c"), c_code)?;
@@ -352,21 +411,26 @@ where
 pub fn generate_parser_for_grammar(
     grammar_json: &str,
     semantic_version: Option<(u8, u8, u8)>,
+    diagnostics: &mut Vec<Diagnostic>,
 ) -> GenerateResult<(String, String)> {
-    let input_grammar = parse_grammar(grammar_json)?;
+    let input_grammar = parse_grammar(grammar_json, diagnostics)?;
     let parser = generate_parser_for_grammar_with_opts(
         &input_grammar,
         LANGUAGE_VERSION,
         semantic_version,
         None,
         OptLevel::default(),
+        diagnostics,
     )?;
     Ok((input_grammar.name, parser.c_code))
 }
 
-fn generate_node_types_from_grammar(input_grammar: &InputGrammar) -> GenerateResult<JSONOutput> {
+fn generate_node_types_from_grammar(
+    input_grammar: &InputGrammar,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> GenerateResult<JSONOutput> {
     let (syntax_grammar, lexical_grammar, inlines, simple_aliases) =
-        prepare_grammar(input_grammar)?;
+        prepare_grammar(input_grammar, diagnostics)?;
     let variable_info =
         node_types::get_variable_info(&syntax_grammar, &lexical_grammar, &simple_aliases)?;
 
@@ -394,6 +458,7 @@ fn generate_parser_for_grammar_with_opts(
     semantic_version: Option<(u8, u8, u8)>,
     report_symbol_name: Option<&str>,
     optimizations: OptLevel,
+    diagnostics: &mut Vec<Diagnostic>,
 ) -> GenerateResult<GeneratedParser> {
     let JSONOutput {
         syntax_grammar,
@@ -403,7 +468,7 @@ fn generate_parser_for_grammar_with_opts(
         variable_info,
         #[cfg(feature = "load")]
         node_types_json,
-    } = generate_node_types_from_grammar(input_grammar)?;
+    } = generate_node_types_from_grammar(input_grammar, diagnostics)?;
     let supertype_symbol_map =
         node_types::get_supertype_symbol_map(&syntax_grammar, &simple_aliases, &variable_info);
     let tables = build_tables(
@@ -414,6 +479,7 @@ fn generate_parser_for_grammar_with_opts(
         &inlines,
         report_symbol_name,
         optimizations,
+        diagnostics,
     )?;
     let c_code = render_c_code(
         &input_grammar.name,

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -2114,7 +2114,7 @@ mod tests {
 
     fn get_node_types(grammar: &InputGrammar) -> SuperTypeCycleResult<Vec<NodeInfoJSON>> {
         let (syntax_grammar, lexical_grammar, _, default_aliases) =
-            prepare_grammar(grammar).unwrap();
+            prepare_grammar(grammar, &mut Vec::new()).unwrap();
         let variable_info =
             get_variable_info(&syntax_grammar, &lexical_grammar, &default_aliases).unwrap();
         generate_node_types_json(

--- a/crates/generate/src/parse_grammar.rs
+++ b/crates/generate/src/parse_grammar.rs
@@ -1,12 +1,12 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use log::warn;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use thiserror::Error;
 
 use crate::{
+    Diagnostic,
     grammars::{InputGrammar, PrecedenceEntry, ReservedWordContext, Variable, VariableType},
     rules::{Precedence, Rule},
 };
@@ -163,7 +163,7 @@ impl InputGrammar {
     /// A variable is "used" if it is the start rule, the word token, named in
     /// `extras`/`externals`, or transitively reachable via rule references from
     /// any of the above.
-    fn normalize(mut self) -> Self {
+    fn normalize(mut self, diagnostics: &mut Vec<Diagnostic>) -> Self {
         // Compute the used set via forward DFS from the implicit roots
         // (start rule, word_token, refs in extras and externals).
         //
@@ -230,11 +230,7 @@ impl InputGrammar {
                 _ => false,
             };
             if matches_empty {
-                warn!(
-                    "Named extra rule `{name}` matches the empty string. \
-                     Inline this to avoid infinite loops while parsing.",
-                    name = v.name,
-                );
+                diagnostics.push(Diagnostic::EmptyStringMatch(v.name.clone()));
             }
         }
 
@@ -295,7 +291,10 @@ fn collect_referenced_names<'a>(rule: &'a Rule, skip_top_level: bool, out: &mut 
     }
 }
 
-pub(crate) fn parse_grammar(input: &str) -> ParseGrammarResult<InputGrammar> {
+pub(crate) fn parse_grammar(
+    input: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> ParseGrammarResult<InputGrammar> {
     let grammar_json = serde_json::from_str::<GrammarJSON>(input)?;
 
     let extra_symbols =
@@ -303,7 +302,7 @@ pub(crate) fn parse_grammar(input: &str) -> ParseGrammarResult<InputGrammar> {
             .extras
             .into_iter()
             .try_fold(Vec::<Rule>::new(), |mut acc, item| {
-                let rule = parse_rule(item, false)?;
+                let rule = parse_rule(item, false, diagnostics)?;
                 if let Rule::String(ref value) = rule
                     && value.is_empty()
                 {
@@ -316,7 +315,7 @@ pub(crate) fn parse_grammar(input: &str) -> ParseGrammarResult<InputGrammar> {
     let external_tokens = grammar_json
         .externals
         .into_iter()
-        .map(|e| parse_rule(e, false))
+        .map(|e| parse_rule(e, false, diagnostics))
         .collect::<ParseGrammarResult<Vec<_>>>()?;
 
     let mut precedence_orderings = Vec::with_capacity(grammar_json.precedences.len());
@@ -339,7 +338,7 @@ pub(crate) fn parse_grammar(input: &str) -> ParseGrammarResult<InputGrammar> {
             Ok(Variable {
                 name,
                 kind: VariableType::Named,
-                rule: parse_rule(serde_json::from_value(r)?, false)?,
+                rule: parse_rule(serde_json::from_value(r)?, false, diagnostics)?,
             })
         })
         .collect::<ParseGrammarResult<Vec<_>>>()?;
@@ -354,7 +353,11 @@ pub(crate) fn parse_grammar(input: &str) -> ParseGrammarResult<InputGrammar> {
 
             let mut reserved_words = Vec::with_capacity(rule_values.len());
             for value in rule_values {
-                reserved_words.push(parse_rule(serde_json::from_value(value)?, false)?);
+                reserved_words.push(parse_rule(
+                    serde_json::from_value(value)?,
+                    false,
+                    diagnostics,
+                )?);
             }
             Ok(ReservedWordContext {
                 name,
@@ -375,36 +378,43 @@ pub(crate) fn parse_grammar(input: &str) -> ParseGrammarResult<InputGrammar> {
         external_tokens,
         reserved_words,
     }
-    .normalize();
+    .normalize(diagnostics);
     Ok(grammar)
 }
 
-fn parse_rule(json: RuleJSON, is_token: bool) -> ParseGrammarResult<Rule> {
+fn parse_rule(
+    json: RuleJSON,
+    is_token: bool,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> ParseGrammarResult<Rule> {
     match json {
         RuleJSON::ALIAS {
             content,
             value,
             named,
-        } => parse_rule(*content, is_token).map(|r| Rule::alias(r, value, named)),
+        } => parse_rule(*content, is_token, diagnostics).map(|r| Rule::alias(r, value, named)),
         RuleJSON::BLANK => Ok(Rule::Blank),
         RuleJSON::STRING { value } => Ok(Rule::String(value)),
-        RuleJSON::PATTERN { value, flags } => Ok(Rule::Pattern(
-            value,
-            flags.map_or(String::new(), |f| {
+        RuleJSON::PATTERN { value, flags } => {
+            let processed_flags = flags.map_or(String::new(), |f| {
                 f.matches(|c| {
                     if c == 'i' {
                         true
                     } else {
                         // silently ignore unicode flags
                         if c != 'u' && c != 'v' {
-                            warn!("unsupported flag {c}");
+                            diagnostics.push(Diagnostic::UnsupportedRegexFlag {
+                                flag: c,
+                                pattern: value.clone(),
+                            });
                         }
                         false
                     }
                 })
                 .collect()
-            }),
-        )),
+            });
+            Ok(Rule::Pattern(value, processed_flags))
+        }
         RuleJSON::SYMBOL { name } => {
             if is_token {
                 Err(ParseGrammarError::UnexpectedRule(name))?
@@ -414,43 +424,44 @@ fn parse_rule(json: RuleJSON, is_token: bool) -> ParseGrammarResult<Rule> {
         }
         RuleJSON::CHOICE { members } => members
             .into_iter()
-            .map(|m| parse_rule(m, is_token))
+            .map(|m| parse_rule(m, is_token, diagnostics))
             .collect::<ParseGrammarResult<Vec<_>>>()
             .map(Rule::choice),
         RuleJSON::FIELD { content, name } => {
-            parse_rule(*content, is_token).map(|r| Rule::field(name, r))
+            parse_rule(*content, is_token, diagnostics).map(|r| Rule::field(name, r))
         }
         RuleJSON::SEQ { members } => members
             .into_iter()
-            .map(|m| parse_rule(m, is_token))
+            .map(|m| parse_rule(m, is_token, diagnostics))
             .collect::<ParseGrammarResult<Vec<_>>>()
             .map(Rule::seq),
-        RuleJSON::REPEAT1 { content } => parse_rule(*content, is_token).map(Rule::repeat),
-        RuleJSON::REPEAT { content } => {
-            parse_rule(*content, is_token).map(|m| Rule::choice(vec![Rule::repeat(m), Rule::Blank]))
+        RuleJSON::REPEAT1 { content } => {
+            parse_rule(*content, is_token, diagnostics).map(Rule::repeat)
         }
+        RuleJSON::REPEAT { content } => parse_rule(*content, is_token, diagnostics)
+            .map(|m| Rule::choice(vec![Rule::repeat(m), Rule::Blank])),
         RuleJSON::PREC { value, content } => {
-            parse_rule(*content, is_token).map(|r| Rule::prec(value.into(), r))
+            parse_rule(*content, is_token, diagnostics).map(|r| Rule::prec(value.into(), r))
         }
         RuleJSON::PREC_LEFT { value, content } => {
-            parse_rule(*content, is_token).map(|r| Rule::prec_left(value.into(), r))
+            parse_rule(*content, is_token, diagnostics).map(|r| Rule::prec_left(value.into(), r))
         }
         RuleJSON::PREC_RIGHT { value, content } => {
-            parse_rule(*content, is_token).map(|r| Rule::prec_right(value.into(), r))
+            parse_rule(*content, is_token, diagnostics).map(|r| Rule::prec_right(value.into(), r))
         }
         RuleJSON::PREC_DYNAMIC { value, content } => {
-            parse_rule(*content, is_token).map(|r| Rule::prec_dynamic(value, r))
+            parse_rule(*content, is_token, diagnostics).map(|r| Rule::prec_dynamic(value, r))
         }
         RuleJSON::RESERVED {
             content,
             context_name,
-        } => parse_rule(*content, is_token).map(|r| Rule::Reserved {
+        } => parse_rule(*content, is_token, diagnostics).map(|r| Rule::Reserved {
             rule: Box::new(r),
             context_name,
         }),
-        RuleJSON::TOKEN { content } => parse_rule(*content, true).map(Rule::token),
+        RuleJSON::TOKEN { content } => parse_rule(*content, true, diagnostics).map(Rule::token),
         RuleJSON::IMMEDIATE_TOKEN { content } => {
-            parse_rule(*content, true).map(Rule::immediate_token)
+            parse_rule(*content, true, diagnostics).map(Rule::immediate_token)
         }
     }
 }
@@ -487,6 +498,7 @@ mod tests {
                 }
             }
         }"#,
+            &mut Vec::new(),
         )
         .unwrap();
 

--- a/crates/generate/src/prepare_grammar.rs
+++ b/crates/generate/src/prepare_grammar.rs
@@ -35,7 +35,7 @@ use super::{
     },
     rules::{AliasMap, Precedence, Rule, Symbol},
 };
-use crate::grammars::ReservedWordContext;
+use crate::{Diagnostic, grammars::ReservedWordContext};
 
 pub struct IntermediateGrammar<T, U> {
     variables: Vec<Variable>,
@@ -152,6 +152,7 @@ impl std::fmt::Display for ConflictingPrecedenceOrderingError {
 /// for parse table construction.
 pub fn prepare_grammar(
     input_grammar: &InputGrammar,
+    diagnostics: &mut Vec<Diagnostic>,
 ) -> PrepareGrammarResult<(
     SyntaxGrammar,
     LexicalGrammar,
@@ -161,7 +162,7 @@ pub fn prepare_grammar(
     validate_precedences(input_grammar)?;
     validate_indirect_recursion(input_grammar)?;
 
-    let interned_grammar = intern_symbols(input_grammar)?;
+    let interned_grammar = intern_symbols(input_grammar, diagnostics)?;
     let (syntax_grammar, lexical_grammar) = extract_tokens(interned_grammar)?;
     let syntax_grammar = expand_repeats(syntax_grammar);
     let mut syntax_grammar = flatten_grammar(syntax_grammar)?;

--- a/crates/generate/src/prepare_grammar/intern_symbols.rs
+++ b/crates/generate/src/prepare_grammar/intern_symbols.rs
@@ -1,9 +1,9 @@
-use log::warn;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::InternedGrammar;
 use crate::{
+    Diagnostic,
     grammars::{InputGrammar, ReservedWordContext, Variable, VariableType},
     rules::{Rule, Symbol},
 };
@@ -24,7 +24,10 @@ pub enum InternSymbolsError {
     UndefinedWordToken(String),
 }
 
-pub(super) fn intern_symbols(grammar: &InputGrammar) -> InternSymbolsResult<InternedGrammar> {
+pub(super) fn intern_symbols(
+    grammar: &InputGrammar,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> InternSymbolsResult<InternedGrammar> {
     let interner = Interner { grammar };
 
     if variable_type_for_name(&grammar.variables[0].name) == VariableType::Hidden {
@@ -36,13 +39,13 @@ pub(super) fn intern_symbols(grammar: &InputGrammar) -> InternSymbolsResult<Inte
         variables.push(Variable {
             name: variable.name.clone(),
             kind: variable_type_for_name(&variable.name),
-            rule: interner.intern_rule(&variable.rule, Some(&variable.name))?,
+            rule: interner.intern_rule(&variable.rule, Some(&variable.name), diagnostics)?,
         });
     }
 
     let mut external_tokens = Vec::with_capacity(grammar.external_tokens.len());
     for external_token in &grammar.external_tokens {
-        let rule = interner.intern_rule(external_token, None)?;
+        let rule = interner.intern_rule(external_token, None, diagnostics)?;
         let (name, kind) = if let Rule::NamedSymbol(name) = external_token {
             (name.clone(), variable_type_for_name(name))
         } else {
@@ -53,7 +56,7 @@ pub(super) fn intern_symbols(grammar: &InputGrammar) -> InternSymbolsResult<Inte
 
     let mut extra_symbols = Vec::with_capacity(grammar.extra_symbols.len());
     for extra_token in &grammar.extra_symbols {
-        extra_symbols.push(interner.intern_rule(extra_token, None)?);
+        extra_symbols.push(interner.intern_rule(extra_token, None, diagnostics)?);
     }
 
     let mut supertype_symbols = Vec::with_capacity(grammar.supertype_symbols.len());
@@ -67,7 +70,7 @@ pub(super) fn intern_symbols(grammar: &InputGrammar) -> InternSymbolsResult<Inte
     for reserved_word_set in &grammar.reserved_words {
         let mut interned_set = Vec::with_capacity(reserved_word_set.reserved_words.len());
         for rule in &reserved_word_set.reserved_words {
-            interned_set.push(interner.intern_rule(rule, None)?);
+            interned_set.push(interner.intern_rule(rule, None, diagnostics)?);
         }
         reserved_words.push(ReservedWordContext {
             name: reserved_word_set.name.clone(),
@@ -129,31 +132,40 @@ struct Interner<'a> {
 }
 
 impl Interner<'_> {
-    fn intern_rule(&self, rule: &Rule, name: Option<&str>) -> InternSymbolsResult<Rule> {
+    fn intern_rule(
+        &self,
+        rule: &Rule,
+        name: Option<&str>,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> InternSymbolsResult<Rule> {
         match rule {
             Rule::Choice(elements) => {
-                Self::check_single(elements, name, "choice");
+                Self::check_single(elements, name, true, diagnostics);
                 let mut result = Vec::with_capacity(elements.len());
                 for element in elements {
-                    result.push(self.intern_rule(element, name)?);
+                    result.push(self.intern_rule(element, name, diagnostics)?);
                 }
                 Ok(Rule::Choice(result))
             }
             Rule::Seq(elements) => {
-                Self::check_single(elements, name, "seq");
+                Self::check_single(elements, name, false, diagnostics);
                 let mut result = Vec::with_capacity(elements.len());
                 for element in elements {
-                    result.push(self.intern_rule(element, name)?);
+                    result.push(self.intern_rule(element, name, diagnostics)?);
                 }
                 Ok(Rule::Seq(result))
             }
-            Rule::Repeat(content) => Ok(Rule::Repeat(Box::new(self.intern_rule(content, name)?))),
+            Rule::Repeat(content) => Ok(Rule::Repeat(Box::new(self.intern_rule(
+                content,
+                name,
+                diagnostics,
+            )?))),
             Rule::Metadata { rule, params } => Ok(Rule::Metadata {
-                rule: Box::new(self.intern_rule(rule, name)?),
+                rule: Box::new(self.intern_rule(rule, name, diagnostics)?),
                 params: params.clone(),
             }),
             Rule::Reserved { rule, context_name } => Ok(Rule::Reserved {
-                rule: Box::new(self.intern_rule(rule, name)?),
+                rule: Box::new(self.intern_rule(rule, name, diagnostics)?),
                 context_name: context_name.clone(),
             }),
             Rule::NamedSymbol(name) => self.intern_name(name).map_or_else(
@@ -184,12 +196,19 @@ impl Interner<'_> {
 
     // In the case of a seq or choice rule of 1 element in a hidden rule, weird
     // inconsistent behavior with queries can occur. So we should warn the user about it.
-    fn check_single(elements: &[Rule], name: Option<&str>, kind: &str) {
+    fn check_single(
+        elements: &[Rule],
+        name: Option<&str>,
+        is_choice: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         if elements.len() == 1 && matches!(elements[0], Rule::String(_) | Rule::Pattern(_, _)) {
-            warn!(
-                "rule {} contains a `{kind}` rule with a single element. This is unnecessary.",
-                name.unwrap_or_default()
-            );
+            let name = name.map(str::to_string);
+            diagnostics.push(if is_choice {
+                Diagnostic::UnaryChoice { name }
+            } else {
+                Diagnostic::UnarySeq { name }
+            });
         }
     }
 }
@@ -208,11 +227,14 @@ mod tests {
 
     #[test]
     fn test_basic_repeat_expansion() {
-        let grammar = intern_symbols(&build_grammar(vec![
-            Variable::named("x", Rule::choice(vec![Rule::named("y"), Rule::named("_z")])),
-            Variable::named("y", Rule::named("_z")),
-            Variable::named("_z", Rule::string("a")),
-        ]))
+        let grammar = intern_symbols(
+            &build_grammar(vec![
+                Variable::named("x", Rule::choice(vec![Rule::named("y"), Rule::named("_z")])),
+                Variable::named("y", Rule::named("_z")),
+                Variable::named("_z", Rule::string("a")),
+            ]),
+            &mut Vec::new(),
+        )
         .unwrap();
 
         assert_eq!(
@@ -244,7 +266,7 @@ mod tests {
             .external_tokens
             .extend(vec![Rule::named("y"), Rule::named("z")]);
 
-        let grammar = intern_symbols(&input_grammar).unwrap();
+        let grammar = intern_symbols(&input_grammar, &mut Vec::new()).unwrap();
 
         // Variable `y` is referred to by its internal index.
         // Variable `z` is referred to by its external index.
@@ -276,7 +298,10 @@ mod tests {
 
     #[test]
     fn test_grammar_with_undefined_symbols() {
-        let result = intern_symbols(&build_grammar(vec![Variable::named("x", Rule::named("y"))]));
+        let result = intern_symbols(
+            &build_grammar(vec![Variable::named("x", Rule::named("y"))]),
+            &mut Vec::new(),
+        );
 
         assert!(result.is_err(), "Expected an error but got none");
         let e = result.err().unwrap();


### PR DESCRIPTION
The generate crate is presented as a library, but was really written for just tree-sitter-cli. We've taken some incremental steps along the way to clean up some rough edges in this regard already, namely returning structured errors via `thiserror`  instead of `anyhow`'s loose display only info. 

Today, the generate crate prints warnings for 4 separate non-fatal issue points throughout parser generation. These warnings are unconditionally sent to stderr via `log`, and aren't accessible at all to library consumers. Furthermore, these prints to stderr clash unintuitively with the CLI's `--json` flag. 

Most of these errors are fairly easy to detect by examining the grammar definition, besides the unnecessary conflicts warning which requires a non-trivial amount of logic to run first. It makes sense to gather this warning information as structured data so that it can both be displayed regularly, displayed as JSON, or consumed programmatically by projects depending on `tree-sitter-generate`. 