### PR TITLE
fix(rust): remove `must_use` attribute from `Tree::changed_ranges`

### DIFF
--- a/lib/binding_rust/lib.rs
+++ b/lib/binding_rust/lib.rs
@@ -1542,7 +1542,6 @@ impl Tree {
     /// functions. Call it on the old tree that was passed to parse, and
     /// pass the new tree that was returned from `parse`.
     #[doc(alias = "ts_tree_get_changed_ranges")]
-    #[must_use]
     pub fn changed_ranges(&self, other: &Self) -> impl ExactSizeIterator<Item = Range> {
         let mut count = 0u32;
         unsafe {


### PR DESCRIPTION
`ExactSizeIterator` implements `std::iter::Iterator`, which is already `must_use`.

This is the one actionable lint I got from checking with nightly before the compiler crashed (looks like https://github.com/rust-lang/rust/issues/161542, works with `-Znext-solver=coherence`). Best to address this now before it becomes a surprise failure with a future stable rust version :slightly_smiling_face: 

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
