### PR TITLE
Update README.md

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -12,7 +12,7 @@ The Tree-sitter CLI allows you to develop, test, and use Tree-sitter grammars fr
 
 ### Installation
 
-You can install the `tree-sitter-cli` with [`cargo-install`](https://github.com/cargo-bins/cargo-binstall) :
+You can install the `tree-sitter-cli` with [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall):
 
 ```sh
 cargo binstall tree-sitter-cli

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -12,7 +12,7 @@ The Tree-sitter CLI allows you to develop, test, and use Tree-sitter grammars fr
 
 ### Installation
 
-You can install the `tree-sitter-cli` with `cargo-binstall`:
+You can install the `tree-sitter-cli` with [`cargo-install`](https://github.com/cargo-bins/cargo-binstall) :
 
 ```sh
 cargo binstall tree-sitter-cli


### PR DESCRIPTION
On a fresh install of cargo, it seems that `cargo binstall` is no longer valid. `cargo install` should be used to install binaries.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [ ] If AI tools were used: I have disclosed the tool and extent of usage below.
