### PR TITLE
fix(highlight): use `std::sync::OnceCell` for various loader fields

### DIFF
--- a/crates/loader/src/loader.rs
+++ b/crates/loader/src/loader.rs
@@ -21,7 +21,7 @@ use std::{
 use etcetera::BaseStrategy as _;
 use libloading::{Library, Symbol};
 use log::{error, info, warn};
-use once_cell::unsync::OnceCell;
+use once_cell::sync::OnceCell;
 use regex::{Regex, RegexBuilder};
 use semver::Version;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -710,8 +710,6 @@ impl<'a> CompileConfig<'a> {
         }
     }
 }
-
-unsafe impl Sync for Loader {}
 
 /// Generate a temporary file path for atomic writes. The temp file is a hidden
 /// dotfile alongside the target, tagged with the current process and thread id


### PR DESCRIPTION
Changes: 
1. Changed OnceCell from unsync to sync for thread safety.
2. Removed manual Sync trait for Loader, since now it can be automatically inferred.

`struct Loader` has field `languages_by_id: Vec<(PathBuf, OnceCell<Language>, Option<Vec<PathBuf>>)>`. Loader has manually been given the Sync trait, despite the fact that OnceCell is !Sync (since it is imported as `once_cell::unsync::OnceCell`).  There are at least three different vectors for callers to get data races by calling this API in entirely safe ways. 

One way is: Loader has public method `language_for_configuration()`, which calls `language_for_id()`, which calls `get_or_try_init()` on a OnceCell (which performs a write if OnceCell is empty). If you have two threads call language_for_configuration() on the same Loader (which is possible since Loader is Sync and the method takes an immut ref), it is possible that both would call `get_or_try_init()` on the same empty OnceCell without synchronization, which would be undefined behaviour (a data race in this case).

For example, ThreadSanitizer reported a data race on the following test:

```
#[cfg(test)]
mod tests {
    use super::*;
    use std::path::Path;

    #[test]
    fn prove_loader_data_race() {
        let grammar_path = Path::new("/tmp/tree-sitter-json");

        let mut loader = Loader::new().unwrap();
        loader.find_language_configurations_at_path(grammar_path, false).unwrap();

        std::thread::scope(|s| {
            for _ in 0..4 {
                let loader_ref = &loader;
                s.spawn(move || {
                    let config = loader_ref.get_all_language_configurations()[0].0;
                    let _ = loader_ref.language_for_configuration(config);
                });
            }
        });
    }
}
```

The other two data races are from the fact that `struct LanguageConfiguration` also has two OnceCell fields (highlight_config and tags_config), and has methods that modify these fields through shared `&self` references without synchronization (highlight_config() and tags_config()). Loader holds some LanguageConfigurations, so they can also be shared across threads, meaning you can get data races with these too. By making OnceCell thread-safe, this PR also addresses these data races.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.