### PR TITLE
Update D grammar to much newer canonical site.

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -36,7 +36,7 @@ There are bindings that allow Tree-sitter to be used from the following language
 - [C# (.NET)](https://github.com/zabbius/dotnet-tree-sitter)
 - [C++](https://github.com/nsumner/cpp-tree-sitter)
 - [Crystal](https://github.com/crystal-lang-tools/crystal-tree-sitter)
-- [D](https://github.com/aminya/d-tree-sitter)
+- [D](https://github.com/gdamore/tree-sitter-d)
 - [Delphi](https://github.com/modersohn/delphi-tree-sitter)
 - [ELisp](https://www.gnu.org/software/emacs/manual/html_node/elisp/Parsing-Program-Source.html)
 - [Go](https://github.com/alexaandru/go-tree-sitter-bare)


### PR DESCRIPTION
The D grammar for tree-sitter referenced on this doc is very old (effectively unmaintained), and not in wide use.  This updates to my version which is updated regularly, and used by most mainstream editors that consume tree-sitter.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
