### PR TITLE
fix(query): short-circuit longest-match dedup for disjoint states

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -1350,6 +1350,35 @@ fn test_query_matches_with_repeated_leaf_nodes() {
 }
 
 #[test]
+fn test_query_matches_optional_capture_before_uncaptured_required_sibling() {
+    allocations::record(|| {
+        let language = get_language("rust");
+        let query = Query::new(&language, "(block (line_comment)? @doc (line_comment))").unwrap();
+
+        // The optional `(line_comment)? @doc` before an *uncaptured* required
+        // `(line_comment)` yields two candidate completions at the block:
+        //     - one where the optional captured `// a` (the required node is then `// b`),
+        //     - one where the optional matched zero (the required node absorbs `// a`,
+        //     leaving `@doc` unbound).
+        // The zero-match completion's captures are a strict subset of the other's, so the
+        // longest-match rule must drop it (there is exactly one match). This regressed when
+        // the dedup pass gained an early-break. Without the accompanying capture-position
+        // sort, the break skips the subset "loser" and it leaks as an extra empty match.
+        assert_query_matches(
+            &language,
+            &query,
+            "
+            fn f() {
+                // a
+                // b
+            }
+            ",
+            &[(0, vec![("doc", "// a")])],
+        );
+    });
+}
+
+#[test]
 fn test_query_matches_with_optional_nodes_inside_of_repetitions() {
     allocations::record(|| {
         let language = get_language("javascript");

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -3687,6 +3687,46 @@ void ts_query_cursor__compare_captures(
   }
 }
 
+// Order two in-progress states for the longest-match dedup pass. Within a
+// (start_depth, pattern_index) group, states with no captures sort first, as they are a
+// subset of every other state (so the dedup pass must always compare them). The rest
+// sort by the start byte of their first capture.
+static bool ts_query_cursor__state_precedes(
+  const TSQueryCursor *self,
+  const QueryState *a,
+  const QueryState *b
+) {
+  if (a->start_depth != b->start_depth) return a->start_depth < b->start_depth;
+  if (a->pattern_index != b->pattern_index) return a->pattern_index < b->pattern_index;
+  const CaptureList *a_caps = capture_list_pool_get(&self->capture_list_pool, a->capture_list_id);
+  const CaptureList *b_caps = capture_list_pool_get(&self->capture_list_pool, b->capture_list_id);
+  if ((a_caps->size == 0) != (b_caps->size == 0)) return a_caps->size == 0;
+  if (a_caps->size == 0) return false;
+  return
+    ts_node_start_byte(array_get(a_caps, 0)->node) <
+    ts_node_start_byte(array_get(b_caps, 0)->node);
+}
+
+// Stable-sort the in-progress states with the order dictated by `ts_query_cursor__state_precedes`.
+// This runs once per node, right before the dedup pass.
+static void ts_query_cursor__sort_states_by_capture(TSQueryCursor *self) {
+  QueryStateList *states = &self->states;
+  for (uint32_t i = 1; i < states->size; i++) {
+    // Fast+common path: this state is already ordered after its predecessor, so it does not need
+    // to move.
+    if (!ts_query_cursor__state_precedes(
+      self, array_get(states, i), array_get(states, i - 1)
+    )) continue;
+    QueryState key = *array_get(states, i);
+    uint32_t j = i;
+    do {
+      *array_get(states, j) = *array_get(states, j - 1);
+      j--;
+    } while (j > 0 && ts_query_cursor__state_precedes(self, &key, array_get(states, j - 1)));
+    *array_get(states, j) = key;
+  }
+}
+
 static void ts_query_cursor__add_state(
   TSQueryCursor *self,
   const PatternEntry *pattern
@@ -4378,6 +4418,10 @@ static inline bool ts_query_cursor__advance(
           }
         }
 
+        // Order states by capture position so the dedup pass below can stop scanning a
+        // group once the remaining states are disjoint from the current one.
+        ts_query_cursor__sort_states_by_capture(self);
+
         for (unsigned j = 0; j < self->states.size; j++) {
           QueryState *state = array_get(&self->states, j);
           if (state->dead) {
@@ -4393,7 +4437,10 @@ static inline bool ts_query_cursor__advance(
           for (unsigned k = j + 1; k < self->states.size; k++) {
             QueryState *other_state = array_get(&self->states, k);
 
-            // Query states are kept in ascending order of start_depth and pattern_index.
+            // Query states are kept in ascending order of start_depth and pattern_index, and
+            // (via the above call to `ts_query_cursor__sort_states_by_capture`) in ascending
+            // order of first-capture position within each such group.
+            //
             // Since the longest-match criteria is only used for deduping matches of the same
             // pattern and root node, we only need to perform pairwise comparisons within a
             // small slice of the states array.
@@ -4401,6 +4448,25 @@ static inline bool ts_query_cursor__advance(
               other_state->start_depth != state->start_depth ||
               other_state->pattern_index != state->pattern_index
             ) break;
+
+            // States in a group acquire their first capture in tree-traversal order, so the
+            // group is ordered by first-capture position. Once `other_state`'s captures begin
+            // at or after where `state`'s captures end, `other_state` (and every state after
+            // it in the group) is disjoint from `state`: neither can be a capture-subset of
+            // the other, so there is nothing to drop and no longest-match alternative to
+            // record. Stop scanning `state` against the rest of the group.
+            const CaptureList *state_captures =
+              capture_list_pool_get(&self->capture_list_pool, state->capture_list_id);
+            const CaptureList *other_captures =
+              capture_list_pool_get(&self->capture_list_pool, other_state->capture_list_id);
+            if (
+              state_captures->size > 0 &&
+              other_captures->size > 0 &&
+              ts_node_start_byte(array_get(other_captures, 0)->node) >=
+                ts_node_end_byte(array_get(state_captures, state_captures->size - 1)->node)
+            ) {
+              break;
+            }
 
             bool left_contains_right, right_contains_left;
             ts_query_cursor__compare_captures(


### PR DESCRIPTION
## The Problem

An unanchored quantified sibling like `(program (comment)+ @doc (class))` keeps one match state per matching sibling. #5603 stopped over-pruning them, but the per-node longest-match dedup is pairwise, so with n live states matching became O(n^3).

## The Solution

Two states can only be capture subsets of one another if their captured byte ranges overlap, so keep each group ordered by first-capture position and stop the pairwise scan once the rest of the group is disjoint.

The problematic query from tree-sitter-ruby is:

```scm
 (program
   (comment)+ @comment.documentation
   (class))
```

which is probably a mistake. Assuming I'm reading it correctly, there should be an anchor between `comment` and `class` so that comments are captured as documentation only if they directly precede a class. However, we should still fix this in the query engine.

In order to get a clearer look at the regression, I made a throw-away rust project rather than test things interactively in neovim. The program parses a file with `A #` repeated a given number of times, and measures how long the query takes to run.

### The numbers:

**Full tree-sitter-ruby highlights query**

| Line Count     | `master` time (ms) | PR time (ms)  |
| :---             | :---   |:---      |
| 250      | 22.2       | 1.2   |
| 500   | 176.1        | 4.2      |
| 1000   | 1,412.8        | 16.6      |
| 2000   | 13,706.9        | 64.5      |
| 4000   | 89,088.4        | 248.0      |


**Problematic query itself**

| Line Count     | `master` time (ms) | PR time (ms)  |
| :---             | :---   |:---      |
| 250      | 22.9       | 1.1   |
| 500   | 174.3        | 3.9      |
| 1000   | 1,395.9        | 15.2      |
| 2000   | 11,101.6        | 59.6      |
| 4000   | 88,186.1        | 236.7      |

**Problematic query with anchor**

| Line Count     | `master` time (ms) | PR time (ms)  |
| :---             | :---   |:---      |
| 250      | 0.12       | 0.14   |
| 500   | 0.25        | 0.30      |
| 1000   | 0.50       | 0.64      |
| 2000   | 1.07        | 1.30      |
| 4000   | 2.19        | 2.70      |


We do pay a small cost in normal runs for this fix (it's the sorting done by `ts_query_cursor__sort_states_by_capture`. However this cost is small (typically around ~2%) and does not scale drastically with line  count.

- Fixes neovim/neovim#40517

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

Opus 4.8 to track down where the regression was, and to find the interesting edge case that made sorting necessary.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
