### PR TITLE
docs(comment): misleading/wrong comment stating that initial state TSStateId is 0 rather than 1

### DIFF
--- a/lib/src/stack.h
+++ b/lib/src/stack.h
@@ -40,7 +40,7 @@ uint32_t ts_stack_version_count(const Stack *self);
 uint32_t ts_stack_halted_version_count(Stack *self);
 
 // Get the state at the top of the given version of the stack. If the stack is
-// empty, this returns the initial state, 0.
+// empty, this returns the initial state, 1.
 TSStateId ts_stack_state(const Stack *self, StackVersion version);
 
 // Get the last external token associated with a given version of the stack.


### PR DESCRIPTION
### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

### Change

This is a minor edit to a comment about the state ID assigned to the starting state of the parser.  The TSStateId 0 is reserved for the error state, while 1 is used for the starting state, whereas the erroneous comment gives 0 as the starting state.

### Notes

Erroneous comment reflects old start state ID, which was changed with commit 8c26d99:
```diff
-    stack_node_new(NULL, NULL, false, 0, ts_length_zero(), &self->node_pool);
+    stack_node_new(NULL, NULL, false, 1, ts_length_zero(), &self->node_pool);
```

See 
- lib/src/stack.c:434
- lib/src/error_costs.h:4
- crates/generate/src/build_tables/build_parse_table.rs:279-291


