### PR TITLE
rust: trim unused imports

### DIFF
--- a/crates/cli/benches/benchmark.rs
+++ b/crates/cli/benches/benchmark.rs
@@ -2,7 +2,6 @@ use std::{
     collections::BTreeMap,
     env, fs,
     path::{Path, PathBuf},
-    str,
     sync::LazyLock,
     time::Instant,
 };

--- a/crates/cli/src/highlight.rs
+++ b/crates/cli/src/highlight.rs
@@ -4,7 +4,6 @@ use std::{
     fs,
     io::{self, Write as _},
     path::{self, Path, PathBuf},
-    str,
     sync::{Arc, atomic::AtomicUsize},
     time::Instant,
 };

--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -1,7 +1,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
-    str::{self, FromStr},
+    str::FromStr as _,
 };
 
 use anyhow::{Context, Result, anyhow};

--- a/crates/cli/src/playground.rs
+++ b/crates/cli/src/playground.rs
@@ -3,7 +3,7 @@ use std::{
     env, fs,
     net::TcpListener,
     path::{Path, PathBuf},
-    str::{self, FromStr as _},
+    str::FromStr as _,
 };
 
 use anyhow::{Context, Result, anyhow};

--- a/crates/cli/src/tags.rs
+++ b/crates/cli/src/tags.rs
@@ -2,7 +2,6 @@ use std::{
     fs,
     io::{self, Write},
     path::Path,
-    str,
     sync::{Arc, atomic::AtomicUsize},
     time::Instant,
 };

--- a/crates/cli/src/test.rs
+++ b/crates/cli/src/test.rs
@@ -5,7 +5,6 @@ use std::{
     fs,
     io::{self, Write},
     path::{Path, PathBuf},
-    str,
     time::Duration,
 };
 

--- a/crates/cli/src/tests/helpers/edits.rs
+++ b/crates/cli/src/tests/helpers/edits.rs
@@ -1,4 +1,4 @@
-use std::{ops::Range, str};
+use std::ops::Range;
 
 #[derive(Debug)]
 pub struct ReadRecorder<'a> {

--- a/crates/cli/src/tests/highlight_test.rs
+++ b/crates/cli/src/tests/highlight_test.rs
@@ -2,7 +2,7 @@ use std::{
     ffi::CString,
     fs,
     os::raw::c_char,
-    ptr, slice, str,
+    ptr, slice,
     sync::{
         LazyLock,
         atomic::{AtomicUsize, Ordering},

--- a/crates/cli/src/tests/tags_test.rs
+++ b/crates/cli/src/tests/tags_test.rs
@@ -1,6 +1,6 @@
 use std::{
     ffi::{CStr, CString},
-    fs, ptr, slice, str,
+    fs, ptr, slice,
     sync::atomic::{AtomicUsize, Ordering},
 };
 

--- a/crates/cli/src/tests/tree_test.rs
+++ b/crates/cli/src/tests/tree_test.rs
@@ -1,5 +1,3 @@
-use std::str;
-
 use tree_sitter::{InputEdit, Parser, Point, Range, Tree};
 
 use super::helpers::fixtures::get_language;

--- a/crates/generate/src/nfa.rs
+++ b/crates/generate/src/nfa.rs
@@ -1,5 +1,4 @@
 use std::{
-    char,
     cmp::{Ordering, max},
     fmt,
     iter::ExactSizeIterator,

--- a/crates/highlight/src/c_lib.rs
+++ b/crates/highlight/src/c_lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap, ffi::CStr, fmt, os::raw::c_char, process::abort, slice, str,
+    collections::HashMap, ffi::CStr, fmt, os::raw::c_char, process::abort, slice,
     sync::atomic::AtomicUsize,
 };
 

--- a/crates/highlight/src/highlight.rs
+++ b/crates/highlight/src/highlight.rs
@@ -8,7 +8,6 @@ use std::{
     marker::PhantomData,
     mem::{self, MaybeUninit},
     ops::{self, ControlFlow},
-    str,
     sync::{
         LazyLock,
         atomic::{AtomicUsize, Ordering},

--- a/crates/tags/src/c_lib.rs
+++ b/crates/tags/src/c_lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap, ffi::CStr, fmt, os::raw::c_char, process::abort, slice, str,
+    collections::HashMap, ffi::CStr, fmt, os::raw::c_char, process::abort, slice,
     sync::atomic::AtomicUsize,
 };
 

--- a/crates/tags/src/tags.rs
+++ b/crates/tags/src/tags.rs
@@ -3,13 +3,11 @@
 pub mod c_lib;
 
 use std::{
-    char,
     collections::HashMap,
     ffi::{CStr, CString},
     mem,
     ops::{ControlFlow, Range},
     os::raw::c_char,
-    str,
     sync::atomic::{AtomicUsize, Ordering},
 };
 

--- a/lib/binding_rust/ffi.rs
+++ b/lib/binding_rust/ffi.rs
@@ -21,7 +21,7 @@ unsafe extern "C" {
     pub(crate) fn _ts_dup(handle: *mut std::os::raw::c_void) -> std::os::raw::c_int;
 }
 
-use core::{marker::PhantomData, mem::ManuallyDrop, ptr::NonNull, str};
+use core::{marker::PhantomData, mem::ManuallyDrop, ptr::NonNull};
 
 use crate::{
     Language, LookaheadIterator, Node, ParseState, Parser, Query, QueryCursor, QueryCursorState,


### PR DESCRIPTION
Importing `char` brings deprecated methods into scope in some cases. Importing `str` isn't necessary in many other cases.

Just some minor cleanup here, no behavior changes. While working on #5844, I noticed that `char::from_u32` was deprecated in favor of...`char::from_u32`. Using the non-deprecated version just requires removing the import so the function resolves to the one implemented on the builtin type, rather than the standard library's `char` module. This method is marked deprecated with TBD, meaning it's silently allowed for now. There's no reason not to clean this up when we notice it to avoid CI failures in the future. The removed `str` imports don't remove any deprecated methods, but are unnecessary.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
Used gpt5.6-sol to scan for other soft deprecated/unused imports after noticing the afforementioned `char` issue myself. 
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
