### PR TITLE
fix(lib): address strict aliasing violations in `TreeCursor` type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,7 +211,7 @@ jobs:
         make -j CFLAGS="$CFLAGS" CC=$CC AR=$AR
       env:
         PLATFORM: ${{ matrix.platform }}
-        CFLAGS: -g -Werror -Wall -Wextra -Wshadow -Wpedantic -Werror=incompatible-pointer-types
+        CFLAGS: -g -Werror -Wall -Wextra -Wshadow -Wpedantic -Werror=incompatible-pointer-types -Werror=strict-aliasing -Wstrict-aliasing=2
 
     - name: Build C library (CMake)
       if: "!matrix.cross && !matrix.vm"

--- a/.github/workflows/wasm_exports.yml
+++ b/.github/workflows/wasm_exports.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build C library (make)
         run: make -j CFLAGS="$CFLAGS"
         env:
-          CFLAGS: -g -Werror -Wall -Wextra -Wshadow -Wpedantic -Werror=incompatible-pointer-types
+          CFLAGS: -g -Werror -Wall -Wextra -Wshadow -Wpedantic -Werror=incompatible-pointer-types -Werror=strict-aliasing -Wstrict-aliasing=2
 
       - name: Build Wasm Library
         working-directory: lib/binding_web

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,8 @@ if(MSVC)
 else()
   target_compile_options(tree-sitter PRIVATE
                          -Wall -Wextra -Wshadow -Wpedantic
-                         -Werror=incompatible-pointer-types)
+                         -Werror=incompatible-pointer-types
+                         -Werror=strict-aliasing -Wstrict-aliasing=2)
 endif()
 
 if(TREE_SITTER_FEATURE_WASM)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ OBJ := $(SRC:.c=.o)
 
 # define default flags, and override to append mandatory flags
 ARFLAGS := rcs
-CFLAGS ?= -O3 -Wall -Wextra -Wshadow -Wpedantic -Werror=incompatible-pointer-types
+CFLAGS ?= -O3 -Wall -Wextra -Wshadow -Wpedantic -Werror=incompatible-pointer-types -Werror=strict-aliasing -Wstrict-aliasing=2
 override CFLAGS += -std=c11 -fPIC -fvisibility=hidden
 override CFLAGS += -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_DARWIN_C_SOURCE
 override CFLAGS += -Ilib/src -Ilib/src/wasm -Ilib/include

--- a/lib/binding_rust/build.rs
+++ b/lib/binding_rust/build.rs
@@ -39,7 +39,7 @@ fn main() {
     }
 
     config
-        .flag_if_supported("-std=c11")
+        .std("c11")
         .flag_if_supported("-fvisibility=hidden")
         .flag_if_supported("-Wshadow")
         .flag_if_supported("-Wno-unused-parameter")

--- a/lib/src/tree_cursor.c
+++ b/lib/src/tree_cursor.c
@@ -3,6 +3,11 @@
 #include "./language.h"
 #include "./tree.h"
 
+_Static_assert(
+  sizeof(TreeCursor) <= sizeof(TSTreeCursor),
+  "TreeCursor must fit within TSTreeCursor"
+);
+
 typedef struct {
   Subtree parent;
   const TSTree *tree;
@@ -153,8 +158,10 @@ static inline bool ts_tree_cursor_child_iterator_previous(
 // TSTreeCursor - lifecycle
 
 TSTreeCursor ts_tree_cursor_new(TSNode node) {
-  TSTreeCursor self = {NULL, NULL, {0, 0, 0}};
-  ts_tree_cursor_init((TreeCursor *)&self, node);
+  TreeCursor cursor = {0};
+  ts_tree_cursor_init(&cursor, node);
+  TSTreeCursor self = {0};
+  memcpy(&self, &cursor, sizeof(cursor));
   return self;
 }
 
@@ -697,12 +704,13 @@ const char *ts_tree_cursor_current_field_name(const TSTreeCursor *_self) {
 
 TSTreeCursor ts_tree_cursor_copy(const TSTreeCursor *_cursor) {
   const TreeCursor *cursor = (const TreeCursor *)_cursor;
-  TSTreeCursor res = {NULL, NULL, {0, 0}};
-  TreeCursor *copy = (TreeCursor *)&res;
-  copy->tree = cursor->tree;
-  copy->root_alias_symbol = cursor->root_alias_symbol;
-  array_init(&copy->stack);
-  array_push_all(&copy->stack, &cursor->stack);
+  TreeCursor copy = {0};
+  copy.tree = cursor->tree;
+  copy.root_alias_symbol = cursor->root_alias_symbol;
+  array_init(&copy.stack);
+  array_push_all(&copy.stack, &cursor->stack);
+  TSTreeCursor res = {0};
+  memcpy(&res, &copy, sizeof(copy));
   return res;
 }
 


### PR DESCRIPTION
This addresses the remaining strict aliasing violations in the core C library. Instead of type casting pointers between the internal `TreeCursor` and public facing `TSTreeCursor`, we instead just zero initialize and `memcpy` over. A `_Static_assert` is added to ensure that `TSTreeCursor` is greater than or equal to `TreeCursor` in size. This ensures both `memcpy`s never read OOB, but still allows usage on architectures where the two aren't identical in size (i.e. m68k). In addition to the code fix, I also added some build flags to guard against future regressions in this area.

This will cause compilation to fail on targets where `alignof(void*) > 2*sizeof(uint32_t)` (see https://github.com/tree-sitter/tree-sitter/issues/4960#issuecomment-3707523955). While a build error isn't great, silent data corruption (the situation today on those targets) is much much worse.

If, sometime in the future, we're able to add said architectures to our CI matrix (or at the very least, we gain access to a machine to test builds on as needed), some fixes can be made to ensure compatibility across the board. One solution I saw (but did not implement for this PR, as we have no means of testing it) is to inline the `Array` fields for `TreeCursor`'s `stack` field. This would eliminate any problematic struct padding for the array, and should work with the existing `array_` macros we use today because they just duck-type the `contents`, `size`, and `capacity` fields.

- Closes #5259

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

Used Clause Opus 4.8 to discuss solutions and look into the effects on unconventional architectures (i..e CHERI and m68k).
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
