### PR TITLE
fix(dsl): forbid invalid field names

### DIFF
--- a/crates/generate/src/dsl.js
+++ b/crates/generate/src/dsl.js
@@ -34,6 +34,9 @@ function blank() {
 }
 
 function field(name, rule) {
+  if (typeof name !== "string" || !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
+    throw new Error(`Invalid field name '${name}': field names must start with a letter or underscore, followed by letters, digits, or underscores`);
+  }
   return {
     type: "FIELD",
     name,


### PR DESCRIPTION
### The Problem

The JS DSL performs no validation of field names. This can lead to the following (somewhat) confusing situation:

Given:

```js
export default grammar({
    name: 'bad_field',
    rules: {
        source_file: $ => field('my-field', 'x'),
    }
});
```

```sh
$ tree-sitter generate # works fine!
```

```sh
$ tree-sitter build
Error: Failed to compile parser

Caused by:
    Parser compilation failed.
    Stdout:
    Stderr: /home/lillis/projects/grammars/bad_field/src/parser.c:55:11: error: expected ',' or '}' before '-' token
       55 |   field_my-field = 1,
          |           ^
    /home/lillis/projects/grammars/bad_field/src/parser.c:60:13: error: 'field' undeclared here (not in a function); did you mean 'field_my'?
       60 |   [field_my-field] = "my-field",
          |             ^~~~~
          |             field_my
    /home/lillis/projects/grammars/bad_field/src/parser.c:60:4: error: array index in initializer not of integer type
       60 |   [field_my-field] = "my-field",
          |    ^~~~~~~~
    /home/lillis/projects/grammars/bad_field/src/parser.c:60:4: note: (near initialization for 'ts_field_names')
```

While the error _is_ eventually surfaced, it happens fairly late and can be a bit surprising. Typically (unless you're working with an external scanner), the assumption is that if `tree-sitter generate` succeeds, you have  a valid parser.

### The Solution

Just ensure that field names are valid C enum identifiers.

```sh
$ tree-sitter generate
file:///home/lillis/projects/grammars/bad_field/[eval1]:40
    throw new Error(`Invalid field name '${name}': field names must start with a letter or underscore, followed by letters, digits, or underscores`);
          ^

Error: Invalid field name 'my-field': field names must start with a letter or underscore, followed by letters, digits, or underscores
    at field (file:///home/lillis/projects/grammars/bad_field/[eval1]:40:11)
    at Proxy.source_file (file:///home/lillis/projects/grammars/bad_field/grammar.js:4:27)
    at grammar (file:///home/lillis/projects/grammars/bad_field/[eval1]:331:27)
    at file:///home/lillis/projects/grammars/bad_field/grammar.js:1:16
    at ModuleJob.run (node:internal/modules/esm/module_job:439:25)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async node:internal/modules/esm/loader:636:26
    at async file:///home/lillis/projects/grammars/bad_field/[eval1]:547:14

Node.js v26.1.0
Error: Error when generating parser

Caused by:
    Failed to load grammar.js -- `node` process exited with status 1
```

The grammar.js stack trace leaves a lot to be desired, but more on that later ;)