### PR TITLE
Expose `OptLevel` on `generate_parser_for_grammar`

### DIFF
--- a/crates/cli/src/tests.rs
+++ b/crates/cli/src/tests.rs
@@ -17,7 +17,7 @@ mod tree_test;
 #[cfg(feature = "wasm")]
 mod wasm_language_test;
 
-use tree_sitter_generate::GenerateResult;
+use tree_sitter_generate::{GenerateResult, OptLevel};
 
 pub use crate::fuzz::{
     ITERATION_COUNT, allocations,
@@ -33,6 +33,7 @@ fn generate_parser(grammar_json: &str) -> GenerateResult<(String, String)> {
     tree_sitter_generate::generate_parser_for_grammar(
         grammar_json,
         Some((0, 0, 0)),
+        OptLevel::default(),
         &mut Vec::new(),
     )
 }

--- a/crates/cli/src/tests/corpus_test.rs
+++ b/crates/cli/src/tests/corpus_test.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, env, fs};
 
 use anyhow::Context;
 use tree_sitter::Parser;
+use tree_sitter_generate::OptLevel;
 use tree_sitter_proc_macro::test_with_seed;
 
 use crate::{
@@ -378,6 +379,7 @@ fn test_feature_corpus_files() {
         let generate_result = tree_sitter_generate::generate_parser_for_grammar(
             &grammar_json,
             Some((0, 0, 0)),
+            OptLevel::default(),
             &mut Vec::new(),
         );
 

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -411,6 +411,7 @@ where
 pub fn generate_parser_for_grammar(
     grammar_json: &str,
     semantic_version: Option<(u8, u8, u8)>,
+    optimizations: OptLevel,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> GenerateResult<(String, String)> {
     let input_grammar = parse_grammar(grammar_json, diagnostics)?;
@@ -419,7 +420,7 @@ pub fn generate_parser_for_grammar(
         LANGUAGE_VERSION,
         semantic_version,
         None,
-        OptLevel::default(),
+        optimizations,
         diagnostics,
     )?;
     Ok((input_grammar.name, parser.c_code))


### PR DESCRIPTION
As per https://github.com/tree-sitter/tree-sitter/issues/4711, I need the ability to disable this optimization. Previously this function had them disabled by default, but it was (sensibly) updated to enable them by default.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
