### PR TITLE
fix(query): don't emit captures when `ERROR` and `MISSING` steps never match

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -5046,6 +5046,25 @@ fn test_query_is_pattern_guaranteed_at_step() {
                 ("(heredoc_end)", true),
             ],
         },
+        Row {
+            description: "an error step and the steps after it are never guaranteed",
+            language: get_language("java"),
+            pattern: r#"(labeled_statement (ERROR) ":")"#,
+            results_by_substring: &[("(ERROR)", false), ("\":\"", false)],
+        },
+        Row {
+            description: "an error pattern does not affect a following pattern",
+            language: get_language("java"),
+            pattern: r"(class_declaration [(ERROR)+ (superclass)])
+                (class_declaration (class_body) @b)",
+            results_by_substring: &[("(class_body) @b", true)],
+        },
+        Row {
+            description: "steps reachable through a quantifier skip path stay guaranteed",
+            language: get_language("java"),
+            pattern: r#"(class_body "{" (MISSING)? "}")"#,
+            results_by_substring: &[("\"}\"", true)],
+        },
         // TODO: figure out why line comments, an extra, are no longer allowed *anywhere*
         // likely culprits are the fact that it's no longer a token itself or that it uses an
         // external token
@@ -6350,6 +6369,78 @@ fn test_query_allows_error_nodes_with_children() {
         let matches = cursor.matches(&query, root, code.as_bytes());
         let matches = collect_matches(matches, &query, code);
         assert_eq!(matches, &[(0, vec![("error", ".bar")])]);
+    });
+}
+
+#[test]
+fn test_query_captures_error_and_missing_steps() {
+    allocations::record(|| {
+        let language = get_language("java");
+        let mut parser = Parser::new();
+        parser.set_language(&language).unwrap();
+
+        let valid = "class A extends B {\n}\n";
+        let no_super = "class A extends {\n}\n";
+        let bad_label = "class A { void m() { foo: %% ; } }\n";
+        let bad_block = "class A { void m() { x y z ~ } }\n";
+        let later = "class A { }\nclass B ~~ { }\n";
+        let no_semi = "class A {\n  int x = 1\n}\n";
+
+        // https://github.com/tree-sitter/tree-sitter/issues/5079
+        for (code, pattern, expected) in [
+            (valid, "(superclass (ERROR)) @a", &[][..]),
+            (valid, "(superclass (MISSING)) @a", &[][..]),
+            (
+                valid,
+                "(class_declaration [(identifier) (superclass)] (ERROR)) @c",
+                &[][..],
+            ),
+            (
+                valid,
+                "(class_declaration (MISSING identifier)) @a",
+                &[][..],
+            ),
+            (no_super, "(ERROR (identifier)) @e", &[][..]),
+            (bad_label, "(labeled_statement (ERROR) @e \":\")", &[][..]),
+            (
+                bad_block,
+                "(block (ERROR (type_identifier) @x (block)))",
+                &[][..],
+            ),
+            (
+                later,
+                "(program (class_declaration (ERROR))) @whole",
+                &[("whole", later)][..],
+            ),
+            (
+                no_super,
+                "(class_declaration (ERROR)) @c",
+                &[("c", "class A extends {\n}")][..],
+            ),
+            (
+                no_semi,
+                "(field_declaration (MISSING \";\")?) @f",
+                &[("f", "int x = 1")][..],
+            ),
+        ] {
+            let tree = parser.parse(code, None).unwrap();
+            let query = Query::new(&language, pattern).unwrap();
+
+            let mut cursor = QueryCursor::new();
+            let captures = cursor.captures(&query, tree.root_node(), code.as_bytes());
+            assert_eq!(
+                collect_captures(captures, &query, code),
+                expected,
+                "captures for pattern: {pattern}"
+            );
+
+            let matches = if expected.is_empty() {
+                vec![]
+            } else {
+                vec![(0, expected.to_vec())]
+            };
+            assert_query_matches(&language, &query, code, &matches);
+        }
     });
 }
 

--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -5098,6 +5098,18 @@ fn test_query_is_pattern_guaranteed_at_step() {
                 ("(heredoc_end)", true),
             ],
         },
+        Row {
+            description: "an error step and its successors",
+            language: get_language("java"),
+            pattern: r#"(labeled_statement (ERROR) ":")"#,
+            results_by_substring: &[("(ERROR)", false), ("\":\"", false)],
+        },
+        Row {
+            description: "a step after an alternation with a clean branch",
+            language: get_language("java"),
+            pattern: r"(class_declaration [(ERROR) (superclass)] (class_body))",
+            results_by_substring: &[("(class_body)", true)],
+        },
         // TODO: figure out why line comments, an extra, are no longer allowed *anywhere*
         // likely culprits are the fact that it's no longer a token itself or that it uses an
         // external token
@@ -6429,6 +6441,67 @@ fn test_query_allows_error_nodes_with_children() {
         let matches = cursor.matches(&query, root, code.as_bytes());
         let matches = collect_matches(matches, &query, code);
         assert_eq!(matches, &[(0, vec![("error", ".bar")])]);
+    });
+}
+
+#[test]
+fn test_query_captures_with_unguaranteed_steps() {
+    allocations::record(|| {
+        let language = get_language("java");
+        let mut parser = Parser::new();
+        parser.set_language(&language).unwrap();
+
+        let plain = "class A {}\n";
+        let valid = "class A extends B {\n}\n";
+        let later = "class A { }\nclass B ~~ { }\n";
+        let no_semi = "class A {\n  int x = 1\n}\n";
+
+        for (code, pattern, expected) in [
+            (
+                plain,
+                r#"(class_declaration ["class" (identifier)] (superclass)) @c"#,
+                &[][..],
+            ),
+            (valid, "(superclass (ERROR)) @a", &[][..]),
+            (
+                plain,
+                "(class_declaration [(ERROR) @e (class_body) @b]) @c",
+                &[("c", "class A {}"), ("b", "{}")][..],
+            ),
+            (
+                valid,
+                "(class_declaration (MISSING identifier)) @a",
+                &[][..],
+            ),
+            (
+                later,
+                "(program (class_declaration (ERROR))) @whole",
+                &[("whole", later)][..],
+            ),
+            (
+                no_semi,
+                "(field_declaration (MISSING \";\")?) @f",
+                &[("f", "int x = 1")][..],
+            ),
+        ] {
+            let tree = parser.parse(code, None).unwrap();
+            let query = Query::new(&language, pattern).unwrap();
+
+            let mut cursor = QueryCursor::new();
+            let captures = cursor.captures(&query, tree.root_node(), code.as_bytes());
+            assert_eq!(
+                collect_captures(captures, &query, code),
+                expected,
+                "captures: {pattern}"
+            );
+
+            let matches = if expected.is_empty() {
+                vec![]
+            } else {
+                vec![(0, expected.to_vec())]
+            };
+            assert_query_matches(&language, &query, code, &matches);
+        }
     });
 }
 

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -2049,6 +2049,36 @@ static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
     }
   }
 
+  // Mark as fallible every step reachable only through an ERROR or MISSING step.
+  for (unsigned i = 0; i < self->patterns.size; i++) {
+    QueryPattern *pattern = array_get(&self->patterns, i);
+    unsigned start = pattern->steps.offset;
+    unsigned end = start + pattern->steps.length - 1; // exclude DONE
+    unsigned fallible_end = start;
+    for (unsigned j = start; j < end; j++) {
+      QueryStep *step = array_get(&self->steps, j);
+      if (step->is_missing || step->symbol == ts_builtin_sym_error) {
+        unsigned limit = step->alternative_is_skip ? step->alternative_index : end;
+        if (limit > fallible_end) fallible_end = limit;
+      }
+      if (j < fallible_end) {
+        step->parent_pattern_guaranteed = false;
+        step->root_pattern_guaranteed = false;
+      }
+    }
+
+    // A dead end keeps its initialized flags, which would halt the chase below.
+    if (fallible_end > start) {
+      for (unsigned j = start; j < end; j++) {
+        QueryStep *step = array_get(&self->steps, j);
+        if (step->is_dead_end) {
+          step->parent_pattern_guaranteed = false;
+          step->root_pattern_guaranteed = false;
+        }
+      }
+    }
+  }
+
   // Propagate fallibility. If a pattern is fallible at a given step, then it is
   // fallible at all of its preceding steps.
   bool done = self->steps.size == 0;

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -1650,6 +1650,46 @@ static void ts_query__dump_steps(const TSQuery *self, const char *label) {
 }
 #endif
 
+// Mark fallible ERROR/MISSING steps and what only follows one.
+static void ts_query__mark_fallible_steps(TSQuery *self) {
+  Array(bool) entered = array_new();
+  array_grow_by(&entered, self->steps.size);
+  for (unsigned i = 0; i < self->patterns.size; i++) {
+    *array_get(&entered, array_get(&self->patterns, i)->steps.offset) = true;
+  }
+  bool done = false;
+  while (!done) {
+    done = true;
+    for (unsigned i = 0; i < self->steps.size; i++) {
+      QueryStep *step = array_get(&self->steps, i);
+      if (!*array_get(&entered, i) || step->depth == PATTERN_DONE_MARKER) continue;
+      // A dead end or fallible step gets no sequence edge; alternative edges are unguarded.
+      if (
+        !step->is_dead_end &&
+        !(step->is_missing || step->symbol == ts_builtin_sym_error) &&
+        i + 1 < self->steps.size &&
+        !*array_get(&entered, i + 1)
+      ) {
+        *array_get(&entered, i + 1) = true;
+        done = false;
+      }
+      if (step->alternative_index != NONE && !*array_get(&entered, step->alternative_index)) {
+        *array_get(&entered, step->alternative_index) = true;
+        done = false;
+      }
+    }
+  }
+  for (unsigned i = 0; i < self->steps.size; i++) {
+    QueryStep *step = array_get(&self->steps, i);
+    if (step->depth == PATTERN_DONE_MARKER) continue;
+    if ((step->is_missing || step->symbol == ts_builtin_sym_error) || !*array_get(&entered, i)) {
+      step->parent_pattern_guaranteed = false;
+      step->root_pattern_guaranteed = false;
+    }
+  }
+  array_delete(&entered);
+}
+
 static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
   Array(uint16_t) non_rooted_pattern_start_steps = array_new();
   for (unsigned i = 0; i < self->pattern_map.size; i++) {
@@ -2049,6 +2089,8 @@ static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
     }
   }
 
+  ts_query__mark_fallible_steps(self);
+
   // Propagate fallibility. If a pattern is fallible at a given step, then it is
   // fallible at all of its preceding steps.
   bool done = self->steps.size == 0;
@@ -2061,7 +2103,7 @@ static bool ts_query__analyze_patterns(TSQuery *self, unsigned *error_offset) {
       // Determine if this step is definite or has definite alternatives.
       bool parent_pattern_guaranteed = false;
       for (;;) {
-        if (step->root_pattern_guaranteed) {
+        if (step->root_pattern_guaranteed && !step->is_dead_end) {
           parent_pattern_guaranteed = true;
           break;
         }


### PR DESCRIPTION
### The problem

On valid source with no errors, a captures query like `(superclass (ERROR)) @a` still emits the capture. Only captures are affected. In matches mode the same query correctly returns nothing, so you need `-c` to see it.

```console
$ cat A.java
class A extends B {}
$ cat q.scm
(superclass (ERROR)) @a
```

Before:
```console
$ tree-sitter query -c q.scm A.java
A.java
    pattern:  0, capture: 0 - a, start: (0, 8), end: (0, 17), text: `extends B`
```

After:
```console
$ tree-sitter query -c q.scm A.java
A.java
```

### The solution

Clear those flags on every step reachable only through an `ERROR` or `MISSING` step, stopping at the zero-match skip targets of `?` and `*`. This also stops a multi-step `ERROR`/`MISSING` match from being dropped under a match limit.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

Sonnet 5 wrote the regression tests.
Opus 4.8 validated the  solution.
Opus 5 back-to-back testing