### PR TITLE
fix(deps): zig manifest for wasmtime is missing windows hashes

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -34,7 +34,7 @@
         },
         .wasmtime_c_api_aarch64_windows = .{
             .url = "https://github.com/bytecodealliance/wasmtime/releases/download/v36.0.12/wasmtime-v36.0.12-aarch64-windows-c-api.zip",
-            .hash = "",
+            .hash = "N-V-__8AACOXoQRCB0HW3hoqzY9elM7RhAvktyKPoc9gcrgH",
             .lazy = true,
         },
         .wasmtime_c_api_armv7_linux = .{
@@ -49,7 +49,7 @@
         },
         .wasmtime_c_api_i686_windows = .{
             .url = "https://github.com/bytecodealliance/wasmtime/releases/download/v36.0.12/wasmtime-v36.0.12-i686-windows-c-api.zip",
-            .hash = "",
+            .hash = "N-V-__8AAA95hgTHW0bicUn7H_iZ_hbxZLi_ocFWKgnBPD6W",
             .lazy = true,
         },
         .wasmtime_c_api_riscv64gc_linux = .{
@@ -79,7 +79,7 @@
         },
         .wasmtime_c_api_x86_64_mingw = .{
             .url = "https://github.com/bytecodealliance/wasmtime/releases/download/v36.0.12/wasmtime-v36.0.12-x86_64-mingw-c-api.zip",
-            .hash = "",
+            .hash = "N-V-__8AAB99-QSAk8K-cl7VJ_wwN3b-tEhDdfl6oooAPrCn",
             .lazy = true,
         },
         .wasmtime_c_api_x86_64_musl = .{
@@ -89,7 +89,7 @@
         },
         .wasmtime_c_api_x86_64_windows = .{
             .url = "https://github.com/bytecodealliance/wasmtime/releases/download/v36.0.12/wasmtime-v36.0.12-x86_64-windows-c-api.zip",
-            .hash = "",
+            .hash = "N-V-__8AADMnXgUXBPN-f0nK6cooCXxxuqgV4G5zwjwpGHkw",
             .lazy = true,
         },
     },


### PR DESCRIPTION
Problem: `zig fetch` on 0.16 can't download zip archives, which wasmtime
uses for Windows. This makes `cargo xtask upgrade-wastime` fail silently
with empty hashes for these platforms.

Solution: Re-run xtask with Zig 0.17 nightly.

(This unblocks bumping `tree-sitter` for Neovim.)
