### PR TITLE
perf(lib): fast paths for ascii

### DIFF
--- a/lib/src/lexer.c
+++ b/lib/src/lexer.c
@@ -268,6 +268,27 @@ static void ts_lexer__advance(TSLexer *_self, bool skip) {
     LOG("consume", self->data.lookahead)
   }
 
+  const uint32_t next_position = self->current_position.bytes + 1;
+  const uint32_t current_range_end =
+    self->included_ranges[self->current_included_range_index].end_byte;
+  if (
+    self->input.encoding == TSInputEncodingUTF8 &&
+    self->lookahead_size == 1 &&
+    self->data.lookahead != '\n' &&
+    next_position < current_range_end &&
+    next_position < self->chunk_start + self->chunk_size
+  ) {
+    uint8_t next_byte = (uint8_t)self->chunk[next_position - self->chunk_start];
+    if (next_byte < 0x80) {
+      ts_lexer__increment_column_data(self);
+      self->current_position.bytes++;
+      self->current_position.extent.column++;
+      if (skip) self->token_start_position = self->current_position;
+      self->data.lookahead = next_byte;
+      return;
+    }
+  }
+
   ts_lexer__do_advance(self, skip);
 }
 

--- a/lib/src/lexer.c
+++ b/lib/src/lexer.c
@@ -114,6 +114,13 @@ static void ts_lexer__get_lookahead(Lexer *self) {
   }
 
   const uint8_t *chunk = (const uint8_t *)self->chunk + position_in_chunk;
+
+  if (self->input.encoding == TSInputEncodingUTF8 && chunk[0] < 0x80) {
+    self->data.lookahead = chunk[0];
+    self->lookahead_size = 1;
+    return;
+  }
+
   TSDecodeFunction decode =
     self->input.encoding == TSInputEncodingUTF8    ? ts_decode_utf8     :
     self->input.encoding == TSInputEncodingUTF16LE ? ts_decode_utf16_le :


### PR DESCRIPTION
Two small optimizations that fast track the common case of ASCII UTF8 in the lexer. Yields a 2-3% speed increase for most grammars, with more favorable workloads seeing ~5%. 

This small round of optimizations was inspired by the article written about ast-grep's rewrite of tree-sitter to rust: https://ast-grep.github.io/blog/tree-sitter-rust-rewrite. While most optimizations described there weren't applicable here without shedding necessary features/breaking other important constraints, the ASCII fast paths are a nice, self contained win.

I wanted to note here that I also spent a significant amount of time investigating the `StackNode` (an inline array of 8 `StackLink`s), cutting the `links` field down to a union of `StackLink` and `StackLink *`. Since `StackLink` is 72 bytes, we can use the padding as a discriminator/counter, and have the common case (1 link) be entirely inline while shrinking `StackNode`'s size significantly. When additional links were needed, we `malloc`d an 8 entry chunk and copied the old first entry in, keeping track of the link count in the padding. This proved to be  perf neutral, so it wasn't really worth the churn.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
Handed gpt5.6-sol the article and asked it to see if we could apply any of the optimizations. Everything typed/tested myself. 
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
