### PR TITLE
fix(parser): restart recovery for invalid tokens in the error state

### DIFF
--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -1772,6 +1772,13 @@ static bool ts_parser__advance(
       }
     }
 
+    // If the current lookahead token is not valid and the parser is
+    // already in the error state, restart the error recovery process.
+    if (state == ERROR_STATE) {
+      ts_parser__recover(self, version, lookahead);
+      return true;
+    }
+
     // If the current lookahead token is not valid and the previous subtree on
     // the stack was reused from an old tree, then it wasn't actually valid to
     // reuse that previous subtree. Remove it from the stack, and in its place,


### PR DESCRIPTION
The early `ts_parser__recover` dispatch for `ERROR_STATE` in `ts_parser__advance` was dropped in `201b41cf1`. Without it, tokens with no valid action re-enter `ts_parser__handle_error` per token and fragment the tree instead of extending one ERROR node. Restore it to recover the old (pre-0.25) error recovery behavior.

Testing via `cargo xtask benchmark` showed no performance regression with this change.

CC @maxbrunsfeld Since you removed this block in #3896, do you see any reason not to re-introduce it?

- Closes #5753

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
Used Opus 4.8 to take a second look through the error recovery paths to check for unintended consequences from this change.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
