### PR TITLE
ci: update macos runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,8 @@ jobs:
           - { platform: windows-arm64   , target: aarch64-pc-windows-msvc       , os: windows-11-arm   }
           - { platform: windows-x64     , target: x86_64-pc-windows-msvc        , os: windows-2025     }
           - { platform: windows-x86     , target: i686-pc-windows-msvc          , os: windows-2025     }
-          - { platform: macos-arm64     , target: aarch64-apple-darwin          , os: macos-15         }
-          - { platform: macos-x64       , target: x86_64-apple-darwin           , os: macos-15-intel   }
+          - { platform: macos-arm64     , target: aarch64-apple-darwin          , os: xcode-27         }
+          - { platform: macos-x64       , target: x86_64-apple-darwin           , os: macos-26-intel   }
           - { platform: wasm32          , target: wasm32-unknown-unknown        , os: ubuntu-24.04     }
 
           # illumos is not supported OOTB, it runs in a vm

--- a/.github/workflows/nvim_ts.yml
+++ b/.github/workflows/nvim_ts.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, xcode-27]
         type: [generate, build]
     name: ${{ matrix.os }} - ${{ matrix.type }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
THIS IS A TEST.

(Eventually we want to do a general bump to `latest`, but right now I just want to reproduce a local build failure with Xcode 27 beta.)