### PR TITLE
fix(endian): don't depend on <sys/byteorder.h> in the __sun branch

### DIFF
--- a/lib/src/portable/endian.h
+++ b/lib/src/portable/endian.h
@@ -42,23 +42,53 @@
 # include <sys/endian.h>
 
 #elif defined(__sun)
+#    define __LITTLE_ENDIAN 1234
+#    define __BIG_ENDIAN    4321
+#    define __PDP_ENDIAN    3412
 
-#    include <sys/byteorder.h>
+#    if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 
-#    define htobe16(x) BE_16(x)
-#    define htole16(x) LE_16(x)
-#    define be16toh(x) BE_16(x)
-#    define le16toh(x) LE_16(x)
+#        define __BYTE_ORDER __LITTLE_ENDIAN
 
-#    define htobe32(x) BE_32(x)
-#    define htole32(x) LE_32(x)
-#    define be32toh(x) BE_32(x)
-#    define le32toh(x) LE_32(x)
+#        define htobe16(x) __builtin_bswap16(x)
+#        define htole16(x) (x)
+#        define be16toh(x) __builtin_bswap16(x)
+#        define le16toh(x) (x)
 
-#    define htobe64(x) BE_64(x)
-#    define htole64(x) LE_64(x)
-#    define be64toh(x) BE_64(x)
-#    define le64toh(x) LE_64(x)
+#        define htobe32(x) __builtin_bswap32(x)
+#        define htole32(x) (x)
+#        define be32toh(x) __builtin_bswap32(x)
+#        define le32toh(x) (x)
+
+#        define htobe64(x) __builtin_bswap64(x)
+#        define htole64(x) (x)
+#        define be64toh(x) __builtin_bswap64(x)
+#        define le64toh(x) (x)
+
+#    elif defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+
+#        define __BYTE_ORDER __BIG_ENDIAN
+
+#        define htobe16(x) (x)
+#        define htole16(x) __builtin_bswap16(x)
+#        define be16toh(x) (x)
+#        define le16toh(x) __builtin_bswap16(x)
+
+#        define htobe32(x) (x)
+#        define htole32(x) __builtin_bswap32(x)
+#        define be32toh(x) (x)
+#        define le32toh(x) __builtin_bswap32(x)
+
+#        define htobe64(x) (x)
+#        define htole64(x) __builtin_bswap64(x)
+#        define be64toh(x) (x)
+#        define le64toh(x) __builtin_bswap64(x)
+
+#    else
+
+#        error byte order not supported
+
+#    endif
 
 #elif defined(__APPLE__)
 #    define __BYTE_ORDER    BYTE_ORDER


### PR DESCRIPTION
The __sun branch added in 77cb23fc defines byte order conversions in terms of BE_16/LE_16 from <sys/byteorder.h>. These macros sit behind:

```
  #if !defined(_XPG4_2) || defined(__EXTENSIONS__)
```

This breaks during link time because lib/binding_rust/build.rs defines _POSIX_C_SOURCE=200112L, which sys/feature_tests.h converts to _XPG4_2. This means the BE_16/LE_16 macros are undefined, resulting in a link-time failure:

```
error: linking with `x86_64-unknown-illumos-gcc` failed: exit status: 1
  = note: /usr/local/x86_64-unknown-illumos/lib/gcc/x86_64-pc-solaris2.10/8.4.0/../../../../x86_64-pc-solaris2.10/bin/ld: warning: -z ignore ignored.
          /target/x86_64-unknown-illumos/release-lto/deps/rustcX/libtree_sitter-xxx.rlib(xxx-lib.o): In function `ts_decode_utf16_le':
          lib.c:(.text.ts_decode_utf16_le+0x21): undefined reference to `LE_16'
          /target/x86_64-unknown-illumos/release-lto/deps/rustcX/libtree_sitter-xxx.rlib(xxx-lib.o): In function `ts_decode_utf16_be':
          lib.c:(.text.ts_decode_utf16_be+0x21): undefined reference to `BE_16'
          collect2: error: ld returned 1 exit status
```

The reason this didn't show up in CI is because it's not triggered during the build of a static library, only at the final linking step.

To be consistent w/ the other platforms in this file, this change adopts `__builtin_bswap*` and no longer relies on external system headers.

Tested w/ cross-rs & illumos/sysroot release 20181213-de6af22ae73b-v1

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
  - Anthropic Claude Opus 5 ("high") for initial debugging & diff generation.

