### PR TITLE
fix(query): various anchor fixes

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -1259,6 +1259,45 @@ function foo() {}
 }
 
 #[test]
+fn test_query_matches_with_last_child_anchor_after_optional() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            "(preproc_if (preproc_def)+ @def . (preproc_else)? @else .)",
+        )
+        .unwrap();
+
+        // The optional `(preproc_else)?` is absent, so the trailing anchor's
+        // last-child requirement transfers to the last `preproc_def`. A trailing
+        // comment means the def is not the last child, so nothing matches.
+        assert_query_matches(
+            &language,
+            &query,
+            "
+#if X
+#define A
+// c
+#endif
+",
+            &[],
+        );
+
+        // With the def as the last child, the (else-less) match is allowed.
+        assert_query_matches(
+            &language,
+            &query,
+            "
+#if X
+#define A
+#endif
+",
+            &[(0, vec![("def", "#define A\n")])],
+        );
+    });
+}
+
+#[test]
 fn test_query_matches_with_last_named_child() {
     allocations::record(|| {
         let language = get_language("c");

--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -257,6 +257,51 @@ fn test_query_errors_on_invalid_syntax() {
 }
 
 #[test]
+fn test_query_errors_on_anchor_at_group_edge() {
+    allocations::record(|| {
+        let language = get_language("javascript");
+
+        // Anchors between siblings, or at the first/last position of a *node*
+        // pattern, are valid.
+        assert!(Query::new(&language, "((_) . (_))").is_ok());
+        assert!(Query::new(&language, "(program (_) (_) .)").is_ok());
+        assert!(Query::new(&language, "(program (_)* @x . (_))").is_ok());
+
+        // A `.` at the edge of a *group* is rejected. A group is not a node, so it
+        // has no last child to anchor, and there is no sibling within the group to
+        // anchor to.
+        assert_eq!(
+            Query::new(&language, "((_) .)").unwrap_err(),
+            QueryError {
+                row: 0,
+                offset: 5,
+                column: 5,
+                kind: QueryErrorKind::Syntax,
+                message: [
+                    "((_) .)", //
+                    "     ^"
+                ]
+                .join("\n")
+            }
+        );
+        assert_eq!(
+            Query::new(&language, "(program ((_)+ .)? (_))").unwrap_err(),
+            QueryError {
+                row: 0,
+                offset: 15,
+                column: 15,
+                kind: QueryErrorKind::Syntax,
+                message: [
+                    "(program ((_)+ .)? (_))", //
+                    "               ^"
+                ]
+                .join("\n")
+            }
+        );
+    });
+}
+
+#[test]
 fn test_query_errors_on_invalid_symbols() {
     allocations::record(|| {
         let language = get_language("javascript");

--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -1223,6 +1223,42 @@ fn test_query_matches_with_immediate_siblings() {
 }
 
 #[test]
+fn test_query_matches_with_anchor_after_zero_quantifier() {
+    allocations::record(|| {
+        let language = get_language("javascript");
+        let query = Query::new(
+            &language,
+            "(program (comment)* @doc . (function_declaration name: (identifier) @name))",
+        )
+        .unwrap();
+
+        // No comments and the function is not the first child. An anchor after a
+        // zero-matched quantifier is vacuous, so the function still matches.
+        assert_query_matches(
+            &language,
+            &query,
+            "
+class X {}
+function foo() {}
+",
+            &[(0, vec![("name", "foo")])],
+        );
+
+        // With at least one comment the anchor applies, so the comments must
+        // immediately precede the function.
+        assert_query_matches(
+            &language,
+            &query,
+            "
+// c
+function foo() {}
+",
+            &[(0, vec![("doc", "// c"), ("name", "foo")])],
+        );
+    });
+}
+
+#[test]
 fn test_query_matches_with_last_named_child() {
     allocations::record(|| {
         let language = get_language("c");

--- a/docs/src/using-parsers/queries/2-operators.md
+++ b/docs/src/using-parsers/queries/2-operators.md
@@ -180,7 +180,7 @@ depending on where it's placed inside a query.
 
 When `.` is placed before the _first_ child within a parent pattern, the child will only match when it is the first named
 node in the parent. For example, the below pattern matches a given `array` node at most once, assigning the `@the-element`
-capture to the first `identifier` node in the parent `array`:
+capture to the first node in the parent `array`, only if it's an `identifier` node:
 
 ```query
 (array . (identifier) @the-element)

--- a/docs/src/using-parsers/queries/2-operators.md
+++ b/docs/src/using-parsers/queries/2-operators.md
@@ -211,4 +211,37 @@ Without the anchor, non-consecutive pairs like `a, c` and `b, d` would also be m
 
 The restrictions placed on a pattern by an anchor operator ignore anonymous nodes.
 
+### Anchors with Quantifiers and Groups
+
+When an anchor is next to a quantified node (`*`, `+`, `?`), its meaning depends on whether the
+anchor sits _between two patterns_ or _at the edge of a parent node_.
+
+An anchor _between two child patterns_ constrains the two matched nodes to be immediate siblings.
+If one of those patterns is a quantifier that matches zero nodes, there is no node on that side,
+so the anchor imposes no constraint. For example, given
+
+```query
+(translation_unit (comment)* @doc . (function_definition) @function)
+```
+
+a `function_definition` with no preceding `comment` still matches, with `@doc` capturing nothing.
+When comments are present, they must immediately precede the function.
+
+An anchor at the _start or end of a node pattern_ (a leading or trailing `.`) constrains the
+matched sequence to begin at the parent's first, or end at its last, named child. If the pattern
+element next to that edge is a quantifier that matches zero nodes, the constraint applies to the
+nearest node that the pattern _does_ match. For example, given
+
+```query
+(preproc_if (preproc_def)+ @def . (preproc_else)? @else .)
+```
+
+the trailing anchor requires the last matched node to be the parent's last named child: when a
+`preproc_else` is present it must be last. When it is absent, the last `preproc_def` must be last.
+
+An anchor may not appear at the first or last position inside a group `(...)` or an alternation
+`[...]`. A group or alternation is not a node, so it has no first or last child to anchor against,
+and there is no sibling on that side to anchor to. For example, write `(comment)* @doc . (function)`
+rather than `((comment)+ @doc .)? (function)`.
+
 [regex]: https://en.wikipedia.org/wiki/Regular_expression#Basic_concepts

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -18,6 +18,11 @@
 
 // #define DEBUG_ANALYZE_QUERY
 // #define DEBUG_EXECUTE_QUERY
+// #define DEBUG_QUERY_STEPS
+
+#if defined(DEBUG_QUERY_STEPS) || defined(DEBUG_ANALYZE_QUERY) || defined(DEBUG_EXECUTE_QUERY)
+#define DEBUG_DUMP_STEPS
+#endif
 
 #define MAX_STEP_CAPTURE_COUNT 3
 #define MAX_NEGATED_FIELD_COUNT 8
@@ -1601,6 +1606,44 @@ static void ts_query__perform_analysis(
   }
 }
 
+#ifdef DEBUG_DUMP_STEPS
+static void ts_query__dump_steps(const TSQuery *self, const char *label) {
+  printf("=== STEPS (%s) ===\n", label);
+  for (unsigned i = 0; i < self->steps.size; i++) {
+    const QueryStep *s = array_get(&self->steps, i);
+    if (s->depth == PATTERN_DONE_MARKER) {
+      printf("%3u: DONE\n", i);
+      continue;
+    }
+    printf("%3u: depth=%u sym=%s", i, s->depth,
+      s->symbol == WILDCARD_SYMBOL ? "_" : ts_language_symbol_name(self->language, s->symbol));
+    if (s->supertype_symbol) {
+      printf(" super=%s", ts_language_symbol_name(self->language, s->supertype_symbol));
+    }
+    if (s->field) {
+      printf(" field=%s", ts_language_field_name_for_id(self->language, s->field));
+    }
+    if (s->alternative_index != NONE) printf(" alt=%u", s->alternative_index);
+    if (s->is_immediate) printf(" IMM");
+    if (s->is_pass_through) printf(" PASS");
+    if (s->is_dead_end) printf(" DEAD");
+    if (s->is_last_child) printf(" LAST");
+    if (s->is_named) printf(" NAMED");
+    if (s->is_missing) printf(" MISSING");
+    if (s->is_inside_alternation) printf(" INALT");
+    if (s->contains_captures) printf(" HASCAP");
+    if (s->parent_pattern_guaranteed) printf(" PPG");
+    if (s->root_pattern_guaranteed) printf(" RPG");
+    for (unsigned c = 0; c < MAX_STEP_CAPTURE_COUNT && s->capture_ids[c] != NONE; c++) {
+      uint32_t cap_len;
+      const char *cap_name = symbol_table_name_for_id(&self->captures, s->capture_ids[c], &cap_len);
+      printf(" @%.*s", (int)cap_len, cap_name);
+    }
+    printf("\n");
+  }
+}
+#endif
+
 static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
   Array(uint16_t) non_rooted_pattern_start_steps = array_new();
   for (unsigned i = 0; i < self->pattern_map.size; i++) {
@@ -2038,25 +2081,7 @@ static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
   }
 
   #ifdef DEBUG_ANALYZE_QUERY
-    printf("Steps:\n");
-    for (unsigned i = 0; i < self->steps.size; i++) {
-      QueryStep *step = array_get(&self->steps, i);
-      if (step->depth == PATTERN_DONE_MARKER) {
-        printf("  %u: DONE\n", i);
-      } else {
-        printf(
-          "  %u: {symbol: %s, field: %s, depth: %u, parent_pattern_guaranteed: %d, root_pattern_guaranteed: %d}\n",
-          i,
-          (step->symbol == WILDCARD_SYMBOL)
-            ? "ANY"
-            : ts_language_symbol_name(self->language, step->symbol),
-          (step->field ? ts_language_field_name_for_id(self->language, step->field) : "-"),
-          step->depth,
-          step->parent_pattern_guaranteed,
-          step->root_pattern_guaranteed
-        );
-      }
-    }
+    ts_query__dump_steps(self, "analysis");
   #endif
 
   // Determine which repetition symbols in this language have the possibility
@@ -3148,11 +3173,19 @@ TSQuery *ts_query_new(
     }
   }
 
+  #ifdef DEBUG_DUMP_STEPS
+    ts_query__dump_steps(self, "post-parse");
+  #endif
+
   if (!ts_query__analyze_patterns(self, error_offset)) {
     *error_type = TSQueryErrorStructure;
     ts_query_delete(self);
     return NULL;
   }
+
+  #ifdef DEBUG_DUMP_STEPS
+    ts_query__dump_steps(self, "post-analysis");
+  #endif
 
   array_delete(&self->string_buffer);
   return self;

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -2485,9 +2485,17 @@ static TSQueryError ts_query__parse_pattern(
       CaptureQuantifiers child_capture_quantifiers = capture_quantifiers_new();
       for (;;) {
         if (stream->next == '.') {
+          const char *anchor_start = stream->input;
           child_is_immediate = true;
           stream_advance(stream);
           stream_skip_whitespace(stream);
+          // A `.` at a group's end has no sibling to anchor, and a group is not a
+          // node, so there is no last child to anchor against.
+          if (stream->next == ')') {
+            stream_reset(stream, anchor_start);
+            capture_quantifiers_delete(&child_capture_quantifiers);
+            return TSQueryErrorSyntax;
+          }
         }
         TSQueryError e = ts_query__parse_pattern(
           self,

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -4450,6 +4450,17 @@ static inline bool ts_query_cursor__advance(
                 k--;
               }
 
+              // A `?`/`*` zero-skip past a step that carries a trailing last-child
+              // anchor transfers that requirement to the last matched node. The
+              // skip is only valid if that node really is the last named child.
+              if (
+                child_step->alternative_is_skip &&
+                child_step->is_last_child &&
+                has_later_named_siblings
+              ) {
+                continue;
+              }
+
               QueryState *copy = ts_query_cursor__copy_state(self, &child_state);
               if (copy) {
                 LOG(

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -80,6 +80,10 @@ typedef struct {
  * - `is_pass_through` - Indicates that state has no matching logic of its own,
  *    and exists only to split a state. One copy of the state advances immediately
  *    to the next step, and one moves to the alternative step.
+ * - `alternative_is_skip` - Indicates that this step's `alternative_index` is the
+ *    forward skip introduced by a `?` or `*` quantifier (the branch taken when the
+ *    quantifier matches zero occurrences). For a state that follows it, an
+ *    immediately-following anchor is vacuous.
  * - `is_inside_alternation` - Indicates that state is inside an alternation.
  *    Currently only written to quantifier steps, read by logic that maintains
  *    correctness for quantifiers inside alternations.
@@ -115,6 +119,7 @@ typedef struct {
   bool root_pattern_guaranteed: 1;
   bool parent_pattern_guaranteed: 1;
   bool is_missing: 1;
+  bool alternative_is_skip: 1;
 } QueryStep;
 
 /*
@@ -210,6 +215,7 @@ typedef struct {
   bool has_in_progress_alternatives: 1;
   bool dead: 1;
   bool needs_parent: 1;
+  bool skipped_quantifier: 1;
 } QueryState;
 
 typedef Array(QueryState) QueryStateList;
@@ -2992,6 +2998,7 @@ static TSQueryError ts_query__parse_pattern(
         step = array_get(&self->steps, step->alternative_index);
       }
       step->alternative_index = self->steps.size;
+      step->alternative_is_skip = true;
       break;
     case TSQuantifierZeroOrOne:
       step = array_get(&self->steps, starting_step_index);
@@ -2999,6 +3006,7 @@ static TSQueryError ts_query__parse_pattern(
         step = array_get(&self->steps, step->alternative_index);
       }
       step->alternative_index = self->steps.size;
+      step->alternative_is_skip = true;
       break;
     default:
       break;
@@ -3827,6 +3835,7 @@ static void ts_query_cursor__add_state(
     .has_in_progress_alternatives = false,
     .needs_parent = step->depth == 1,
     .dead = false,
+    .skipped_quantifier = false,
   }));
 }
 
@@ -4267,7 +4276,7 @@ static inline bool ts_query_cursor__advance(
             node_does_match = symbol == step->symbol && (!step->is_missing || is_missing);
           }
           bool later_sibling_can_match = has_later_siblings;
-          if ((step->is_immediate && is_named) || state->seeking_immediate_match) {
+          if ((step->is_immediate && is_named && !state->skipped_quantifier) || state->seeking_immediate_match) {
             later_sibling_can_match = false;
           }
           if (step->is_last_child && has_later_named_siblings) {
@@ -4410,6 +4419,9 @@ static inline bool ts_query_cursor__advance(
           } else {
               state->seeking_immediate_match = false;
           }
+          // The zero-skip's vacuous-anchor exemption only covers the immediate
+          // step it lands on. Once the state advances, a later anchor is normal.
+          state->skipped_quantifier = false;
 
           if (stop_on_definite_step && next_step->root_pattern_guaranteed) did_match = true;
 
@@ -4453,6 +4465,11 @@ static inline bool ts_query_cursor__advance(
                 copy->step_index = child_step->alternative_index;
                 if (child_step->is_pass_through) {
                   copy->seeking_immediate_match = true;
+                }
+                // Taking a `?`/`*` zero-skip means the quantified subpattern matched
+                // nothing, so an immediately-following anchor is vacuous for this copy.
+                if (child_step->alternative_is_skip) {
+                  copy->skipped_quantifier = true;
                 }
               }
             }


### PR DESCRIPTION
Fixes several closely related issues for query anchors. The commit messages and docs additions have more details, but here's a quick TLDR:

- Improve query.c's existing debug dump output
- Make nonsense anchors at the end of a group (i.e. `((comment)+ @c .)`) an error. On master today, these anchors are silently dropped. Note that _leading_ anchors here are already an error.
- For something like `(parent (comment)* @c . (decl))`, if `comment` fails to match, then the anchor is ignored
- For something like `(p (a)+ @A . (b)? @b .)`, if `b` fails to match, then `a` must fulfill the trailing anchor (it must be the last child of `p`)
- Document these behaviors

I think most of these fixes (besides the nonsense anchor error) make sense to backport. CC @clason if you think that's too breaking for a backport, I can drop the label and just cherry-pick the other commits myself.

- Fixes #2889
- Fixes #5714
- Fixes #5703
- Progress towards #5382 

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

Used Claude Opus 4.8 to help determine the root cause and fix for each issue.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->