### PR TITLE
feat(query): add #has-ancestor? / #capture-ancestor? predicates

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -418,6 +418,48 @@ fn test_query_errors_on_invalid_predicates() {
 }
 
 #[test]
+fn test_query_errors_on_invalid_ancestor_predicates() {
+    allocations::record(|| {
+        let language = get_language("javascript");
+
+        // An unresolved ancestor type name is a NodeType error (precise offset),
+        // not a silently-ignored predicate.
+        assert_eq!(
+            Query::new(
+                &language,
+                "((identifier) @x (#has-ancestor? @x not_a_real_node))",
+            )
+            .unwrap_err()
+            .kind,
+            QueryErrorKind::NodeType,
+        );
+        assert_eq!(
+            Query::new(
+                &language,
+                "((identifier) @x (#capture-ancestor? @x bogus_node @c))",
+            )
+            .unwrap_err()
+            .kind,
+            QueryErrorKind::NodeType,
+        );
+
+        // Malformed arity / argument order is a Syntax error.
+        for q in [
+            "((identifier) @x (#has-ancestor? @x))", // no type
+            "((identifier) @x (#has-ancestor? statement_block @x))", // anchor not first
+            "((identifier) @x (#capture-ancestor? @x class_declaration))", // missing output
+            "((identifier) @x (#capture-ancestor? @x @c class_declaration))", // wrong order
+        ] {
+            assert_eq!(
+                Query::new(&language, q).unwrap_err().kind,
+                QueryErrorKind::Syntax,
+                "query should be a syntax error: {q}",
+            );
+        }
+    });
+}
+
+#[test]
 fn test_query_errors_on_impossible_patterns() {
     let js_lang = get_language("javascript");
     let rb_lang = get_language("ruby");
@@ -648,6 +690,96 @@ fn test_query_matches_with_simple_pattern() {
                 (0, vec![("fn-name", "one")]),
                 (0, vec![("fn-name", "three")]),
             ],
+        );
+    });
+}
+
+#[test]
+fn test_query_has_ancestor_predicate() {
+    allocations::record(|| {
+        let language = get_language("javascript");
+
+        // `#has-ancestor?` scopes a capture to nodes nested -- at any depth --
+        // inside an enclosing node of the given type. Here only the identifier
+        // within a method body's `statement_block` survives; the class name and
+        // the top-level binding are excluded.
+        let query = Query::new(
+            &language,
+            "((identifier) @x (#has-ancestor? @x statement_block))",
+        )
+        .unwrap();
+
+        assert_query_matches(
+            &language,
+            &query,
+            "class A { foo() { let inside = 1; } }\nlet outside = 2;\n",
+            &[(0, vec![("x", "inside")])],
+        );
+    });
+}
+
+#[test]
+fn test_query_capture_ancestor_predicate() {
+    allocations::record(|| {
+        let language = get_language("javascript");
+
+        // `#capture-ancestor?` gates like `#has-ancestor?` but also binds the
+        // matched ancestor to a fresh capture, so ordinary text predicates can
+        // inspect the enclosing context (e.g. a builder's name). The bound
+        // ancestor is appended after the anchor capture.
+        let query = Query::new(
+            &language,
+            "((identifier) @x (#capture-ancestor? @x class_declaration @ctx))",
+        )
+        .unwrap();
+
+        let class = "class A { foo() { let inside = 1; } }";
+        assert_query_matches(
+            &language,
+            &query,
+            "class A { foo() { let inside = 1; } }\nlet outside = 2;\n",
+            &[
+                (0, vec![("x", "A"), ("ctx", class)]),
+                (0, vec![("x", "inside"), ("ctx", class)]),
+            ],
+        );
+    });
+}
+
+#[test]
+fn test_query_ancestor_predicate_on_streaming_capture_path() {
+    allocations::record(|| {
+        let language = get_language("javascript");
+
+        // `(array "[" ... "]")` is a *guaranteed* pattern: the `[` capture is
+        // streamed by `captures()` before the pattern finishes at `]`. An
+        // ancestor constraint can still reject the (structurally complete)
+        // match at finish time, so the guarantee must be suppressed -- otherwise
+        // the definite `[` capture leaks before the ancestor is ever checked.
+        let query = Query::new(
+            &language,
+            r#"((array "[" @lb "]" @rb) (#has-ancestor? @lb function_declaration))"#,
+        )
+        .unwrap();
+
+        let mut parser = Parser::new();
+        parser.set_language(&language).unwrap();
+
+        // Array with no enclosing function: nothing may be captured.
+        let source = "let a = [1, 2, 3];\n";
+        let tree = parser.parse(source, None).unwrap();
+        let mut cursor = QueryCursor::new();
+        let captures = cursor.captures(&query, tree.root_node(), source.as_bytes());
+        assert!(collect_captures(captures, &query, source).is_empty());
+
+        // Same array inside a function: both brackets are captured.
+        let source = "function f() { let a = [1]; }\n";
+        let tree = parser.parse(source, None).unwrap();
+        let mut cursor = QueryCursor::new();
+        let captures = cursor.captures(&query, tree.root_node(), source.as_bytes());
+        assert_eq!(
+            collect_captures(captures, &query, source),
+            vec![("lb", "["), ("rb", "]")],
         );
     });
 }

--- a/docs/src/using-parsers/queries/3-predicates-and-directives.md
+++ b/docs/src/using-parsers/queries/3-predicates-and-directives.md
@@ -126,6 +126,58 @@ to determine whether a given node is a local variable or not, for example:
 
 This pattern would match any builtin variable that is not a local variable, because the `#is-not? local` predicate is used.
 
+## The `has-ancestor?` predicate
+
+The `has-ancestor?` predicate keeps a match only when the captured node is nested — at any depth —
+inside an enclosing node whose type is one of the given node types. It takes a capture followed by
+one or more node-type names, and matches if _any_ of those types is found among the node's
+ancestors. This lets you scope a pattern to its surrounding context without writing out the full
+nesting.
+
+It is useful when a node only takes on a special meaning inside a particular construct. For example,
+this pattern highlights `this` only when it appears inside a class body, leaving top-level uses alone:
+
+```query
+((this) @variable.builtin
+  (#has-ancestor? @variable.builtin class_body))
+```
+
+Multiple node types act as an "any-of" set. The nearest matching ancestor is the one that counts,
+which mirrors the way innermost scopes shadow outer ones.
+
+```query
+((identifier) @local
+  (#has-ancestor? @local statement_block function_declaration))
+```
+
+## The `capture-ancestor?` predicate
+
+The `capture-ancestor?` predicate works like `#has-ancestor?`, but it also _binds_ the matched
+ancestor to a new capture, so you can then apply ordinary text predicates (`#eq?`, `#match?`,
+`#any-of?`) to the enclosing context. It takes exactly three arguments: the capture to test, a single
+ancestor node type, and the output capture that receives the matched ancestor.
+
+This is what you need when several constructs parse to the same node type and you must tell them
+apart by their text. In the illustration below (for a grammar where many builder-style blocks share a
+single `builder_block` node), a set of identifiers should be treated as keywords only inside the
+`query` builder:
+
+```query
+((identifier) @keyword.operator
+  (#any-of? @keyword.operator "select" "where" "join" "group" "order")
+  (#capture-ancestor? @keyword.operator builder_block @_block)
+  (#match? @_block "^query\\b"))
+```
+
+The match is dropped entirely when no ancestor of the given type exists, so the following text
+predicate is never evaluated against an empty capture.
+
+Both `#has-ancestor?` and `#capture-ancestor?` are enforced by the Tree-sitter library itself during
+matching (see the note at the end of this page), rather than by higher-level bindings, so they behave
+identically across every binding. They consider only node types in the syntax tree, never the source
+text — any text condition on the enclosing node is expressed with the standard predicates applied to
+the captured ancestor.
+
 # Directives
 
 Similar to predicates, directives are a way to associate arbitrary metadata with a pattern. The only difference between
@@ -174,6 +226,10 @@ To recap about the predicates and directives Tree-sitter's bindings support:
 
 - `#is?` checks for a property on a capture
 
+- `#has-ancestor?` keeps a match only when the captured node is nested inside one of the given ancestor node types
+
+- `#capture-ancestor?` does the same and binds the matched ancestor to a capture, so it can be tested with the predicates above
+
 - Adding `not-` to the beginning of these predicates will negate the match
 
 - By default, a quantified capture will only match if _all_ the nodes match the predicate
@@ -187,13 +243,18 @@ To recap about the predicates and directives Tree-sitter's bindings support:
 - `#strip!` removes text from a capture
 
 ```admonish info
-Predicates and directives are not handled directly by the Tree-sitter C library.
+Most predicates and directives are not handled directly by the Tree-sitter C library.
 They are just exposed in a structured form so that higher-level code can perform
-the filtering. However, higher-level bindings to Tree-sitter like
+the filtering. Higher-level bindings to Tree-sitter like
 [the Rust Crate][rust crate]
 or the [WebAssembly binding][wasm binding]
 do implement a few common predicates like those explained above. In the future, more "standard" predicates and directives
 may be added.
+
+The `#has-ancestor?` and `#capture-ancestor?` predicates are the exception: because they depend only
+on the structure of the syntax tree (not the source text), they are enforced by the C library itself
+while the query is matched. As a result they apply uniformly in every binding, and a binding does not
+need to implement them to get correct results.
 ```
 
 [cgo]: https://pkg.go.dev/cmd/cgo

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -292,6 +292,33 @@ typedef struct {
 } StatePredecessorMap;
 
 /*
+ * AncestorConstraint - the compiled form of a `#has-ancestor?` or
+ * `#capture-ancestor?` predicate. These let a pattern require that a captured
+ * node be nested (at any depth) inside an enclosing node of a given type --
+ * the structural context needed to scope keywords/operators to a monadic
+ * builder block (F# computation expressions, Haskell `do`, OCaml binding
+ * operators, Scala for-comprehensions, ...).
+ *
+ * Enforced structurally at match-finish time by walking the parents of the
+ * anchor capture's node. This keeps the feature in the shared core matcher --
+ * every language binding inherits it for free -- and relies only on tree
+ * structure (node symbols), never on source text. Any text condition on the
+ * enclosing builder (e.g. its name == "query") is layered on top via the
+ * binding's existing `#eq?`/`#any-of?` predicates, which operate on the
+ * ancestor node bound by `#capture-ancestor?`.
+ */
+typedef struct {
+  uint16_t pattern_index;
+  uint16_t anchor_capture_id;
+  uint16_t out_capture_id; // NONE for `#has-ancestor?` (a gate with no binding)
+  // The accepted ancestor types, stored as a slice of `TSQuery.ancestor_symbols`
+  // (any-of semantics). `#has-ancestor?` allows several; `#capture-ancestor?`
+  // has exactly one.
+  uint32_t symbol_offset;
+  uint16_t symbol_count;
+} AncestorConstraint;
+
+/*
  * TSQuery - A tree query, compiled from a string of S-expressions. The query
  * itself is immutable. The mutable state used in the process of executing the
  * query is stored in a `TSQueryCursor`.
@@ -308,6 +335,8 @@ struct TSQuery {
   Array(TSFieldId) negated_fields;
   Array(char) string_buffer;
   Array(TSSymbol) repeat_symbols_with_rootless_patterns;
+  Array(AncestorConstraint) ancestor_constraints;
+  Array(TSSymbol) ancestor_symbols;
   const TSLanguage *language;
   uint16_t wildcard_root_pattern_count;
 };
@@ -614,10 +643,98 @@ static void finished_state_erase(
   }
 }
 
+// Check the `#has-ancestor?` / `#capture-ancestor?` constraints for a finished
+// state's pattern. For each constraint, the anchor capture's node is walked
+// upward until a node of an accepted ancestor type is found (nearest match
+// wins, mirroring the innermost-builder rule). If none is found the match is
+// rejected. For `#capture-ancestor?` the matched ancestor is appended to the
+// state's capture list so the binding's text predicates can inspect it.
+static bool ts_query_cursor__satisfies_ancestor_constraints(
+  TSQueryCursor *self,
+  const QueryState *state
+) {
+  const TSQuery *query = self->query;
+  if (query->ancestor_constraints.size == 0) return true;
+
+  // Fast path: most patterns have no ancestor constraints.
+  bool has_constraint = false;
+  for (uint32_t i = 0; i < query->ancestor_constraints.size; i++) {
+    if (array_get(&query->ancestor_constraints, i)->pattern_index == state->pattern_index) {
+      has_constraint = true;
+      break;
+    }
+  }
+  if (!has_constraint) return true;
+
+  // A constrained pattern must have captured its anchor, so it must own a
+  // capture list. If it doesn't, the constraint cannot be satisfied.
+  if (state->capture_list_id == CAPTURE_LIST_NONE) return false;
+
+  CaptureList *captures = capture_list_pool_get_mut(
+    &self->capture_list_pool, state->capture_list_id
+  );
+
+  for (uint32_t i = 0; i < query->ancestor_constraints.size; i++) {
+    const AncestorConstraint *constraint =
+      array_get(&query->ancestor_constraints, i);
+    if (constraint->pattern_index != state->pattern_index) continue;
+
+    // Locate the anchor node among the state's captures.
+    TSNode anchor;
+    bool found_anchor = false;
+    for (uint32_t c = 0; c < captures->size; c++) {
+      TSQueryCapture *capture = array_get(captures, c);
+      if (capture->index == constraint->anchor_capture_id) {
+        anchor = capture->node;
+        found_anchor = true;
+        break;
+      }
+    }
+    if (!found_anchor) return false;
+
+    // Walk ancestors looking for an accepted type (nearest wins).
+    const TSSymbol *symbols =
+      array_get(&query->ancestor_symbols, constraint->symbol_offset);
+    TSNode ancestor = ts_node_parent(anchor);
+    bool matched = false;
+    while (!ts_node_is_null(ancestor)) {
+      TSSymbol symbol = ts_node_symbol(ancestor);
+      for (uint16_t s = 0; s < constraint->symbol_count; s++) {
+        if (symbol == symbols[s]) {
+          matched = true;
+          break;
+        }
+      }
+      if (matched) break;
+      ancestor = ts_node_parent(ancestor);
+    }
+    if (!matched) return false;
+
+    if (constraint->out_capture_id != NONE) {
+      array_push(captures, ((TSQueryCapture) {
+        .node = ancestor,
+        .index = constraint->out_capture_id,
+      }));
+      // array_push may reallocate; refresh the pointer for later iterations.
+      captures = capture_list_pool_get_mut(
+        &self->capture_list_pool, state->capture_list_id
+      );
+    }
+  }
+
+  return true;
+}
+
 static void ts_query_cursor__push_finished_state(
   TSQueryCursor *self,
   QueryState *state
 ) {
+  // Drop the match if it fails its structural ancestor constraints. The
+  // caller transfers capture-list ownership to us, so release it on rejection.
+  if (!ts_query_cursor__satisfies_ancestor_constraints(self, state)) {
+    capture_list_pool_release(&self->capture_list_pool, state->capture_list_id);
+    return;
+  }
   state->heap_insert_order = self->next_finished_state_id++;
   array_push(&self->finished_states, *state);
 }
@@ -2277,10 +2394,48 @@ static TSQueryError ts_query__parse_predicate(
   }));
   stream_skip_whitespace(stream);
 
+  // The ancestor predicates carry structural meaning that the core enforces,
+  // so they are validated here (arity, argument order, and that each type name
+  // resolves to a grammar symbol) instead of being silently ignored later.
+  // `#capture-ancestor?` also introduces a brand-new capture -- its 2nd capture
+  // argument binds the matched ancestor -- which is registered on demand rather
+  // than required to already appear on a node in the pattern.
+  bool is_has_ancestor =
+    length == 13 && memcmp(predicate_name, "has-ancestor?", 13) == 0;
+  bool is_capture_ancestor =
+    length == 17 && memcmp(predicate_name, "capture-ancestor?", 17) == 0;
+  bool is_ancestor = is_has_ancestor || is_capture_ancestor;
+  uint32_t arg_index = 0;
+  uint32_t capture_arg_count = 0;
+  uint32_t type_arg_count = 0;
+  bool first_arg_is_capture = false;
+  bool last_arg_is_capture = false;
+
   for (;;) {
+    const char *arg_start = stream->input;
+
     if (stream->next == ')') {
       stream_advance(stream);
       stream_skip_whitespace(stream);
+
+      // Validate ancestor-predicate shape now that all arguments are known.
+      // `#has-ancestor?`: (anchor-capture type+) -- the anchor first, then one
+      // or more node types. `#capture-ancestor?`: (anchor-capture type
+      // output-capture) -- exactly one type, bracketed by the two captures.
+      if (
+        (is_has_ancestor && !(
+          arg_index >= 2 && first_arg_is_capture &&
+          capture_arg_count == 1 && type_arg_count >= 1
+        )) ||
+        (is_capture_ancestor && !(
+          arg_index == 3 && first_arg_is_capture && last_arg_is_capture &&
+          capture_arg_count == 2 && type_arg_count == 1
+        ))
+      ) {
+        stream_reset(stream, predicate_name);
+        return TSQueryErrorSyntax;
+      }
+
       array_push(&self->predicate_steps, ((TSQueryPredicateStep) {
         .type = TSQueryPredicateStepTypeDone,
         .value_id = 0,
@@ -2298,16 +2453,30 @@ static TSQueryError ts_query__parse_predicate(
       stream_scan_identifier(stream);
       uint32_t capture_length = (uint32_t)(stream->input - capture_name);
 
-      // Add the capture id to the first step of the pattern
-      int capture_id = symbol_table_id_for_name(
-        &self->captures,
-        capture_name,
-        capture_length
-      );
-      if (capture_id == -1) {
-        stream_reset(stream, capture_name);
-        return TSQueryErrorCapture;
+      // Resolve the capture id. The output capture of `#capture-ancestor?`
+      // is registered on demand; every other capture must already be defined.
+      int capture_id;
+      if (is_capture_ancestor && capture_arg_count == 1) {
+        capture_id = (int)symbol_table_insert_name(
+          &self->captures,
+          capture_name,
+          capture_length
+        );
+      } else {
+        capture_id = symbol_table_id_for_name(
+          &self->captures,
+          capture_name,
+          capture_length
+        );
+        if (capture_id == -1) {
+          stream_reset(stream, capture_name);
+          return TSQueryErrorCapture;
+        }
       }
+      if (arg_index == 0) first_arg_is_capture = true;
+      last_arg_is_capture = true;
+      capture_arg_count++;
+      arg_index++;
 
       array_push(&self->predicate_steps, ((TSQueryPredicateStep) {
         .type = TSQueryPredicateStepTypeCapture,
@@ -2319,11 +2488,25 @@ static TSQueryError ts_query__parse_predicate(
     else if (stream->next == '"') {
       TSQueryError e = ts_query__parse_string_literal(self, stream);
       if (e) return e;
+      // In an ancestor predicate, every non-capture argument names an ancestor
+      // node type and must resolve to a grammar symbol.
+      if (is_ancestor && !ts_language_symbol_for_name(
+        self->language, self->string_buffer.contents, self->string_buffer.size, true
+      ) && !ts_language_symbol_for_name(
+        self->language, self->string_buffer.contents, self->string_buffer.size, false
+      )) {
+        stream_reset(stream, arg_start);
+        return TSQueryErrorNodeType;
+      }
       uint16_t query_id = symbol_table_insert_name(
         &self->predicate_values,
         self->string_buffer.contents,
         self->string_buffer.size
       );
+      if (arg_index == 0) first_arg_is_capture = false;
+      last_arg_is_capture = false;
+      type_arg_count++;
+      arg_index++;
       array_push(&self->predicate_steps, ((TSQueryPredicateStep) {
         .type = TSQueryPredicateStepTypeString,
         .value_id = query_id,
@@ -2335,11 +2518,23 @@ static TSQueryError ts_query__parse_predicate(
       const char *symbol_start = stream->input;
       stream_scan_identifier(stream);
       uint32_t symbol_length = (uint32_t)(stream->input - symbol_start);
+      if (is_ancestor && !ts_language_symbol_for_name(
+        self->language, symbol_start, symbol_length, true
+      ) && !ts_language_symbol_for_name(
+        self->language, symbol_start, symbol_length, false
+      )) {
+        stream_reset(stream, arg_start);
+        return TSQueryErrorNodeType;
+      }
       uint16_t query_id = symbol_table_insert_name(
         &self->predicate_values,
         symbol_start,
         symbol_length
       );
+      if (arg_index == 0) first_arg_is_capture = false;
+      last_arg_is_capture = false;
+      type_arg_count++;
+      arg_index++;
       array_push(&self->predicate_steps, ((TSQueryPredicateStep) {
         .type = TSQueryPredicateStepTypeString,
         .value_id = query_id,
@@ -3005,6 +3200,8 @@ TSQuery *ts_query_new(
     .string_buffer = array_new(),
     .negated_fields = array_new(),
     .repeat_symbols_with_rootless_patterns = array_new(),
+    .ancestor_constraints = array_new(),
+    .ancestor_symbols = array_new(),
     .wildcard_root_pattern_count = 0,
     .language = ts_language_copy(language),
   };
@@ -3041,6 +3238,91 @@ TSQuery *ts_query_new(
       capture_quantifiers_delete(&capture_quantifiers);
       ts_query_delete(self);
       return NULL;
+    }
+
+    // Lower any `#has-ancestor?` / `#capture-ancestor?` predicates in this
+    // pattern into structural AncestorConstraints, resolving the ancestor type
+    // name(s) to grammar symbols. These are enforced by the core matcher at
+    // match-finish time; bindings still see them as (ignored) general
+    // predicates, so no binding changes are required.
+    for (uint32_t pi = start_predicate_step_index; pi < self->predicate_steps.size;) {
+      uint32_t pj = pi;
+      while (
+        pj < self->predicate_steps.size &&
+        array_get(&self->predicate_steps, pj)->type != TSQueryPredicateStepTypeDone
+      ) pj++;
+
+      TSQueryPredicateStep *head = array_get(&self->predicate_steps, pi);
+      if (head->type == TSQueryPredicateStepTypeString) {
+        uint32_t name_len;
+        const char *name = symbol_table_name_for_id(
+          &self->predicate_values, head->value_id, &name_len
+        );
+        bool is_has = name_len == 13 && memcmp(name, "has-ancestor?", 13) == 0;
+        bool is_cap = name_len == 17 && memcmp(name, "capture-ancestor?", 17) == 0;
+        if (is_has || is_cap) {
+          uint32_t symbol_offset = self->ancestor_symbols.size;
+          uint16_t anchor_capture_id = NONE;
+          uint16_t out_capture_id = NONE;
+          uint16_t symbol_count = 0;
+          uint32_t arg = pi + 1;
+
+          // arg 0: the anchor capture, whose node we walk up from.
+          if (
+            arg < pj &&
+            array_get(&self->predicate_steps, arg)->type == TSQueryPredicateStepTypeCapture
+          ) {
+            anchor_capture_id =
+              (uint16_t)array_get(&self->predicate_steps, arg)->value_id;
+            arg++;
+          }
+
+          // The remaining string args are ancestor type names (any-of). A
+          // trailing capture (for `#capture-ancestor?`) binds the ancestor.
+          for (; arg < pj; arg++) {
+            TSQueryPredicateStep *step = array_get(&self->predicate_steps, arg);
+            if (step->type == TSQueryPredicateStepTypeCapture) {
+              if (is_cap) out_capture_id = (uint16_t)step->value_id;
+              continue;
+            }
+            uint32_t type_len;
+            const char *type_name = symbol_table_name_for_id(
+              &self->predicate_values, step->value_id, &type_len
+            );
+            TSSymbol symbol =
+              ts_language_symbol_for_name(self->language, type_name, type_len, true);
+            if (!symbol) {
+              symbol =
+                ts_language_symbol_for_name(self->language, type_name, type_len, false);
+            }
+            if (symbol) {
+              array_push(&self->ancestor_symbols, symbol);
+              symbol_count++;
+            }
+          }
+
+          // parse_predicate has already validated arity and that each type name
+          // resolves, so a well-formed predicate always yields >= 1 symbol.
+          if (anchor_capture_id != NONE && symbol_count > 0) {
+            array_push(&self->ancestor_constraints, ((AncestorConstraint) {
+              .pattern_index = (uint16_t)pattern_index,
+              .anchor_capture_id = anchor_capture_id,
+              .out_capture_id = out_capture_id,
+              .symbol_offset = symbol_offset,
+              .symbol_count = symbol_count,
+            }));
+            if (out_capture_id != NONE) {
+              capture_quantifiers_add_for_id(
+                &capture_quantifiers, out_capture_id, TSQuantifierOne
+              );
+            }
+          } else {
+            self->ancestor_symbols.size = symbol_offset; // keep the array tidy
+          }
+        }
+      }
+
+      pi = (pj < self->predicate_steps.size) ? pj + 1 : pj;
     }
 
     // Maintain a list of capture quantifiers for each pattern
@@ -3154,6 +3436,22 @@ TSQuery *ts_query_new(
     return NULL;
   }
 
+  // A pattern carrying an ancestor constraint can fail at match-finish time
+  // (when the parent walk finds no accepted ancestor) even after matching
+  // structurally. It is therefore NOT guaranteed: clear the guarantee flags on
+  // its steps so that `ts_query_cursor_next_capture` does not stream captures
+  // early via the "definite" path, which runs before the constraint is checked
+  // and would otherwise leak captures that the constraint should reject.
+  for (uint32_t i = 0; i < self->ancestor_constraints.size; i++) {
+    uint16_t constrained = array_get(&self->ancestor_constraints, i)->pattern_index;
+    QueryPattern *pattern = array_get(&self->patterns, constrained);
+    for (uint32_t s = 0; s < pattern->steps.length; s++) {
+      QueryStep *step = array_get(&self->steps, pattern->steps.offset + s);
+      step->root_pattern_guaranteed = false;
+      step->parent_pattern_guaranteed = false;
+    }
+  }
+
   array_delete(&self->string_buffer);
   return self;
 }
@@ -3168,6 +3466,8 @@ void ts_query_delete(TSQuery *self) {
     array_delete(&self->string_buffer);
     array_delete(&self->negated_fields);
     array_delete(&self->repeat_symbols_with_rootless_patterns);
+    array_delete(&self->ancestor_constraints);
+    array_delete(&self->ancestor_symbols);
     ts_language_delete(self->language);
     symbol_table_delete(&self->captures);
     symbol_table_delete(&self->predicate_values);
@@ -4451,7 +4751,11 @@ bool ts_query_cursor_next_match(
   TSQueryCursor *self,
   TSQueryMatch *match
 ) {
-  if (self->finished_states.size == 0) {
+  // Keep advancing until a match actually materializes. A single advance can
+  // report progress yet leave `finished_states` empty if every candidate it
+  // produced was rejected by an ancestor constraint, so loop rather than
+  // assuming one advance yields a finished state.
+  while (self->finished_states.size == 0) {
     if (!ts_query_cursor__advance(self, false)) {
       return false;
     }


### PR DESCRIPTION
#### Query predicates for ancestor context: `#has-ancestor?` / `#capture-ancestor?`

Hello again, yet another AI-assisted PR from weird-edge-case-issues of non-mainstream environments. ;-) 
This PR adds two query predicates that let a pattern constrain a capture by its **enclosing context** (can I avoid mentioning monad here...almost) — i.e. require that a captured node be nested, at any depth, inside a node of a given type, and optionally bind that ancestor so the existing text predicates can inspect it.

```scheme
;; gate: keep @x only when it is somewhere inside a `class_body`
((identifier) @x (#has-ancestor? @x class_body))

;; gate + bind: also expose the enclosing node as @ctx for #eq?/#match?
((identifier) @op
 (#capture-ancestor? @op call_expression @ctx)
 (#eq? @ctx "..."))
```

The feature lives entirely in the **core query matcher**, so every language binding inherits it with no per-binding work, and it uses only tree structure (node symbols) — never source text — so it needs no access to the document.

#### Compatibility

- **ABI:** no bump, unchanged.
- **Generated parsers / grammars:** unchanged. parser.c unchanged.
- **Bindings:** unchanged; the predicates work through the shared core matcher.
- **Existing queries:** unaffected — the enforcement path is a no-op when a query defines no ancestor constraints.

So no breaking changes of any kind...

#### The Problem

Tree-sitter's query language has no way to express *"match X only when it is inside Y."* Patterns match by structural nesting written out explicitly, and there is no descendant/ancestor axis. This makes a whole class of common
highlighting/analysis tasks impossible to express precisely:

- **Context-sensitive keywords/operators.**: Many languages give ordinary-looking identifiers special meaning *only inside a particular block*. The widest example is functional / monadic builder syntax, where the same word is a keyword in one block and a plain function elsewhere:
  - **Haskell** `do`-notation / list comprehensions.
  - **F#** computation expressions: `select`, `where`, `join`, … are keywords inside `query { … }` but are also normal names (`List.where`, `Seq.head`) everywhere else.
  - **OCaml** binding operators (`let*`, `let+`, `and*`, …).
  - **Scala** for-comprehension generators.
- **Scope-dependent identifiers.**: Highlight `self` / `this` only inside a class body; `yield` only inside a generator function; a label only inside the loop it belongs to.
- **Embedded sub-languages. (EDSL)**: Treat certain identifiers as keywords only inside a specific construct (e.g. an SQL/query builder block, a shader block, a format-string call).

Today the only options are 
- highlight the word everywhere — a flood of false positives, since those names are common — or 
- restructure the grammar to give the construct a distinct node type, which grows the generated parser and is often impossible (the distinction is semantic, not syntactic). Neither is acceptable, so these cases simply go un-highlighted or mis-highlighted.

#### A Solution

As usual, I have a problem, I don't care who fixes it and how, as long as I have a solution. What this PR adds:

Two predicates, recognised and enforced by the core matcher:

##### `#has-ancestor? @capture <type>...`

Keeps a match only if the captured node has an ancestor (at any depth) whose type is one of the listed node types (any-of). Pure structural gate; needs no source text. Covers every language where the enclosing construct is already its
own node type.

```scheme
; OCaml: highlight binding-operator keywords only inside an expression block
((value_name) @keyword.operator
 (#any-of? @keyword.operator "let*" "let+" "and*" "and+")
 (#has-ancestor? @keyword.operator do_expression))

; highlight `this` only inside a class
((this) @variable.builtin (#has-ancestor? @variable.builtin class_body))
```

##### `#capture-ancestor? @capture <type> @out`

Same gate, but also binds the matched (nearest) ancestor to a new capture `@out`, so the binding's existing `#eq?` / `#match?` / `#any-of?` text predicates can test the enclosing context — for example, *which* builder a block belongs to when several share one node type.

```scheme
; F#: the 40+ query custom operations, but ONLY inside `query { ... }`
; (not inside seq/async/task CEs, and not as List.head / Seq.where elsewhere)
((identifier) @keyword.operator
 (#any-of? @keyword.operator
   "select" "where" "join" "groupBy" "sortBy" "thenBy" "count" "distinct"
   "head" "last" "take" "skip" "exists" "all" "contains" "zip" ...)
 (#capture-ancestor? @keyword.operator ce_expression @_ce)
 (#match? @_ce "^query\\b"))
```

Because `#capture-ancestor?` rejects the match when no such ancestor exists, the downstream text predicate never sees a vacuous (empty-capture) pass.

##### How it works (all within `lib/src/query.c`):

1. **Lowering at compile time.** In `ts_query_new`, after a pattern is parsed, its predicate steps are scanned for `#has-ancestor?` / `#capture-ancestor?` and lowered into `AncestorConstraint`s on the `TSQuery` (anchor capture, accepted ancestor symbols as a slice of a shared symbol array, optional output capture). `#capture-ancestor?` registers its output capture on demand.

2. **Enforcement at match-finish.** `ts_query_cursor__push_finished_state` — the single point every finished match flows through — walks `ts_node_parent` from the anchor capture's node (nearest accepted ancestor wins, mirroring innermost-scope semantics). If none is found, the match is dropped; for `#capture-ancestor?`, the matched ancestor is appended to the capture list. Cost is O(depth) per candidate, only for constrained patterns.

3. **Streaming correctness.** A constrained pattern can fail *after* matching structurally, so it is no longer "guaranteed": its `root_pattern_guaranteed` / `parent_pattern_guaranteed` flags are cleared after analysis, preventing `ts_query_cursor_next_capture` from streaming "definite" captures before the constraint is checked. `next_match` advances in a loop, since a rejected candidate can leave `finished_states` empty.

4. **Validation.** `ts_query__parse_predicate` checks arity and argument order and resolves each ancestor type name to a grammar symbol, returning `TSQueryErrorNodeType` / `TSQueryErrorSyntax` with precise offsets instead of silently ignoring a malformed predicate.

Bindings that don't know these predicates still treat them as opaque general predicates (ignored at the binding layer) — but the core has already enforced the constraint during matching, so the results are correct everywhere with zero
binding changes.

##### Why ancestor matching (not a general descendant axis)

A full arbitrary-depth descendant combinator in the forward matcher would ripple through depth bookkeeping, the longest-match rule, quantifiers, the guaranteed-step analysis, and the capture-list pool — large and risky. Matching *upward* from a finished capture is a bounded parent walk that reuses existing node APIs, perturbs nothing in forward matching, and maps directly onto the "enclosing context" question these 


### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

Yes, I have used Claude Opus 4.8 to help with code and documentation, as neither Rust or English are my main languages.

Thanks for reading.