### PR TITLE
ci(release): add nightly builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,14 @@
 name: Release
 
 on:
+  schedule:
+    - cron: '5 5 * * *'
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name for release'
+        required: false
+        default: nightly
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
@@ -21,6 +28,17 @@ jobs:
       attestations: write
       contents: write
     steps:
+      - if: github.event_name == 'workflow_dispatch'
+        env:
+          TAG_NAME: ${{ github.event.inputs.tag_name }}
+        run: echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_ENV
+
+      - if: github.event_name == 'schedule'
+        run: echo 'TAG_NAME=nightly' >> $GITHUB_ENV
+
+      - if: github.event_name == 'push'
+        run: echo "TAG_NAME=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
 
@@ -59,9 +77,17 @@ jobs:
             target/tree-sitter-cli-*.zip
             target/web-tree-sitter.tar.gz
 
+      - if: env.TAG_NAME == 'nightly'
+        run: |
+          echo 'PRERELEASE=--prerelease' >> $GITHUB_ENV
+          gh release delete nightly --yes || true
+          git push https://${GITHUB_ACTOR}:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY} :nightly || true
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Create release
         run: |-
-          gh release create $GITHUB_REF_NAME \
+          gh release create ${{ env.TAG_NAME }} $PRERELEASE \
             target/tree-sitter-*.gz \
             target/tree-sitter-cli-*.zip \
             target/web-tree-sitter.tar.gz
@@ -70,6 +96,7 @@ jobs:
 
   crates_io:
     name: Publish packages to Crates.io
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name != 'nightly')
     runs-on: ubuntu-latest
     environment: crates
     permissions:
@@ -94,6 +121,7 @@ jobs:
 
   npm:
     name: Publish packages to npmjs.com
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name != 'nightly')
     runs-on: ubuntu-latest
     environment: npm
     permissions:


### PR DESCRIPTION
Problem: Checking whether a problem is fixed on `master` before opening an issue is too difficult.

Solution: Add a "nightly" build to the release workflow (that is not published). Also extend the `workflow_dispatch` trigger to allow specifying a tag so a broken release/publish workflow can be re-run from a fixed (on `master`!) workflow.

Test-run (dispatch) on my fork:
* nightly workflow run: https://github.com/clason/tree-sitter/actions/runs/31201979347
* nightly release: https://github.com/clason/tree-sitter/releases/tag/nightly (updated)
* tag workflow run: https://github.com/clason/tree-sitter/actions/runs/31201461941 (no tokens on my fork so publish fails of course -- but is triggered)
* tag release: https://github.com/clason/tree-sitter/releases/tag/v0.26.3

**NOTE:** If you use https://github.com/tree-sitter/setup-action in your downstream workflow, you should then be able to opt-in to nightlies via 
```yaml
- uses: tree-sitter/setup-action@v2
  with:
    tree-sitter-ref: nightly
```
(not tested).