### PR TITLE
Remove Dockerfile mention from flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,6 @@
             ./flake.lock
             ./FUNDING.json
             ./README.md
-            ./Dockerfile
             (fs.fileFilter (file: lib.strings.hasInfix ".git" file.name) ./.)
             (fs.fileFilter (file: file.hasExt "nix") ./.)
           ]


### PR DESCRIPTION
When the Dockerfile was removed in https://github.com/tree-sitter/tree-sitter/commit/2452dc7a71a55c9e356e130054b4f74cab4714b9 , it looks like the reference to it in the nix flake was forgotten.

Note: There is a second issue with the build, which is related to https://github.com/NixOS/nixpkgs/pull/524985 and probably just needs a `nix flake update`, I'll investigate that as well in a separate pr. 

I've tested this fix by building the package in my nixos configuration, using the following input configuration, with a just-updated lockfile:

My nixpkgs is also on `nixpkgs-unstable`.

```nix
    tree-sitter = {
      url = "github:abeforgit/tree-sitter/fix/remove-dockerfile-mention";
      inputs.nixpkgs.follows = "nixpkgs";
    };
```




fixes: #5891 

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.

<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
no AI was used