### PR TITLE
Fix installation command in CLI README

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -15,7 +15,7 @@ The Tree-sitter CLI allows you to develop, test, and use Tree-sitter grammars fr
 You can install the `tree-sitter-cli` with [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall):
 
 ```sh
-cargo binstall tree-sitter-cli
+cargo install tree-sitter-cli
 ```
 
 or you can build it from source:


### PR DESCRIPTION
Updated installation command from 'cargo binstall' to 'cargo install'.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

Github CoPilot autogenerated the commit message and description for me. Actual edit to the file was done by me, a human.