### PR TITLE
release v0.26.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(tree-sitter
-        VERSION "0.26.12"
+        VERSION "0.26.13"
         DESCRIPTION "An incremental parsing system for programming tools"
         HOMEPAGE_URL "https://tree-sitter.github.io/tree-sitter/"
         LANGUAGES C)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.12"
+version = "0.26.13"
 dependencies = [
  "bindgen",
  "cc",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-cli"
-version = "0.26.12"
+version = "0.26.13"
 dependencies = [
  "ansi_colours",
  "anstyle",
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-config"
-version = "0.26.12"
+version = "0.26.13"
 dependencies = [
  "etcetera",
  "log",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-generate"
-version = "0.26.12"
+version = "0.26.13"
 dependencies = [
  "bitflags",
  "dunce",
@@ -2144,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-highlight"
-version = "0.26.12"
+version = "0.26.13"
 dependencies = [
  "regex",
  "streaming-iterator",
@@ -2158,7 +2158,7 @@ version = "0.1.7"
 
 [[package]]
 name = "tree-sitter-loader"
-version = "0.26.12"
+version = "0.26.13"
 dependencies = [
  "cc",
  "etcetera",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-tags"
-version = "0.26.12"
+version = "0.26.13"
 dependencies = [
  "memchr",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.26.12"
+version = "0.26.13"
 authors = [
   "Max Brunsfeld <maxbrunsfeld@gmail.com>",
   "Amaan Qureshi <amaanq12@gmail.com>",
@@ -153,11 +153,11 @@ walkdir = "2.5.0"
 wasmparser = "0.243.0"
 webbrowser = "1.0.5"
 
-tree-sitter = { version = "0.26.12", path = "./lib" }
-tree-sitter-generate = { version = "0.26.12", path = "./crates/generate", default-features = false }
-tree-sitter-loader = { version = "0.26.12", path = "./crates/loader" }
-tree-sitter-config = { version = "0.26.12", path = "./crates/config" }
-tree-sitter-highlight = { version = "0.26.12", path = "./crates/highlight" }
-tree-sitter-tags = { version = "0.26.12", path = "./crates/tags" }
+tree-sitter = { version = "0.26.13", path = "./lib" }
+tree-sitter-generate = { version = "0.26.13", path = "./crates/generate", default-features = false }
+tree-sitter-loader = { version = "0.26.13", path = "./crates/loader" }
+tree-sitter-config = { version = "0.26.13", path = "./crates/config" }
+tree-sitter-highlight = { version = "0.26.13", path = "./crates/highlight" }
+tree-sitter-tags = { version = "0.26.13", path = "./crates/tags" }
 
 tree-sitter-language = { version = "0.1", path = "./crates/language" }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.26.12
+VERSION := 0.26.13
 DESCRIPTION := An incremental parsing system for programming tools
 HOMEPAGE_URL := https://tree-sitter.github.io/tree-sitter/
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .tree_sitter,
     .fingerprint = 0x841224b447ac0d4f,
-    .version = "0.26.12",
+    .version = "0.26.13",
     .minimum_zig_version = "0.14.1",
     .paths = .{
         "build.zig",

--- a/crates/cli/npm/package-lock.json
+++ b/crates/cli/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-cli",
-  "version": "0.26.12",
+  "version": "0.26.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-cli",
-      "version": "0.26.12",
+      "version": "0.26.13",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/crates/cli/npm/package.json
+++ b/crates/cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-cli",
-  "version": "0.26.12",
+  "version": "0.26.13",
   "author": {
     "name": "Max Brunsfeld",
     "email": "maxbrunsfeld@gmail.com"

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
       eachSystem = lib.genAttrs systems;
       pkgsFor = inputs.nixpkgs.legacyPackages;
 
-      version = "0.26.12";
+          version = "0.26.13";
 
       fs = lib.fileset;
       src = fs.toSource {

--- a/lib/binding_web/package-lock.json
+++ b/lib/binding_web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-tree-sitter",
-  "version": "0.26.12",
+  "version": "0.26.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-tree-sitter",
-      "version": "0.26.12",
+      "version": "0.26.13",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.1",

--- a/lib/binding_web/package.json
+++ b/lib/binding_web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-tree-sitter",
-  "version": "0.26.12",
+  "version": "0.26.13",
   "description": "Tree-sitter bindings for the web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
(hopefully) final release of the 0.26 branch, with another fix-up to regressions around the anchor changes in the query engine.