### PR TITLE
fix(generate)!: error when nonexistent _file_ path is passed to `generate_parser_in_directory`.

### DIFF
--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -76,7 +76,7 @@ pub type GenerateResult<T> = Result<T, GenerateError>;
 #[derive(Debug, Error, Serialize, Deserialize)]
 pub enum GenerateError {
     #[error("Error with specified path -- {0}")]
-    GrammarPath(String),
+    GrammarPath(IoError),
     #[error(transparent)]
     IO(IoError),
     #[cfg(feature = "load")]
@@ -347,7 +347,7 @@ where
         let path_buf: PathBuf = path.into();
         if !path_buf
             .try_exists()
-            .map_err(|e| GenerateError::GrammarPath(e.to_string()))?
+            .map_err(|e| GenerateError::GrammarPath(IoError::new(e, Some(&path_buf))))?
         {
             // A nonexistent path with an extension (i.e. tree-sitter-foo/grammar.json)
             // is a missing input file, not a directory to create.

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -82,6 +82,8 @@ pub enum GenerateError {
     #[cfg(feature = "load")]
     #[error(transparent)]
     LoadGrammarFile(#[from] LoadGrammarError),
+    #[error("Grammar file `{0}` not found")]
+    GrammarFileNotFound(PathBuf),
     #[error(transparent)]
     ParseGrammar(#[from] ParseGrammarError),
     #[error(transparent)]
@@ -347,6 +349,11 @@ where
             .try_exists()
             .map_err(|e| GenerateError::GrammarPath(e.to_string()))?
         {
+            // A nonexistent path with an extension (i.e. tree-sitter-foo/grammar.json)
+            // is a missing input file, not a directory to create.
+            if path_buf.extension().is_some() {
+                return Err(GenerateError::GrammarFileNotFound(path_buf));
+            }
             fs::create_dir_all(&path_buf)
                 .map_err(|e| GenerateError::IO(IoError::new(e, Some(path_buf.as_path()))))?;
             repo_path = path_buf;


### PR DESCRIPTION
Bug/bad behavior fix for the first commit. The second is a nice cleanup for the ongoing structured data effort that I spotted while in that part of the code base.

Both commits marked as breaking because they alter the public `GenerateError` enum.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
An agent of mine hit this several times while running a benchmarking harness. Fix done entirely myself.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
