### PR TITLE
docs: specify Emscripten version constraints for web binding builds

### DIFF
--- a/docs/src/6-contributing.md
+++ b/docs/src/6-contributing.md
@@ -89,6 +89,10 @@ npm install # or your JS package manager of choice
 npm run build
 ```
 
+```admonish note
+If using a local Emscripten installation, the version must match the one [pinned by this repository][emscripten-version].
+```
+
 Build the Rust libraries and the CLI:
 
 ```sh
@@ -338,6 +342,7 @@ and the tree-sitter module is fetched from [here][js url]. This, along with the 
 [docker]: https://www.docker.com
 [docs src]: https://github.com/tree-sitter/tree-sitter/tree/master/docs/src
 [emscripten]: https://emscripten.org
+[emscripten-version]: https://github.com/tree-sitter/tree-sitter/blob/master/crates/loader/emscripten-version
 [generate crate]: https://crates.io/crates/tree-sitter-generate
 [gh.io repo]: https://github.com/tree-sitter/tree-sitter.github.io
 [go.dev]: https://pkg.go.dev

--- a/lib/binding_web/CONTRIBUTING.md
+++ b/lib/binding_web/CONTRIBUTING.md
@@ -39,6 +39,8 @@ npm run build
 Note that the build process requires a Rust toolchain to be installed. If you don't have one installed, you can install it
 by visiting the [Rust website][rust] and following the instructions there.
 
+If you use a local Emscripten installation, it must match the [version pinned in this repository][emscripten-version].
+
 > [!NOTE]
 > By default, the build process will emit an ES6 module. If you need a CommonJS module, export `CJS` to `true`, or just
 > run `CJS=true npm run build` (or the equivalent command for Windows).
@@ -134,6 +136,7 @@ file mentioned earlier, namely in the `run_wasm` function.
 [docker]: https://www.docker.com
 [dts-buddy]: https://github.com/Rich-Harris/dts-buddy
 [emscripten]: https://emscripten.org
+[emscripten-version]: ../../crates/loader/emscripten-version
 [exports.txt]: lib/exports.txt
 [podman]: https://podman.io
 [rust]: https://www.rust-lang.org/tools/install


### PR DESCRIPTION
- Closes #5037
- Supersedes #5038

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
