### PR TITLE
fix(rust)!: tie query iterators to options lifetime

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -5,8 +5,8 @@ use rand::{SeedableRng, prelude::StdRng};
 use streaming_iterator::StreamingIterator;
 use tree_sitter::{
     CaptureQuantifier, InputEdit, Language, Node, Parser, Point, Query, QueryCursor,
-    QueryCursorOptions, QueryError, QueryErrorKind, QueryPredicate, QueryPredicateArg,
-    QueryProperty, Range,
+    QueryCursorOptions, QueryCursorState, QueryError, QueryErrorKind, QueryPredicate,
+    QueryPredicateArg, QueryProperty, Range,
 };
 use tree_sitter_generate::load_grammar_file;
 use unindent::Unindent;
@@ -6022,21 +6022,21 @@ fn test_query_execution_with_timeout() {
     let tree = parser.parse(&source_code, None).unwrap();
 
     let query = Query::new(&language, "(function_declaration) @function").unwrap();
-    let mut cursor = QueryCursor::new();
-
     let start_time = std::time::Instant::now();
+    let mut progress_callback = |_: &QueryCursorState| {
+        if start_time.elapsed().as_micros() > 1000 {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    };
+    let mut cursor = QueryCursor::new();
     let matches = cursor
         .matches_with_options(
             &query,
             tree.root_node(),
             source_code.as_bytes(),
-            QueryCursorOptions::new().progress_callback(&mut |_| {
-                if start_time.elapsed().as_micros() > 1000 {
-                    ControlFlow::Break(())
-                } else {
-                    ControlFlow::Continue(())
-                }
-            }),
+            QueryCursorOptions::new().progress_callback(&mut progress_callback),
         )
         .count();
     assert!(matches < 1000);
@@ -6045,6 +6045,33 @@ fn test_query_execution_with_timeout() {
         .matches(&query, tree.root_node(), source_code.as_bytes())
         .count();
     assert_eq!(matches, 1000);
+}
+
+#[test]
+fn test_query_progress_callback_lives_as_long_as_matches() {
+    let language = get_language("javascript");
+    let mut parser = Parser::new();
+    parser.set_language(&language).unwrap();
+
+    let source_code = "function foo() {}\n".repeat(1000);
+    let tree = parser.parse(&source_code, None).unwrap();
+    let query = Query::new(&language, "(function_declaration) @function").unwrap();
+
+    let mut cursor = QueryCursor::new();
+    let mut callback_was_called = false;
+    let mut progress_callback = |_: &QueryCursorState| {
+        callback_was_called = true;
+        ControlFlow::Continue(())
+    };
+    let matches = cursor.matches_with_options(
+        &query,
+        tree.root_node(),
+        source_code.as_bytes(),
+        QueryCursorOptions::new().progress_callback(&mut progress_callback),
+    );
+
+    assert_eq!(matches.count(), 1000);
+    assert!(callback_was_called);
 }
 
 #[test]

--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -276,9 +276,12 @@ impl<'a> QueryCursorOptions<'a> {
     }
 }
 
-struct QueryCursorOptionsDrop(*mut ffi::TSQueryCursorOptions);
+struct QueryCursorOptionsDrop<'options>(
+    *mut ffi::TSQueryCursorOptions,
+    PhantomData<QueryProgressCallback<'options>>,
+);
 
-impl Drop for QueryCursorOptionsDrop {
+impl Drop for QueryCursorOptionsDrop<'_> {
     fn drop(&mut self) {
         unsafe {
             if !(*self.0).payload.is_null() {
@@ -398,14 +401,14 @@ pub struct QueryMatch<'cursor, 'tree> {
 }
 
 /// A sequence of [`QueryMatch`]es associated with a given [`QueryCursor`].
-pub struct QueryMatches<'query, 'tree, T: TextProvider<I>, I: AsRef<[u8]>> {
+pub struct QueryMatches<'query, 'tree, 'options, T: TextProvider<I>, I: AsRef<[u8]>> {
     ptr: *mut ffi::TSQueryCursor,
     query: &'query Query,
     text_provider: T,
     buffer1: Vec<u8>,
     buffer2: Vec<u8>,
     current_match: Option<QueryMatch<'query, 'tree>>,
-    _options: Option<QueryCursorOptionsDrop>,
+    _options: Option<QueryCursorOptionsDrop<'options>>,
     _phantom: PhantomData<(&'tree (), I)>,
 }
 
@@ -413,14 +416,14 @@ pub struct QueryMatches<'query, 'tree, T: TextProvider<I>, I: AsRef<[u8]>> {
 ///
 /// During iteration, each element contains a [`QueryMatch`] and index. The index can
 /// be used to access the new capture inside of the [`QueryMatch::captures`]'s [`captures`].
-pub struct QueryCaptures<'query, 'tree, T: TextProvider<I>, I: AsRef<[u8]>> {
+pub struct QueryCaptures<'query, 'tree, 'options, T: TextProvider<I>, I: AsRef<[u8]>> {
     ptr: *mut ffi::TSQueryCursor,
     query: &'query Query,
     text_provider: T,
     buffer1: Vec<u8>,
     buffer2: Vec<u8>,
     current_match: Option<(QueryMatch<'query, 'tree>, usize)>,
-    _options: Option<QueryCursorOptionsDrop>,
+    _options: Option<QueryCursorOptionsDrop<'options>>,
     _phantom: PhantomData<(&'tree (), I)>,
 }
 
@@ -3088,7 +3091,7 @@ impl QueryCursor {
         query: &'query Query,
         node: Node<'tree>,
         text_provider: T,
-    ) -> QueryMatches<'query, 'tree, T, I> {
+    ) -> QueryMatches<'query, 'tree, 'static, T, I> {
         let ptr = self.ptr.as_ptr();
         unsafe { ffi::ts_query_cursor_exec(ptr, query.ptr.as_ptr(), node.0) };
         QueryMatches {
@@ -3114,6 +3117,7 @@ impl QueryCursor {
         'query,
         'cursor: 'query,
         'tree,
+        'options,
         T: TextProvider<I>,
         I: AsRef<[u8]>,
     >(
@@ -3121,8 +3125,8 @@ impl QueryCursor {
         query: &'query Query,
         node: Node<'tree>,
         text_provider: T,
-        options: QueryCursorOptions,
-    ) -> QueryMatches<'query, 'tree, T, I> {
+        options: QueryCursorOptions<'options>,
+    ) -> QueryMatches<'query, 'tree, 'options, T, I> {
         unsafe extern "C" fn progress(state: *mut ffi::TSQueryCursorState) -> bool {
             unsafe {
                 let callback = (*state)
@@ -3138,10 +3142,13 @@ impl QueryCursor {
         }
 
         let query_options = options.progress_callback.map(|cb| {
-            QueryCursorOptionsDrop(Box::into_raw(Box::new(ffi::TSQueryCursorOptions {
-                payload: Box::into_raw(Box::new(cb)).cast::<c_void>(),
-                progress_callback: Some(progress),
-            })))
+            QueryCursorOptionsDrop(
+                Box::into_raw(Box::new(ffi::TSQueryCursorOptions {
+                    payload: Box::into_raw(Box::new(cb)).cast::<c_void>(),
+                    progress_callback: Some(progress),
+                })),
+                PhantomData,
+            )
         });
 
         let ptr = self.ptr.as_ptr();
@@ -3180,7 +3187,7 @@ impl QueryCursor {
         query: &'query Query,
         node: Node<'tree>,
         text_provider: T,
-    ) -> QueryCaptures<'query, 'tree, T, I> {
+    ) -> QueryCaptures<'query, 'tree, 'static, T, I> {
         let ptr = self.ptr.as_ptr();
         unsafe { ffi::ts_query_cursor_exec(ptr, query.ptr.as_ptr(), node.0) };
         QueryCaptures {
@@ -3205,6 +3212,7 @@ impl QueryCursor {
         'query,
         'cursor: 'query,
         'tree,
+        'options,
         T: TextProvider<I>,
         I: AsRef<[u8]>,
     >(
@@ -3212,8 +3220,8 @@ impl QueryCursor {
         query: &'query Query,
         node: Node<'tree>,
         text_provider: T,
-        options: QueryCursorOptions,
-    ) -> QueryCaptures<'query, 'tree, T, I> {
+        options: QueryCursorOptions<'options>,
+    ) -> QueryCaptures<'query, 'tree, 'options, T, I> {
         unsafe extern "C" fn progress(state: *mut ffi::TSQueryCursorState) -> bool {
             unsafe {
                 let callback = (*state)
@@ -3229,10 +3237,13 @@ impl QueryCursor {
         }
 
         let query_options = options.progress_callback.map(|cb| {
-            QueryCursorOptionsDrop(Box::into_raw(Box::new(ffi::TSQueryCursorOptions {
-                payload: Box::into_raw(Box::new(cb)).cast::<c_void>(),
-                progress_callback: Some(progress),
-            })))
+            QueryCursorOptionsDrop(
+                Box::into_raw(Box::new(ffi::TSQueryCursorOptions {
+                    payload: Box::into_raw(Box::new(cb)).cast::<c_void>(),
+                    progress_callback: Some(progress),
+                })),
+                PhantomData,
+            )
         });
 
         let ptr = self.ptr.as_ptr();
@@ -3510,7 +3521,7 @@ impl QueryProperty {
 /// underlying object in the C library gets updated on each iteration. Copies would
 /// have their internal state overwritten, leading to Undefined Behavior
 impl<'query, 'tree, T: TextProvider<I>, I: AsRef<[u8]>> StreamingIterator
-    for QueryMatches<'query, 'tree, T, I>
+    for QueryMatches<'query, 'tree, '_, T, I>
 {
     type Item = QueryMatch<'query, 'tree>;
 
@@ -3540,14 +3551,14 @@ impl<'query, 'tree, T: TextProvider<I>, I: AsRef<[u8]>> StreamingIterator
     }
 }
 
-impl<T: TextProvider<I>, I: AsRef<[u8]>> StreamingIteratorMut for QueryMatches<'_, '_, T, I> {
+impl<T: TextProvider<I>, I: AsRef<[u8]>> StreamingIteratorMut for QueryMatches<'_, '_, '_, T, I> {
     fn get_mut(&mut self) -> Option<&mut Self::Item> {
         self.current_match.as_mut()
     }
 }
 
 impl<'query, 'tree, T: TextProvider<I>, I: AsRef<[u8]>> StreamingIterator
-    for QueryCaptures<'query, 'tree, T, I>
+    for QueryCaptures<'query, 'tree, '_, T, I>
 {
     type Item = (QueryMatch<'query, 'tree>, usize);
 
@@ -3583,13 +3594,13 @@ impl<'query, 'tree, T: TextProvider<I>, I: AsRef<[u8]>> StreamingIterator
     }
 }
 
-impl<T: TextProvider<I>, I: AsRef<[u8]>> StreamingIteratorMut for QueryCaptures<'_, '_, T, I> {
+impl<T: TextProvider<I>, I: AsRef<[u8]>> StreamingIteratorMut for QueryCaptures<'_, '_, '_, T, I> {
     fn get_mut(&mut self) -> Option<&mut Self::Item> {
         self.current_match.as_mut()
     }
 }
 
-impl<T: TextProvider<I>, I: AsRef<[u8]>> QueryMatches<'_, '_, T, I> {
+impl<T: TextProvider<I>, I: AsRef<[u8]>> QueryMatches<'_, '_, '_, T, I> {
     #[doc(alias = "ts_query_cursor_set_byte_range")]
     pub fn set_byte_range(&mut self, range: ops::Range<usize>) {
         unsafe {
@@ -3605,7 +3616,7 @@ impl<T: TextProvider<I>, I: AsRef<[u8]>> QueryMatches<'_, '_, T, I> {
     }
 }
 
-impl<T: TextProvider<I>, I: AsRef<[u8]>> QueryCaptures<'_, '_, T, I> {
+impl<T: TextProvider<I>, I: AsRef<[u8]>> QueryCaptures<'_, '_, '_, T, I> {
     #[doc(alias = "ts_query_cursor_set_byte_range")]
     pub fn set_byte_range(&mut self, range: ops::Range<usize>) {
         unsafe {


### PR DESCRIPTION
`QueryMatches` and `QueryCaptures` retain query cursor options while they are being iterated. However, their types did not preserve the lifetime of the options' progress callback, allowing the callback to be dropped while it was still referenced by the cursor.

Add an explicit options lifetime to both iterator types and propagate it through `matches_with_options` and `captures_with_options`. Use a static options lifetime for iterators created without options.

Another, smaller fix for this involves just using the `'query` lifetime rather than introducing a new `'options` lifetime. While this is slightly more restrictive, I decided to add a new `'options` lifetime for readability's sake. `matches_with_options` and friends are already full of many generic parameters and lifetimes. I thought it would be confusing to come back later and have to figure out _why_ the options lifetime was tied to the query.

- Closes #5810

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
Used gpt5.6-sol to discuss whether to tie the lifetime to `QueryCursorOptionsDrop` or just the `callback` parameter via `'query`.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
