### PR TITLE
fix(query): correctly identify `MISSING` nodes in queries

### DIFF
--- a/crates/cli/src/tests/query_test.rs
+++ b/crates/cli/src/tests/query_test.rs
@@ -416,6 +416,16 @@ fn test_query_errors_on_invalid_symbols() {
                 message: "\"fakefield\"".to_string()
             }
         );
+        assert_eq!(
+            Query::new(&language, "(MISS)").unwrap_err(),
+            QueryError {
+                row: 0,
+                offset: 1,
+                column: 1,
+                kind: QueryErrorKind::NodeType,
+                message: "\"MISS\"".to_string(),
+            }
+        );
     });
 }
 

--- a/lib/src/query.c
+++ b/lib/src/query.c
@@ -2551,7 +2551,7 @@ static TSQueryError ts_query__parse_pattern(
         // Parse the wildcard symbol
         if (length == 1 && node_name[0] == '_') {
           symbol = WILDCARD_SYMBOL;
-        } else if (!strncmp(node_name, "MISSING", length)) {
+        } else if (length == 7 && !strncmp(node_name, "MISSING", length)) {
           is_missing = true;
           stream_skip_whitespace(stream);
 


### PR DESCRIPTION
Small patch I found while looking into the query code. Wanted to open a PR before it was lost/forgotten.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
Bug found by Opus 5 during a larger investigation of the query code, fix and everything else done by hand.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
