### PR TITLE
fix(ci): re-set executable permission on release artifacts before zipping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
 
           for platform in $(cd artifacts; ls | sed 's/^tree-sitter\.//'); do
             exe=$(ls artifacts/tree-sitter.$platform/tree-sitter*)
+            chmod +x $exe
             gzip --stdout --name $exe > target/tree-sitter-$platform.gz
             zip -j9 target/tree-sitter-cli-$platform.zip $exe
           done


### PR DESCRIPTION
I spent some time poking around at this issue, and it seems like `zip` _does_ preserve executable permission bits. The upload artifact action that runs before our use of `zip` and `gzip` does not: https://github.com/actions/upload-artifact#permission-loss.

Setting the executable bit here _should_ fix zip archives, but not gz. At worst, it's harmless and essentially costs us nothing.

- References #5564