### PR TITLE
Add tree-sitter highlight --formatter=latex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,6 +2088,7 @@ dependencies = [
 name = "tree-sitter-highlight"
 version = "0.27.0"
 dependencies = [
+ "anstyle",
  "regex",
  "streaming-iterator",
  "thiserror",

--- a/crates/cli/src/highlight.rs
+++ b/crates/cli/src/highlight.rs
@@ -548,6 +548,9 @@ pub struct HighlightOptions {
     pub formatter: Formatter,
     /// Command prefix for generated LaTeX macros (without a leading backslash), default "TS".
     pub prefix: String,
+    /// Indices (into `theme.highlight_names`) of scopes whose contents use
+    /// LaTeX math-mode escaping. Empty when `--math-escape` is not given.
+    pub math_escape_indices: HashSet<usize>,
     pub quiet: bool,
     pub print_time: bool,
     pub cancellation_flag: Arc<AtomicUsize>,
@@ -708,7 +711,7 @@ pub fn highlight(
 
         Formatter::Latex(layout, style) => {
             let prefix = &opts.prefix; // already trimmed of leading backslash in main.rs
-            let mut renderer = TexRenderer::new(prefix.clone());
+            let mut renderer = TexRenderer::new(prefix.clone(), opts.math_escape_indices.clone());
             let attribute_callback = |highlight: Highlight, output: &mut Vec<u8>| {
                 let name = theme.highlight_names[highlight.0].as_bytes();
                 match style {

--- a/crates/cli/src/highlight.rs
+++ b/crates/cli/src/highlight.rs
@@ -18,7 +18,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer, ser::SerializeMap}
 use serde_json::{Value, json};
 use tree_sitter::ffi::{self, TSInputEncoding};
 use tree_sitter_highlight::{
-    HighlightConfiguration, Highlighter, HtmlRenderer, Renderer, TerminalRenderer,
+    Highlight, HighlightConfiguration, Highlighter, HtmlRenderer, Renderer, TEX_CHAR_ESCAPES,
+    TerminalRenderer, TexRenderer,
 };
 use tree_sitter_loader::Loader;
 
@@ -306,6 +307,199 @@ fn write_color(buffer: &mut String, color: Color) {
     }
 }
 
+/// Resolve whether an `anstyle::Style` requests italic, bold, and/or underline.
+/// Returns `(italic, bold, underline)`.
+fn style_flags(style: anstyle::Style) -> (bool, bool, bool) {
+    let effects = style.get_effects();
+    (
+        effects.contains(anstyle::Effects::ITALIC),
+        effects.contains(anstyle::Effects::BOLD),
+        effects.contains(anstyle::Effects::UNDERLINE),
+    )
+}
+
+/// Resolve the foreground RGB (0–255) of an `anstyle::Style`, or `None` if there is no color.
+fn style_rgb(style: anstyle::Style) -> Option<(u8, u8, u8)> {
+    match style.get_fg_color()? {
+        Color::Rgb(RgbColor(r, g, b)) => Some((r, g, b)),
+        Color::Ansi256(Ansi256Color(n)) => {
+            let (r, g, b) = rgb_from_ansi256(n);
+            Some((r, g, b))
+        }
+        Color::Ansi(color) => Some(match color {
+            AnsiColor::Black => (0, 0, 0),
+            AnsiColor::Red => (187, 0, 0),
+            AnsiColor::Green => (0, 187, 0),
+            AnsiColor::Yellow => (187, 187, 0),
+            AnsiColor::Blue => (0, 0, 187),
+            AnsiColor::Magenta => (187, 0, 187),
+            AnsiColor::Cyan => (0, 187, 187),
+            AnsiColor::White => (187, 187, 187),
+            _ => (0, 0, 0),
+        }),
+    }
+}
+
+/// Emit the shared LaTeX preamble/definitions common to `--layout document` and `--layout line-numbers`.
+/// Writes the document header, the `\${prefix}@*` macro block, and (when `style == Classes`) one
+/// `\@namedef{...@tok@scope}{...}` color definition per colored scope, then closes with `\makeatother`.
+fn write_tex_preamble<W: io::Write>(
+    w: &mut W,
+    prefix: &str,
+    theme: &Theme,
+    style: HtmlStyling,
+) -> Result<()> {
+    w.write_all(b"\\makeatletter\n")?;
+    // Character-escaping macros: `\TSZdl` expands to an unescaped `$`, etc.
+    // The mapping from character to macro suffix is shared with `TexRenderer::escape_char`
+    // via `TEX_CHAR_ESCAPES` so the two stay in sync.
+    for (ch, suffix) in TEX_CHAR_ESCAPES {
+        w.write_all(
+            format!(
+                "\\def\\{prefix}{suffix}{{\\char`\\{ch}}}\n",
+                prefix = prefix,
+                suffix = suffix,
+                ch = ch
+            )
+            .as_bytes(),
+        )?;
+    }
+    w.write_all(
+        format!(
+            "\\def\\{prefix}@reset{{\\let\\{prefix}@it=\\relax\\let\\{prefix}@bf=\\relax\\let\\{prefix}@ul=\\relax \\let\\{prefix}@tc=\\relax\\let\\{prefix}@bc=\\relax\\let\\{prefix}@ff=\\relax}}\n",
+            prefix = prefix
+        )
+        .as_bytes(),
+    )?;
+    w.write_all(
+        format!(
+            "\\def\\{prefix}@tok#1{{\\csname {prefix}@tok@#1\\endcsname}}\n",
+            prefix = prefix
+        )
+        .as_bytes(),
+    )?;
+    w.write_all(
+        format!(
+            "\\def\\{prefix}@toks#1+{{\\ifx\\relax#1\\empty\\else\\{prefix}@tok{{#1}}\\expandafter\\{prefix}@toks\\fi}}\n",
+            prefix = prefix
+        )
+        .as_bytes(),
+    )?;
+    w.write_all(
+        format!(
+            "\\def\\{prefix}@do#1{{\\{prefix}@bc{{\\{prefix}@tc{{\\{prefix}@ul{{\\{prefix}@it{{\\{prefix}@bf{{\\{prefix}@ff{{#1}}}}}}}}}}}}}}\n",
+            prefix = prefix
+        )
+        .as_bytes(),
+    )?;
+    w.write_all(
+        format!(
+            "\\def\\{prefix}#1#2{{\\{prefix}@reset\\{prefix}@toks#1+\\relax+\\{prefix}@do{{#2}}}}\n",
+            prefix = prefix
+        )
+        .as_bytes(),
+    )?;
+    if style != HtmlStyling::Inline {
+        for (name, style) in theme.highlight_names.iter().zip(&theme.styles) {
+            let rgb = style_rgb(style.ansi);
+            let (italic, bold, underline) = style_flags(style.ansi);
+            // Emit a named color/style definition whenever the scope carries a
+            // color or any of the supported font styles (italic/bold/underline).
+            if rgb.is_some() || italic || bold || underline {
+                let mut def = String::new();
+                // Style switches are emitted before `\def\TS@tc` so they take
+                // effect when `@do` applies the token (see the `\TS@do` macro).
+                if italic {
+                    def.push_str(&format!("\\let\\{prefix}@it=\\textit"));
+                }
+                if bold {
+                    def.push_str(&format!("\\let\\{prefix}@bf=\\textbf"));
+                }
+                if underline {
+                    def.push_str(&format!("\\let\\{prefix}@ul=\\underline"));
+                }
+                if let Some((r, g, b)) = rgb {
+                    let (r, g, b) = (r as f64 / 255.0, g as f64 / 255.0, b as f64 / 255.0);
+                    def.push_str(&format!(
+                        "\\def\\{prefix}@tc##1{{\\textcolor[rgb]{{{r:.4},{g:.4},{b:.4}}}{{##1}}}}",
+                        prefix = prefix,
+                        r = r,
+                        g = g,
+                        b = b
+                    ));
+                } else {
+                    // No color: reset the text-color slot to a no-op so only the
+                    // style switches (if any) apply.
+                    def.push_str(&format!("\\let\\{prefix}@tc=\\relax"));
+                }
+                w.write_all(
+                    format!("\\@namedef{{{prefix}@tok@{name}}}{{{def}}}\n", prefix = prefix, name = name, def = def)
+                        .as_bytes(),
+                )?;
+            }
+        }
+    }
+    w.write_all(b"\\makeatother\n")?;
+    Ok(())
+}
+
+/// Emit a complete, standalone LaTeX document wrapping the rendered `body` in a `Verbatim` block.
+fn write_tex_document<W: io::Write>(
+    w: &mut W,
+    prefix: &str,
+    theme: &Theme,
+    style: HtmlStyling,
+    body: &str,
+) -> Result<()> {
+    w.write_all(b"\\documentclass{article}\n")?;
+    w.write_all(b"\\usepackage{fancyvrb}\n")?;
+    w.write_all(b"\\usepackage{color}\n")?;
+    w.write_all(b"\\usepackage[utf8]{inputenc}\n")?;
+    w.write_all(b"\n")?;
+    write_tex_preamble(w, prefix, theme, style)?;
+    w.write_all(b"\\begin{document}\n")?;
+    w.write_all(b"\n")?;
+    w.write_all(
+        b"\\begin{Verbatim}[commandchars=\\\\\\{\\},codes={\\catcode`\\$=3\\catcode`\\^=7\\catcode`\\_=8\\relax}]\n",
+    )?;
+    w.write_all(body.as_bytes())?;
+    w.write_all(b"\\end{Verbatim}\n")?;
+    w.write_all(b"\n")?;
+    w.write_all(b"\\end{document}\n")?;
+    Ok(())
+}
+
+/// Emit a complete, standalone LaTeX document wrapping each line of `body` in a two-column
+/// `longtable` (line number + code), with leading whitespace preserved.
+fn write_tex_linenumbers<W: io::Write>(
+    w: &mut W,
+    prefix: &str,
+    theme: &Theme,
+    style: HtmlStyling,
+    body: &str,
+) -> Result<()> {
+    w.write_all(b"\\documentclass{article}\n")?;
+    w.write_all(b"\\usepackage{fancyvrb}\n")?;
+    w.write_all(b"\\usepackage{color}\n")?;
+    w.write_all(b"\\usepackage[utf8]{inputenc}\n")?;
+    w.write_all(b"\\usepackage{longtable}\n")?;
+    w.write_all(b"\n")?;
+    write_tex_preamble(w, prefix, theme, style)?;
+    w.write_all(b"\\begin{document}\n")?;
+    w.write_all(b"\n")?;
+    w.write_all(b"\\begin{longtable}{rl}\n")?;
+    let lines: Vec<&str> = body.split('\n').collect();
+    // `render()` appends a trailing newline, so the final element is an empty string; skip it.
+    let count = lines.len().saturating_sub(1);
+    for (i, line) in lines.into_iter().take(count).enumerate() {
+        w.write_all(format!("{} & \\Verb[commandchars=\\\\\\{{\\}},codes={{\\catcode`\\$=3\\catcode`\\^=7\\catcode`\\_=8\\relax}}]-{line}-\\\\\n", i + 1).as_bytes())?;
+    }
+    w.write_all(b"\\end{longtable}\n")?;
+    w.write_all(b"\n")?;
+    w.write_all(b"\\end{document}\n")?;
+    Ok(())
+}
+
 fn terminal_supports_truecolor() -> bool {
     std::env::var("COLORTERM")
         .is_ok_and(|truecolor| truecolor == "truecolor" || truecolor == "24bit")
@@ -342,6 +536,8 @@ pub enum Formatter {
     Terminal,
     /// HTML output, reusing `--layout`/`--style` for structure and styling.
     Html(HtmlOutput, HtmlStyling),
+    /// TeX/LaTeX output, reusing `--layout`/`--style` for structure and styling.
+    Latex(HtmlOutput, HtmlStyling),
 }
 
 pub struct HighlightOptions {
@@ -350,6 +546,8 @@ pub struct HighlightOptions {
     pub captures_path: Option<PathBuf>,
     /// The output format, default `Formatter::Terminal`.
     pub formatter: Formatter,
+    /// Command prefix for generated LaTeX macros (without a leading backslash), default "TS".
+    pub prefix: String,
     pub quiet: bool,
     pub print_time: bool,
     pub cancellation_flag: Arc<AtomicUsize>,
@@ -508,6 +706,56 @@ pub fn highlight(
             }
         }
 
+        Formatter::Latex(layout, style) => {
+            let prefix = &opts.prefix; // already trimmed of leading backslash in main.rs
+            let mut renderer = TexRenderer::new(prefix.clone());
+            let attribute_callback = |highlight: Highlight, output: &mut Vec<u8>| {
+                let name = theme.highlight_names[highlight.0].as_bytes();
+                match style {
+                    HtmlStyling::Inline => {
+                        // Open a single group; within it emit font switches
+                        // (`\bf`/`\it`) and a color command (no extra group of
+                        // its own). `end_highlight` closes the group with a
+                        // single `}`, keeping the brace balance automatic.
+                        output.push(b'{');
+                        let (italic, bold, _underline) =
+                            style_flags(theme.styles[highlight.0].ansi);
+                        if bold {
+                            output.extend(b"\\bf");
+                        }
+                        if italic {
+                            output.extend(b"\\it");
+                        }
+                        if let Some((r, g, b)) = style_rgb(theme.styles[highlight.0].ansi) {
+                            let (r, g, b) = (r as f64 / 255.0, g as f64 / 255.0, b as f64 / 255.0);
+                            write!(output, "\\color[rgb]{{{r:.4},{g:.4},{b:.4}}}").unwrap();
+                        }
+                    }
+                    HtmlStyling::Classes | HtmlStyling::Minimal => {
+                        output.extend(b"\\");
+                        output.extend(prefix.as_bytes());
+                        output.extend(b"{");
+                        output.extend(name);
+                        output.extend(b"}{");
+                    }
+                }
+            };
+            renderer.render(events, &source, &attribute_callback)?;
+
+            let body = String::from_utf8(renderer.content().clone()).unwrap();
+            match layout {
+                HtmlOutput::Fragment => {
+                    write!(&mut stdout, "{body}")?;
+                }
+                HtmlOutput::Document => {
+                    write_tex_document(&mut stdout, &opts.prefix, theme, *style, &body)?;
+                }
+                HtmlOutput::NumberedDocument => {
+                    write_tex_linenumbers(&mut stdout, &opts.prefix, theme, *style, &body)?;
+                }
+            }
+        }
+
         Formatter::Terminal => {
             let styles: Vec<anstyle::Style> = theme.styles.iter().map(|style| style.ansi).collect();
             let mut renderer = TerminalRenderer::new(&styles, theme.default_style().ansi);
@@ -572,5 +820,134 @@ mod tests {
         } else {
             unsafe { env::remove_var("COLORTERM") };
         }
+    }
+
+    /// Build a one-scope theme (color is optional) with the given flags,
+    /// returning the parsed inner `anstyle::Style`.
+    fn style_with(
+        name: &str,
+        color: Option<&str>,
+        bold: bool,
+        italic: bool,
+        underline: bool,
+    ) -> anstyle::Style {
+        let mut json = serde_json::Map::new();
+        if let Some(c) = color {
+            json.insert("color".into(), Value::String(c.to_string()));
+        }
+        if bold {
+            json.insert("bold".into(), Value::Bool(true));
+        }
+        if italic {
+            json.insert("italic".into(), Value::Bool(true));
+        }
+        if underline {
+            json.insert("underline".into(), Value::Bool(true));
+        }
+        let theme: Theme =
+            serde_json::from_value(json!({ name: Value::Object(json) })).unwrap();
+        theme.styles[0].ansi
+    }
+
+    #[test]
+    fn test_latex_classes_style_switches() {
+        // keyword: color + italic; parameter: color + underline;
+        // constant: color + bold; comment: italic only (no color).
+        let theme = Theme {
+            highlight_names: vec![
+                "keyword".into(),
+                "variable.parameter".into(),
+                "constant.builtin".into(),
+                "comment".into(),
+            ],
+            styles: vec![
+                Style { ansi: style_with("keyword", Some("#3d7a7a"), false, true, false), css: None },
+                Style { ansi: style_with("variable.parameter", Some("#fcfcfc"), false, false, true), css: None },
+                Style { ansi: style_with("constant.builtin", Some("#5f00af"), true, false, false), css: None },
+                Style { ansi: style_with("comment", None, false, true, false), css: None },
+            ],
+        };
+        let mut buf = Vec::new();
+        write_tex_preamble(&mut buf, "TS", &theme, HtmlStyling::Classes).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+
+        // italic emits \let\TS@it=\textit before the color definition.
+        assert!(
+            out.contains("\\@namedef{TS@tok@keyword}{\\let\\TS@it=\\textit\\def\\TS@tc##1{\\textcolor[rgb]{0.2392,0.4784,0.4784}{##1}}}"),
+            "keyword namedef missing italic switch:\n{out}"
+        );
+        // underline emits \let\TS@ul=\underline.
+        assert!(
+            out.contains("\\@namedef{TS@tok@variable.parameter}{\\let\\TS@ul=\\underline\\def\\TS@tc##1{\\textcolor[rgb]{0.9882,0.9882,0.9882}{##1}}}"),
+            "parameter namedef missing underline switch:\n{out}"
+        );
+        // bold emits \let\TS@bf=\textbf.
+        assert!(
+            out.contains("\\@namedef{TS@tok@constant.builtin}{\\let\\TS@bf=\\textbf\\def\\TS@tc##1{\\textcolor[rgb]{0.3725,0.0000,0.6863}{##1}}}"),
+            "constant namedef missing bold switch:\n{out}"
+        );
+        // No color: only the italic switch, with @tc reset to \relax.
+        assert!(
+            out.contains("\\@namedef{TS@tok@comment}{\\let\\TS@it=\\textit\\let\\TS@tc=\\relax}"),
+            "comment namedef (no color) wrong:\n{out}"
+        );
+    }
+
+    #[test]
+    fn test_latex_inline_style_switches() {
+        // Replicate the inline attribute_callback for a bold+italic+color scope.
+        let style = style_with("kw", Some("#3d7a7a"), true, true, false);
+        let (italic, bold, _underline) = style_flags(style);
+
+        let mut output: Vec<u8> = Vec::new();
+        output.push(b'{');
+        if bold {
+            output.extend(b"\\bf");
+        }
+        if italic {
+            output.extend(b"\\it");
+        }
+        if let Some((r, g, b)) = style_rgb(style) {
+            let (r, g, b) = (r as f64 / 255.0, g as f64 / 255.0, b as f64 / 255.0);
+            write!(
+                output,
+                "\\color[rgb]{{{r:.4},{g:.4},{b:.4}}}"
+            )
+            .unwrap();
+        }
+        // The renderer closes the single group with one `}`.
+        output.extend(b"}");
+
+        let out = String::from_utf8(output).unwrap();
+        assert_eq!(
+            out,
+            "{\\bf\\it\\color[rgb]{0.2392,0.4784,0.4784}}",
+            "inline markup mismatch: {out}"
+        );
+    }
+
+    #[test]
+    fn test_latex_inline_no_style_opens_single_group() {
+        let style = style_with("plain", Some("#abcdef"), false, false, false);
+        let (italic, bold, _underline) = style_flags(style);
+
+        let mut output: Vec<u8> = Vec::new();
+        output.push(b'{');
+        if bold {
+            output.extend(b"\\bf");
+        }
+        if italic {
+            output.extend(b"\\it");
+        }
+        if let Some((r, g, b)) = style_rgb(style) {
+            let (r, g, b) = (r as f64 / 255.0, g as f64 / 255.0, b as f64 / 255.0);
+            write!(output, "\\color[rgb]{{{r:.4},{g:.4},{b:.4}}}").unwrap();
+        }
+        output.extend(b"}");
+
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            "{\\color[rgb]{0.6706,0.8039,0.9373}}"
+        );
     }
 }

--- a/crates/cli/src/highlight.rs
+++ b/crates/cli/src/highlight.rs
@@ -17,7 +17,9 @@ use log::{info, warn};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, ser::SerializeMap};
 use serde_json::{Value, json};
 use tree_sitter::ffi::{self, TSInputEncoding};
-use tree_sitter_highlight::{HighlightConfiguration, HighlightEvent, Highlighter, HtmlRenderer};
+use tree_sitter_highlight::{
+    HighlightConfiguration, HighlightEvent, Highlighter, HtmlRenderer, Renderer,
+};
 use tree_sitter_loader::Loader;
 
 pub const HTML_HEAD_HEADER: &str = "

--- a/crates/cli/src/highlight.rs
+++ b/crates/cli/src/highlight.rs
@@ -333,12 +333,21 @@ pub enum HtmlStyling {
     Minimal,
 }
 
+/// The output format for highlighting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Formatter {
+    /// ANSI-colored terminal output (the default).
+    Terminal,
+    /// HTML output, reusing `--layout`/`--style` for structure and styling.
+    Html(HtmlOutput, HtmlStyling),
+}
+
 pub struct HighlightOptions {
     pub theme: Theme,
     pub check: bool,
     pub captures_path: Option<PathBuf>,
-    /// `None` for regular output, `Some((layout, style))` when emitting HTML.
-    pub html: Option<(HtmlOutput, HtmlStyling)>,
+    /// The output format, default `Formatter::Terminal`.
+    pub formatter: Formatter,
     pub quiet: bool,
     pub print_time: bool,
     pub cancellation_flag: Arc<AtomicUsize>,
@@ -421,93 +430,98 @@ pub fn highlight(
     let theme = &opts.theme;
 
     // A fragment is pure code markup, so it must not be prefixed with the filename.
-    let html_fragment = opts
-        .html
-        .is_some_and(|(layout, _)| layout == HtmlOutput::Fragment);
+    let html_fragment = matches!(
+        opts.formatter,
+        Formatter::Html(layout, _) if layout == HtmlOutput::Fragment
+    );
     if !opts.quiet && print_name && !html_fragment {
         writeln!(&mut stdout, "{name}")?;
     }
 
-    if let Some((layout, style)) = opts.html {
-        if !opts.quiet && layout != HtmlOutput::Fragment {
-            writeln!(&mut stdout, "{HTML_HEAD_HEADER}")?;
-            if layout == HtmlOutput::NumberedDocument {
-                writeln!(&mut stdout, "{HTML_LINE_NUMBER_STYLE}")?;
-            }
-            if style == HtmlStyling::Classes {
-                for (name, style) in theme.highlight_names.iter().zip(&theme.styles) {
-                    if let Some(css) = &style.css {
-                        writeln!(&mut stdout, "    .{name} {{ {css}; }}")?;
+    match &opts.formatter {
+        Formatter::Html(layout, style) => {
+            if !opts.quiet && *layout != HtmlOutput::Fragment {
+                writeln!(&mut stdout, "{HTML_HEAD_HEADER}")?;
+                if *layout == HtmlOutput::NumberedDocument {
+                    writeln!(&mut stdout, "{HTML_LINE_NUMBER_STYLE}")?;
+                }
+                if *style == HtmlStyling::Classes {
+                    for (name, style) in theme.highlight_names.iter().zip(&theme.styles) {
+                        if let Some(css) = &style.css {
+                            writeln!(&mut stdout, "    .{name} {{ {css}; }}")?;
+                        }
                     }
                 }
+                writeln!(&mut stdout, "  </style>")?;
+                writeln!(&mut stdout, "{HTML_BODY_HEADER}")?;
             }
-            writeln!(&mut stdout, "  </style>")?;
-            writeln!(&mut stdout, "{HTML_BODY_HEADER}")?;
-        }
 
-        let mut renderer = HtmlRenderer::new();
-        renderer.render(events, &source, &move |highlight, output| {
-            if style == HtmlStyling::Inline {
-                output.extend(b"style='");
-                output.extend(
-                    theme.styles[highlight.0]
-                        .css
-                        .as_ref()
-                        .map_or_else(|| "".as_bytes(), |css_style| css_style.as_bytes()),
-                );
-            } else {
-                output.extend(b"class='");
-                let mut parts = theme.highlight_names[highlight.0].split('.').peekable();
-                while let Some(part) = parts.next() {
-                    output.extend(part.as_bytes());
-                    if parts.peek().is_some() {
-                        output.extend(b" ");
+            let mut renderer = HtmlRenderer::new();
+            renderer.render(events, &source, &move |highlight, output| {
+                if *style == HtmlStyling::Inline {
+                    output.extend(b"style='");
+                    output.extend(
+                        theme.styles[highlight.0]
+                            .css
+                            .as_ref()
+                            .map_or_else(|| "".as_bytes(), |css_style| css_style.as_bytes()),
+                    );
+                } else {
+                    output.extend(b"class='");
+                    let mut parts = theme.highlight_names[highlight.0].split('.').peekable();
+                    while let Some(part) = parts.next() {
+                        output.extend(part.as_bytes());
+                        if parts.peek().is_some() {
+                            output.extend(b" ");
+                        }
                     }
                 }
-            }
-            output.extend(b"'");
-        })?;
+                output.extend(b"'");
+            })?;
 
-        if !opts.quiet {
-            if layout == HtmlOutput::NumberedDocument {
-                writeln!(&mut stdout, "<table>")?;
-                for (i, line) in renderer.lines().enumerate() {
+            if !opts.quiet {
+                if *layout == HtmlOutput::NumberedDocument {
+                    writeln!(&mut stdout, "<table>")?;
+                    for (i, line) in renderer.lines().enumerate() {
+                        writeln!(
+                            &mut stdout,
+                            "<tr><td class=line-number>{}</td><td class=line>{line}</td></tr>",
+                            i + 1,
+                        )?;
+                    }
+                    writeln!(&mut stdout, "</table>")?;
+                } else {
+                    let mut body = renderer.lines().collect::<String>();
+                    if body.ends_with('\n') {
+                        body.pop();
+                    }
                     writeln!(
                         &mut stdout,
-                        "<tr><td class=line-number>{}</td><td class=line>{line}</td></tr>",
-                        i + 1,
+                        "<div class=\"highlight\">\n<pre><code>{body}</code></pre>\n</div>",
                     )?;
                 }
-                writeln!(&mut stdout, "</table>")?;
-            } else {
-                let mut body = renderer.lines().collect::<String>();
-                if body.ends_with('\n') {
-                    body.pop();
+                if *layout != HtmlOutput::Fragment {
+                    writeln!(&mut stdout, "{HTML_FOOTER}")?;
                 }
-                writeln!(
-                    &mut stdout,
-                    "<div class=\"highlight\">\n<pre><code>{body}</code></pre>\n</div>",
-                )?;
-            }
-            if layout != HtmlOutput::Fragment {
-                writeln!(&mut stdout, "{HTML_FOOTER}")?;
             }
         }
-    } else {
-        let mut style_stack = vec![theme.default_style().ansi];
-        for event in events {
-            match event? {
-                HighlightEvent::HighlightStart(highlight) => {
-                    style_stack.push(theme.styles[highlight.0].ansi);
-                }
-                HighlightEvent::HighlightEnd => {
-                    style_stack.pop();
-                }
-                HighlightEvent::Source { start, end } => {
-                    let style = style_stack.last().unwrap();
-                    write!(&mut stdout, "{style}").unwrap();
-                    stdout.write_all(&source[start..end])?;
-                    write!(&mut stdout, "{style:#}").unwrap();
+
+        Formatter::Terminal => {
+            let mut style_stack = vec![theme.default_style().ansi];
+            for event in events {
+                match event? {
+                    HighlightEvent::HighlightStart(highlight) => {
+                        style_stack.push(theme.styles[highlight.0].ansi);
+                    }
+                    HighlightEvent::HighlightEnd => {
+                        style_stack.pop();
+                    }
+                    HighlightEvent::Source { start, end } => {
+                        let style = style_stack.last().unwrap();
+                        write!(&mut stdout, "{style}").unwrap();
+                        stdout.write_all(&source[start..end])?;
+                        write!(&mut stdout, "{style:#}").unwrap();
+                    }
                 }
             }
         }

--- a/crates/cli/src/highlight.rs
+++ b/crates/cli/src/highlight.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer, ser::SerializeMap}
 use serde_json::{Value, json};
 use tree_sitter::ffi::{self, TSInputEncoding};
 use tree_sitter_highlight::{
-    HighlightConfiguration, HighlightEvent, Highlighter, HtmlRenderer, Renderer,
+    HighlightConfiguration, Highlighter, HtmlRenderer, Renderer, TerminalRenderer,
 };
 use tree_sitter_loader::Loader;
 
@@ -509,23 +509,10 @@ pub fn highlight(
         }
 
         Formatter::Terminal => {
-            let mut style_stack = vec![theme.default_style().ansi];
-            for event in events {
-                match event? {
-                    HighlightEvent::HighlightStart(highlight) => {
-                        style_stack.push(theme.styles[highlight.0].ansi);
-                    }
-                    HighlightEvent::HighlightEnd => {
-                        style_stack.pop();
-                    }
-                    HighlightEvent::Source { start, end } => {
-                        let style = style_stack.last().unwrap();
-                        write!(&mut stdout, "{style}").unwrap();
-                        stdout.write_all(&source[start..end])?;
-                        write!(&mut stdout, "{style:#}").unwrap();
-                    }
-                }
-            }
+            let styles: Vec<anstyle::Style> = theme.styles.iter().map(|style| style.ansi).collect();
+            let mut renderer = TerminalRenderer::new(&styles, theme.default_style().ansi);
+            renderer.render(events, &source, &|_highlight, _output| {})?;
+            stdout.write_all(renderer.content())?;
         }
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -19,7 +19,7 @@ use tree_sitter_cli::{
         DEFAULT_EDIT_COUNT, DEFAULT_ITERATION_COUNT, EDIT_COUNT, FuzzOptions, ITERATION_COUNT,
         LOG_ENABLED, LOG_GRAPH_ENABLED, START_SEED, fuzz_language_corpus,
     },
-    highlight::{self, HighlightOptions, HtmlOutput, HtmlStyling},
+    highlight::{self, Formatter, HighlightOptions, HtmlOutput, HtmlStyling},
     init::{JsonConfigOpts, TREE_SITTER_JSON_SCHEMA, generate_grammar_files},
     input::{CliInput, get_input, get_tmp_source_file},
     logger, paint,
@@ -502,20 +502,34 @@ struct Query {
     pub rebuild: bool,
 }
 
+/// The output format for the `highlight` command, used by `--formatter`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum FormatterArg {
+    /// ANSI-colored terminal output.
+    #[value(name = "terminal")]
+    Terminal,
+    /// HTML output.
+    #[value(name = "html")]
+    Html,
+}
+
 #[derive(Args)]
-#[command(alias = "hi")]
+#[command(alias = "hi", group(clap::ArgGroup::new("markup").args(["html", "formatter"])))]
 struct Highlight {
     /// Generate highlighting as an HTML document
-    #[arg(long, short = 'H')]
+    #[arg(long, short = 'H', conflicts_with = "formatter")]
     pub html: bool,
+    /// Output formats
+    #[arg(long, value_enum, default_value = "terminal", conflicts_with = "html")]
+    pub formatter: FormatterArg,
     /// Deprecated: use `--style classes`
-    #[arg(long, requires = "html", conflicts_with = "style")]
+    #[arg(long, requires = "markup", conflicts_with = "style")]
     pub css_classes: bool,
-    /// When generating HTML, the document structure to emit
-    #[arg(long, requires = "html", value_enum, default_value = "document")]
+    /// When generating markup, the document structure to emit
+    #[arg(long, requires = "markup", value_enum, default_value = "document")]
     pub layout: HtmlOutput,
-    /// When generating HTML, how token colors are applied
-    #[arg(long, requires = "html", value_enum, default_value = "classes")]
+    /// When generating markup, how token colors are applied
+    #[arg(long, requires = "markup", value_enum, default_value = "classes")]
     pub style: HtmlStyling,
     /// Check that highlighting captures conform strictly to standards
     #[arg(long)]
@@ -1718,11 +1732,20 @@ impl Highlight {
             self.style
         };
 
+        let formatter = if self.html {
+            Formatter::Html(self.layout, style)
+        } else {
+            match self.formatter {
+                FormatterArg::Terminal => Formatter::Terminal,
+                FormatterArg::Html => Formatter::Html(self.layout, style),
+            }
+        };
+
         let options = HighlightOptions {
             theme: theme_config.theme,
             check: self.check,
             captures_path: self.captures_path,
-            html: self.html.then_some((self.layout, style)),
+            formatter,
             quiet: self.quiet,
             print_time: self.time,
             cancellation_flag: cancellation_flag.clone(),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -514,6 +514,9 @@ pub enum FormatterArg {
     /// HTML output.
     #[value(name = "html")]
     Html,
+    /// LaTeX (TeX) output.
+    #[value(name = "latex")]
+    Latex,
 }
 
 #[derive(Args)]
@@ -525,6 +528,9 @@ struct Highlight {
     /// Output formats
     #[arg(long, value_enum, default_value = "terminal", conflicts_with = "html")]
     pub formatter: FormatterArg,
+    /// Command prefix for generated LaTeX macros
+    #[arg(long, default_value = "TS")]
+    pub prefix: String,
     /// Deprecated: use `--style classes`
     #[arg(long, requires = "markup", conflicts_with = "style")]
     pub css_classes: bool,
@@ -1750,6 +1756,19 @@ impl Highlight {
             }
         }
 
+        // `--prefix` only namespaces the generated macros of the LaTeX formatter, so it
+        // carries no meaning with the terminal or HTML formatters. Reject an explicit use
+        // of it instead of silently ignoring it.
+        if (self.html || !matches!(self.formatter, FormatterArg::Latex))
+            && matches
+                .value_source("prefix")
+                .is_some_and(|s| s == ValueSource::CommandLine)
+        {
+            return Err(anyhow!(
+                "--prefix is not valid with the terminal or HTML formatters"
+            ));
+        }
+
         let style = if self.css_classes {
             // TODO: Remove during the 0.28 release cycle
             warn!("--css-classes is deprecated, use --style classes instead");
@@ -1764,6 +1783,7 @@ impl Highlight {
             match self.formatter {
                 FormatterArg::Terminal => Formatter::Terminal,
                 FormatterArg::Html => Formatter::Html(self.layout, style),
+                FormatterArg::Latex => Formatter::Latex(self.layout, style),
             }
         };
 
@@ -1772,6 +1792,7 @@ impl Highlight {
             check: self.check,
             captures_path: self.captures_path,
             formatter,
+            prefix: self.prefix.trim_start_matches('\\').to_string(),
             quiet: self.quiet,
             print_time: self.time,
             cancellation_flag: cancellation_flag.clone(),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6,7 +6,10 @@ use std::{
 
 use anstyle::{AnsiColor, Color, Style};
 use anyhow::{Context, Result, anyhow};
-use clap::{ArgGroup, Args, Command, FromArgMatches as _, Subcommand, ValueEnum, crate_authors};
+use clap::parser::ValueSource;
+use clap::{
+    ArgGroup, ArgMatches, Args, Command, FromArgMatches as _, Subcommand, ValueEnum, crate_authors,
+};
 use clap_complete::generate;
 use dialoguer::{Confirm, FuzzySelect, Input, MultiSelect, theme::ColorfulTheme};
 use heck::ToUpperCamelCase;
@@ -1696,7 +1699,12 @@ impl Query {
 }
 
 impl Highlight {
-    fn run(self, mut loader: loader::Loader, current_dir: &Path) -> Result<()> {
+    fn run(
+        self,
+        matches: &ArgMatches,
+        mut loader: loader::Loader,
+        current_dir: &Path,
+    ) -> Result<()> {
         let config = Config::load(self.config_path)?;
         let theme_config: tree_sitter_cli::highlight::ThemeConfig = config.get()?;
         loader.configure_highlights(&theme_config.theme.highlight_names);
@@ -1723,6 +1731,24 @@ impl Highlight {
             Encoding::Utf16LE => ffi::TSInputEncodingUTF16LE,
             Encoding::Utf16BE => ffi::TSInputEncodingUTF16BE,
         });
+
+        // `--layout`/`--style` only affect markup formatters (html/latex). When the
+        // formatter is `terminal` (the default), those flags carry no meaning, so reject
+        // an explicit use of them instead of silently ignoring it.
+        if matches!(self.formatter, FormatterArg::Terminal) && !self.html {
+            if matches
+                .value_source("layout")
+                .is_some_and(|s| s == ValueSource::CommandLine)
+            {
+                return Err(anyhow!("--layout is not valid with the terminal formatter"));
+            }
+            if matches
+                .value_source("style")
+                .is_some_and(|s| s == ValueSource::CommandLine)
+            {
+                return Err(anyhow!("--style is not valid with the terminal formatter"));
+            }
+        }
 
         let style = if self.css_classes {
             // TODO: Remove during the 0.28 release cycle
@@ -2108,7 +2134,8 @@ fn run() -> Result<()> {
         .disable_colored_help(false);
     let mut cli = Commands::augment_subcommands(cli);
 
-    let command = Commands::from_arg_matches(&cli.clone().get_matches())?;
+    let matches = cli.clone().get_matches();
+    let command = Commands::from_arg_matches(&matches)?;
 
     let current_dir = match &command {
         Commands::Init(Init { grammar_path, .. })
@@ -2141,7 +2168,10 @@ fn run() -> Result<()> {
         Commands::Version(version_options) => version_options.run(current_dir)?,
         Commands::Fuzz(fuzz_options) => fuzz_options.run(loader, &current_dir)?,
         Commands::Query(query_options) => query_options.run(loader, &current_dir)?,
-        Commands::Highlight(highlight_options) => highlight_options.run(loader, &current_dir)?,
+        Commands::Highlight(highlight_options) => {
+            let sub_matches = matches.subcommand_matches("highlight").unwrap();
+            highlight_options.run(sub_matches, loader, &current_dir)?
+        }
         Commands::Tags(tags_options) => tags_options.run(loader, &current_dir)?,
         Commands::Playground(playground_options) => playground_options.run(&current_dir)?,
         Commands::DumpLanguages(dump_options) => dump_options.run(loader)?,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -531,6 +531,11 @@ struct Highlight {
     /// Command prefix for generated LaTeX macros
     #[arg(long, default_value = "TS")]
     pub prefix: String,
+    /// Comma-separated scopes whose contents use LaTeX math-mode escaping
+    /// (like pygmentize), e.g. `comment,string`. `comment` also matches
+    /// `comment.*`. Only valid with `--formatter=latex`.
+    #[arg(long, default_value = "")]
+    pub math_escape: String,
     /// Deprecated: use `--style classes`
     #[arg(long, requires = "markup", conflicts_with = "style")]
     pub css_classes: bool,
@@ -1769,6 +1774,19 @@ impl Highlight {
             ));
         }
 
+        // `--math-escape` only namespaces the escaping behavior of the LaTeX
+        // formatter, so it carries no meaning with the terminal or HTML
+        // formatters. Reject an explicit use of it instead of silently ignoring it.
+        if (self.html || !matches!(self.formatter, FormatterArg::Latex))
+            && matches
+                .value_source("math_escape")
+                .is_some_and(|s| s == ValueSource::CommandLine)
+        {
+            return Err(anyhow!(
+                "--math-escape is not valid with the terminal or HTML formatters"
+            ));
+        }
+
         let style = if self.css_classes {
             // TODO: Remove during the 0.28 release cycle
             warn!("--css-classes is deprecated, use --style classes instead");
@@ -1787,12 +1805,38 @@ impl Highlight {
             }
         };
 
+        // Resolve `--math-escape` scope patterns into the set of highlight
+        // indices they match. `comment` matches `comment` and `comment.*`.
+        let math_escape_indices: HashSet<usize> = {
+            let patterns: Vec<&str> = self
+                .math_escape
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .collect();
+            if patterns.is_empty() {
+                HashSet::new()
+            } else {
+                theme_config
+                    .theme
+                    .highlight_names
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, name)| {
+                        patterns.iter().any(|p| *name == p || name.starts_with(&format!("{p}.")))
+                    })
+                    .map(|(i, _)| i)
+                    .collect()
+            }
+        };
+
         let options = HighlightOptions {
             theme: theme_config.theme,
             check: self.check,
             captures_path: self.captures_path,
             formatter,
             prefix: self.prefix.trim_start_matches('\\').to_string(),
+            math_escape_indices,
             quiet: self.quiet,
             print_time: self.time,
             cancellation_flag: cancellation_flag.clone(),

--- a/crates/cli/src/tests/highlight_test.rs
+++ b/crates/cli/src/tests/highlight_test.rs
@@ -10,7 +10,8 @@ use std::{
 };
 
 use tree_sitter_highlight::{
-    Error, Highlight, HighlightConfiguration, HighlightEvent, Highlighter, HtmlRenderer, c,
+    Error, Highlight, HighlightConfiguration, HighlightEvent, Highlighter, HtmlRenderer, Renderer,
+    c,
 };
 
 use super::helpers::fixtures::{get_highlight_config, get_language, get_language_queries_path};

--- a/crates/highlight/Cargo.toml
+++ b/crates/highlight/Cargo.toml
@@ -21,6 +21,7 @@ crate-type = [ "lib", "staticlib" ]
 path       = "src/highlight.rs"
 
 [dependencies]
+anstyle.workspace              = true
 regex.workspace              = true
 streaming-iterator.workspace = true
 thiserror.workspace          = true

--- a/crates/highlight/src/c_lib.rs
+++ b/crates/highlight/src/c_lib.rs
@@ -6,7 +6,7 @@ use std::{
 use regex::Regex;
 use tree_sitter::{Language, ffi};
 
-use super::{Error, Highlight, HighlightConfiguration, Highlighter, HtmlRenderer};
+use super::{Error, Highlight, HighlightConfiguration, Highlighter, HtmlRenderer, Renderer};
 
 pub struct TSHighlighter {
     pub languages: HashMap<String, (Option<Regex>, HighlightConfiguration)>,
@@ -15,9 +15,10 @@ pub struct TSHighlighter {
     pub carriage_return_index: Option<usize>,
 }
 
-pub struct TSHighlightBuffer {
+#[derive(Default)]
+pub struct TSHighlightBuffer<T: Renderer = HtmlRenderer> {
     highlighter: Highlighter,
-    renderer: HtmlRenderer,
+    renderer: T,
 }
 
 #[repr(C)]
@@ -151,10 +152,7 @@ pub unsafe extern "C" fn ts_highlighter_add_language(
 
 #[unsafe(no_mangle)]
 pub extern "C" fn ts_highlight_buffer_new() -> *mut TSHighlightBuffer {
-    Box::into_raw(Box::new(TSHighlightBuffer {
-        highlighter: Highlighter::new(),
-        renderer: HtmlRenderer::new(),
-    }))
+    Box::into_raw(Box::new(TSHighlightBuffer::default()))
 }
 
 /// Deletes a [`TSHighlighter`] instance.
@@ -201,8 +199,8 @@ pub unsafe extern "C" fn ts_highlight_buffer_delete(this: *mut TSHighlightBuffer
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn ts_highlight_buffer_content(this: *const TSHighlightBuffer) -> *const u8 {
     unsafe {
-        let this = unwrap_ptr(this);
-        this.renderer.html.as_slice().as_ptr()
+        let this = unwrap_mut_ptr(this as *mut TSHighlightBuffer);
+        this.renderer.content().as_slice().as_ptr()
     }
 }
 
@@ -222,8 +220,8 @@ pub unsafe extern "C" fn ts_highlight_buffer_line_offsets(
     this: *const TSHighlightBuffer,
 ) -> *const u32 {
     unsafe {
-        let this = unwrap_ptr(this);
-        this.renderer.line_offsets.as_slice().as_ptr()
+        let this = unwrap_mut_ptr(this as *mut TSHighlightBuffer);
+        this.renderer.line_offsets().as_slice().as_ptr()
     }
 }
 
@@ -236,8 +234,8 @@ pub unsafe extern "C" fn ts_highlight_buffer_line_offsets(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn ts_highlight_buffer_len(this: *const TSHighlightBuffer) -> u32 {
     unsafe {
-        let this = unwrap_ptr(this);
-        this.renderer.html.len() as u32
+        let this = unwrap_mut_ptr(this as *mut TSHighlightBuffer);
+        this.renderer.content().len() as u32
     }
 }
 
@@ -250,8 +248,8 @@ pub unsafe extern "C" fn ts_highlight_buffer_len(this: *const TSHighlightBuffer)
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn ts_highlight_buffer_line_count(this: *const TSHighlightBuffer) -> u32 {
     unsafe {
-        let this = unwrap_ptr(this);
-        this.renderer.line_offsets.len() as u32
+        let this = unwrap_mut_ptr(this as *mut TSHighlightBuffer);
+        this.renderer.line_offsets().len() as u32
     }
 }
 

--- a/crates/highlight/src/highlight.rs
+++ b/crates/highlight/src/highlight.rs
@@ -4,6 +4,7 @@ pub mod c_lib;
 use core::slice;
 use std::{
     collections::HashSet,
+    io::Write as _,
     iter,
     marker::PhantomData,
     mem::{self, MaybeUninit},
@@ -137,6 +138,112 @@ pub struct HighlightConfiguration {
 pub struct Highlighter {
     pub parser: Parser,
     cursors: Vec<QueryCursor>,
+}
+
+/// Converts a general-purpose syntax highlighting iterator into ANSI-colored terminal text.
+///
+/// Unlike `HtmlRenderer`/`TexRenderer`, which open and close a span per highlight scope, the
+/// terminal renderer re-emits the active ANSI style before *every* source segment and resets it
+/// after, so that adjacent source segments at the same scope are each individually wrapped. This
+/// keeps colored output correct even when other code interleaves raw bytes onto the same terminal
+/// stream.
+pub struct TerminalRenderer {
+    content: Vec<u8>,
+    line_offsets: Vec<u32>,
+    // The offset in `self.content` of the last carriage return.
+    last_carriage_return: Option<usize>,
+    /// Stack of active highlight scopes, bottom-to-top.
+    highlight: Vec<Highlight>,
+    /// The style applied outside of any highlight scope.
+    default_style: anstyle::Style,
+    /// ANSI styles indexed by highlight index (`Highlight.0`).
+    styles: Vec<anstyle::Style>,
+}
+
+impl Default for TerminalRenderer {
+    fn default() -> Self {
+        Self::new(&[], anstyle::Style::new())
+    }
+}
+
+impl TerminalRenderer {
+    #[must_use]
+    pub fn new(styles: &[anstyle::Style], default_style: anstyle::Style) -> Self {
+        Self {
+            content: Vec::with_capacity(BUFFER_RESERVE_CAPACITY),
+            line_offsets: Vec::with_capacity(BUFFER_LINES_RESERVE_CAPACITY),
+            last_carriage_return: None,
+            highlight: Vec::new(),
+            default_style,
+            styles: styles.to_vec(),
+        }
+    }
+}
+
+impl Renderer for TerminalRenderer {
+    fn content(&mut self) -> &mut Vec<u8> {
+        &mut self.content
+    }
+
+    fn line_offsets(&mut self) -> &mut Vec<u32> {
+        &mut self.line_offsets
+    }
+
+    fn last_carriage_return(&mut self) -> &mut Option<usize> {
+        &mut self.last_carriage_return
+    }
+
+    fn add_carriage_return<F>(&mut self, _offset: usize, _attribute_callback: &F)
+    where
+        F: Fn(Highlight, &mut Vec<u8>),
+    {
+        // Terminal output has no standalone carriage-return styling.
+    }
+
+    fn set_carriage_return_highlight(&mut self, _highlight: Option<Highlight>) {}
+
+    fn start_highlight<F>(&mut self, _h: Highlight, _attribute_callback: &F)
+    where
+        F: Fn(Highlight, &mut Vec<u8>),
+    {
+        // The terminal renderer drives its own event loop in `render` rather than the shared
+        // span-based loop, so this is unused.
+    }
+
+    fn end_highlight(&mut self) {}
+
+    fn render<F>(
+        &mut self,
+        highlighter: impl Iterator<Item = Result<HighlightEvent, Error>>,
+        source: &[u8],
+        _attribute_callback: &F,
+    ) -> Result<(), Error>
+    where
+        F: Fn(Highlight, &mut Vec<u8>),
+    {
+        self.highlight.clear();
+        for event in highlighter {
+            match event? {
+                HighlightEvent::HighlightStart(highlight) => {
+                    self.highlight.push(highlight);
+                }
+                HighlightEvent::HighlightEnd => {
+                    self.highlight.pop();
+                }
+                HighlightEvent::Source { start, end } => {
+                    let style = self
+                        .highlight
+                        .last()
+                        .map(|h| self.styles[h.0])
+                        .unwrap_or(self.default_style);
+                    write!(&mut self.content, "{style}").unwrap();
+                    self.content.extend_from_slice(&source[start..end]);
+                    write!(&mut self.content, "{style:#}").unwrap();
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Converts a general-purpose syntax highlighting iterator into a sequence of lines of HTML.

--- a/crates/highlight/src/highlight.rs
+++ b/crates/highlight/src/highlight.rs
@@ -1486,6 +1486,121 @@ impl Renderer for HtmlRenderer {
     }
 }
 
+/// The special characters that must be escaped in TeX output, paired with the suffix of the
+/// `\${prefix}Zxx` macro that represents them. The macro definitions are emitted by the CLI's
+/// LaTeX preamble (see `write_tex_preamble`); `TexRenderer::escape_char` turns a character into
+/// `\${prefix}` + suffix. Shared so the two never drift apart.
+pub const TEX_CHAR_ESCAPES: &[(char, &str)] = &[
+    ('\\', "Zbs"),
+    ('_', "Zus"),
+    ('{', "Zob"),
+    ('}', "Zcb"),
+    ('^', "Zca"),
+    ('&', "Zam"),
+    ('<', "Zlt"),
+    ('>', "Zgt"),
+    ('#', "Zsh"),
+    ('%', "Zpc"),
+    ('$', "Zdl"),
+    ('-', "Zhy"),
+    ('\'', "Zsq"),
+    ('"', "Zdq"),
+    ('~', "Zti"),
+];
+
+/// Converts a general-purpose syntax highlighting iterator into TeX markup.
+pub struct TexRenderer {
+    content: Vec<u8>,
+    line_offsets: Vec<u32>,
+    carriage_return_highlight: Option<Highlight>,
+    // The offset in `self.content` of the last carriage return.
+    last_carriage_return: Option<usize>,
+    // Command prefix (without a leading backslash), e.g. "TS" -> emits `\TS{...}{...}`.
+    tex_prefix: String,
+}
+
+impl Default for TexRenderer {
+    fn default() -> Self {
+        Self::new("TS".to_string())
+    }
+}
+
+impl TexRenderer {
+    #[must_use]
+    pub fn new(tex_prefix: String) -> Self {
+        let mut result = Self {
+            content: Vec::with_capacity(BUFFER_RESERVE_CAPACITY),
+            line_offsets: Vec::with_capacity(BUFFER_LINES_RESERVE_CAPACITY),
+            carriage_return_highlight: None,
+            last_carriage_return: None,
+            tex_prefix,
+        };
+        result.line_offsets.push(0);
+        result
+    }
+}
+
+impl Renderer for TexRenderer {
+    fn content(&mut self) -> &mut Vec<u8> {
+        &mut self.content
+    }
+
+    fn line_offsets(&mut self) -> &mut Vec<u32> {
+        &mut self.line_offsets
+    }
+
+    fn last_carriage_return(&mut self) -> &mut Option<usize> {
+        &mut self.last_carriage_return
+    }
+
+    fn add_carriage_return<F>(&mut self, offset: usize, attribute_callback: &F)
+    where
+        F: Fn(Highlight, &mut Vec<u8>),
+    {
+        if let Some(highlight) = self.carriage_return_highlight {
+            let rest = self.content.split_off(offset);
+            // The callback writes the full opening markup (\TS{scope}{ or
+            // \textcolor[rgb]{r,g,b}{); we close the (empty) content group here.
+            (attribute_callback)(highlight, &mut self.content);
+            self.content.extend(b"}");
+            self.content.extend(rest);
+        }
+    }
+
+    fn set_carriage_return_highlight(&mut self, highlight: Option<Highlight>) {
+        self.carriage_return_highlight = highlight;
+    }
+
+    fn start_highlight<F>(&mut self, h: Highlight, attribute_callback: &F)
+    where
+        F: Fn(Highlight, &mut Vec<u8>),
+    {
+        // TeX has no uniform opening frame, so the callback writes the entire
+        // opening markup (\TS{scope}{ or \textcolor[rgb]{r,g,b}{). The renderer
+        // owns only the closing brace (see `end_highlight`).
+        (attribute_callback)(h, &mut self.content);
+    }
+
+    fn end_highlight(&mut self) {
+        self.content.extend(b"}");
+    }
+
+    fn escape_char(&self, c: u8) -> Option<Vec<u8>> {
+        // Special characters are emitted as named macros (e.g. `\TSZdl`), whose
+        // definitions live in the LaTeX preamble (see `write_tex_preamble`).
+        let suffix = TEX_CHAR_ESCAPES
+            .iter()
+            .find(|(ch, _)| *ch == c as char)
+            .map(|(_, suffix)| *suffix)?;
+        let mut bytes = Vec::with_capacity(self.tex_prefix.len() + suffix.len() + 1);
+        bytes.push(b'\\');
+        bytes.extend_from_slice(self.tex_prefix.as_bytes());
+        bytes.extend_from_slice(suffix.as_bytes());
+        bytes.extend(b"{}");
+        Some(bytes)
+    }
+}
+
 fn injection_for_match<'a>(
     config: &'a HighlightConfiguration,
     parent_name: Option<&'a str>,

--- a/crates/highlight/src/highlight.rs
+++ b/crates/highlight/src/highlight.rs
@@ -1319,7 +1319,11 @@ pub trait Renderer: Default {
 
     fn end_highlight(&mut self);
 
-    fn escape_char(&self, c: u8) -> Option<Vec<u8>> {
+    fn escape_char(
+        &mut self,
+        c: u8,
+        _highlights: &[Highlight],
+    ) -> Option<Vec<u8>> {
         match c as char {
             _ => None,
         }
@@ -1353,7 +1357,7 @@ pub trait Renderer: Default {
                 for scope in highlights {
                     self.start_highlight(*scope, attribute_callback);
                 }
-            } else if let Some(escape) = self.escape_char(c) {
+            } else if let Some(escape) = self.escape_char(c, highlights) {
                 self.content().extend(escape);
             } else {
                 self.content().push(c);
@@ -1474,7 +1478,7 @@ impl Renderer for HtmlRenderer {
         self.content().extend(b"</span>");
     }
 
-    fn escape_char(&self, c: u8) -> Option<Vec<u8>> {
+    fn escape_char(&mut self, c: u8, _highlights: &[Highlight]) -> Option<Vec<u8>> {
         match c as char {
             '>' => Some(b"&gt;".to_vec()),
             '<' => Some(b"&lt;".to_vec()),
@@ -1517,23 +1521,35 @@ pub struct TexRenderer {
     last_carriage_return: Option<usize>,
     // Command prefix (without a leading backslash), e.g. "TS" -> emits `\TS{...}{...}`.
     tex_prefix: String,
+    /// Indices (into a theme's `highlight_names`) of scopes whose contents use
+    /// LaTeX math-mode escaping (like pygmentize). Empty by default.
+    math_escape_indices: HashSet<usize>,
+    /// Whether we are currently inside a `$...$` math-mode region within a
+    /// math-escape scope.
+    in_math_mode: bool,
 }
 
 impl Default for TexRenderer {
     fn default() -> Self {
-        Self::new("TS".to_string())
+        Self::new("TS".to_string(), HashSet::new())
     }
 }
 
 impl TexRenderer {
+    /// Create a renderer with the given command `prefix` and the set of scope
+    /// indices that use LaTeX math-mode escaping (like pygmentize). Within those
+    /// scopes, characters between a pair of `$` delimiters are emitted verbatim
+    /// (so `$x_1$` is not mangled).
     #[must_use]
-    pub fn new(tex_prefix: String) -> Self {
+    pub fn new(tex_prefix: String, math_escape_indices: HashSet<usize>) -> Self {
         let mut result = Self {
             content: Vec::with_capacity(BUFFER_RESERVE_CAPACITY),
             line_offsets: Vec::with_capacity(BUFFER_LINES_RESERVE_CAPACITY),
             carriage_return_highlight: None,
             last_carriage_return: None,
             tex_prefix,
+            math_escape_indices,
+            in_math_mode: false,
         };
         result.line_offsets.push(0);
         result
@@ -1585,7 +1601,31 @@ impl Renderer for TexRenderer {
         self.content.extend(b"}");
     }
 
-    fn escape_char(&self, c: u8) -> Option<Vec<u8>> {
+    fn escape_char(&mut self, c: u8, highlights: &[Highlight]) -> Option<Vec<u8>> {
+        // Whether the current character sits within a math-escape scope. A scope
+        // is active if it is anywhere in the open-highlight stack.
+        let in_math_scope = highlights
+            .iter()
+            .any(|h| self.math_escape_indices.contains(&h.0));
+
+        if in_math_scope {
+            // A `$` toggles math mode and is emitted verbatim. Inside the `$...$`
+            // region, characters are left untouched (matching pygmentize's LaTeX
+            // formatter), so subscripts, carets, etc. render naturally. Outside
+            // the delimiters, special characters are still escaped as usual.
+            if c == b'$' {
+                self.in_math_mode = !self.in_math_mode;
+                return None;
+            }
+            if self.in_math_mode {
+                return None;
+            }
+        } else {
+            // Leaving a math-escape scope (or being outside one entirely) clears
+            // math-mode state so it cannot leak into a later region.
+            self.in_math_mode = false;
+        }
+
         // Special characters are emitted as named macros (e.g. `\TSZdl`), whose
         // definitions live in the LaTeX preamble (see `write_tex_preamble`).
         let suffix = TEX_CHAR_ESCAPES

--- a/crates/highlight/src/highlight.rs
+++ b/crates/highlight/src/highlight.rs
@@ -24,7 +24,7 @@ use tree_sitter::{
 };
 
 const CANCELLATION_CHECK_INTERVAL: usize = 100;
-const BUFFER_HTML_RESERVE_CAPACITY: usize = 10 * 1024;
+const BUFFER_RESERVE_CAPACITY: usize = 10 * 1024;
 const BUFFER_LINES_RESERVE_CAPACITY: usize = 1000;
 
 static STANDARD_CAPTURE_NAMES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
@@ -141,10 +141,10 @@ pub struct Highlighter {
 
 /// Converts a general-purpose syntax highlighting iterator into a sequence of lines of HTML.
 pub struct HtmlRenderer {
-    pub html: Vec<u8>,
-    pub line_offsets: Vec<u32>,
+    content: Vec<u8>,
+    line_offsets: Vec<u32>,
     carriage_return_highlight: Option<Highlight>,
-    // The offset in `self.html` of the last carriage return.
+    // The offset in `self.content` of the last carriage return.
     last_carriage_return: Option<usize>,
 }
 
@@ -1161,7 +1161,7 @@ impl HtmlRenderer {
     #[must_use]
     pub fn new() -> Self {
         let mut result = Self {
-            html: Vec::with_capacity(BUFFER_HTML_RESERVE_CAPACITY),
+            content: Vec::with_capacity(BUFFER_RESERVE_CAPACITY),
             line_offsets: Vec::with_capacity(BUFFER_LINES_RESERVE_CAPACITY),
             carriage_return_highlight: None,
             last_carriage_return: None,
@@ -1169,18 +1169,94 @@ impl HtmlRenderer {
         result.line_offsets.push(0);
         result
     }
+}
 
-    pub const fn set_carriage_return_highlight(&mut self, highlight: Option<Highlight>) {
-        self.carriage_return_highlight = highlight;
+/// Common interface for renderers that consume a [`HighlightEvent`] iterator.
+///
+/// A renderer owns a content buffer (exposed via [`Self::content`]) and knows how to
+/// escape individual characters in its target format ([`Self::escape`]). The event
+/// loop that drives a render is shared across all renderers via the provided
+/// [`Self::render`] method.
+///
+/// The attribute callback ([`Self::render`]'s `attribute_callback`) is
+/// `Fn(Highlight, &mut Vec<u8>)` for every implementor:
+/// the callback writes the *variable* part of a highlight's opening markup into
+/// the renderer's content buffer (e.g. ` class='keyword'` or `\TS{keyword}`),
+/// while the renderer owns the *structural* part
+/// (e.g. `<span` or `\` followed by the content-opening `{`).
+pub trait Renderer: Default {
+    /// The content buffer for the rendered document.
+    /// Every byte written by the renderer goes here.
+    fn content(&mut self) -> &mut Vec<u8>;
+
+    /// The line offsets of the rendered document.
+    fn line_offsets(&mut self) -> &mut Vec<u32>;
+
+    fn last_carriage_return(&mut self) -> &mut Option<usize>;
+
+    fn set_carriage_return_highlight(&mut self, highlight: Option<Highlight>);
+
+    fn add_carriage_return<F>(&mut self, offset: usize, attribute_callback: &F)
+    where
+        F: Fn(Highlight, &mut Vec<u8>);
+
+    fn reset(&mut self) {
+        shrink_and_clear(&mut self.content(), BUFFER_RESERVE_CAPACITY);
+        shrink_and_clear(&mut self.line_offsets(), BUFFER_LINES_RESERVE_CAPACITY);
+        self.line_offsets().push(0);
     }
 
-    pub fn reset(&mut self) {
-        shrink_and_clear(&mut self.html, BUFFER_HTML_RESERVE_CAPACITY);
-        shrink_and_clear(&mut self.line_offsets, BUFFER_LINES_RESERVE_CAPACITY);
-        self.line_offsets.push(0);
+    fn start_highlight<F>(&mut self, h: Highlight, attribute_callback: &F)
+    where
+        F: Fn(Highlight, &mut Vec<u8>);
+
+    fn end_highlight(&mut self);
+
+    fn escape_char(&self, c: u8) -> Option<Vec<u8>> {
+        match c as char {
+            _ => None,
+        }
     }
 
-    pub fn render<F>(
+    fn add_text<F>(&mut self, src: &[u8], highlights: &[Highlight], attribute_callback: &F)
+    where
+        F: Fn(Highlight, &mut Vec<u8>),
+    {
+        for c in LossyUtf8::new(src).flat_map(|p| p.bytes()) {
+            // Don't render carriage return characters, but allow lone carriage returns (not
+            // followed by line feeds) to be styled via the attribute callback.
+            if c == b'\r' {
+                *self.last_carriage_return() = Some(self.content().len());
+                continue;
+            }
+            if let Some(offset) = self.last_carriage_return().take()
+                && c != b'\n'
+            {
+                self.add_carriage_return(offset, attribute_callback);
+            }
+
+            // At line boundaries, close and re-open all of the open tags.
+            if c == b'\n' {
+                for _ in highlights {
+                    self.end_highlight();
+                }
+                self.content().push(c);
+                let offset = self.content().len() as u32;
+                self.line_offsets().push(offset);
+                for scope in highlights {
+                    self.start_highlight(*scope, attribute_callback);
+                }
+            } else if let Some(escape) = self.escape_char(c) {
+                self.content().extend(escape);
+            } else {
+                self.content().push(c);
+            }
+        }
+    }
+
+    /// Drives the full render from a [`HighlightEvent`] iterator. This is the shared
+    /// event loop; renderers normally do not override it.
+    fn render<F>(
         &mut self,
         highlighter: impl Iterator<Item = Result<HighlightEvent, Error>>,
         source: &[u8],
@@ -1194,43 +1270,66 @@ impl HtmlRenderer {
             match event {
                 Ok(HighlightEvent::HighlightStart(s)) => {
                     highlights.push(s);
-                    self.start_highlight(s, &attribute_callback);
+                    self.start_highlight(s, attribute_callback);
                 }
                 Ok(HighlightEvent::HighlightEnd) => {
                     highlights.pop();
                     self.end_highlight();
                 }
                 Ok(HighlightEvent::Source { start, end }) => {
-                    self.add_text(&source[start..end], &highlights, &attribute_callback);
+                    self.add_text(&source[start..end], &highlights, attribute_callback);
                 }
-                Err(a) => return Err(a),
+                Err(e) => return Err(e),
             }
         }
-        if let Some(offset) = self.last_carriage_return.take() {
+        if let Some(offset) = self.last_carriage_return().take() {
             self.add_carriage_return(offset, attribute_callback);
         }
-        if self.html.last() != Some(&b'\n') {
-            self.html.push(b'\n');
+        if self.content().last() != Some(&b'\n') {
+            self.content().push(b'\n');
         }
-        if self.line_offsets.last() == Some(&(self.html.len() as u32)) {
-            self.line_offsets.pop();
+        let content_len = self.content().len() as u32;
+        if self.line_offsets().last() == Some(&content_len) {
+            self.line_offsets().pop();
         }
         Ok(())
     }
 
-    pub fn lines(&self) -> impl Iterator<Item = &str> {
-        self.line_offsets
+    fn lines(&mut self) -> impl Iterator<Item = &str> {
+        // Clone the offsets into an owned value and reborrow the content as a shared
+        // slice, so we can slice without repeatedly borrowing `self` mutably from
+        // inside the closure (a `FnMut` closure cannot let a reference to a captured
+        // variable escape its body).
+        let offsets = self.line_offsets().clone();
+        let content: &[u8] = &*self.content();
+        offsets
             .iter()
             .enumerate()
-            .map(move |(i, line_start)| {
+            .map(|(i, line_start)| {
                 let line_start = *line_start as usize;
-                let line_end = if i + 1 == self.line_offsets.len() {
-                    self.html.len()
+                let line_end = if i + 1 == offsets.len() {
+                    content.len()
                 } else {
-                    self.line_offsets[i + 1] as usize
+                    offsets[i + 1] as usize
                 };
-                str::from_utf8(&self.html[line_start..line_end]).unwrap()
+                str::from_utf8(&content[line_start..line_end]).unwrap()
             })
+            .collect::<Vec<&str>>()
+            .into_iter()
+    }
+}
+
+impl Renderer for HtmlRenderer {
+    fn content(&mut self) -> &mut Vec<u8> {
+        &mut self.content
+    }
+
+    fn line_offsets(&mut self) -> &mut Vec<u32> {
+        &mut self.line_offsets
+    }
+
+    fn last_carriage_return(&mut self) -> &mut Option<usize> {
+        &mut self.last_carriage_return
     }
 
     fn add_carriage_return<F>(&mut self, offset: usize, attribute_callback: &F)
@@ -1243,70 +1342,39 @@ impl HtmlRenderer {
             // whether it is part of CRLF or on its own. To avoid unbounded
             // lookahead, save the offset of the CR and insert there now that we
             // know.
-            let rest = self.html.split_off(offset);
-            self.html.extend(b"<span ");
-            (attribute_callback)(highlight, &mut self.html);
-            self.html.extend(b"></span>");
-            self.html.extend(rest);
+            let rest = self.content.split_off(offset);
+            self.content.extend(b"<span ");
+            (attribute_callback)(highlight, &mut self.content);
+            self.content.extend(b"></span>");
+            self.content.extend(rest);
         }
+    }
+
+    fn set_carriage_return_highlight(&mut self, highlight: Option<Highlight>) {
+        self.carriage_return_highlight = highlight;
     }
 
     fn start_highlight<F>(&mut self, h: Highlight, attribute_callback: &F)
     where
         F: Fn(Highlight, &mut Vec<u8>),
     {
-        self.html.extend(b"<span ");
-        (attribute_callback)(h, &mut self.html);
-        self.html.extend(b">");
+        self.content().extend(b"<span ");
+        (attribute_callback)(h, &mut self.content());
+        self.content().extend(b">");
     }
 
     fn end_highlight(&mut self) {
-        self.html.extend(b"</span>");
+        self.content().extend(b"</span>");
     }
 
-    fn add_text<F>(&mut self, src: &[u8], highlights: &[Highlight], attribute_callback: &F)
-    where
-        F: Fn(Highlight, &mut Vec<u8>),
-    {
-        pub const fn html_escape(c: u8) -> Option<&'static [u8]> {
-            match c as char {
-                '>' => Some(b"&gt;"),
-                '<' => Some(b"&lt;"),
-                '&' => Some(b"&amp;"),
-                '\'' => Some(b"&#39;"),
-                '"' => Some(b"&quot;"),
-                _ => None,
-            }
-        }
-
-        for c in LossyUtf8::new(src).flat_map(|p| p.bytes()) {
-            // Don't render carriage return characters, but allow lone carriage returns (not
-            // followed by line feeds) to be styled via the attribute callback.
-            if c == b'\r' {
-                self.last_carriage_return = Some(self.html.len());
-                continue;
-            }
-            if let Some(offset) = self.last_carriage_return.take()
-                && c != b'\n'
-            {
-                self.add_carriage_return(offset, attribute_callback);
-            }
-
-            // At line boundaries, close and re-open all of the open tags.
-            if c == b'\n' {
-                for _ in highlights {
-                    self.end_highlight();
-                }
-                self.html.push(c);
-                self.line_offsets.push(self.html.len() as u32);
-                for scope in highlights {
-                    self.start_highlight(*scope, attribute_callback);
-                }
-            } else if let Some(escape) = html_escape(c) {
-                self.html.extend_from_slice(escape);
-            } else {
-                self.html.push(c);
-            }
+    fn escape_char(&self, c: u8) -> Option<Vec<u8>> {
+        match c as char {
+            '>' => Some(b"&gt;".to_vec()),
+            '<' => Some(b"&lt;".to_vec()),
+            '&' => Some(b"&amp;".to_vec()),
+            '\'' => Some(b"&#39;".to_vec()),
+            '"' => Some(b"&quot;".to_vec()),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
Close #3390

- **feat(cli): add --formatter={terminal,html}**
- **chore(highlight): add trait Renderer**
- **feat(highlight): add TeXRenderer**
- move the code about Formatter::Terminal of crates/cli/src/highlight.rs
  to TerminalRender of crates/highlight/src/highlight.rs
- add math escape for TeXRenderer

Some explanations:

Currently, tree-sitter highlight output to terminal by default, and output HTML by `--html` option.
If we want to support more output format, we need to add more options.
A `--formatter` option is same as pygmentize's `-f` option, which can support more output format in the future.

Related, we must create an enum `Formatter` to represent the output format.

For each `Formatter::XXX`, we have a `XXXRenderer`. They share many same behaviour,
So we can create a trait `Renderer` to represent the common behaviour, and each `XXXRenderer` implement it.

For HTMLRenderer, crates/cli/src/highlight.rs provide layout and style.
LaTeX is same, --layout=line-numbers will output a longtable environment with line number,
--layout=document will output a Verbatim environment, and --layout=fragment will not output any environment.
--style=minimal will not output the relationship of scope name and responding colors, so user must `\input XXX.tex`
their own style file, just like HTML's CSS files. `--style=classes` is default behaviour,
which will output `\TS{scope_name}{text}`. `--style=inline` will output `\textcolor{color}{text}`.
color name is like `r1.000g0.000b0.000`. User must define the color name by themselves.

`\TS` is default prefix name, like pygmentize's `\PY`.

pygementize support math escape, when it is enabled, math formula in comment will not be escaped.

Except HTMLRenderer and TeXRenderer, I think we can provide a similar TerminalRenderer
to wrap the code of Terminal output.

Some example output:

```conf
Section "InputClass"
  Identifier "Keyboard catchall"
  MatchIsKeyboard "on"
  Option "XkbModel" "pc104"
  Option "XkbLayout" "us"
  Option "XkbOptions" "terminate:ctrl_alt_bksp"
  
EndSection
```

### Document

```tex
\documentclass{article}
\usepackage{fancyvrb}
\usepackage{color}
\usepackage[utf8]{inputenc}

\makeatletter
\def\TSZbs{\char`\\}
\def\TSZus{\char`\_}
\def\TSZob{\char`\{}
\def\TSZcb{\char`\}}
\def\TSZca{\char`\^}
\def\TSZam{\char`\&}
\def\TSZlt{\char`\<}
\def\TSZgt{\char`\>}
\def\TSZsh{\char`\#}
\def\TSZpc{\char`\%}
\def\TSZdl{\char`\$}
\def\TSZhy{\char`\-}
\def\TSZsq{\char`\'}
\def\TSZdq{\char`\"}
\def\TSZti{\char`\~}
\def\TS@reset{\let\TS@it=\relax\let\TS@bf=\relax\let\TS@ul=\relax \let\TS@tc=\relax\let\TS@bc=\relax\let\TS@ff=\relax}
\def\TS@tok#1{\csname TS@tok@#1\endcsname}
\def\TS@toks#1+{\ifx\relax#1\empty\else\TS@tok{#1}\expandafter\TS@toks\fi}
\def\TS@do#1{\TS@bc{\TS@tc{\TS@ul{\TS@it{\TS@bf{\TS@ff{#1}}}}}}}
\def\TS#1#2{\TS@reset\TS@toks#1+\relax+\TS@do{#2}}
\@namedef{TS@tok@attribute}{\def\TS@tc##1{\textcolor[rgb]{0.6863,0.0000,0.0000}{##1}}}
\@namedef{TS@tok@comment}{\def\TS@tc##1{\textcolor[rgb]{0.5412,0.5412,0.5412}{##1}}}
\@namedef{TS@tok@constant}{\def\TS@tc##1{\textcolor[rgb]{0.5294,0.3725,0.0000}{##1}}}
\@namedef{TS@tok@constant.builtin}{\def\TS@tc##1{\textcolor[rgb]{0.5294,0.3725,0.0000}{##1}}}
\@namedef{TS@tok@constructor}{\def\TS@tc##1{\textcolor[rgb]{0.6863,0.5294,0.0000}{##1}}}
\@namedef{TS@tok@function}{\def\TS@tc##1{\textcolor[rgb]{0.0000,0.3725,0.8431}{##1}}}
\@namedef{TS@tok@function.builtin}{\def\TS@tc##1{\textcolor[rgb]{0.0000,0.3725,0.8431}{##1}}}
\@namedef{TS@tok@keyword}{\def\TS@tc##1{\textcolor[rgb]{0.3725,0.0000,0.8431}{##1}}}
\@namedef{TS@tok@module}{\def\TS@tc##1{\textcolor[rgb]{0.6863,0.5294,0.0000}{##1}}}
\@namedef{TS@tok@number}{\def\TS@tc##1{\textcolor[rgb]{0.5294,0.3725,0.0000}{##1}}}
\@namedef{TS@tok@operator}{\def\TS@tc##1{\textcolor[rgb]{0.3059,0.3059,0.3059}{##1}}}
\@namedef{TS@tok@property}{\def\TS@tc##1{\textcolor[rgb]{0.6863,0.0000,0.0000}{##1}}}
\@namedef{TS@tok@punctuation.bracket}{\def\TS@tc##1{\textcolor[rgb]{0.3059,0.3059,0.3059}{##1}}}
\@namedef{TS@tok@punctuation.delimiter}{\def\TS@tc##1{\textcolor[rgb]{0.3059,0.3059,0.3059}{##1}}}
\@namedef{TS@tok@string}{\def\TS@tc##1{\textcolor[rgb]{0.0000,0.5294,0.0000}{##1}}}
\@namedef{TS@tok@string.special}{\def\TS@tc##1{\textcolor[rgb]{0.0000,0.5294,0.5294}{##1}}}
\@namedef{TS@tok@tag}{\def\TS@tc##1{\textcolor[rgb]{0.0000,0.0000,0.5294}{##1}}}
\@namedef{TS@tok@type}{\def\TS@tc##1{\textcolor[rgb]{0.0000,0.3725,0.3725}{##1}}}
\@namedef{TS@tok@type.builtin}{\def\TS@tc##1{\textcolor[rgb]{0.0000,0.3725,0.3725}{##1}}}
\makeatother
\begin{document}

\begin{Verbatim}[commandchars=\\\{\},codes={\catcode`\$=3\catcode`\^=7\catcode`\_=8\relax}]
\TS{keyword}{Section} \TS{constant}{\TSZdq{}InputClass\TSZdq{}}
  Identifier \TS{string}{\TSZdq{}Keyboard catchall\TSZdq{}}
  MatchIsKeyboard \TS{string}{\TSZdq{}on\TSZdq{}}
  Option \TS{string}{\TSZdq{}XkbModel\TSZdq{}} \TS{string}{\TSZdq{}pc104\TSZdq{}}
  Option \TS{string}{\TSZdq{}XkbLayout\TSZdq{}} \TS{string}{\TSZdq{}us\TSZdq{}}
  Option \TS{string}{\TSZdq{}XkbOptions\TSZdq{}} \TS{string}{\TSZdq{}terminate:ctrl\TSZus{}alt\TSZus{}bksp\TSZdq{}}

\TS{keyword}{EndSection}
\end{Verbatim}

\end{document}
```

### line numbers

```tex
\documentclass{article}
\usepackage{fancyvrb}
\usepackage{color}
\usepackage[utf8]{inputenc}

\makeatletter
\def\TSZbs{\char`\\}
\def\TSZus{\char`\_}
\def\TSZob{\char`\{}
\def\TSZcb{\char`\}}
\def\TSZca{\char`\^}
\def\TSZam{\char`\&}
\def\TSZlt{\char`\<}
\def\TSZgt{\char`\>}
\def\TSZsh{\char`\#}
\def\TSZpc{\char`\%}
\def\TSZdl{\char`\$}
\def\TSZhy{\char`\-}
\def\TSZsq{\char`\'}
\def\TSZdq{\char`\"}
\def\TSZti{\char`\~}
\def\TS@reset{\let\TS@it=\relax\let\TS@bf=\relax\let\TS@ul=\relax \let\TS@tc=\relax\let\TS@bc=\relax\let\TS@ff=\relax}
\def\TS@tok#1{\csname TS@tok@#1\endcsname}
\def\TS@toks#1+{\ifx\relax#1\empty\else\TS@tok{#1}\expandafter\TS@toks\fi}
\def\TS@do#1{\TS@bc{\TS@tc{\TS@ul{\TS@it{\TS@bf{\TS@ff{#1}}}}}}}
\def\TS#1#2{\TS@reset\TS@toks#1+\relax+\TS@do{#2}}
\@namedef{TS@tok@attribute}{\def\TS@tc##1{\textcolor[rgb]{0.6863,0.0000,0.0000}{##1}}}
\@namedef{TS@tok@comment}{\def\TS@tc##1{\textcolor[rgb]{0.5412,0.5412,0.5412}{##1}}}
\@namedef{TS@tok@constant}{\def\TS@tc##1{\textcolor[rgb]{0.5294,0.3725,0.0000}{##1}}}
\@namedef{TS@tok@constant.builtin}{\def\TS@tc##1{\textcolor[rgb]{0.5294,0.3725,0.0000}{##1}}}
\@namedef{TS@tok@constructor}{\def\TS@tc##1{\textcolor[rgb]{0.6863,0.5294,0.0000}{##1}}}
\@namedef{TS@tok@function}{\def\TS@tc##1{\textcolor[rgb]{0.0000,0.3725,0.8431}{##1}}}
\@namedef{TS@tok@function.builtin}{\def\TS@tc##1{\textcolor[rgb]{0.0000,0.3725,0.8431}{##1}}}
\@namedef{TS@tok@keyword}{\def\TS@tc##1{\textcolor[rgb]{0.3725,0.0000,0.8431}{##1}}}
\@namedef{TS@tok@module}{\def\TS@tc##1{\textcolor[rgb]{0.6863,0.5294,0.0000}{##1}}}
\@namedef{TS@tok@number}{\def\TS@tc##1{\textcolor[rgb]{0.5294,0.3725,0.0000}{##1}}}
\@namedef{TS@tok@operator}{\def\TS@tc##1{\textcolor[rgb]{0.3059,0.3059,0.3059}{##1}}}
\@namedef{TS@tok@property}{\def\TS@tc##1{\textcolor[rgb]{0.6863,0.0000,0.0000}{##1}}}
\@namedef{TS@tok@punctuation.bracket}{\def\TS@tc##1{\textcolor[rgb]{0.3059,0.3059,0.3059}{##1}}}
\@namedef{TS@tok@punctuation.delimiter}{\def\TS@tc##1{\textcolor[rgb]{0.3059,0.3059,0.3059}{##1}}}
\@namedef{TS@tok@string}{\def\TS@tc##1{\textcolor[rgb]{0.0000,0.5294,0.0000}{##1}}}
\@namedef{TS@tok@string.special}{\def\TS@tc##1{\textcolor[rgb]{0.0000,0.5294,0.5294}{##1}}}
\@namedef{TS@tok@tag}{\def\TS@tc##1{\textcolor[rgb]{0.0000,0.0000,0.5294}{##1}}}
\@namedef{TS@tok@type}{\def\TS@tc##1{\textcolor[rgb]{0.0000,0.3725,0.3725}{##1}}}
\@namedef{TS@tok@type.builtin}{\def\TS@tc##1{\textcolor[rgb]{0.0000,0.3725,0.3725}{##1}}}
\makeatother
\usepackage{longtable}
\begin{document}

\begin{longtable}{rl}
1 & \Verb[commandchars=\\\{\},codes={\catcode`\$=3\catcode`\^=7\catcode`\_=8\relax}]-\TS{keyword}{Section} \TS{constant}{\TSZdq{}InputClass\TSZdq{}}-\\
2 & \Verb[commandchars=\\\{\},codes={\catcode`\$=3\catcode`\^=7\catcode`\_=8\relax}]-  Identifier \TS{string}{\TSZdq{}Keyboard catchall\TSZdq{}}-\\
3 & \Verb[commandchars=\\\{\},codes={\catcode`\$=3\catcode`\^=7\catcode`\_=8\relax}]-  MatchIsKeyboard \TS{string}{\TSZdq{}on\TSZdq{}}-\\
4 & \Verb[commandchars=\\\{\},codes={\catcode`\$=3\catcode`\^=7\catcode`\_=8\relax}]-  Option \TS{string}{\TSZdq{}XkbModel\TSZdq{}} \TS{string}{\TSZdq{}pc104\TSZdq{}}-\\
5 & \Verb[commandchars=\\\{\},codes={\catcode`\$=3\catcode`\^=7\catcode`\_=8\relax}]-  Option \TS{string}{\TSZdq{}XkbLayout\TSZdq{}} \TS{string}{\TSZdq{}us\TSZdq{}}-\\
6 & \Verb[commandchars=\\\{\},codes={\catcode`\$=3\catcode`\^=7\catcode`\_=8\relax}]-  Option \TS{string}{\TSZdq{}XkbOptions\TSZdq{}} \TS{string}{\TSZdq{}terminate:ctrl\TSZus{}alt\TSZus{}bksp\TSZdq{}}-\\
7 & \Verb[commandchars=\\\{\},codes={\catcode`\$=3\catcode`\^=7\catcode`\_=8\relax}]-  -\\
8 & \Verb[commandchars=\\\{\},codes={\catcode`\$=3\catcode`\^=7\catcode`\_=8\relax}]-\TS{keyword}{EndSection}-\\
\end{longtable}

\end{document}
```

Based `tree-sitter highlight --formatter=tex --layout=fragment`, we can create a LaTeX package like https://github.com/gpoore/minted/
based on pygments.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->

Use copilot-language-server to complete code, use github copilot agent for coding, claude code for coding and discussion.
