### PR TITLE
fix(xtask): eliminate silent errors in zig fetch

### DIFF
--- a/crates/xtask/src/generate.rs
+++ b/crates/xtask/src/generate.rs
@@ -68,9 +68,11 @@ pub fn run_bindings() -> Result<()> {
     let output = Command::new("cargo")
         .args(["metadata", "--format-version", "1"])
         .output()
-        .unwrap();
+        .context("Failed to execute cargo metadata")?;
+    bail_on_err(&output, "Failed to run cargo metadata")?;
 
-    let metadata = serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
+    let metadata = serde_json::from_slice::<serde_json::Value>(&output.stdout)
+        .context("Failed to parse cargo metadata output")?;
 
     let Some(rust_version) = metadata
         .get("packages")
@@ -118,7 +120,7 @@ pub fn run_bindings() -> Result<()> {
 
     bindings
         .write_to_file("lib/binding_rust/bindings.rs")
-        .with_context(|| "Failed to write bindings")
+        .context("Failed to write bindings")
 }
 
 pub fn run_wasm_exports() -> Result<()> {

--- a/crates/xtask/src/upgrade_wasmtime.rs
+++ b/crates/xtask/src/upgrade_wasmtime.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 use anyhow::{Context, Result};
 use semver::Version;
 
-use crate::{UpgradeWasmtime, create_commit};
+use crate::{UpgradeWasmtime, bail_on_err, create_commit};
 
 const WASMTIME_RELEASE_URL: &str = "https://github.com/bytecodealliance/wasmtime/releases/download";
 
@@ -22,11 +22,13 @@ fn update_cargo(version: &Version) -> Result<()> {
 
     std::fs::write("lib/Cargo.toml", new_lines.join("\n") + "\n")?;
 
-    Command::new("cargo")
+    let output = Command::new("cargo")
         .arg("update")
-        .status()
-        .map(|_| ())
-        .with_context(|| "Failed to execute cargo update")
+        .spawn()?
+        .wait_with_output()?;
+    bail_on_err(&output, "Failed to run cargo update")?;
+
+    Ok(())
 }
 
 fn zig_fetch(lines: &mut Vec<String>, version: &Version, url_suffix: &str) -> Result<()> {
@@ -39,9 +41,15 @@ fn zig_fetch(lines: &mut Vec<String>, version: &Version, url_suffix: &str) -> Re
         .arg(url)
         .output()
         .with_context(|| format!("Failed to execute zig fetch {url}"))?;
+    bail_on_err(&output, &format!("`zig fetch {url}` failed"))?;
 
-    let hash = String::from_utf8_lossy(&output.stdout);
-    lines.push(format!("            .hash = \"{}\",", hash.trim_end()));
+    let hash = std::str::from_utf8(&output.stdout)
+        .with_context(|| format!("`zig fetch {url}` produced non-UTF-8 output"))?
+        .trim_end();
+    if hash.is_empty() {
+        anyhow::bail!("`zig fetch {url}` produced an empty hash");
+    }
+    lines.push(format!("            .hash = \"{hash}\","));
 
     Ok(())
 }


### PR DESCRIPTION
ref https://github.com/tree-sitter/tree-sitter/pull/5719#issuecomment-4830394109

CC @clason I wasn't able to reproduce the empty hash failure with zig 16.0 (maybe it's MacOS only?). Can you make sure this catches the silent error you were seeing earlier?
