### PR TITLE
feat(cli)!: make parents flags a hard requirements via clap

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anstyle::{AnsiColor, Color, Style};
 use anyhow::{Context, Result, anyhow};
-use clap::{Args, Command, FromArgMatches as _, Subcommand, ValueEnum, crate_authors};
+use clap::{ArgGroup, Args, Command, FromArgMatches as _, Subcommand, ValueEnum, crate_authors};
 use clap_complete::generate;
 use dialoguer::{Confirm, FuzzySelect, Input, MultiSelect, theme::ColorfulTheme};
 use heck::ToUpperCamelCase;
@@ -195,6 +195,7 @@ struct Build {
 
 #[derive(Args)]
 #[command(alias = "p")]
+#[command(group(ArgGroup::new("graph_output").multiple(true)))]
 struct Parse {
     /// The path to a file with paths to source file(s)
     #[arg(long = "paths")]
@@ -226,13 +227,13 @@ struct Parse {
     #[arg(long, short = '0')]
     pub debug_build: bool,
     /// Produce the log.html file with debug graphs
-    #[arg(long, short = 'D')]
+    #[arg(long, short = 'D', group = "graph_output")]
     pub debug_graph: bool,
     /// Compile parsers to Wasm instead of native dynamic libraries
     #[arg(long, hide = cfg!(not(feature = "wasm")))]
     pub wasm: bool,
     /// Output the parse data with graphviz dot
-    #[arg(long = "dot")]
+    #[arg(long = "dot", group = "graph_output")]
     pub output_dot: bool,
     /// Output the parse data in XML format
     #[arg(long = "xml", short = 'x')]
@@ -266,8 +267,8 @@ struct Parse {
     /// The encoding of the input files
     #[arg(long)]
     pub encoding: Option<Encoding>,
-    /// Open `log.html` in the default browser, if `--debug-graph` is supplied
-    #[arg(long)]
+    /// Open `log.html` in the default browser, if `--debug-graph` or `--dot` is supplied
+    #[arg(long, requires = "graph_output")]
     pub open_log: bool,
     /// Deprecated: use --json-summary
     #[arg(long, conflicts_with = "json_summary", conflicts_with = "stat")]
@@ -335,7 +336,7 @@ struct Test {
     #[arg(long, hide = cfg!(not(feature = "wasm")))]
     pub wasm: bool,
     /// Open `log.html` in the default browser, if `--debug-graph` is supplied
-    #[arg(long)]
+    #[arg(long, requires = "debug_graph")]
     pub open_log: bool,
     /// The path to an alternative config.json file
     #[arg(long)]
@@ -508,13 +509,13 @@ struct Highlight {
     #[arg(long, short = 'H')]
     pub html: bool,
     /// When generating HTML, use css classes rather than inline styles
-    #[arg(long)]
+    #[arg(long, requires = "html")]
     pub css_classes: bool,
     /// Check that highlighting captures conform strictly to standards
     #[arg(long)]
     pub check: bool,
     /// The path to a file with captures
-    #[arg(long)]
+    #[arg(long, requires = "check")]
     pub captures_path: Option<PathBuf>,
     /// The paths to files with queries
     #[arg(long, num_args = 1..)]

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -71,8 +71,8 @@ pub struct LogSession {
     open_log: bool,
 }
 
-pub fn print_tree_graph(tree: &Tree, path: &str, quiet: bool) -> Result<()> {
-    let session = LogSession::new(path, quiet)?;
+pub fn print_tree_graph(tree: &Tree, path: &str, open_log: bool) -> Result<()> {
+    let session = LogSession::new(path, open_log)?;
     tree.print_dot_graph(session.dot_process_stdin.as_ref().unwrap());
     Ok(())
 }

--- a/docs/src/cli/parse.md
+++ b/docs/src/cli/parse.md
@@ -88,7 +88,7 @@ in `UTF-16BE` or `UTF-16LE`. If no `BOM` is present, `UTF-8` is the default. One
 
 ### `--open-log`
 
-When using the `--debug-graph` option, open the log file in the default browser.
+When using the `--debug-graph` or `--dot` options, open the log file in the default browser.
 
 ### `-j/--json-summary`
 


### PR DESCRIPTION
Also correct a parameter name in `print_tree_graph`

The `tree-sitter-cli` offers a large number of flags for each subcommand, which can be hard to follow. It's clearer to the end user to error on an unused flag rather than to silently swallow it.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
Used Opus 4.8 to do a pass checking for other flags where `requires` could be applied.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
