### PR TITLE
fix(rust): address new clippy lints

### DIFF
--- a/crates/cli/src/fuzz/scope_sequence.rs
+++ b/crates/cli/src/fuzz/scope_sequence.rs
@@ -49,7 +49,7 @@ impl ScopeSequence {
         for i in 0..(self.0.len().max(other.0.len())) {
             let stack = &self.0.get(i);
             let other_stack = &other.0.get(i);
-            if *stack != *other_stack && ![b'\r', b'\n'].contains(&text[i]) {
+            if *stack != *other_stack && !b"\r\n".contains(&text[i]) {
                 let containing_range = known_changed_ranges
                     .iter()
                     .find(|range| range.start_point <= position && position < range.end_point);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1960,7 +1960,7 @@ impl DumpLanguages {
                 concat!(
                     "name: {}\n",
                     "scope: {}\n",
-                    "parser: {:?}\n",
+                    "parser: {}\n",
                     "highlights: {:?}\n",
                     "file_types: {:?}\n",
                     "content_regex: {:?}\n",
@@ -1968,7 +1968,7 @@ impl DumpLanguages {
                 ),
                 configuration.language_name,
                 configuration.scope.as_ref().unwrap_or(&String::new()),
-                language_path,
+                language_path.display(),
                 configuration.highlights_filenames,
                 configuration.file_types,
                 configuration.content_regex,

--- a/crates/cli/src/tags.rs
+++ b/crates/cli/src/tags.rs
@@ -49,7 +49,7 @@ pub fn generate_tags(
                 &mut stdout,
                 "{indent_str}{:<10}\t | {:<8}\t{} {} - {} `{}`",
                 str::from_utf8(&source[tag.name_range]).unwrap_or(""),
-                &config.syntax_type_name(tag.syntax_type_id),
+                config.syntax_type_name(tag.syntax_type_id),
                 if tag.is_definition { "def" } else { "ref" },
                 tag.span.start,
                 tag.span.end,
@@ -59,7 +59,7 @@ pub fn generate_tags(
                 if docs.len() > 120 {
                     write!(&mut stdout, "\t{:?}...", docs.get(0..120).unwrap_or(""))?;
                 } else {
-                    write!(&mut stdout, "\t{:?}", &docs)?;
+                    write!(&mut stdout, "\t{docs:?}")?;
                 }
             }
             writeln!(&mut stdout)?;

--- a/crates/cli/src/tests/parser_test.rs
+++ b/crates/cli/src/tests/parser_test.rs
@@ -1129,7 +1129,7 @@ fn test_parsing_with_timeout_during_balancing() {
                 Some(ParseOptions::new().progress_callback(&mut |state| {
                     // Because we've already finished parsing, we should only be resuming the
                     // balancing phase.
-                    assert!(state.current_byte_offset() == current_byte_offset);
+                    assert_eq!(state.current_byte_offset(), current_byte_offset);
                     ControlFlow::Continue(())
                 })),
             )

--- a/crates/generate/src/build_tables/build_parse_table.rs
+++ b/crates/generate/src/build_tables/build_parse_table.rs
@@ -348,8 +348,7 @@ impl<'a> ParseTableBuilder<'a> {
         if !self.actual_conflicts.is_empty() {
             warn!(
                 "unnecessary conflicts:\n  {}",
-                &self
-                    .actual_conflicts
+                self.actual_conflicts
                     .iter()
                     .map(|conflict| {
                         conflict

--- a/crates/tags/src/tags.rs
+++ b/crates/tags/src/tags.rs
@@ -518,13 +518,10 @@ where
                         // reuse results from the previous tag.
                         let mut prev_utf16_column = 0;
                         let mut prev_utf8_byte = name_range.start - span.start.column;
-                        let line_info = self.prev_line_info.as_ref().and_then(|info| {
-                            if info.utf8_position.row == span.start.row {
-                                Some(info)
-                            } else {
-                                None
-                            }
-                        });
+                        let line_info = self
+                            .prev_line_info
+                            .as_ref()
+                            .filter(|&info| info.utf8_position.row == span.start.row);
                         let line_range = if let Some(line_info) = line_info {
                             if line_info.utf8_position.column <= span.start.column {
                                 prev_utf8_byte = line_info.utf8_byte;

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -2398,9 +2398,7 @@ impl Query {
         }
         let column = offset - line_start;
 
-        let kind;
-        let message;
-        match error_type {
+        let (message, kind) = match error_type {
             // Error types that report names
             ffi::TSQueryErrorNodeType | ffi::TSQueryErrorField | ffi::TSQueryErrorCapture => {
                 let suffix = source.split_at(offset).1;
@@ -2423,27 +2421,29 @@ impl Query {
                         }
                     })
                     .unwrap_or(suffix.len());
-                message = format!("\"{}\"", suffix.split_at(end_offset).0);
-                kind = match error_type {
-                    ffi::TSQueryErrorNodeType => QueryErrorKind::NodeType,
-                    ffi::TSQueryErrorField => QueryErrorKind::Field,
-                    ffi::TSQueryErrorCapture => QueryErrorKind::Capture,
-                    _ => unreachable!(),
-                };
+                (
+                    format!("\"{}\"", suffix.split_at(end_offset).0),
+                    match error_type {
+                        ffi::TSQueryErrorNodeType => QueryErrorKind::NodeType,
+                        ffi::TSQueryErrorField => QueryErrorKind::Field,
+                        ffi::TSQueryErrorCapture => QueryErrorKind::Capture,
+                        _ => unreachable!(),
+                    },
+                )
             }
 
             // Error types that report positions
-            _ => {
-                message = line_containing_error.map_or_else(
+            _ => (
+                line_containing_error.map_or_else(
                     || "Unexpected EOF".to_string(),
                     |line| line.to_string() + "\n" + &" ".repeat(offset - line_start) + "^",
-                );
-                kind = match error_type {
+                ),
+                match error_type {
                     ffi::TSQueryErrorStructure => QueryErrorKind::Structure,
                     _ => QueryErrorKind::Syntax,
-                };
-            }
-        }
+                },
+            ),
+        };
 
         Err(QueryError {
             row,


### PR DESCRIPTION
Manual backport of #5742 

One additional clippy fix was necessary (the code had changed on master), and the `as_chunks` change had to be reverted because the MSRV on the release branch is < 1.88.