### PR TITLE
feat(highlight)!: include underlying `LanguageError` in highlight and tag crates' error enums

### DIFF
--- a/crates/cli/src/tests/highlight_test.rs
+++ b/crates/cli/src/tests/highlight_test.rs
@@ -496,7 +496,7 @@ fn test_highlighting_cancellation() {
     let found_cancellation_error = events.any(|event| match event {
         Ok(_) => false,
         Err(Error::Cancelled) => true,
-        Err(Error::InvalidLanguage | Error::Unknown) => {
+        Err(Error::InvalidLanguage(_) | Error::Unknown) => {
             unreachable!("Unexpected error type while iterating events")
         }
     });

--- a/crates/highlight/src/c_lib.rs
+++ b/crates/highlight/src/c_lib.rs
@@ -416,7 +416,7 @@ impl TSHighlighter {
             });
             match result {
                 Err(Error::Cancelled | Error::Unknown) => ErrorCode::Timeout,
-                Err(Error::InvalidLanguage) => ErrorCode::InvalidLanguage,
+                Err(Error::InvalidLanguage(_)) => ErrorCode::InvalidLanguage,
                 Ok(()) => ErrorCode::Ok,
             }
         } else {

--- a/crates/highlight/src/highlight.rs
+++ b/crates/highlight/src/highlight.rs
@@ -95,8 +95,8 @@ pub struct Highlight(pub usize);
 pub enum Error {
     #[error("Cancelled")]
     Cancelled,
-    #[error("Invalid language")]
-    InvalidLanguage,
+    #[error("Invalid language: {0}")]
+    InvalidLanguage(#[from] tree_sitter::LanguageError),
     #[error("Unknown error")]
     Unknown,
 }
@@ -541,10 +541,7 @@ impl<'a> HighlightIterLayer<'a> {
         let mut queue = Vec::new();
         loop {
             if highlighter.parser.set_included_ranges(&ranges).is_ok() {
-                highlighter
-                    .parser
-                    .set_language(&config.language)
-                    .map_err(|_| Error::InvalidLanguage)?;
+                highlighter.parser.set_language(&config.language)?;
 
                 let progress_callack = &mut |_: &ParseState| {
                     if let Some(cancellation_flag) = cancellation_flag {

--- a/crates/tags/src/c_lib.rs
+++ b/crates/tags/src/c_lib.rs
@@ -123,7 +123,7 @@ pub unsafe extern "C" fn ts_tagger_add_language(
             Err(Error::Query(_)) => TSTagsError::InvalidQuery,
             Err(Error::Regex(_)) => TSTagsError::InvalidRegex,
             Err(Error::Cancelled) => TSTagsError::Timeout,
-            Err(Error::InvalidLanguage) => TSTagsError::InvalidLanguage,
+            Err(Error::InvalidLanguage(_)) => TSTagsError::InvalidLanguage,
             Err(Error::InvalidCapture(_)) => TSTagsError::InvalidCapture,
         }
     }
@@ -171,7 +171,7 @@ pub unsafe extern "C" fn ts_tagger_tag(
                 }
                 Err(e) => {
                     return match e {
-                        Error::InvalidLanguage => TSTagsError::InvalidLanguage,
+                        Error::InvalidLanguage(_) => TSTagsError::InvalidLanguage,
                         _ => TSTagsError::Timeout,
                     };
                 }

--- a/crates/tags/src/tags.rs
+++ b/crates/tags/src/tags.rs
@@ -77,8 +77,8 @@ pub enum Error {
     Regex(#[from] regex::Error),
     #[error("Cancelled")]
     Cancelled,
-    #[error("Invalid language")]
-    InvalidLanguage,
+    #[error("Invalid language: {0}")]
+    InvalidLanguage(#[from] tree_sitter::LanguageError),
     #[error(
         "Invalid capture @{0}. Expected one of: @definition.*, @reference.*, @doc, @name, @local.(scope|definition|reference)."
     )]
@@ -286,9 +286,7 @@ impl TagsContext {
         source: &'a [u8],
         cancellation_flag: Option<&'a AtomicUsize>,
     ) -> Result<(impl Iterator<Item = Result<Tag, Error>> + 'a, bool), Error> {
-        self.parser
-            .set_language(&config.language)
-            .map_err(|_| Error::InvalidLanguage)?;
+        self.parser.set_language(&config.language)?;
         self.parser.reset();
         let tree = self
             .parser


### PR DESCRIPTION
### The Problem

The repro in #5747 failed to set the highlighter's parser's wasm store. 

```rust
use std::fs;
use tree_sitter::{WasmStore, wasmtime::Engine};
use tree_sitter_highlight::{HighlightConfiguration, Highlighter};

fn main() {
    let mut store = WasmStore::new(&Engine::default()).unwrap();

    let wasm = fs::read("tree-sitter-javascript.wasm").expect("Failed to read WASM file");
    let lang = store
        .load_language("javascript", &wasm)
        .expect("Failed to load language from WASM");

    let highlight_query = fs::read_to_string("highlights.scm").expect("Failed to read SCM file");

    let config = HighlightConfiguration::new(lang, "javascript", &highlight_query, "", "")
        .expect("Failed to create HighlightConfiguration");

    let mut highlighter = Highlighter::new();
    highlighter.parser.set_wasm_store(store).unwrap(); // !!! Missing this line !!!

    highlighter
        .highlight(&config, b"let x = 1;", None, |_| None)
        .unwrap();
}
``` 

The  error returned by tree-sitter isn't a bug here, but its messaging could definitely be improved:

```
thread 'main' (247033) panicked at src/main.rs:22:10:
called `Result::unwrap()` on an `Err` value: InvalidLanguage
```

### The Solution

Include the inner `LanguageError` to provide more information to callers:

When unwrapping: 

```
thread 'main' (2439974) panicked at src/main.rs:23:10:
called `Result::unwrap()` on an `Err` value: InvalidLanguage(Wasm)
```

When using the error's `Display` impl (i.e. from within a `panic!` message):
```
thread 'main' (2441275) panicked at src/main.rs:23:19:
Invalid language: Failed to load the Wasm store.
```

- Closes #5747

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
