### PR TITLE
docs(web): add WASM version compatibility section

### DIFF
--- a/lib/binding_web/README.md
+++ b/lib/binding_web/README.md
@@ -193,6 +193,19 @@ npx tree-sitter build --wasm node_modules/tree-sitter-javascript
 
 If everything is fine, file `tree-sitter-javascript.wasm` should be generated in current directory.
 
+### Wasm compatibility
+
+`web-tree-sitter` supports the same parser ABI versions as the corresponding tree-sitter library:
+
+| web-tree-sitter version | Min parser ABI version | Max parser ABI version |
+|-------------------------|------------------------|------------------------|
+| 0.24.x                  | 13                     | 14                     |
+| >= 0.25.0               | 13                     | 15                     |
+
+> [!WARNING]
+> Some prebuilt `.wasm` files use an older dynamic-linking format that newer versions of `web-tree-sitter` cannot
+> load, even if their parser ABI is supported. Rebuild these files using a current tree-sitter CLI.
+
 ### Running .wasm in Node.js
 
 Notice that executing `.wasm` files in Node.js is considerably slower than running [Node.js bindings][node bindings].


### PR DESCRIPTION
Add documentation about version compatibility requirements between web-tree-sitter and tree-sitter-cli for WASM file generation.

This helps users understand why Language.load() might fail when using pre-built WASM files from third-party packages that were built with incompatible tree-sitter-cli versions.

- Supersedes #5172

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
Used gpt5.6-sol to double check wasm legacy dynamic linking format issues.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
