### PR TITLE
fix(web): free the scratch query cursor after each query

### DIFF
--- a/lib/binding_web/lib/tree-sitter.c
+++ b/lib/binding_web/lib/tree-sitter.c
@@ -939,6 +939,9 @@ void ts_query_matches_wasm(
   TRANSFER_BUFFER[0] = (const void *)(match_count);
   TRANSFER_BUFFER[1] = (const void *)result.contents;
   TRANSFER_BUFFER[2] = (const void *)(did_exceed_match_limit);
+
+  ts_query_cursor_delete(scratch_query_cursor);
+  scratch_query_cursor = NULL;
 }
 
 void ts_query_captures_wasm(
@@ -1016,4 +1019,7 @@ void ts_query_captures_wasm(
   TRANSFER_BUFFER[0] = (const void *)(capture_count);
   TRANSFER_BUFFER[1] = (const void *)result.contents;
   TRANSFER_BUFFER[2] = (const void *)(did_exceed_match_limit);
+
+  ts_query_cursor_delete(scratch_query_cursor);
+  scratch_query_cursor = NULL;
 }


### PR DESCRIPTION
Fixes #5547

## Problem

`ts_query_matches_wasm` and `ts_query_captures_wasm` share a single file-scope `scratch_query_cursor`, created lazily and then reused for the lifetime of the module. A `TSQueryCursor` holds three arrays - `states`, `finished_states`, and `capture_list_pool` - that grow to fit the most demanding query run through them and are never shrunk.

The result: the cursor permanently retains the peak capacity of the largest query ever executed, even when every subsequent query is trivial. In a long-lived session touching many grammars, that memory is unreachable from JS and never returned.

## Fix

Delete the cursor at the end of each function and null the pointer, so the existing lazy-init path recreates it (at `ts_query_cursor_new`'s small initial capacity) on the next call.

This is safe because the cursor carries no state across calls that is expected to persist: `match_limit`, point range, byte range, containing ranges, and max start depth are all set from function arguments at the top of *every* invocation, before any use. Nothing is inherited from a previous call today, so nothing is lost by starting fresh.

`ts_query_cursor_new` allocates a cursor with `array_reserve(..., 8)` on each array - a handful of small allocations, negligible against the cost of executing the query itself.

## Verification

I could not reproduce the reporter's 300–900 MB figures locally, the scale in the issue appears to depend on grammars heavier than the test fixtures provide, plus a WASM-specific amplification (linear memory can grow but never shrink, per spec) that a native build cannot replicate. What I *did* verify is the mechanism itself, precisely.

Process RSS turned out to be useless as a metric here - glibc retains freed memory in the process arena rather than returning it to the OS, so RSS is flat whether or not the memory was actually freed. I used `ts_set_allocator` instead to track live bytes directly, which is immune to that.

The harness runs a large query (tree-sitter-c's real `highlights.scm`, 605,596 matches over `tree-sitter-c/src/parser.c`) and then a trivial one (`(comment) @c`, 1 match), and reports what the cursor still holds after the *small* query - with the tree, parser, and queries all freed first, so only cursor memory is in view.

Reused cursor (current behavior):
```
round 1: big query (605596 matches), then tiny query (1 matches) -- cursor retains 3736 bytes
round 2: big query (605596 matches), then tiny query (1 matches) -- cursor retains 3736 bytes
round 3: big query (605596 matches), then tiny query (1 matches) -- cursor retains 3736 bytes
```

Cursor created and deleted per call (this patch's behavior):
```
round 1: big query (605596 matches), then tiny query (1 matches) -- cursor retains 0 bytes
round 2: big query (605596 matches), then tiny query (1 matches) -- cursor retains 0 bytes
round 3: big query (605596 matches), then tiny query (1 matches) -- cursor retains 0 bytes
```

Reproduced identically on two machines. The retained figure is the capacity from the *large* query surviving a *small* one - exactly the accumulation the issue describes, just at fixture scale rather than production scale.

<details>
<summary>Harness source (drop in repo root, build instructions below)</summary>

```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include "tree_sitter/api.h"

const TSLanguage *tree_sitter_c(void);
static long long live_bytes = 0;

static void *tracked_malloc(size_t size) {
  size_t *block = malloc(size + sizeof(size_t));
  if (!block) return NULL;
  *block = size;
  live_bytes += (long long)size;
  return block + 1;
}
static void *tracked_calloc(size_t count, size_t size) {
  void *p = tracked_malloc(count * size);
  if (p) memset(p, 0, count * size);
  return p;
}
static void *tracked_realloc(void *ptr, size_t size) {
  if (!ptr) return tracked_malloc(size);
  size_t *block = (size_t *)ptr - 1;
  live_bytes -= (long long)*block;
  size_t *new_block = realloc(block, size + sizeof(size_t));
  if (!new_block) return NULL;
  *new_block = size;
  live_bytes += (long long)size;
  return new_block + 1;
}
static void tracked_free(void *ptr) {
  if (!ptr) return;
  size_t *block = (size_t *)ptr - 1;
  live_bytes -= (long long)*block;
  free(block);
}

static char *read_file(const char *path, size_t *out_len) {
  FILE *f = fopen(path, "rb");
  if (!f) { perror("fopen"); exit(1); }
  fseek(f, 0, SEEK_END);
  long len = ftell(f);
  fseek(f, 0, SEEK_SET);
  char *buf = malloc((size_t)len + 1);
  if (fread(buf, 1, (size_t)len, f) != (size_t)len) { perror("fread"); exit(1); }
  buf[len] = '\0';
  fclose(f);
  *out_len = (size_t)len;
  return buf;
}

static TSQueryCursor *scratch_query_cursor = NULL;

static uint32_t run_with_scratch_cursor(const TSQuery *query, TSNode root) {
  if (!scratch_query_cursor) scratch_query_cursor = ts_query_cursor_new();
  ts_query_cursor_exec(scratch_query_cursor, query, root);
  uint32_t count = 0;
  TSQueryMatch match;
  while (ts_query_cursor_next_match(scratch_query_cursor, &match)) count++;
  return count;
}

static uint32_t run_with_fresh_cursor(const TSQuery *query, TSNode root) {
  TSQueryCursor *cursor = ts_query_cursor_new();
  ts_query_cursor_exec(cursor, query, root);
  uint32_t count = 0;
  TSQueryMatch match;
  while (ts_query_cursor_next_match(cursor, &match)) count++;
  ts_query_cursor_delete(cursor);
  return count;
}

int main(int argc, char **argv) {
  if (argc < 4) {
    fprintf(stderr, "usage: %s <c-source-file> <highlights.scm> <mode: scratch|fresh> [rounds]\n", argv[0]);
    return 1;
  }
  const char *source_path = argv[1];
  const char *query_path = argv[2];
  const char *mode = argv[3];
  int rounds = argc > 4 ? atoi(argv[4]) : 5;

  ts_set_allocator(tracked_malloc, tracked_calloc, tracked_realloc, tracked_free);

  size_t len, qlen;
  char *source = read_file(source_path, &len);
  char *big_query_src = read_file(query_path, &qlen);
  const char *tiny_query_src = "(comment) @c";

  TSParser *parser = ts_parser_new();
  ts_parser_set_language(parser, tree_sitter_c());
  TSTree *tree = ts_parser_parse_string(parser, NULL, source, (uint32_t)len);
  TSNode root = ts_tree_root_node(tree);

  uint32_t err_offset; TSQueryError err_type;
  TSQuery *big_query = ts_query_new(tree_sitter_c(), big_query_src, (uint32_t)qlen, &err_offset, &err_type);
  if (!big_query) { fprintf(stderr, "big query failed to compile\n"); return 1; }
  TSQuery *tiny_query = ts_query_new(tree_sitter_c(), tiny_query_src, (uint32_t)strlen(tiny_query_src), &err_offset, &err_type);

  long long baseline_bytes = live_bytes;
  printf("Mode: %s cursor\n", mode);
  printf("Baseline (tree + parser + queries, no cursor yet): %lld bytes\n", baseline_bytes);

  for (int i = 0; i < rounds; i++) {
    uint32_t big_matches, tiny_matches;
    if (strcmp(mode, "fresh") == 0) {
      big_matches = run_with_fresh_cursor(big_query, root);
      tiny_matches = run_with_fresh_cursor(tiny_query, root);
    } else {
      big_matches = run_with_scratch_cursor(big_query, root);
      tiny_matches = run_with_scratch_cursor(tiny_query, root);
    }
    printf("  round %d: big query (%u matches), then tiny query (%u matches) -- cursor retains %lld bytes\n",
      i + 1, big_matches, tiny_matches, live_bytes - baseline_bytes);
  }

  ts_query_delete(big_query);
  ts_query_delete(tiny_query);
  ts_tree_delete(tree);
  ts_parser_delete(parser);
  if (scratch_query_cursor) ts_query_cursor_delete(scratch_query_cursor);
  free(source);
  free(big_query_src);

  printf("Live bytes after full cleanup: %lld (should be 0)\n", live_bytes);
  return 0;
}
```

```bash
gcc -O2 -I lib/include -I lib/src -c lib/src/lib.c -o /tmp/ts_lib.o
gcc -O2 -I lib/include -c /path/to/tree-sitter-c/src/parser.c -o /tmp/parser_c.o
gcc -O2 -I lib/include repro5547.c /tmp/ts_lib.o /tmp/parser_c.o -o repro5547

./repro5547 /path/to/tree-sitter-c/src/parser.c \
            /path/to/tree-sitter-c/queries/highlights.scm scratch 3   # reused cursor
./repro5547 /path/to/tree-sitter-c/src/parser.c \
            /path/to/tree-sitter-c/queries/highlights.scm fresh 3     # this patch
```

`scratch` mode models current behavior; `fresh` mode models this patch. Both paths are otherwise identical.
</details>

## Note on a regression test

I didn't add one. The effect is a few KB against a ~90 MB baseline in the vitest environment, which is well under the noise floor of anything observable from JS - a test asserting on it would be flaky rather than protective. If you'd like one, `Module.HEAPU8.buffer.byteLength` is probably the right metric (monotonic, GC-independent), and I'm happy to build that out.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

I have used Claude for discussion of solution, not for coding.
