### PR TITLE
feat(web): expand `Language::load` to accept `URL` filepath

### DIFF
--- a/lib/binding_web/src/language.ts
+++ b/lib/binding_web/src/language.ts
@@ -227,9 +227,10 @@ export class Language {
 
   /**
    * Load a language from a WebAssembly module.
-   * The module can be provided as a path to a file or as a buffer.
+   * The module can be provided as a path to a file, a `URL` to a file, or as a
+   * buffer.
    */
-  static async load(input: string | Uint8Array): Promise<Language> {
+  static async load(input: string | URL | Uint8Array): Promise<Language> {
     let binary: Uint8Array | WebAssembly.Module;
     if (input instanceof Uint8Array) {
       binary = input;

--- a/lib/binding_web/test/language.test.ts
+++ b/lib/binding_web/test/language.test.ts
@@ -4,6 +4,7 @@ import { LookaheadIterator, Language } from '../src';
 import { Parser } from '../src';
 import { C } from '../src/constants';
 import { readFile } from 'fs/promises';
+import { pathToFileURL } from 'url';
 
 let JavaScript: Language;
 let Rust: Language;
@@ -53,6 +54,24 @@ describe('Language', () => {
   });
 
   describe('.load', () => {
+    it('loads a language from a file URL', async () => {
+      const wasmURL = pathToFileURL(languageURL('javascript'));
+      expect(wasmURL).toBeInstanceOf(URL);
+
+      const lang = await Language.load(wasmURL);
+      expect(lang.name).toBe('javascript');
+
+      // Verify the language actually works by parsing a snippet
+      const parser = new Parser();
+      parser.setLanguage(lang);
+      const tree = parser.parse('const x = 1;');
+      expect(tree).not.toBeNull();
+      expect(tree!.rootNode.type).toBe('program');
+      expect(tree!.rootNode.childCount).toBe(1);
+      expect(tree!.rootNode.firstChild!.type).toBe('lexical_declaration');
+      parser.delete();
+    });
+
     it('reports when an async-loaded module has no language function', async () => {
       const loadWebAssemblyModule = C.loadWebAssemblyModule;
       const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);


### PR DESCRIPTION
- Closes #5628

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

Used Opus 4.8 to talk through JS basics and ensure there weren't any unintended side effects with this change.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
