### PR TITLE
fix(generate): further node-types.json cleanup

### DIFF
--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -49,7 +49,7 @@ struct NodeInfoJSON {
     subtypes: Option<Vec<NodeTypeRef>>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg(feature = "load")]
 struct NodeTypeRef {
     kind: StrId,
@@ -644,7 +644,7 @@ fn generate_node_types(
         &extra_names,
     );
 
-    let mut result = node_types_json.into_iter().map(|e| e.1).collect::<Vec<_>>();
+    let mut result = node_types_json.into_values().collect::<Vec<_>>();
     result.extend(anonymous_node_types);
     result.sort_unstable_by(|a, b| {
         b.subtypes
@@ -779,7 +779,7 @@ fn collect_extra_names(
 /// Add one JSON entry per supertype and build the supertype-to-subtypes map.
 #[cfg(feature = "load")]
 fn build_supertype_entries(
-    node_types_json: &mut BTreeMap<StrId, NodeInfoJSON>,
+    node_types_json: &mut BTreeMap<NodeTypeRef, NodeInfoJSON>,
     syntax_grammar: &SyntaxGrammar,
     lexical_grammar: &LexicalGrammar,
     default_aliases: &AliasMap,
@@ -795,7 +795,10 @@ fn build_supertype_entries(
         }
         let variable = &syntax_grammar.variables[i];
         let node_type_json = node_types_json
-            .entry(variable.name)
+            .entry(NodeTypeRef {
+                kind: variable.name,
+                named: true,
+            })
             .or_insert_with(|| NodeInfoJSON {
                 kind: variable.name,
                 named: true,
@@ -837,7 +840,7 @@ fn build_supertype_entries(
     reason = "all parameters are required to build the entries"
 )]
 fn build_regular_entries(
-    node_types_json: &mut BTreeMap<StrId, NodeInfoJSON>,
+    node_types_json: &mut BTreeMap<NodeTypeRef, NodeInfoJSON>,
     syntax_grammar: &SyntaxGrammar,
     lexical_grammar: &LexicalGrammar,
     default_aliases: &AliasMap,
@@ -873,27 +876,32 @@ fn build_regular_entries(
                 continue;
             };
 
-            // There may already be an entry with this name, because multiple
-            // rules may be aliased with the same name.
+            // There may already be an entry with this node identity, because multiple
+            // rules may be aliased with the same name and namedness.
             let mut node_type_existed = true;
-            let node_type_json = node_types_json.entry(*kind).or_insert_with(|| {
-                node_type_existed = false;
-                NodeInfoJSON {
+            let node_type_json = node_types_json
+                .entry(NodeTypeRef {
                     kind: *kind,
                     named: is_named,
-                    root: i == 0,
-                    extra: extra_names.contains(kind),
-                    fields: Some(BTreeMap::new()),
-                    children: None,
-                    subtypes: None,
-                }
-            });
+                })
+                .or_insert_with(|| {
+                    node_type_existed = false;
+                    NodeInfoJSON {
+                        kind: *kind,
+                        named: is_named,
+                        root: i == 0,
+                        extra: extra_names.contains(kind),
+                        fields: Some(BTreeMap::new()),
+                        children: None,
+                        subtypes: None,
+                    }
+                });
 
             let fields_json = node_type_json.fields.as_mut().unwrap();
             for (new_field, field_info) in &info.fields {
                 let field_json = fields_json.entry(*new_field).or_insert_with(|| {
-                    // If another rule is aliased with the same name, and does *not* have this
-                    // field, then this field cannot be required.
+                    // If another rule is aliased with the same node identity, and
+                    // does *not* have this field, then this field cannot be required.
                     let mut field_json = FieldInfoJSON::default();
                     if node_type_existed {
                         field_json.required = false;
@@ -910,8 +918,8 @@ fn build_regular_entries(
                 );
             }
 
-            // If another rule is aliased with the same name, any fields that aren't present in
-            // this cannot be required.
+            // If another rule is aliased with the same node identity, any fields
+            // that aren't present in this cannot be required.
             for (existing_field, field_json) in fields_json.iter_mut() {
                 if !info.fields.contains_key(existing_field) {
                     field_json.required = false;
@@ -975,7 +983,7 @@ fn sort_subtype_map_topologically(
 /// field type lists.
 #[cfg(feature = "load")]
 fn apply_supertype_collapsing(
-    node_types_json: &mut BTreeMap<StrId, NodeInfoJSON>,
+    node_types_json: &mut BTreeMap<NodeTypeRef, NodeInfoJSON>,
     subtype_map: &[(NodeTypeRef, Vec<NodeTypeRef>)],
 ) {
     for node_type_json in node_types_json.values_mut() {
@@ -1002,7 +1010,7 @@ fn apply_supertype_collapsing(
 /// appended separately.
 #[cfg(feature = "load")]
 fn build_token_entries(
-    node_types_json: &mut BTreeMap<StrId, NodeInfoJSON>,
+    node_types_json: &mut BTreeMap<NodeTypeRef, NodeInfoJSON>,
     syntax_grammar: &SyntaxGrammar,
     lexical_grammar: &LexicalGrammar,
     aliases_by_symbol: &FxHashMap<Symbol, BTreeSet<Option<Alias>>>,
@@ -1048,15 +1056,20 @@ fn build_token_entries(
     for (&name, kind) in regular_tokens.chain(external_tokens) {
         match kind {
             VariableType::Named => {
-                let node_type_json = node_types_json.entry(name).or_insert_with(|| NodeInfoJSON {
-                    kind: name,
-                    named: true,
-                    root: false,
-                    extra: extra_names.contains(&name),
-                    fields: None,
-                    children: None,
-                    subtypes: None,
-                });
+                let node_type_json = node_types_json
+                    .entry(NodeTypeRef {
+                        kind: name,
+                        named: true,
+                    })
+                    .or_insert_with(|| NodeInfoJSON {
+                        kind: name,
+                        named: true,
+                        root: false,
+                        extra: extra_names.contains(&name),
+                        fields: None,
+                        children: None,
+                        subtypes: None,
+                    });
                 if let Some(children) = &mut node_type_json.children {
                     children.required = false;
                 }
@@ -1820,6 +1833,48 @@ mod tests {
                 named: true,
             }]
         );
+    }
+
+    #[test]
+    fn test_node_types_distinguish_named_and_anonymous_aliases() {
+        let mut pool = RulePool::default();
+        let node = named(&mut pool, "_node");
+        let named_alias = alias(&mut pool, node, "same", true);
+        let anonymous_alias = alias(&mut pool, node, "same", false);
+        let document = pool.choice(&[named_alias, anonymous_alias]);
+        let node = {
+            let value = named(&mut pool, "value");
+            let suffix = string(&mut pool, "!");
+            pool.seq(&[value, suffix])
+        };
+        let value = pattern(&mut pool, "[a-z]+");
+        let same_name = pool.intern("same");
+        let node_types = get_node_types(InputGrammar {
+            variables: vec![
+                Variable {
+                    name: pool.intern("document"),
+                    root: document,
+                },
+                Variable {
+                    name: pool.intern("_node"),
+                    root: node,
+                },
+                Variable {
+                    name: pool.intern("value"),
+                    root: value,
+                },
+            ],
+            pool,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let named = node_types
+            .iter()
+            .filter(|node_type| node_type.kind == same_name)
+            .map(|node_type| node_type.named)
+            .collect::<Vec<_>>();
+        assert_eq!(named, [false, true]);
     }
 
     /// A supertype whose only child is a hidden external token

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -829,8 +829,8 @@ fn build_supertype_entries(
     subtype_map
 }
 
-/// Add JSON entries for visible non-supertype rules, merged into every name
-/// they can appear under.
+/// Add JSON entries for visible non-supertype rules and aliased supertypes (treated
+/// as regular, concrete nodes), merged into every regular name they can appear under.
 #[cfg(feature = "load")]
 #[expect(
     clippy::too_many_arguments,
@@ -849,27 +849,29 @@ fn build_regular_entries(
     let empty = BTreeSet::new();
     for (i, info) in variable_info.iter().enumerate() {
         let symbol = Symbol::non_terminal(i);
-        if syntax_grammar.supertype_symbols.contains(&symbol)
-            || syntax_grammar.variables_to_inline.contains(&symbol)
-        {
+        // Inlined symbols don't have their own node-types entries.
+        if syntax_grammar.variables_to_inline.contains(&symbol) {
             continue;
         }
+        let is_supertype = syntax_grammar.supertype_symbols.contains(&symbol);
         let variable = &syntax_grammar.variables[i];
 
         // If a rule is aliased under multiple names, then its information
         // contributes to multiple entries in the final JSON.
         for alias in aliases_by_symbol.get(&symbol).unwrap_or(&empty) {
-            let kind;
-            let is_named;
-            if let Some(alias) = alias {
-                kind = &alias.value;
-                is_named = alias.is_named;
-            } else if variable.kind.is_visible() {
-                kind = &variable.name;
-                is_named = variable.kind == VariableType::Named;
-            } else {
+            // The canonical supertype is emitted separately with its subtypes.
+            // An alias of that supertype is treated as a regular, visible node
+            // and handled here.
+            if is_supertype && alias.is_none() {
                 continue;
             }
+            let (kind, is_named) = if let Some(alias) = alias {
+                (&alias.value, alias.is_named)
+            } else if variable.kind.is_visible() {
+                (&variable.name, variable.kind == VariableType::Named)
+            } else {
+                continue;
+            };
 
             // There may already be an entry with this name, because multiple
             // rules may be aliased with the same name.
@@ -1771,6 +1773,52 @@ mod tests {
                     .collect()
                 )
             }
+        );
+    }
+
+    #[test]
+    fn test_node_types_with_aliased_supertype() {
+        let mut pool = RulePool::default();
+        let expression = named(&mut pool, "_expression");
+        let document = alias(&mut pool, expression, "expression_target", true);
+        let expression = named(&mut pool, "identifier");
+        let identifier = pattern(&mut pool, "[a-z]+");
+        let expression_name = pool.intern("_expression");
+        let expression_target_name = pool.intern("expression_target");
+        let identifier_name = pool.intern("identifier");
+        let node_types = get_node_types(InputGrammar {
+            supertype_names: vec![expression_name],
+            variables: vec![
+                Variable {
+                    name: pool.intern("document"),
+                    root: document,
+                },
+                Variable {
+                    name: expression_name,
+                    root: expression,
+                },
+                Variable {
+                    name: identifier_name,
+                    root: identifier,
+                },
+            ],
+            pool,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let alias = node_types
+            .iter()
+            .find(|node_type| node_type.kind == expression_target_name)
+            .expect("the aliased supertype should have its own node-types entry");
+        assert!(alias.named);
+        assert!(alias.subtypes.is_none());
+        assert_eq!(
+            alias.children.as_ref().unwrap().types,
+            [NodeTypeRef {
+                kind: identifier_name,
+                named: true,
+            }]
         );
     }
 

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -142,13 +142,15 @@ impl ChildQuantity {
 
 pub type VariableInfoResult<T> = Result<T, VariableInfoError>;
 
-#[derive(Debug, Error, Serialize, Deserialize)]
+#[derive(Debug, Error, PartialEq, Eq, Serialize, Deserialize)]
 pub enum VariableInfoError {
     #[error(transparent)]
     InvalidSupertype(InvalidSupertypeError),
+    #[error("Named alias `{0}` conflicts with a supertype of the same name.")]
+    SupertypeAliasCollision(String),
 }
 
-#[derive(Debug, Error, Serialize, Deserialize)]
+#[derive(Debug, Error, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InvalidSupertypeError {
     supertype: String,
     child: Option<String>,
@@ -200,6 +202,7 @@ pub fn get_variable_info(
     default_aliases: &AliasMap,
     str_pool: &StrPool,
 ) -> VariableInfoResult<Vec<VariableInfo>> {
+    validate_supertype_aliases(syntax_grammar, default_aliases, str_pool)?;
     let mut result =
         compute_variable_info_fixed_point(syntax_grammar, lexical_grammar, default_aliases);
     validate_supertype_structure(
@@ -211,6 +214,34 @@ pub fn get_variable_info(
     )?;
     strip_hidden_child_types(&mut result, syntax_grammar, lexical_grammar);
     Ok(result)
+}
+
+/// Reject aliases that have the same public identity as a canonical supertype.
+/// The node-types schema cannot represent one identity as both an abstract supertype
+/// and a concrete aliased node.
+fn validate_supertype_aliases(
+    syntax_grammar: &SyntaxGrammar,
+    default_aliases: &AliasMap,
+    str_pool: &StrPool,
+) -> VariableInfoResult<()> {
+    let aliases_by_symbol = get_aliases_by_symbol(syntax_grammar, default_aliases);
+    for supertype_symbol in &syntax_grammar.supertype_symbols {
+        let supertype = &syntax_grammar.variables[supertype_symbol.index as usize];
+        let collision = Alias {
+            value: supertype.name,
+            is_named: true,
+        };
+        if aliases_by_symbol
+            .values()
+            .any(|aliases| aliases.contains(&Some(collision)))
+        {
+            return Err(VariableInfoError::SupertypeAliasCollision(
+                str_pool.resolve(supertype.name).to_string(),
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 /// Iteratively compute variable info for every syntax variable until a fixed
@@ -610,7 +641,8 @@ fn generate_node_types(
     str_pool: &StrPool,
 ) -> SuperTypeCycleResult<Vec<NodeInfoJSON>> {
     let aliases_by_symbol = get_aliases_by_symbol(syntax_grammar, default_aliases);
-    let extra_names = collect_extra_names(syntax_grammar, lexical_grammar, &aliases_by_symbol);
+    let extra_node_types =
+        collect_extra_node_types(syntax_grammar, lexical_grammar, &aliases_by_symbol);
 
     let mut node_types_json = BTreeMap::new();
     let mut subtype_map = build_supertype_entries(
@@ -620,7 +652,7 @@ fn generate_node_types(
         default_aliases,
         variable_info,
         str_pool,
-        &extra_names,
+        &extra_node_types,
     );
     build_regular_entries(
         &mut node_types_json,
@@ -630,7 +662,7 @@ fn generate_node_types(
         variable_info,
         str_pool,
         &aliases_by_symbol,
-        &extra_names,
+        &extra_node_types,
     );
 
     sort_subtype_map_topologically(&mut subtype_map, str_pool)?;
@@ -641,7 +673,7 @@ fn generate_node_types(
         syntax_grammar,
         lexical_grammar,
         &aliases_by_symbol,
-        &extra_names,
+        &extra_node_types,
     );
 
     let mut result = node_types_json.into_values().collect::<Vec<_>>();
@@ -656,10 +688,7 @@ fn generate_node_types(
             })
             .then_with(|| cmp_str_ids(a.kind, b.kind, str_pool))
             .then_with(|| a.named.cmp(&b.named))
-            .then_with(|| a.root.cmp(&b.root))
-            .then_with(|| a.extra.cmp(&b.extra))
     });
-    result.dedup();
     Ok(result)
 }
 
@@ -738,13 +767,13 @@ fn populate_field_info_json(
     }
 }
 
-/// Collect every name an `extra` symbol can appear under, including aliases.
+/// Collect every node identity an `extra` symbol can appear under, including aliases.
 #[cfg(feature = "load")]
-fn collect_extra_names(
+fn collect_extra_node_types(
     syntax_grammar: &SyntaxGrammar,
     lexical_grammar: &LexicalGrammar,
     aliases_by_symbol: &FxHashMap<Symbol, BTreeSet<Option<Alias>>>,
-) -> FxHashSet<StrId> {
+) -> FxHashSet<NodeTypeRef> {
     let empty = BTreeSet::new();
     syntax_grammar
         .extra_symbols
@@ -755,24 +784,37 @@ fn collect_extra_names(
                 .unwrap_or(&empty)
                 .iter()
                 .map(|alias| {
-                    alias.as_ref().map_or_else(
+                    let (kind, variable_type) = alias.as_ref().map_or_else(
                         || match symbol.kind {
                             SymbolType::NonTerminal => {
-                                syntax_grammar.variables[symbol.index as usize].name
+                                let variable = &syntax_grammar.variables[symbol.index as usize];
+                                (&variable.name, variable.kind)
                             }
                             SymbolType::Terminal => {
-                                lexical_grammar.variables[symbol.index as usize].name
+                                let variable = &lexical_grammar.variables[symbol.index as usize];
+                                (&variable.name, variable.kind)
                             }
                             SymbolType::External => {
-                                syntax_grammar.external_tokens[symbol.index as usize].name
+                                let variable =
+                                    &syntax_grammar.external_tokens[symbol.index as usize];
+                                (&variable.name, variable.kind)
                             }
-                            _ => unreachable!(),
+                            // `eof()` in an extra is rejected during lexical separator expansion, so
+                            // `End` cannot reach `SyntaxGrammar::extra_symbols`.
+                            SymbolType::End
+                            // Lookahead marker that `build_parse_table` inserts for nonterminal
+                            // extras _after_ this pass runs.
+                            | SymbolType::EndOfNonTerminalExtra => unreachable!(),
                         },
-                        |alias| alias.value,
-                    )
+                        |alias| (&alias.value, alias.kind()),
+                    );
+                    NodeTypeRef {
+                        kind: *kind,
+                        named: variable_type != VariableType::Anonymous,
+                    }
                 })
         })
-        .collect::<FxHashSet<_>>()
+        .collect()
 }
 
 /// Add one JSON entry per supertype and build the supertype-to-subtypes map.
@@ -784,7 +826,7 @@ fn build_supertype_entries(
     default_aliases: &AliasMap,
     variable_info: &[VariableInfo],
     str_pool: &StrPool,
-    extra_names: &FxHashSet<StrId>,
+    extra_node_types: &FxHashSet<NodeTypeRef>,
 ) -> Vec<(NodeTypeRef, Vec<NodeTypeRef>)> {
     let mut subtype_map = Vec::new();
     for (i, info) in variable_info.iter().enumerate() {
@@ -793,16 +835,17 @@ fn build_supertype_entries(
             continue;
         }
         let variable = &syntax_grammar.variables[i];
+        let node_type = NodeTypeRef {
+            kind: variable.name,
+            named: true,
+        };
         let node_type_json = node_types_json
-            .entry(NodeTypeRef {
-                kind: variable.name,
-                named: true,
-            })
+            .entry(node_type)
             .or_insert_with(|| NodeInfoJSON {
                 kind: variable.name,
                 named: true,
                 root: false,
-                extra: extra_names.contains(&variable.name),
+                extra: extra_node_types.contains(&node_type),
                 fields: None,
                 children: None,
                 subtypes: None,
@@ -846,7 +889,7 @@ fn build_regular_entries(
     variable_info: &[VariableInfo],
     str_pool: &StrPool,
     aliases_by_symbol: &FxHashMap<Symbol, BTreeSet<Option<Alias>>>,
-    extra_names: &FxHashSet<StrId>,
+    extra_node_types: &FxHashSet<NodeTypeRef>,
 ) {
     let empty = BTreeSet::new();
     for (i, info) in variable_info.iter().enumerate() {
@@ -878,23 +921,22 @@ fn build_regular_entries(
             // There may already be an entry with this node identity, because multiple
             // rules may be aliased with the same name and namedness.
             let mut node_type_existed = true;
-            let node_type_json = node_types_json
-                .entry(NodeTypeRef {
+            let node_type = NodeTypeRef {
+                kind: *kind,
+                named: is_named,
+            };
+            let node_type_json = node_types_json.entry(node_type).or_insert_with(|| {
+                node_type_existed = false;
+                NodeInfoJSON {
                     kind: *kind,
                     named: is_named,
-                })
-                .or_insert_with(|| {
-                    node_type_existed = false;
-                    NodeInfoJSON {
-                        kind: *kind,
-                        named: is_named,
-                        root: i == 0,
-                        extra: extra_names.contains(kind),
-                        fields: Some(BTreeMap::new()),
-                        children: None,
-                        subtypes: None,
-                    }
-                });
+                    root: i == 0,
+                    extra: extra_node_types.contains(&node_type),
+                    fields: Some(BTreeMap::new()),
+                    children: None,
+                    subtypes: None,
+                }
+            });
 
             let fields_json = node_type_json.fields.as_mut().unwrap();
             for (new_field, field_info) in &info.fields {
@@ -946,33 +988,33 @@ fn sort_subtype_map_topologically(
     subtype_map: &mut [(NodeTypeRef, Vec<NodeTypeRef>)],
     str_pool: &StrPool,
 ) -> SuperTypeCycleResult<()> {
-    let mut sorted_kinds = Vec::with_capacity(subtype_map.len());
-    let mut top_sort = topological_sort::TopologicalSort::<StrId>::new();
+    let mut sorted_node_types = Vec::with_capacity(subtype_map.len());
+    let mut top_sort = topological_sort::TopologicalSort::<NodeTypeRef>::new();
     for (supertype, subtypes) in subtype_map.iter() {
         for subtype in subtypes {
-            top_sort.add_dependency(subtype.kind, supertype.kind);
+            top_sort.add_dependency(*subtype, *supertype);
         }
     }
     loop {
-        let mut next_kinds = top_sort.pop_all();
-        match (next_kinds.is_empty(), top_sort.is_empty()) {
+        let mut next_node_types = top_sort.pop_all();
+        match (next_node_types.is_empty(), top_sort.is_empty()) {
             (true, true) => break,
             (true, false) => {
                 let mut items = top_sort
-                    .map(|s| str_pool.resolve(s).to_string())
+                    .map(|node_type| str_pool.resolve(node_type.kind).to_string())
                     .collect::<Vec<String>>();
                 items.sort();
                 return Err(SuperTypeCycleError { items });
             }
             (false, _) => {
-                next_kinds.sort_unstable_by(|a, b| cmp_str_ids(*a, *b, str_pool));
-                sorted_kinds.extend(next_kinds);
+                sort_node_type_refs(&mut next_node_types, str_pool);
+                sorted_node_types.extend(next_node_types);
             }
         }
     }
     subtype_map.sort_by(|a, b| {
-        let a_idx = sorted_kinds.iter().position(|n| *n == a.0.kind).unwrap();
-        let b_idx = sorted_kinds.iter().position(|n| *n == b.0.kind).unwrap();
+        let a_idx = sorted_node_types.iter().position(|n| *n == a.0).unwrap();
+        let b_idx = sorted_node_types.iter().position(|n| *n == b.0).unwrap();
         a_idx.cmp(&b_idx)
     });
     Ok(())
@@ -1012,7 +1054,7 @@ fn build_token_entries(
     syntax_grammar: &SyntaxGrammar,
     lexical_grammar: &LexicalGrammar,
     aliases_by_symbol: &FxHashMap<Symbol, BTreeSet<Option<Alias>>>,
-    extra_names: &FxHashSet<StrId>,
+    extra_node_types: &FxHashSet<NodeTypeRef>,
 ) {
     let empty = BTreeSet::new();
 
@@ -1054,8 +1096,9 @@ fn build_token_entries(
         match kind {
             VariableType::Named | VariableType::Anonymous => {
                 let named = kind == VariableType::Named;
+                let node_type = NodeTypeRef { kind: name, named };
                 node_types_json
-                    .entry(NodeTypeRef { kind: name, named })
+                    .entry(node_type)
                     .and_modify(|node_type_json| {
                         // This token is a leaf appearance of an existing node identity,
                         // so children and fields from other appearances are optional.
@@ -1072,7 +1115,7 @@ fn build_token_entries(
                         kind: name,
                         named,
                         root: false,
-                        extra: extra_names.contains(&name),
+                        extra: extra_node_types.contains(&node_type),
                         fields: None,
                         children: None,
                         subtypes: None,
@@ -1915,6 +1958,189 @@ mod tests {
                 kind: value_name,
                 named: true,
             }]
+        );
+    }
+
+    #[test]
+    fn test_node_types_distinguish_extra_metadata_by_namedness() {
+        let mut pool = RulePool::default();
+        let node = named(&mut pool, "_node");
+        let node = alias(&mut pool, node, "same", false);
+        let extra = named(&mut pool, "_extra");
+        let extra_alias = alias(&mut pool, extra, "same", true);
+        let document = pool.choice(&[node, extra_alias]);
+        let node = {
+            let value = named(&mut pool, "value");
+            let suffix = string(&mut pool, "?");
+            pool.seq(&[value, suffix])
+        };
+        let extra_rule = {
+            let prefix = string(&mut pool, "#");
+            let value = named(&mut pool, "extra_value");
+            pool.seq(&[prefix, value])
+        };
+        let value = pattern(&mut pool, "[a-z]+");
+        let extra_value = pattern(&mut pool, "[A-Z]+");
+        let same_name = pool.intern("same");
+        let node_types = get_node_types(InputGrammar {
+            extra_roots: vec![extra],
+            variables: vec![
+                Variable {
+                    name: pool.intern("document"),
+                    root: document,
+                },
+                Variable {
+                    name: pool.intern("_node"),
+                    root: node,
+                },
+                Variable {
+                    name: pool.intern("_extra"),
+                    root: extra_rule,
+                },
+                Variable {
+                    name: pool.intern("value"),
+                    root: value,
+                },
+                Variable {
+                    name: pool.intern("extra_value"),
+                    root: extra_value,
+                },
+            ],
+            pool,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let mut aliases = node_types
+            .iter()
+            .filter(|node_type| node_type.kind == same_name)
+            .collect::<Vec<_>>();
+        aliases.sort_unstable_by_key(|node_type| node_type.named);
+        assert_eq!(aliases.len(), 2);
+        assert!(!aliases[0].named);
+        assert!(!aliases[0].extra);
+        assert!(aliases[1].named);
+        assert!(aliases[1].extra);
+    }
+
+    #[test]
+    fn test_node_types_distinguish_supertype_dependencies_by_namedness() {
+        let mut pool = RulePool::default();
+        let document = named(&mut pool, "_super");
+        let supertype = {
+            let item = named(&mut pool, "item");
+            let item = alias(&mut pool, item, "_super", false);
+            let other = named(&mut pool, "other");
+            pool.choice(&[item, other])
+        };
+        let item = string(&mut pool, "x");
+        let other = string(&mut pool, "y");
+        let super_name = pool.intern("_super");
+        let node_types = get_node_types(InputGrammar {
+            supertype_names: vec![super_name],
+            variables: vec![
+                Variable {
+                    name: pool.intern("document"),
+                    root: document,
+                },
+                Variable {
+                    name: super_name,
+                    root: supertype,
+                },
+                Variable {
+                    name: pool.intern("item"),
+                    root: item,
+                },
+                Variable {
+                    name: pool.intern("other"),
+                    root: other,
+                },
+            ],
+            pool,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let mut named = node_types
+            .iter()
+            .filter(|node_type| node_type.kind == super_name)
+            .map(|node_type| node_type.named)
+            .collect::<Vec<_>>();
+        named.sort_unstable();
+        assert_eq!(named, [false, true]);
+    }
+
+    #[test]
+    fn test_node_types_with_alias_matching_canonical_supertype() {
+        let mut pool = RulePool::default();
+        let document = {
+            let node = named(&mut pool, "_node");
+            let node = alias(&mut pool, node, "_super", true);
+            let supertype = named(&mut pool, "_super");
+            pool.choice(&[node, supertype])
+        };
+        let supertype = {
+            let (one, two) = (named(&mut pool, "one"), named(&mut pool, "two"));
+            pool.choice(&[one, two])
+        };
+        let node = {
+            let value = named(&mut pool, "value");
+            let suffix = string(&mut pool, "?");
+            pool.seq(&[value, suffix])
+        };
+        let one = string(&mut pool, "1");
+        let two = string(&mut pool, "2");
+        let value = pattern(&mut pool, "[a-z]+");
+        let super_name = pool.intern("_super");
+        let grammar = InputGrammar {
+            supertype_names: vec![super_name],
+            variables: vec![
+                Variable {
+                    name: pool.intern("document"),
+                    root: document,
+                },
+                Variable {
+                    name: super_name,
+                    root: supertype,
+                },
+                Variable {
+                    name: pool.intern("_node"),
+                    root: node,
+                },
+                Variable {
+                    name: pool.intern("one"),
+                    root: one,
+                },
+                Variable {
+                    name: pool.intern("two"),
+                    root: two,
+                },
+                Variable {
+                    name: pool.intern("value"),
+                    root: value,
+                },
+            ],
+            pool,
+            ..Default::default()
+        };
+        let PreparedGrammar {
+            syntax_grammar,
+            lexical_grammar,
+            default_aliases,
+            str_pool,
+            ..
+        } = prepare_grammar(grammar, &mut Vec::new()).unwrap();
+        let error = get_variable_info(
+            &syntax_grammar,
+            &lexical_grammar,
+            &default_aliases,
+            &str_pool,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            VariableInfoError::SupertypeAliasCollision("_super".into())
         );
     }
 

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -636,7 +636,7 @@ fn generate_node_types(
     sort_subtype_map_topologically(&mut subtype_map, str_pool)?;
     apply_supertype_collapsing(&mut node_types_json, &subtype_map);
 
-    let anonymous_node_types = build_token_entries(
+    build_token_entries(
         &mut node_types_json,
         syntax_grammar,
         lexical_grammar,
@@ -645,7 +645,6 @@ fn generate_node_types(
     );
 
     let mut result = node_types_json.into_values().collect::<Vec<_>>();
-    result.extend(anonymous_node_types);
     result.sort_unstable_by(|a, b| {
         b.subtypes
             .is_some()
@@ -1006,8 +1005,7 @@ fn apply_supertype_collapsing(
     }
 }
 
-/// Add JSON entries for named tokens, returning the anonymous ones to be
-/// appended separately.
+/// Add JSON entries for visible tokens.
 #[cfg(feature = "load")]
 fn build_token_entries(
     node_types_json: &mut BTreeMap<NodeTypeRef, NodeInfoJSON>,
@@ -1015,9 +1013,8 @@ fn build_token_entries(
     lexical_grammar: &LexicalGrammar,
     aliases_by_symbol: &FxHashMap<Symbol, BTreeSet<Option<Alias>>>,
     extra_names: &FxHashSet<StrId>,
-) -> Vec<NodeInfoJSON> {
+) {
     let empty = BTreeSet::new();
-    let mut anonymous_node_types = Vec::new();
 
     let regular_tokens = lexical_grammar
         .variables
@@ -1055,44 +1052,35 @@ fn build_token_entries(
 
     for (&name, kind) in regular_tokens.chain(external_tokens) {
         match kind {
-            VariableType::Named => {
-                let node_type_json = node_types_json
-                    .entry(NodeTypeRef {
-                        kind: name,
-                        named: true,
+            VariableType::Named | VariableType::Anonymous => {
+                let named = kind == VariableType::Named;
+                node_types_json
+                    .entry(NodeTypeRef { kind: name, named })
+                    .and_modify(|node_type_json| {
+                        // This token is a leaf appearance of an existing node identity,
+                        // so children and fields from other appearances are optional.
+                        if let Some(children) = &mut node_type_json.children {
+                            children.required = false;
+                        }
+                        if let Some(fields) = &mut node_type_json.fields {
+                            for field in fields.values_mut() {
+                                field.required = false;
+                            }
+                        }
                     })
                     .or_insert_with(|| NodeInfoJSON {
                         kind: name,
-                        named: true,
+                        named,
                         root: false,
                         extra: extra_names.contains(&name),
                         fields: None,
                         children: None,
                         subtypes: None,
                     });
-                if let Some(children) = &mut node_type_json.children {
-                    children.required = false;
-                }
-                if let Some(fields) = &mut node_type_json.fields {
-                    for field in fields.values_mut() {
-                        field.required = false;
-                    }
-                }
             }
-            VariableType::Anonymous => anonymous_node_types.push(NodeInfoJSON {
-                kind: name,
-                named: false,
-                root: false,
-                extra: extra_names.contains(&name),
-                fields: None,
-                children: None,
-                subtypes: None,
-            }),
             _ => {}
         }
     }
-
-    anonymous_node_types
 }
 
 #[cfg(feature = "load")]
@@ -1877,10 +1865,62 @@ mod tests {
         assert_eq!(named, [false, true]);
     }
 
-    /// A supertype whose only child is a hidden external token
-    /// xgust not cause generation to panic. The subtype map must
-    /// skip entries with empty subtypes to avoid a lookup failure
-    /// in the topological sort.
+    #[test]
+    fn test_node_types_merge_anonymous_node_and_token_aliases() {
+        let mut pool = RulePool::default();
+        let node = named(&mut pool, "_node");
+        let node = alias(&mut pool, node, "same", false);
+        let token = string(&mut pool, "!");
+        let token = alias(&mut pool, token, "same", false);
+        let document = pool.choice(&[node, token]);
+        let node = {
+            let (value1, value2) = (named(&mut pool, "value"), named(&mut pool, "value"));
+            let suffix = string(&mut pool, "?");
+            pool.seq(&[value1, value2, suffix])
+        };
+        let value = pattern(&mut pool, "[a-z]+");
+        let same_name = pool.intern("same");
+        let value_name = pool.intern("value");
+        let node_types = get_node_types(InputGrammar {
+            variables: vec![
+                Variable {
+                    name: pool.intern("document"),
+                    root: document,
+                },
+                Variable {
+                    name: pool.intern("_node"),
+                    root: node,
+                },
+                Variable {
+                    name: value_name,
+                    root: value,
+                },
+            ],
+            pool,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let aliases = node_types
+            .iter()
+            .filter(|node_type| node_type.kind == same_name && !node_type.named)
+            .collect::<Vec<_>>();
+        assert_eq!(aliases.len(), 1);
+        let children = aliases[0].children.as_ref().unwrap();
+        assert!(children.multiple);
+        assert!(!children.required);
+        assert_eq!(
+            children.types,
+            [NodeTypeRef {
+                kind: value_name,
+                named: true,
+            }]
+        );
+    }
+
+    /// A supertype whose only child is a hidden external token must not cause
+    /// generation to panic. The subtype map must skip entries with empty subtypes
+    /// to avoid a lookup failure in the topological sort.
     #[test]
     fn test_node_types_supertype_with_only_hidden_child() {
         let mut pool = RulePool::default();


### PR DESCRIPTION
See commit messages for details. This fixes #1654, as well as several other issues I discovered along the way. The last commit adds a new error variant to `tree-sitter-generate`. I think this is the proper direction in this case (as opposed to adding a warning), because _not_ catching this issue can lead to panics, nondeterministic output, and other unfun things. No grammar in the nvim-treesitter corpus currently exercises this error path.

- Fixes #1654 
- Supersedes #5271

After the changes were made, I had an agent go through the entire nvim-treesitter corpus, comparing each grammar's node-types.json file as generated on master vs. this PR. Some commit hashes may be old compared to nvim-treesitter's current main branch, but I don't think anything has drifted too far. I did a quick check through of the agent's findings myself (Note this wasn't exhaustive, that would take a very long time and I'm fairly confident in both the results here as well as the source code changes, CI run TBD). Here's a summary of all changes found (feel free to ignore, pasting here in case there's unintended side effects that we need to track down):

### Missing supertype-alias entries

These are the fix for #1654. The parser can produce a concrete alias wrapper, but master omitted its top-level schema entry.

  - Python-derived grammars:
      - Python
      - BitBake
      - Starlark and its vendored Python
      - Snakemake’s vendored Python
      - as_pattern_target, named, is added as a regular concrete node.
      - It has one required child drawn from the expression alternatives.
      - It does not inherit the canonical supertype’s subtypes.

  - Smali:
      - Adds named field_type.
      - Its required child is one of array_type, class_identifier, or primitive_type, matching the aliased type supertype.

  - Wing:
      - Adds named keyword_argument_value.
      - Its required child is one of the expression alternatives such as call, reference, binary_expression, or a literal.

  - V:
      - Adds named element and interpolation_expression.
      - Both wrap one required _expression alternative.

  - Fortran:
      - Adds named concurrent_mask.
      - It wraps one required _expression alternative.

### Supertype aliases merged into existing identities

Here the alias name already had an entry, so adding another object would be wrong. The existing object is widened to describe every possible appearance.

- Snakemake:
      - as_pattern_target, named, was previously represented as a leaf.
      - It now has fields: {} and the possible expression children.
      - children.required is false because this identity still has another leaf appearance.
      - The result remains one as_pattern_target entry.

  - PHP and PHP-only:
      - Named name previously had only fields: {}.
      - It now also permits an optional expression child.
      - The child alternatives include assignment_expression, binary_expression, primary_expression, yield_expression, and the other PHP expression forms.
      - The child is optional because ordinary leaf-like name appearances still exist.

  - HLSL and Slang:
      - Named semantics already permitted an optional identifier child.
      - Its child union now also includes the expression alternatives contributed by aliases such as alias(seq(":", $.expression), $.semantics).
      - It remains one entry with optional children.

### Named and anonymous identities separated

Master keyed regular aggregation by text alone. In these files, two runtime identities had the same text but different named values. The branch emits both.

  - Just:
      - Adds anonymous expression alongside the existing named expression.
      - The anonymous entry has optional if_expression or value children.

  - Djot:
      - Retains anonymous class.
      - Adds the distinct named class rule entry.

  - TypoScript:
      - Adds anonymous identifier alongside named identifier.

  - Hurl:
      - Master incorrectly attached the anonymous alias’s structure to named json_key_string.
      - The structured entry is now correctly named: false.
      - A separate named json_key_string entry represents the named rule.

  - Fortran:
      - Adds anonymous method_name alongside named method_name.
      - Adds named statement_label_reference alongside its anonymous alias.
      - This file also contains the concurrent_mask supertype fix above.

  - Surface:
      - Emits both named and anonymous comment.
      - Emits both named and anonymous expression_value.
      - Master collapsed each pair into a single entry whose namedness depended on aggregation order.

### Duplicate anonymous identities merged

Master appended anonymous token entries separately from structured aliases. That could produce two objects with exactly the same (type, named) identity. The branch routes both through the same map.

  - Cylc: anonymous empty-string identity, 2 → 1.
  - HTML-Django: anonymous empty-string identity, 2 → 1.
  - Perl: anonymous >, 2 → 1.
  - Haskell: anonymous (#, 2 → 1.
  - Idris: anonymous empty-string identity, 2 → 1.
  - KCL: anonymous null_assignment, 2 → 1.
      - The surviving structured entry’s child becomes optional because the identity also has a leaf-token appearance.

  - Nushell: anonymous _prefix, 2 → 1.
  - Swift: anonymous ?, 2 → 1.
  - Typst: anonymous ( and ), each 2 → 1.
  - Razor: 23 anonymous identities, each 2 → 1:
      - `at_attribute`, `at_await`, `at_block`, `at_do`, `at_for`, `at_foreach`, `at_if`, `at_implements`, `at_inherits`, `at_inject`, `at_layout`, `at_lock`, `at_model`, `at_namespace`, `at_page`, `at_preservewhitespace`, `at_rendermode`, `at_section`, `at_switch`, `at_try`, `at_typeparam`, `at_using`, `at_while`

(Except for KCL’s requiredness correction, these diffs simply remove redundant objects. No shape information is discarded.)

### extra metadata separated by namedness

  - Enforce:
      - Anonymous else loses `extra: true`.
      - The distinct named else identity remains the extra.

  - Kconfig:
      - Anonymous comment loses `extra: true`.
      - The distinct named comment identity remains the extra.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
Used gpt5.6-sol to discuss each issue and the proper approach. Each fix hand typed and tested by me. The initial sweep over the nvim-treesitter corpus was also performed by this model, results spot checked by me.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
