### PR TITLE
improve error message and docs for supertypes made invalid by hidden children

### DIFF
--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -33,7 +33,7 @@ mod tables;
 pub use build_tables::ParseTableBuilderError;
 use build_tables::build_tables;
 use grammars::{InlinedProductionMap, InputGrammar, LexicalGrammar, SyntaxGrammar};
-pub use node_types::{SuperTypeCycleError, VariableInfoError};
+pub use node_types::{InvalidSupertypeError, SuperTypeCycleError, VariableInfoError};
 pub use parse_grammar::ParseGrammarError;
 use parse_grammar::parse_grammar;
 pub use prepare_grammar::PrepareGrammarError;

--- a/crates/generate/src/grammars.rs
+++ b/crates/generate/src/grammars.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, fmt};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt,
+};
+
+use crate::node_types::ChildType;
 
 use super::{
     nfa::Nfa,
@@ -74,6 +79,18 @@ pub struct ProductionStep {
     pub alias: Option<Alias>,
     pub field_name: Option<String>,
     pub reserved_word_set_id: ReservedWordSetId,
+}
+
+impl ProductionStep {
+    pub fn child_type(&self, default_aliases: &BTreeMap<Symbol, Alias>) -> ChildType {
+        if let Some(alias) = &self.alias {
+            ChildType::Aliased(alias.clone())
+        } else if let Some(alias) = default_aliases.get(&self.symbol) {
+            ChildType::Aliased(alias.clone())
+        } else {
+            ChildType::Normal(self.symbol)
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -143,10 +143,33 @@ pub type VariableInfoResult<T> = Result<T, VariableInfoError>;
 
 #[derive(Debug, Error, Serialize, Deserialize)]
 pub enum VariableInfoError {
-    #[error(
-        "Grammar error: Supertype symbols must always have a single visible child, but `{0}` can have multiple"
-    )]
-    InvalidSupertype(String),
+    #[error(transparent)]
+    InvalidSupertype(InvalidSupertypeError),
+}
+
+#[derive(Debug, Error, Serialize, Deserialize)]
+pub struct InvalidSupertypeError {
+    supertype: String,
+    child: Option<String>,
+}
+
+impl std::fmt::Display for InvalidSupertypeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let supertype = &self.supertype;
+        write!(
+            f,
+            "Supertypes must have a single visible child, but `{supertype}` can have multiple."
+        )?;
+
+        if let Some(child) = &self.child {
+            write!(
+                f,
+                " The hidden child `{child}` can expand into multiple nodes. Consider making `{child}` visible."
+            )?;
+        }
+
+        Ok(())
+    }
 }
 
 /// Compute a summary of the public-facing structure of each variable in the
@@ -210,13 +233,7 @@ pub fn get_variable_info(
 
                 for step in &production.steps {
                     let child_symbol = step.symbol;
-                    let child_type = if let Some(alias) = &step.alias {
-                        ChildType::Aliased(alias.clone())
-                    } else if let Some(alias) = default_aliases.get(&step.symbol) {
-                        ChildType::Aliased(alias.clone())
-                    } else {
-                        ChildType::Normal(child_symbol)
-                    };
+                    let child_type = step.child_type(default_aliases);
 
                     let child_is_hidden = !child_type_is_visible(&child_type)
                         && !syntax_grammar.supertype_symbols.contains(&child_symbol);
@@ -355,7 +372,28 @@ pub fn get_variable_info(
     for supertype_symbol in &syntax_grammar.supertype_symbols {
         if result[supertype_symbol.index].has_multi_step_production {
             let variable = &syntax_grammar.variables[supertype_symbol.index];
-            Err(VariableInfoError::InvalidSupertype(variable.name.clone()))?;
+            // A symbol can have a multi-step production either directly or via an inlined
+            // anonymous child. In the latter case, we can report a more specific error.
+            let hidden_child_name = variable
+                .productions
+                .iter()
+                .filter(|production| production.steps.len() == 1)
+                .find_map(|production| {
+                    let step = &production.steps[0];
+                    let child_symbol = step.symbol;
+                    let child_type = step.child_type(default_aliases);
+                    let child_is_hidden = !child_type_is_visible(&child_type)
+                        && !syntax_grammar.supertype_symbols.contains(&child_symbol);
+                    (child_is_hidden
+                        && child_symbol.is_non_terminal()
+                        && result[child_symbol.index].has_multi_step_production)
+                        .then(|| syntax_grammar.variables[child_symbol.index].name.clone())
+                });
+
+            Err(VariableInfoError::InvalidSupertype(InvalidSupertypeError {
+                supertype: variable.name.clone(),
+                child: hidden_child_name,
+            }))?;
         }
     }
 

--- a/docs/src/using-parsers/6-static-node-types.md
+++ b/docs/src/using-parsers/6-static-node-types.md
@@ -108,6 +108,10 @@ In Tree-sitter grammars, there are usually certain rules that represent abstract
 "type", "declaration"). In the `grammar.js` file, these are often written as [hidden rules][hidden rules]
 whose definition is a simple [`choice`][grammar dsl] where each member is just a single symbol.
 
+Each member of that `choice` must resolve to a single _visible_ node. A named rule always satisfies this, even when its
+own definition has several children. A [hidden rule][hidden rules] is inlined into its parent, so a hidden member whose
+definition can produce more than one node is not permitted in this position.
+
 Normally, hidden rules are not mentioned in the node types file, since they don't appear in the syntax tree. But if you
 add a hidden rule to the grammar's [`supertypes` list][grammar dsl], then it _will_ show up in the node types file, with
 the following special entry:


### PR DESCRIPTION
### The problem

The error message given when a suepertype contains a hidden child with a multi step production can be confusing

### The solution

Give a better error message, and document the actual constraints imposed.

New message for the repro given in #5119:

```js
module.exports = grammar({
  name: 'mixed',
  supertypes: $ => [$.type_qualifier],
  rules: {
    variable_declaration: $ => seq('integer', optional($.type_qualifier), '::', $.identifier),
    dimension: $ => 'dimension',
    simple: $ => 'simple',
    _maybe_intent: $ => choice($.simple, seq('intent', '(', choice('in', 'out'), ')')),
    type_qualifier: $ => choice($.dimension, $._maybe_intent),
    identifier: $ => /[a-zA-Z_$][\w$]*/,
  }
})
```


```
$ tree-sitter g

Error: Error when generating parser

Caused by:
    Supertypes must have a single visible child, but `type_qualifier` can have multiple. The hidden child `_maybe_intent` can expand into multiple nodes. Consider making `_maybe_intent` visible.
```

- Closes #5119

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
Used Opus 4.8 to go over the exact failure modes, and to refine finding the problematic child for the new error case.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
