### PR TITLE
fix(ci): run all workspace tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,7 +293,7 @@ jobs:
 
     - name: Run main tests
       if: inputs.run-test && !matrix.no-run
-      run: cargo test --target='${{ matrix.target }}' --features='${{ (matrix.run-wasm-test || !inputs.run-test) && matrix.features || '' }}'
+      run: cargo test --workspace --target='${{ matrix.target }}' --features='${{ (matrix.run-wasm-test || !inputs.run-test) && matrix.features || '' }}'
 
     - name: Run Wasm tests
       if: inputs.run-test && !matrix.no-run && contains(matrix.features, 'wasm') && matrix.run-wasm-test

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -254,7 +254,7 @@ impl Default for OptLevel {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Diagnostic {
     UnnecessaryConflicts(Vec<Vec<String>>),
     UnaryChoice { name: Option<String> },

--- a/crates/generate/src/prepare_grammar/intern_symbols.rs
+++ b/crates/generate/src/prepare_grammar/intern_symbols.rs
@@ -445,11 +445,11 @@ mod tests {
         // The supertype entry is dropped with a warning, and the rule stays inlined.
         assert!(meta.supertypes.is_empty());
         assert_eq!(meta.inline, vec![Symbol::non_terminal(1)]);
-        assert_eq!(diagnostics.len(), 1);
         assert_eq!(
-            diagnostics[0].to_string(),
-            "rule `_v2` is both a supertype and inlined. the supertype is \
-             ignored. this will become an error in a future release."
+            diagnostics,
+            [Diagnostic::SupertypeInlined {
+                name: "_v2".to_string()
+            }]
         );
     }
 


### PR DESCRIPTION
Without `--workspace`, all generate tests were silently skipped.### AI Policy

#5389 was updated to remove the statement that the inlined supertype warning will be an error in a future release, as this is still being discussed internally. There is an argument to made for working with older parser versions using the latest CLI.

This was missed because CI isn't running the generate tests at all. Also an improvement to the test assertion, as we should be asserting on structured data when we have it rather than a stringified representation.

I will backport the CI fix separately, rather than using the workflow. (#5867)

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
