### PR TITLE
test(query): regression test for anchored siblings inside a parent

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -1693,6 +1693,49 @@ fn test_matches_with_anchor_sibling_with_quantifier_captured_inside_parent() {
 }
 
 #[test]
+fn test_matches_anchored_quantified_sibling_inside_parent() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            "(translation_unit (comment)* @comment . (declaration) @decl)",
+        )
+        .unwrap();
+        assert_query_matches(
+            &language,
+            &query,
+            "
+void foo() {}
+
+// this one has
+// two comments
+extern int baz;
+
+// this one has a comment
+extern int bar;
+",
+            &[
+                (
+                    0,
+                    vec![
+                        ("comment", "// this one has"),
+                        ("comment", "// two comments"),
+                        ("decl", "extern int baz;"),
+                    ],
+                ),
+                (
+                    0,
+                    vec![
+                        ("comment", "// this one has a comment"),
+                        ("decl", "extern int bar;"),
+                    ],
+                ),
+            ],
+        );
+    });
+}
+
+#[test]
 fn test_query_matches_with_trailing_optional_nodes() {
     allocations::record(|| {
         let language = get_language("javascript");


### PR DESCRIPTION
#5603 was originally targeted at #4688, but also fixes several other closely related issues. This PR adds a regression test to close them out.

- Closes #3683
- Closes #2477
- Closes #3567

One slight caveat is that the problem described in https://github.com/tree-sitter/tree-sitter/issues/3567#issuecomment-2322784894 is _not_ fixed, so ~~I'll extract that to its own issue shortly~~ I created #5714.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

Fixes _discovered_ by Opus 4.8 while doing other query work, manually verified myself.

<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
