### PR TITLE
fix(cli): `init --update` should not update `setup.py` after replacing it

### DIFF
--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -1215,6 +1215,7 @@ fn update_python_setup_py(path: &Path, language_name: &str, opts: &GenerateOpts)
     if !contents.contains("build_ext") {
         info!("Replacing setup.py");
         generate_file(path, SETUP_PY_TEMPLATE, language_name, opts)?;
+        return Ok(());
     }
     if !contents.contains(" and not get_config_var") {
         info!("Updating Python free-threading support in setup.py");

--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -1215,23 +1215,23 @@ fn update_python_setup_py(path: &Path, language_name: &str, opts: &GenerateOpts)
     if !contents.contains("build_ext") {
         info!("Replacing setup.py");
         generate_file(path, SETUP_PY_TEMPLATE, language_name, opts)?;
-        return Ok(());
-    }
-    if !contents.contains(" and not get_config_var") {
-        info!("Updating Python free-threading support in setup.py");
-        contents = contents.replace(
-            r#"startswith("cp"):"#,
-            r#"startswith("cp") and not get_config_var("Py_GIL_DISABLED"):"#,
-        );
-        write_file(path, &contents)?;
-    }
-    if !contents.contains("include(\"src/*.c\")") {
-        info!("Updating sdist file list in setup.py");
-        let contents = contents.replace(
-            "include(\"src/tree_sitter/*.h\")",
-            "include(\"src/tree_sitter/*.h\")\n        self.filelist.include(\"src/*.c\")",
-        );
-        write_file(path, &contents)?;
+    } else {
+        if !contents.contains(" and not get_config_var") {
+            info!("Updating Python free-threading support in setup.py");
+            contents = contents.replace(
+                r#"startswith("cp"):"#,
+                r#"startswith("cp") and not get_config_var("Py_GIL_DISABLED"):"#,
+            );
+            write_file(path, &contents)?;
+        }
+        if !contents.contains("include(\"src/*.c\")") {
+            info!("Updating sdist file list in setup.py");
+            let contents = contents.replace(
+                "include(\"src/tree_sitter/*.h\")",
+                "include(\"src/tree_sitter/*.h\")\n        self.filelist.include(\"src/*.c\")",
+            );
+            write_file(path, &contents)?;
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
`setup.py` can be both replaced and then updated. but the update is based on the old version and undoes the replacement.

i ran into the issue when updating from tree-sitter-cli 0.25.3 to 0.26.9 and noticing that `tree-sitter init --update` was not idempotent. executing this command a second time kept changing `setup.py`. and i observed the output of the first run containing both `Replacing setup.py` and `Updating Python free-threading support in setup.py`.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
