### PR TITLE
fix(lib)!: rework `LookaheadIterator`

### DIFF
--- a/crates/cli/src/fuzz/scope_sequence.rs
+++ b/crates/cli/src/fuzz/scope_sequence.rs
@@ -1,13 +1,13 @@
 use tree_sitter::{Point, Range, Tree};
 
 #[derive(Debug)]
-pub struct ScopeSequence(Vec<ScopeStack>);
+pub struct ScopeSequence<'a>(Vec<ScopeStack<'a>>);
 
-type ScopeStack = Vec<&'static str>;
+type ScopeStack<'a> = Vec<&'a str>;
 
-impl ScopeSequence {
+impl<'a> ScopeSequence<'a> {
     #[must_use]
-    pub fn new(tree: &Tree) -> Self {
+    pub fn new(tree: &'a Tree) -> Self {
         let mut result = Self(Vec::new());
         let mut scope_stack = Vec::new();
 

--- a/crates/cli/src/tests/helpers/query_helpers.rs
+++ b/crates/cli/src/tests/helpers/query_helpers.rs
@@ -7,10 +7,10 @@ use tree_sitter::{
 };
 
 #[derive(Debug)]
-pub struct Pattern {
-    kind: Option<&'static str>,
+pub struct Pattern<'a> {
+    kind: Option<&'a str>,
     named: bool,
-    field: Option<&'static str>,
+    field: Option<&'a str>,
     capture: Option<String>,
     children: Vec<Self>,
 }
@@ -25,8 +25,8 @@ const CAPTURE_NAMES: &[&str] = &[
     "one", "two", "three", "four", "five", "six", "seven", "eight",
 ];
 
-impl Pattern {
-    pub fn random_pattern_in_tree(tree: &Tree, rng: &mut impl Rng) -> (Self, Range<Point>) {
+impl<'a> Pattern<'a> {
+    pub fn random_pattern_in_tree(tree: &'a Tree, rng: &mut impl Rng) -> (Self, Range<Point>) {
         let mut cursor = tree.walk();
 
         // Descend to the node at a random byte offset and depth.
@@ -75,7 +75,7 @@ impl Pattern {
         (pattern, pattern_start..pattern_end)
     }
 
-    fn random_pattern_for_node(cursor: &mut TreeCursor, rng: &mut impl Rng) -> Self {
+    fn random_pattern_for_node(cursor: &mut TreeCursor<'a>, rng: &mut impl Rng) -> Self {
         let node = cursor.node();
 
         // Sometimes specify the node's type, sometimes use a wildcard.
@@ -268,7 +268,7 @@ impl Pattern {
     }
 }
 
-impl std::fmt::Display for Pattern {
+impl std::fmt::Display for Pattern<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut result = String::new();
         self.write_to_string(&mut result, 0);

--- a/crates/cli/src/tests/language_test.rs
+++ b/crates/cli/src/tests/language_test.rs
@@ -31,11 +31,12 @@ fn test_lookahead_iterator() {
     let mut lookahead = language.lookahead_iterator(next_state).unwrap();
     assert_eq!(*lookahead.language(), language);
     assert!(lookahead.iter_names().eq(expected_symbols));
+    assert_eq!(lookahead.iter_names().count(), 0);
 
-    lookahead.reset_state(next_state);
+    assert!(lookahead.reset_state(next_state));
     assert!(lookahead.iter_names().eq(expected_symbols));
 
-    lookahead.reset(&language, next_state);
+    assert!(lookahead.reset(&language, next_state));
     assert!(
         lookahead
             .map(|s| language.node_kind_for_id(s).unwrap())
@@ -64,6 +65,33 @@ fn test_lookahead_iterator_modifiable_only_by_mut() {
 
     let mut names = lookahead.iter_names();
     let _ = names.next();
+}
+
+#[test]
+fn test_lookahead_iterator_exhaustion() {
+    let language = get_language("json");
+
+    for state in 0..language.parse_state_count() {
+        let state = u16::try_from(state).unwrap();
+        let mut lookahead = language.lookahead_iterator(state).unwrap();
+
+        // A fresh iterator is not positioned on a symbol.
+        assert_eq!(lookahead.current_symbol(), None);
+        assert_eq!(lookahead.current_symbol_name(), None);
+
+        let count = lookahead.by_ref().count();
+
+        // An exhausted iterator is not positioned on a symbol, and stays exhausted.
+        assert_eq!(lookahead.current_symbol(), None);
+        assert_eq!(lookahead.current_symbol_name(), None);
+        assert_eq!(lookahead.by_ref().count(), 0);
+        assert_eq!(lookahead.iter_names().count(), 0);
+
+        // Resetting restores it exactly.
+        assert!(lookahead.reset_state(state));
+        assert_eq!(lookahead.current_symbol(), None);
+        assert_eq!(lookahead.by_ref().count(), count);
+    }
 }
 
 #[test]

--- a/crates/cli/src/tests/wasm_language_test.rs
+++ b/crates/cli/src/tests/wasm_language_test.rs
@@ -387,3 +387,18 @@ fn test_wasm_oom() {
         );
     });
 }
+
+#[test]
+fn test_lookahead_iterator_outlives_wasm_language() {
+    allocations::record(|| {
+        let mut store = WasmStore::new(&ENGINE).unwrap();
+        let wasm = fs::read(WASM_DIR.join("tree-sitter-ruby.wasm")).unwrap();
+        let language = store.load_language("ruby", &wasm).unwrap();
+
+        let mut lookahead = language.lookahead_iterator(0).unwrap();
+        drop(language);
+
+        // The iterator retains the language, so the names are still live.
+        assert!(lookahead.iter_names().count() > 0);
+    });
+}

--- a/crates/xtask/src/test.rs
+++ b/crates/xtask/src/test.rs
@@ -139,7 +139,7 @@ pub fn run_wasm() -> Result<()> {
         "npm"
     };
 
-    if !node_modules_dir.join("chai").exists() || !node_modules_dir.join("mocha").exists() {
+    if !node_modules_dir.join("vitest").exists() {
         println!("Installing test dependencies...");
         let output = Command::new(npm).arg("install").output()?;
         bail_on_err(&output, "Failed to install test dependencies")?;

--- a/lib/binding_rust/bindings.rs
+++ b/lib/binding_rust/bindings.rs
@@ -841,7 +841,7 @@ unsafe extern "C" {
     pub fn ts_language_name(self_: *const TSLanguage) -> *const ::core::ffi::c_char;
 }
 unsafe extern "C" {
-    #[doc = " Create a new lookahead iterator for the given language and parse state.\n\n This returns `NULL` if state is invalid for the language.\n\n Repeatedly using [`ts_lookahead_iterator_next`] and\n [`ts_lookahead_iterator_current_symbol`] will generate valid symbols in the\n given parse state. Newly created lookahead iterators will contain the `ERROR`\n symbol.\n\n Lookahead iterators can be useful to generate suggestions and improve syntax\n error diagnostics. To get symbols valid in an ERROR node, use the lookahead\n iterator on its first leaf node state. For `MISSING` nodes, a lookahead\n iterator created on the previous non-extra leaf node, or using the node's\n parse state may be appropriate."]
+    #[doc = " Create a new lookahead iterator for the given language and parse state.\n\n This returns `NULL` if state is invalid for the language.\n\n Repeatedly using [`ts_lookahead_iterator_next`] and\n [`ts_lookahead_iterator_current_symbol`] will generate valid symbols in the\n given parse state. A newly created iterator is not positioned on a symbol\n until [`ts_lookahead_iterator_next`] is called.\n\n The iterator retains the language, so the language may be deleted while the\n iterator is still in use.\n\n Lookahead iterators can be useful to generate suggestions and improve syntax\n error diagnostics. To get symbols valid in an ERROR node, use the lookahead\n iterator on its first leaf node state. For `MISSING` nodes, a lookahead\n iterator created on the previous non-extra leaf node, or using the node's\n parse state may be appropriate."]
     pub fn ts_lookahead_iterator_new(
         self_: *const TSLanguage,
         state: TSStateId,
@@ -852,14 +852,14 @@ unsafe extern "C" {
     pub fn ts_lookahead_iterator_delete(self_: *mut TSLookaheadIterator);
 }
 unsafe extern "C" {
-    #[doc = " Reset the lookahead iterator to another state.\n\n This returns `true` if the iterator was reset to the given state and `false`\n otherwise."]
+    #[doc = " Reset the lookahead iterator to another state.\n\n This returns `true` if the iterator was reset to the given state and `false`\n otherwise. A reset iterator is not positioned on a symbol."]
     pub fn ts_lookahead_iterator_reset_state(
         self_: *mut TSLookaheadIterator,
         state: TSStateId,
     ) -> bool;
 }
 unsafe extern "C" {
-    #[doc = " Reset the lookahead iterator.\n\n This returns `true` if the language was set successfully and `false`\n otherwise."]
+    #[doc = " Reset the lookahead iterator.\n\n This returns `true` if the language was set successfully and `false`\n otherwise. A reset iterator is not positioned on a symbol."]
     pub fn ts_lookahead_iterator_reset(
         self_: *mut TSLookaheadIterator,
         language: *const TSLanguage,
@@ -875,11 +875,11 @@ unsafe extern "C" {
     pub fn ts_lookahead_iterator_next(self_: *mut TSLookaheadIterator) -> bool;
 }
 unsafe extern "C" {
-    #[doc = " Get the current symbol of the lookahead iterator;"]
+    #[doc = " Get the current symbol of the lookahead iterator.\n\n This is only meaningful when the most recent call to\n [`ts_lookahead_iterator_next`] on `self` returned `true`."]
     pub fn ts_lookahead_iterator_current_symbol(self_: *const TSLookaheadIterator) -> TSSymbol;
 }
 unsafe extern "C" {
-    #[doc = " Get the current symbol type of the lookahead iterator as a null terminated\n string."]
+    #[doc = " Get the current symbol type of the lookahead iterator as a null terminated\n string.\n\n This returns `NULL` unless the most recent call to\n [`ts_lookahead_iterator_next`] on `self` returned `true`."]
     pub fn ts_lookahead_iterator_current_symbol_name(
         self_: *const TSLookaheadIterator,
     ) -> *const ::core::ffi::c_char;

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -2315,13 +2315,14 @@ impl LookaheadIterator {
     /// Get the current symbol name of the lookahead iterator.
     #[doc(alias = "ts_lookahead_iterator_current_symbol_name")]
     #[must_use]
-    pub fn current_symbol_name(&self) -> &'static str {
+    pub fn current_symbol_name(&self) -> Option<&'static str> {
         unsafe {
-            CStr::from_ptr(ffi::ts_lookahead_iterator_current_symbol_name(
-                self.0.as_ptr(),
-            ))
-            .to_str()
-            .unwrap()
+            let name = ffi::ts_lookahead_iterator_current_symbol_name(self.0.as_ptr());
+            if name.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(name).to_str().unwrap())
+            }
         }
     }
 
@@ -2354,8 +2355,7 @@ impl Iterator for LookaheadNamesIterator<'_> {
 
     #[doc(alias = "ts_lookahead_iterator_next")]
     fn next(&mut self) -> Option<Self::Item> {
-        unsafe { ffi::ts_lookahead_iterator_next(self.0.0.as_ptr()) }
-            .then(|| self.0.current_symbol_name())
+        self.0.next().and_then(|_| self.0.current_symbol_name())
     }
 }
 

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -508,7 +508,7 @@ impl Language {
     /// Get the name of this language. This returns `None` in older parsers.
     #[doc(alias = "ts_language_name")]
     #[must_use]
-    pub fn name(&self) -> Option<&'static str> {
+    pub fn name(&self) -> Option<&str> {
         let ptr = unsafe { ffi::ts_language_name(self.0) };
         (!ptr.is_null()).then(|| unsafe { CStr::from_ptr(ptr) }.to_str().unwrap())
     }
@@ -582,7 +582,7 @@ impl Language {
     /// Get the name of the node kind for the given numerical id.
     #[doc(alias = "ts_language_symbol_name")]
     #[must_use]
-    pub fn node_kind_for_id(&self, id: u16) -> Option<&'static str> {
+    pub fn node_kind_for_id(&self, id: u16) -> Option<&str> {
         let ptr = unsafe { ffi::ts_language_symbol_name(self.0, id) };
         (!ptr.is_null()).then(|| unsafe { CStr::from_ptr(ptr) }.to_str().unwrap())
     }
@@ -631,7 +631,7 @@ impl Language {
     /// Get the field name for the given numerical id.
     #[doc(alias = "ts_language_field_name_for_id")]
     #[must_use]
-    pub fn field_name_for_id(&self, field_id: u16) -> Option<&'static str> {
+    pub fn field_name_for_id(&self, field_id: u16) -> Option<&str> {
         let ptr = unsafe { ffi::ts_language_field_name_for_id(self.0, field_id) };
         (!ptr.is_null()).then(|| unsafe { CStr::from_ptr(ptr) }.to_str().unwrap())
     }
@@ -1627,7 +1627,7 @@ impl<'tree> Node<'tree> {
     /// Get this node's type as a string.
     #[doc(alias = "ts_node_type")]
     #[must_use]
-    pub fn kind(&self) -> &'static str {
+    pub fn kind(&self) -> &'tree str {
         unsafe { CStr::from_ptr(ffi::ts_node_type(self.0)) }
             .to_str()
             .unwrap()
@@ -1637,7 +1637,7 @@ impl<'tree> Node<'tree> {
     /// aliases as a string.
     #[doc(alias = "ts_node_grammar_type")]
     #[must_use]
-    pub fn grammar_name(&self) -> &'static str {
+    pub fn grammar_name(&self) -> &'tree str {
         unsafe { CStr::from_ptr(ffi::ts_node_grammar_type(self.0)) }
             .to_str()
             .unwrap()
@@ -1844,7 +1844,7 @@ impl<'tree> Node<'tree> {
     /// Get the field name of this node's child at the given index.
     #[doc(alias = "ts_node_field_name_for_child")]
     #[must_use]
-    pub fn field_name_for_child(&self, child_index: u32) -> Option<&'static str> {
+    pub fn field_name_for_child(&self, child_index: u32) -> Option<&'tree str> {
         unsafe {
             let ptr = ffi::ts_node_field_name_for_child(self.0, child_index);
             (!ptr.is_null()).then(|| CStr::from_ptr(ptr).to_str().unwrap())
@@ -1853,7 +1853,7 @@ impl<'tree> Node<'tree> {
 
     /// Get the field name of this node's named child at the given index.
     #[must_use]
-    pub fn field_name_for_named_child(&self, named_child_index: u32) -> Option<&'static str> {
+    pub fn field_name_for_named_child(&self, named_child_index: u32) -> Option<&'tree str> {
         unsafe {
             let ptr = ffi::ts_node_field_name_for_named_child(self.0, named_child_index);
             (!ptr.is_null()).then(|| CStr::from_ptr(ptr).to_str().unwrap())
@@ -2178,7 +2178,7 @@ impl<'tree> TreeCursor<'tree> {
     /// Get the field name of this tree cursor's current node.
     #[doc(alias = "ts_tree_cursor_current_field_name")]
     #[must_use]
-    pub fn field_name(&self) -> Option<&'static str> {
+    pub fn field_name(&self) -> Option<&'tree str> {
         unsafe {
             let ptr = ffi::ts_tree_cursor_current_field_name(&raw const self.0);
             (!ptr.is_null()).then(|| CStr::from_ptr(ptr).to_str().unwrap())

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -670,8 +670,12 @@ impl Language {
     /// This returns `None` if state is invalid for this language.
     ///
     /// Iterating [`LookaheadIterator`] will yield valid symbols in the given
-    /// parse state. Newly created lookahead iterators will return the `ERROR`
-    /// symbol from [`LookaheadIterator::current_symbol`].
+    /// parse state. A newly created iterator is not positioned on a symbol, so
+    /// [`LookaheadIterator::current_symbol`] returns `None` until the first
+    /// [`Iterator::next`] call.
+    ///
+    /// The iterator retains the language, so the language may be dropped while
+    /// the iterator is still in use.
     ///
     /// Lookahead iterators can be useful to generate suggestions and improve
     /// syntax error diagnostics. To get symbols valid in an `ERROR` node, use the
@@ -2337,22 +2341,34 @@ impl LookaheadIterator {
     }
 
     /// Get the current symbol of the lookahead iterator.
+    ///
+    /// Returns `None` if the iterator is not positioned on a symbol:
+    ///
+    /// - Before the first [`Iterator::next`] call
+    /// - After the iterator is exhausted
+    /// - After a [`Self::reset`] or [`Self::reset_state`] call
     #[doc(alias = "ts_lookahead_iterator_current_symbol")]
     #[must_use]
-    pub fn current_symbol(&self) -> u16 {
-        unsafe { ffi::ts_lookahead_iterator_current_symbol(self.0.as_ptr()) }
+    pub fn current_symbol(&self) -> Option<u16> {
+        // C signals "not positioned" through a null symbol name.
+        let name = unsafe { ffi::ts_lookahead_iterator_current_symbol_name(self.0.as_ptr()) };
+        (!name.is_null())
+            .then(|| unsafe { ffi::ts_lookahead_iterator_current_symbol(self.0.as_ptr()) })
     }
 
     /// Get the current symbol name of the lookahead iterator.
+    ///
+    /// Returns `None` if the iterator is not positioned on a symbol.
     #[doc(alias = "ts_lookahead_iterator_current_symbol_name")]
     #[must_use]
-    pub fn current_symbol_name(&self) -> &'static str {
+    pub fn current_symbol_name(&self) -> Option<&str> {
         unsafe {
-            CStr::from_ptr(ffi::ts_lookahead_iterator_current_symbol_name(
-                self.0.as_ptr(),
-            ))
-            .to_str()
-            .unwrap()
+            let name = ffi::ts_lookahead_iterator_current_symbol_name(self.0.as_ptr());
+            if name.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(name).to_str().unwrap())
+            }
         }
     }
 
@@ -2375,30 +2391,43 @@ impl LookaheadIterator {
     }
 
     /// Iterate symbol names.
-    pub fn iter_names(&mut self) -> impl Iterator<Item = &'static str> + '_ {
+    pub fn iter_names(&mut self) -> impl iter::FusedIterator<Item = &str> + '_ {
         LookaheadNamesIterator(self)
     }
 }
 
-impl Iterator for LookaheadNamesIterator<'_> {
-    type Item = &'static str;
+impl<'a> Iterator for LookaheadNamesIterator<'a> {
+    type Item = &'a str;
 
     #[doc(alias = "ts_lookahead_iterator_next")]
     fn next(&mut self) -> Option<Self::Item> {
-        unsafe { ffi::ts_lookahead_iterator_next(self.0.0.as_ptr()) }
-            .then(|| self.0.current_symbol_name())
+        let ptr = self.0.0.as_ptr();
+        // SAFETY: The borrow keeps the iterator (and the language refcount it holds)
+        // alive for `'a`. The name is non-null because the iterator is positioned
+        // whenever `next` returns `true`.
+        unsafe {
+            ffi::ts_lookahead_iterator_next(ptr).then(|| {
+                let name = ffi::ts_lookahead_iterator_current_symbol_name(ptr);
+                debug_assert!(!name.is_null());
+                CStr::from_ptr(name).to_str().unwrap()
+            })
+        }
     }
 }
+
+impl iter::FusedIterator for LookaheadNamesIterator<'_> {}
 
 impl Iterator for LookaheadIterator {
     type Item = u16;
 
     #[doc(alias = "ts_lookahead_iterator_next")]
     fn next(&mut self) -> Option<Self::Item> {
-        // the first symbol is always `0` so we can safely skip it
-        unsafe { ffi::ts_lookahead_iterator_next(self.0.as_ptr()) }.then(|| self.current_symbol())
+        unsafe { ffi::ts_lookahead_iterator_next(self.0.as_ptr()) }
+            .then(|| unsafe { ffi::ts_lookahead_iterator_current_symbol(self.0.as_ptr()) })
     }
 }
+
+impl iter::FusedIterator for LookaheadIterator {}
 
 impl Drop for LookaheadIterator {
     #[doc(alias = "ts_lookahead_iterator_delete")]

--- a/lib/binding_web/src/language.ts
+++ b/lib/binding_web/src/language.ts
@@ -210,8 +210,9 @@ export class Language {
    * This returns `null` if state is invalid for this language.
    *
    * Iterating {@link LookaheadIterator} will yield valid symbols in the given
-   * parse state. Newly created lookahead iterators will return the `ERROR`
-   * symbol from {@link LookaheadIterator#currentType}.
+   * parse state. A newly created iterator is not positioned on a symbol, so
+   * {@link LookaheadIterator#currentType} returns `null` until the first
+   * iteration step.
    *
    * Lookahead iterators can be useful for generating suggestions and improving
    * syntax error diagnostics. To get symbols valid in an `ERROR` node, use the

--- a/lib/binding_web/src/lookahead_iterator.ts
+++ b/lib/binding_web/src/lookahead_iterator.ts
@@ -14,6 +14,9 @@ export class LookaheadIterator implements Iterable<string> {
   private language: Language;
 
   /** @internal */
+  private positioned = false;
+
+  /** @internal */
   constructor(internal: Internal, address: number, language: Language) {
     assertInternal(internal);
     this[0] = address;
@@ -21,14 +24,32 @@ export class LookaheadIterator implements Iterable<string> {
     finalizer?.register(this, address, this);
   }
 
-  /** Get the current symbol of the lookahead iterator. */
-  get currentTypeId(): number {
-    return C._ts_lookahead_iterator_current_symbol(this[0]);
+  /**
+   * Get the current symbol of the lookahead iterator.
+   *
+   * Returns `null` if the iterator is not positioned on a symbol:
+   *
+   * - Before the first iteration step
+   * - After the iterator is exhausted
+   * - After a {@link reset} or {@link resetState} call
+   */
+  get currentTypeId(): number | null {
+    return this.positioned ?
+      C._ts_lookahead_iterator_current_symbol(this[0]) : null;
   }
 
-  /** Get the current symbol name of the lookahead iterator. */
-  get currentType(): string {
-    return this.language.types[this.currentTypeId] || 'ERROR';
+  /**
+   * Get the current symbol name of the lookahead iterator.
+   *
+   * Returns `null` if the iterator is not positioned on a symbol.
+   */
+  get currentType(): string | null {
+    const id = this.currentTypeId;
+    if (id === null) return null;
+    // `Language.types` only holds regular and anonymous symbols, so auxiliary
+    // ones (i.e. `end`) fall back to the language's own name table.
+    return this.language.types[id] ??
+      C.UTF8ToString(C._ts_language_symbol_name(this.language[0], id));
   }
 
   /** Delete the lookahead iterator, freeing its resources. */
@@ -48,6 +69,7 @@ export class LookaheadIterator implements Iterable<string> {
   reset(language: Language, stateId: number): boolean {
     if (C._ts_lookahead_iterator_reset(this[0], language[0], stateId)) {
       this.language = language;
+      this.positioned = false;
       return true;
     }
     return false;
@@ -60,7 +82,9 @@ export class LookaheadIterator implements Iterable<string> {
    * `false` otherwise.
    */
   resetState(stateId: number): boolean {
-    return Boolean(C._ts_lookahead_iterator_reset_state(this[0], stateId));
+    if (!C._ts_lookahead_iterator_reset_state(this[0], stateId)) return false;
+    this.positioned = false;
+    return true;
   }
 
   /**
@@ -72,10 +96,11 @@ export class LookaheadIterator implements Iterable<string> {
   [Symbol.iterator](): Iterator<string> {
     return {
       next: (): IteratorResult<string> => {
-        if (C._ts_lookahead_iterator_next(this[0])) {
-          return { done: false, value: this.currentType };
-        }
-        return { done: true, value: '' };
+        this.positioned = Boolean(C._ts_lookahead_iterator_next(this[0]));
+        const value = this.currentType;
+        return value === null
+          ? { done: true, value: '' }
+          : { done: false, value };
       }
     };
   }

--- a/lib/binding_web/test/language.test.ts
+++ b/lib/binding_web/test/language.test.ts
@@ -249,10 +249,51 @@ describe('Lookahead iterator', () => {
     expect(symbols).toHaveLength(expected.length);
   });
 
+  it('should stay exhausted until reset', () => {
+    expect(lookahead.resetState(state)).toBe(true);
+    expect(Array.from(lookahead)).toHaveLength(expected.length);
+    expect(Array.from(lookahead)).toHaveLength(0);
+    expect(lookahead.currentType).toBeNull();
+    expect(lookahead.currentTypeId).toBeNull();
+  });
+
+  it('should not be positioned before the first step', () => {
+    const fresh = JavaScript.lookaheadIterator(state);
+    expect(fresh).not.toBeNull();
+    expect(fresh?.currentType).toBeNull();
+    expect(fresh?.currentTypeId).toBeNull();
+    fresh?.delete();
+  });
+
   it('should reset', () => {
     expect(lookahead.reset(JavaScript, state)).toBe(true);
     const symbols = Array.from(lookahead);
     expect(symbols).toEqual(expect.arrayContaining(expected));
     expect(symbols).toHaveLength(expected.length);
+  });
+});
+
+describe('Lookahead iterator symbol names', () => {
+  let Json: Language;
+  let state: number;
+
+  beforeAll(async () => {
+    ({ JSON: Json } = await helper);
+    const parser = new Parser();
+    parser.setLanguage(Json);
+    const tree = parser.parse('{"a": 1}')!;
+    parser.delete();
+    const cursor = tree.walk();
+    expect(cursor.gotoFirstChild()).toBe(true); // object
+    state = cursor.currentNode.nextParseState;
+  });
+
+  it('hould name symbols missing from Language.types', () => {
+    const lookahead = Json.lookaheadIterator(state)!;
+    const names = Array.from(lookahead);
+    expect(names).toContain('end');
+    expect(names).not.toContain('ERROR');
+    expect(names).toHaveLength(12);
+    lookahead.delete();
   });
 });

--- a/lib/include/tree_sitter/api.h
+++ b/lib/include/tree_sitter/api.h
@@ -1327,8 +1327,11 @@ const char *ts_language_name(const TSLanguage *self);
  *
  * Repeatedly using [`ts_lookahead_iterator_next`] and
  * [`ts_lookahead_iterator_current_symbol`] will generate valid symbols in the
- * given parse state. Newly created lookahead iterators will contain the `ERROR`
- * symbol.
+ * given parse state. A newly created iterator is not positioned on a symbol
+ * until [`ts_lookahead_iterator_next`] is called.
+ *
+ * The iterator retains the language, so the language may be deleted while the
+ * iterator is still in use.
  *
  * Lookahead iterators can be useful to generate suggestions and improve syntax
  * error diagnostics. To get symbols valid in an ERROR node, use the lookahead
@@ -1347,7 +1350,7 @@ void ts_lookahead_iterator_delete(TSLookaheadIterator *self);
  * Reset the lookahead iterator to another state.
  *
  * This returns `true` if the iterator was reset to the given state and `false`
- * otherwise.
+ * otherwise. A reset iterator is not positioned on a symbol.
 */
 bool ts_lookahead_iterator_reset_state(TSLookaheadIterator *self, TSStateId state);
 
@@ -1355,7 +1358,7 @@ bool ts_lookahead_iterator_reset_state(TSLookaheadIterator *self, TSStateId stat
  * Reset the lookahead iterator.
  *
  * This returns `true` if the language was set successfully and `false`
- * otherwise.
+ * otherwise. A reset iterator is not positioned on a symbol.
 */
 bool ts_lookahead_iterator_reset(TSLookaheadIterator *self, const TSLanguage *language, TSStateId state);
 
@@ -1372,13 +1375,19 @@ const TSLanguage *ts_lookahead_iterator_language(const TSLookaheadIterator *self
 bool ts_lookahead_iterator_next(TSLookaheadIterator *self);
 
 /**
- * Get the current symbol of the lookahead iterator;
+ * Get the current symbol of the lookahead iterator.
+ *
+ * This is only meaningful when the most recent call to
+ * [`ts_lookahead_iterator_next`] on `self` returned `true`.
 */
 TSSymbol ts_lookahead_iterator_current_symbol(const TSLookaheadIterator *self);
 
 /**
  * Get the current symbol type of the lookahead iterator as a null terminated
  * string.
+ *
+ * This returns `NULL` unless the most recent call to
+ * [`ts_lookahead_iterator_next`] on `self` returned `true`.
 */
 const char *ts_lookahead_iterator_current_symbol_name(const TSLookaheadIterator *self);
 

--- a/lib/src/language.c
+++ b/lib/src/language.c
@@ -246,12 +246,15 @@ TSFieldId ts_language_field_id_for_name(
 TSLookaheadIterator *ts_lookahead_iterator_new(const TSLanguage *self, TSStateId state) {
   if (state >= self->state_count) return NULL;
   LookaheadIterator *iterator = ts_malloc(sizeof(LookaheadIterator));
-  *iterator = ts_language_lookaheads(self, state);
+  *iterator = ts_language_lookaheads(ts_language_copy(self), state);
   return (TSLookaheadIterator *)iterator;
 }
 
 void ts_lookahead_iterator_delete(TSLookaheadIterator *self) {
-  ts_free(self);
+  if (!self) return;
+  LookaheadIterator *iterator = (LookaheadIterator *)self;
+  ts_language_delete(iterator->language);
+  ts_free(iterator);
 }
 
 bool ts_lookahead_iterator_reset_state(TSLookaheadIterator * self, TSStateId state) {
@@ -269,7 +272,9 @@ const TSLanguage *ts_lookahead_iterator_language(const TSLookaheadIterator *self
 bool ts_lookahead_iterator_reset(TSLookaheadIterator *self, const TSLanguage *language, TSStateId state) {
   if (state >= language->state_count) return false;
   LookaheadIterator *iterator = (LookaheadIterator *)self;
-  *iterator = ts_language_lookaheads(language, state);
+  const TSLanguage *previous = iterator->language;
+  *iterator = ts_language_lookaheads(ts_language_copy(language), state);
+  ts_language_delete(previous);
   return true;
 }
 
@@ -285,5 +290,6 @@ TSSymbol ts_lookahead_iterator_current_symbol(const TSLookaheadIterator *self) {
 
 const char *ts_lookahead_iterator_current_symbol_name(const TSLookaheadIterator *self) {
   const LookaheadIterator *iterator = (const LookaheadIterator *)self;
+  if (iterator->phase != LookaheadPositioned) return NULL;
   return ts_language_symbol_name(iterator->language, iterator->symbol);
 }

--- a/lib/src/language.h
+++ b/lib/src/language.h
@@ -19,15 +19,20 @@ typedef struct {
   bool is_reusable;
 } TableEntry;
 
+typedef enum {
+  LookaheadFresh,      // no `next()` yet
+  LookaheadPositioned, // last `next()` returned true
+  LookaheadDone,       // last `next()` returned false
+} LookaheadPhase;
+
 typedef struct {
   const TSLanguage *language;
   const uint16_t *data;
   const uint16_t *group_end;
-  TSStateId state;
   uint16_t table_value;
-  uint16_t section_index;
   uint16_t group_count;
   bool is_small_state;
+  LookaheadPhase phase;
 
   const TSParseAction *actions;
   TSSymbol symbol;
@@ -120,7 +125,7 @@ static inline LookaheadIterator ts_language_lookaheads(
     group_end = data + 1;
     group_count = *data;
   } else {
-    data = &self->parse_table[state * self->symbol_count] - 1;
+    data = &self->parse_table[state * self->symbol_count];
   }
   return (LookaheadIterator) {
     .language = self,
@@ -128,19 +133,25 @@ static inline LookaheadIterator ts_language_lookaheads(
     .group_end = group_end,
     .group_count = group_count,
     .is_small_state = is_small_state,
+    .phase = LookaheadFresh,
     .symbol = UINT16_MAX,
     .next_state = 0,
   };
 }
 
 static inline bool ts_lookahead_iterator__next(LookaheadIterator *self) {
+  if (self->phase == LookaheadDone) return false;
+
   // For small parse states, valid symbols are listed explicitly,
   // grouped by their value. There's no need to look up the actions
   // again until moving to the next group.
   if (self->is_small_state) {
     self->data++;
     if (self->data == self->group_end) {
-      if (self->group_count == 0) return false;
+      if (self->group_count == 0) {
+        self->phase = LookaheadDone;
+        return false;
+      }
       self->group_count--;
       self->table_value = *(self->data++);
       unsigned symbol_count = *(self->data++);
@@ -148,6 +159,7 @@ static inline bool ts_lookahead_iterator__next(LookaheadIterator *self) {
       self->symbol = *self->data;
     } else {
       self->symbol = *self->data;
+      self->phase = LookaheadPositioned;
       return true;
     }
   }
@@ -155,12 +167,15 @@ static inline bool ts_lookahead_iterator__next(LookaheadIterator *self) {
   // For large parse states, iterate through every symbol until one
   // is found that has valid actions.
   else {
-    do {
-      self->data++;
-      self->symbol++;
-      if (self->symbol >= self->language->symbol_count) return false;
-      self->table_value = *self->data;
-    } while (!self->table_value);
+    const uint16_t *row = self->data;
+    TSSymbol symbol = self->phase == LookaheadFresh ? 0 : self->symbol + 1;
+    while (symbol < self->language->symbol_count && !row[symbol]) symbol++;
+    if (symbol >= self->language->symbol_count) {
+      self->phase = LookaheadDone;
+      return false;
+    }
+    self->symbol = symbol;
+    self->table_value = row[symbol];
   }
 
   // Depending on if the symbol is terminal or non-terminal, the table value either
@@ -174,6 +189,7 @@ static inline bool ts_lookahead_iterator__next(LookaheadIterator *self) {
     self->action_count = 0;
     self->next_state = self->table_value;
   }
+  self->phase = LookaheadPositioned;
   return true;
 }
 


### PR DESCRIPTION
~~An exhausted iterator that advanced past a large parse state in a grammar with no aliases returns `NULL` from the C side, while the rust bindings assume non-NULL.~~

This serves as a correctness/safety refactor of the `LookaheadIterator` type. See commit messages for details.

- Fixes #5777

~~Note that there are a few other issues I spotted in this area of the bindings. Will open a follow up issue (hopefully) soon.~~

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
Used Opus 5 to help investigate some of the OOB accesses.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
