### PR TITLE
fix(query): keep the trailing anchor when a zero-matched quantifier is anchored on both sides

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -1338,6 +1338,52 @@ function foo() {}
 }
 
 #[test]
+fn test_query_matches_with_leading_anchor_before_zero_quantifier() {
+    allocations::record(|| {
+        let language = get_language("c");
+        let query = Query::new(
+            &language,
+            "(translation_unit . (comment)* (function_definition) @f)",
+        )
+        .unwrap();
+
+        // The leading `.` anchors the comment run to the parent's first child. When the
+        // run matches zero comments, that first-child requirement transfers to the
+        // function, so it matches only when it is itself the first child.
+        assert_query_matches(
+            &language,
+            &query,
+            "
+int main() {}
+",
+            &[(0, vec![("f", "int main() {}")])],
+        );
+
+        // The function is the second child, so with no leading comments it must not match.
+        assert_query_matches(
+            &language,
+            &query,
+            "
+int a;
+int main() {}
+",
+            &[],
+        );
+
+        // With a leading comment the run starts at the first child and the function follows.
+        assert_query_matches(
+            &language,
+            &query,
+            "
+// c
+int main() {}
+",
+            &[(0, vec![("f", "int main() {}")])],
+        );
+    });
+}
+
+#[test]
 fn test_query_matches_with_last_named_child() {
     allocations::record(|| {
         let language = get_language("c");

--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -1298,6 +1298,46 @@ fn test_query_matches_with_last_child_anchor_after_optional() {
 }
 
 #[test]
+fn test_query_matches_with_anchors_on_both_sides_of_zero_quantifier() {
+    allocations::record(|| {
+        let language = get_language("javascript");
+        let query = Query::new(
+            &language,
+            "(program (lexical_declaration) @a . (comment)* . (function_declaration) @b)",
+        )
+        .unwrap();
+
+        // Anchors on both sides of a zero-matched quantifier collapse into a single
+        // adjacency constraint: with no comments, the declaration must be immediately
+        // followed by the function.
+        assert_query_matches(
+            &language,
+            &query,
+            "
+const a = 1;
+const b = 2;
+function foo() {}
+",
+            &[(0, vec![("a", "const b = 2;"), ("b", "function foo() {}")])],
+        );
+
+        // With a comment present the quantifier is non-zero, so the anchors apply
+        // normally: the comment must sit immediately between the declaration and the
+        // function.
+        assert_query_matches(
+            &language,
+            &query,
+            "
+const b = 2;
+// c
+function foo() {}
+",
+            &[(0, vec![("a", "const b = 2;"), ("b", "function foo() {}")])],
+        );
+    });
+}
+
+#[test]
 fn test_query_matches_with_last_named_child() {
     allocations::record(|| {
         let language = get_language("c");

--- a/docs/src/using-parsers/queries/2-operators.md
+++ b/docs/src/using-parsers/queries/2-operators.md
@@ -239,6 +239,21 @@ nearest node that the pattern _does_ match. For example, given
 the trailing anchor requires the last matched node to be the parent's last named child: when a
 `preproc_else` is present it must be last. When it is absent, the last `preproc_def` must be last.
 
+Similarly, if an optionally quantified node is anchored between two siblings and matches zero nodes,
+both sibling anchors collapse into one, constraining the outer nodes together. For example, given
+
+```query
+(translation_unit
+  (declaration) @a
+  .
+  (comment)*
+  .
+  (function_definition) @b)
+```
+
+If there are no comments, `(declaration)` and `(function_definition)` must be immediate siblings
+in order for the query to match.
+
 An anchor may not appear at the first or last position inside a group `(...)` or an alternation
 `[...]`. A group or alternation is not a node, so it has no first or last child to anchor against,
 and there is no sibling on that side to anchor to. For example, write `(comment)* @doc . (function)`

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -4478,8 +4478,12 @@ static inline bool ts_query_cursor__advance(
                   copy->seeking_immediate_match = true;
                 }
                 // Taking a `?`/`*` zero-skip means the quantified subpattern matched
-                // nothing, so an immediately-following anchor is vacuous for this copy.
-                if (child_step->alternative_is_skip) {
+                // nothing, so an immediately-following anchor is vacuous for this copy,
+                // UNLESS the skipped step carried a leading anchor of its own. In that
+                // case the adjacency transfers through the empty run to the step we skip
+                // to, so `A . Q* . B` with zero `Q` still requires `A` and `B` to be
+                // immediate siblings.
+                if (child_step->alternative_is_skip && !child_step->is_immediate) {
                   copy->skipped_quantifier = true;
                 }
               }

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -4478,13 +4478,26 @@ static inline bool ts_query_cursor__advance(
                   copy->seeking_immediate_match = true;
                 }
                 // Taking a `?`/`*` zero-skip means the quantified subpattern matched
-                // nothing, so an immediately-following anchor is vacuous for this copy,
-                // UNLESS the skipped step carried a leading anchor of its own. In that
-                // case the adjacency transfers through the empty run to the step we skip
-                // to, so `A . Q* . B` with zero `Q` still requires `A` and `B` to be
-                // immediate siblings.
-                if (child_step->alternative_is_skip && !child_step->is_immediate) {
-                  copy->skipped_quantifier = true;
+                // nothing. How an adjacent anchor behaves then depends on where it sat:
+                if (child_step->alternative_is_skip) {
+                  if (!child_step->is_immediate) {
+                    // No leading anchor on the skipped step, so an immediately-following
+                    // anchor on the skip target is vacuous (`Q* . B` with zero `Q` lets
+                    // `B` match anywhere).
+                    copy->skipped_quantifier = true;
+                  } else if (
+                    array_get(&self->query->steps, child_state->step_index - 1)->depth <
+                    child_step->depth
+                  ) {
+                    // The skipped step was the parent's first child pattern and carried a
+                    // leading *boundary* anchor (`(P . Q* Y)`). Transfer the first-child
+                    // requirement to the skip target so it survives the empty run: `Y`
+                    // must still be the parent's first named child.
+                    copy->seeking_immediate_match = true;
+                  }
+                  // Otherwise the skipped step carried a leading *between* anchor
+                  // (`A . Q* ...`): with zero `Q` that adjacency vanishes, while the skip
+                  // target's own anchor, if any, still applies (`A . Q* . B` stays adjacent).
                 }
               }
             }


### PR DESCRIPTION
In `A . Q* . B`, a zero-matched `Q` made both anchors vacuous, so `A` and `B` were no longer required to be immediate siblings. Only relax the following anchor on a `?`/`*` zero-skip when the skipped step has no leading anchor of its own; otherwise the adjacency transfers through the empty run.

While debugging this issue, I noticed another pre-existing issue with sibling anchors, which is addressed in this PR's second commit. The two fixes step on each other quite a bit in query.c, however I think they're still valuable as separate, atomic changes.

- Fixes #5759

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
Opus 4.8 to narrow on where the fix should be.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
