### PR TITLE
fix(generate): resolve token names in debug output

### DIFF
--- a/crates/generate/src/build_tables.rs
+++ b/crates/generate/src/build_tables.rs
@@ -105,6 +105,7 @@ pub fn build_tables(
         &keywords,
         &coincident_token_index,
         &token_conflict_map,
+        str_pool,
     );
     populate_external_lex_states(&mut parse_table, syntax_grammar);
     mark_fragile_tokens(&mut parse_table, &token_conflict_map);

--- a/crates/generate/src/build_tables.rs
+++ b/crates/generate/src/build_tables.rs
@@ -28,7 +28,7 @@ use crate::{
     grammars::{InlinedProductionMap, LexicalGrammar, SyntaxGrammar},
     nfa::{CharacterSet, NfaCursor},
     node_types::VariableInfo,
-    rules::{AliasMap, Symbol, SymbolType, TokenSet},
+    rules::{AliasMap, Symbol, SymbolView, TerminalIndex, TokenSet},
     strpool::StrPool,
     tables::{ActionList, ActionListPool, LexTable, ParseAction, ParseTable, ParseTableEntry},
 };
@@ -154,21 +154,22 @@ fn get_following_tokens(
             let right_tokens = builder.first_set(steps[i].symbol());
             let right_reserved_tokens = builder.reserved_first_set(steps[i].symbol());
             for left_token in left_tokens.iter() {
-                if left_token.is_terminal() {
-                    result[left_token.index as usize].insert_all_terminals(right_tokens);
+                if let SymbolView::Terminal(index) = left_token.view() {
+                    let index = usize::from(index);
+                    result[index].insert_all_terminals(right_tokens);
                     if let Some(reserved_tokens) = right_reserved_tokens {
-                        result[left_token.index as usize].insert_all_terminals(reserved_tokens);
+                        result[index].insert_all_terminals(reserved_tokens);
                     }
                 }
             }
         }
     }
     for extra in &syntax_grammar.extra_symbols {
-        if extra.is_terminal() {
+        if let SymbolView::Terminal(index) = extra.view() {
             for entry in &mut result {
                 entry.insert(*extra);
             }
-            result[extra.index as usize] = all_tokens.clone();
+            result[usize::from(index)] = all_tokens.clone();
         }
     }
     result
@@ -190,9 +191,10 @@ fn populate_error_state(
     // any other token in any way, besides matching exactly the same string.
     let conflict_free_tokens = (0..n)
         .filter_map(|i| {
+            let a = TerminalIndex::new(i as u32);
             let conflicts_with_other_tokens = (0..n).any(|j| {
                 j != i
-                    && !coincident_token_index.contains(Symbol::terminal(i), Symbol::terminal(j))
+                    && !coincident_token_index.contains(a, TerminalIndex::new(j as u32))
                     && token_conflict_map.does_match_shorter_or_longer(i, j)
             });
             if conflicts_with_other_tokens {
@@ -219,15 +221,15 @@ fn populate_error_state(
         if !conflict_free_tokens.contains(symbol)
             && !keywords.contains(symbol)
             && syntax_grammar.word_token != Some(symbol)
-            && let Some(t) = conflict_free_tokens.iter().find(|t| {
-                !coincident_token_index.contains(symbol, *t)
-                    && token_conflict_map.does_conflict(symbol.index as usize, t.index as usize)
+            && let Some(index) = conflict_free_tokens.terminals().find(|&other| {
+                !coincident_token_index.contains(TerminalIndex::new(i as u32), other)
+                    && token_conflict_map.does_conflict(i, usize::from(other))
             })
         {
             debug!(
                 "error recovery - exclude token {} because of conflict with {}",
                 str_pool.resolve(lexical_grammar.variables[i].name),
-                str_pool.resolve(lexical_grammar.variables[t.index as usize].name)
+                str_pool.resolve(lexical_grammar.variables[usize::from(index)].name)
             );
             continue;
         }
@@ -250,7 +252,7 @@ fn populate_error_state(
         }
     }
 
-    state.terminal_entries.insert(Symbol::end(), recover_entry);
+    state.terminal_entries.insert(Symbol::End, recover_entry);
 }
 
 fn populate_used_symbols(
@@ -263,17 +265,21 @@ fn populate_used_symbols(
     let mut external_usages = vec![false; syntax_grammar.external_tokens.len()];
     for state in &parse_table.states {
         for symbol in state.terminal_entries.keys() {
-            match symbol.kind {
-                SymbolType::Terminal => terminal_usages[symbol.index as usize] = true,
-                SymbolType::External => external_usages[symbol.index as usize] = true,
-                _ => {}
+            match symbol.view() {
+                SymbolView::Terminal(index) => terminal_usages[usize::from(index)] = true,
+                SymbolView::External(index) => external_usages[usize::from(index)] = true,
+                SymbolView::End | SymbolView::EndOfNonTerminalExtra => {}
+                SymbolView::NonTerminal(_) => unreachable!(),
             }
         }
         for symbol in state.nonterminal_entries.keys() {
-            non_terminal_usages[symbol.index as usize] = true;
+            let SymbolView::NonTerminal(index) = symbol.view() else {
+                unreachable!();
+            };
+            non_terminal_usages[usize::from(index)] = true;
         }
     }
-    parse_table.symbols.push(Symbol::end());
+    parse_table.symbols.push(Symbol::End);
     for (i, value) in terminal_usages.into_iter().enumerate() {
         if value {
             // Assign the grammar's word token a low numerical index. This ensures that
@@ -282,10 +288,13 @@ fn populate_used_symbols(
             // ensure that a subtree's symbol can be successfully reassigned to the word token
             // without having to move the subtree to the heap.
             // See https://github.com/tree-sitter/tree-sitter/issues/258
-            if syntax_grammar
-                .word_token
-                .is_some_and(|t| t.index as usize == i)
-            {
+            if syntax_grammar.word_token.is_some_and(|t| match t.view() {
+                SymbolView::External(index) => usize::from(index) == i,
+                SymbolView::Terminal(index) => usize::from(index) == i,
+                SymbolView::End
+                | SymbolView::EndOfNonTerminalExtra
+                | SymbolView::NonTerminal(_) => false,
+            }) {
                 parse_table.symbols.insert(1, Symbol::terminal(i));
             } else {
                 parse_table.symbols.push(Symbol::terminal(i));
@@ -307,8 +316,11 @@ fn populate_used_symbols(
 fn populate_external_lex_states(parse_table: &mut ParseTable, syntax_grammar: &SyntaxGrammar) {
     let mut external_tokens_by_corresponding_internal_token = FxHashMap::default();
     for (i, external_token) in syntax_grammar.external_tokens.iter().enumerate() {
-        if let Some(symbol) = external_token.corresponding_internal_token {
-            external_tokens_by_corresponding_internal_token.insert(symbol.index, i);
+        if let Some(SymbolView::Terminal(index)) = external_token
+            .corresponding_internal_token
+            .map(Symbol::view)
+        {
+            external_tokens_by_corresponding_internal_token.insert(index, i);
         }
     }
 
@@ -319,13 +331,17 @@ fn populate_external_lex_states(parse_table: &mut ParseTable, syntax_grammar: &S
     for i in 0..parse_table.states.len() {
         let mut external_tokens = TokenSet::new();
         for token in parse_table.states[i].terminal_entries.keys() {
-            if token.is_external() {
-                external_tokens.insert(*token);
-            } else if token.is_terminal()
-                && let Some(index) =
-                    external_tokens_by_corresponding_internal_token.get(&token.index)
-            {
-                external_tokens.insert(Symbol::external(*index));
+            match token.view() {
+                SymbolView::External(_) => external_tokens.insert(*token),
+                SymbolView::Terminal(token_index) => {
+                    if let Some(index) =
+                        external_tokens_by_corresponding_internal_token.get(&token_index)
+                    {
+                        external_tokens.insert(Symbol::external(*index));
+                    }
+                }
+                SymbolView::End | SymbolView::EndOfNonTerminalExtra => {}
+                SymbolView::NonTerminal(_) => unreachable!(),
             }
         }
 
@@ -351,7 +367,13 @@ fn identify_keywords(
         return TokenSet::new();
     }
 
-    let word_token = word_token.unwrap();
+    let word_token_index = match word_token.unwrap().view() {
+        SymbolView::External(index) => usize::from(index),
+        SymbolView::Terminal(index) => usize::from(index),
+        SymbolView::End | SymbolView::EndOfNonTerminalExtra | SymbolView::NonTerminal(_) => {
+            unreachable!()
+        }
+    };
     let mut cursor = NfaCursor::new(&lexical_grammar.nfa, Vec::new());
 
     // First find all of the candidate keyword tokens: tokens that start with
@@ -363,8 +385,8 @@ fn identify_keywords(
         .filter_map(|(i, variable)| {
             cursor.reset(vec![variable.start_state]);
             if all_chars_are_alphabetical(&cursor)
-                && token_conflict_map.does_match_same_string(i, word_token.index as usize)
-                && !token_conflict_map.does_match_different_string(i, word_token.index as usize)
+                && token_conflict_map.does_match_same_string(i, word_token_index)
+                && !token_conflict_map.does_match_different_string(i, word_token_index)
             {
                 debug!(
                     "Keywords - add candidate {}",
@@ -379,32 +401,33 @@ fn identify_keywords(
 
     // Exclude keyword candidates that shadow another keyword candidate.
     let keywords = keyword_candidates
-        .iter()
-        .filter(|token| {
-            for other_token in keyword_candidates.iter() {
-                if other_token != *token
+        .terminals()
+        .filter(|&token| {
+            for other in keyword_candidates.terminals() {
+                if other != token
                     && token_conflict_map
-                        .does_match_same_string(other_token.index as usize, token.index as usize)
+                        .does_match_same_string(usize::from(other), usize::from(token))
                 {
                     debug!(
                         "Keywords - exclude {} because it matches the same string as {}",
-                        str_pool.resolve(lexical_grammar.variables[token.index as usize].name),
-                        str_pool
-                            .resolve(lexical_grammar.variables[other_token.index as usize].name)
+                        str_pool.resolve(lexical_grammar.variables[usize::from(token)].name),
+                        str_pool.resolve(lexical_grammar.variables[usize::from(other)].name)
                     );
                     return false;
                 }
             }
             true
         })
+        .map(Symbol::from)
         .collect::<TokenSet>();
 
     // Exclude keyword candidates for which substituting the keyword capture
     // token would introduce new lexical conflicts with other tokens.
 
     keywords
-        .iter()
-        .filter(|token| {
+        .terminals()
+        .filter(|&token| {
+            let token_index = usize::from(token);
             for other_index in 0..lexical_grammar.variables.len() {
                 if keyword_candidates.contains(Symbol::terminal(other_index)) {
                     continue;
@@ -414,19 +437,19 @@ fn identify_keywords(
                 // this keyword candidate, then substituting the word token won't
                 // introduce any new lexical conflicts.
                 if coincident_token_index
-                    .all_coincident_states_have_word(*token, Symbol::terminal(other_index))
+                    .all_coincident_states_have_word(token, TerminalIndex::new(other_index as u32))
                 {
                     continue;
                 }
 
                 if !token_conflict_map.has_same_conflict_status(
-                    token.index as usize,
-                    word_token.index as usize,
+                    token_index,
+                    word_token_index,
                     other_index,
                 ) {
                     debug!(
                         "Keywords - exclude {} because of conflict with {}",
-                        str_pool.resolve(lexical_grammar.variables[token.index as usize].name),
+                        str_pool.resolve(lexical_grammar.variables[token_index].name),
                         str_pool.resolve(lexical_grammar.variables[other_index].name)
                     );
                     return false;
@@ -435,10 +458,11 @@ fn identify_keywords(
 
             debug!(
                 "Keywords - include {}",
-                str_pool.resolve(lexical_grammar.variables[token.index as usize].name),
+                str_pool.resolve(lexical_grammar.variables[token_index].name),
             );
             true
         })
+        .map(Symbol::from)
         .collect()
 }
 
@@ -447,14 +471,14 @@ fn mark_fragile_tokens(parse_table: &mut ParseTable, token_conflict_map: &TokenC
     for state in &mut parse_table.states {
         valid_terminal_indices.clear();
         for token in state.terminal_entries.keys() {
-            if token.is_terminal() {
-                valid_terminal_indices.push(token.index);
+            if let SymbolView::Terminal(index) = token.view() {
+                valid_terminal_indices.push(index);
             }
         }
         for (token, id) in &mut state.terminal_entries {
-            if token.is_terminal() {
+            if let SymbolView::Terminal(index) = token.view() {
                 for &i in &valid_terminal_indices {
-                    if token_conflict_map.does_overlap(i as usize, token.index as usize) {
+                    if token_conflict_map.does_overlap(usize::from(i), usize::from(index)) {
                         id.set_reusable(false);
                         break;
                     }
@@ -474,7 +498,7 @@ fn report_state_info<'a>(
 ) {
     let mut all_state_indices = BTreeSet::new();
     let mut symbols_with_state_indices = (0..syntax_grammar.variables.len())
-        .map(|i| (Symbol::non_terminal(i), BTreeSet::new()))
+        .map(|i| (i, BTreeSet::new()))
         .collect::<Vec<_>>();
 
     for (i, state) in parse_table.states.iter().enumerate() {
@@ -497,10 +521,10 @@ fn report_state_info<'a>(
         .map(|v| str_pool.resolve(v.name).len())
         .max()
         .unwrap();
-    for (symbol, states) in &symbols_with_state_indices {
+    for (index, states) in &symbols_with_state_indices {
         info!(
             "{:width$}\t{}",
-            str_pool.resolve(syntax_grammar.variables[symbol.index as usize].name),
+            str_pool.resolve(syntax_grammar.variables[*index].name),
             states.len(),
             width = max_symbol_name_length
         );
@@ -512,10 +536,8 @@ fn report_state_info<'a>(
     } else {
         symbols_with_state_indices
             .iter()
-            .find_map(|(symbol, state_indices)| {
-                if str_pool.resolve(syntax_grammar.variables[symbol.index as usize].name)
-                    == report_symbol_name
-                {
+            .find_map(|(index, state_indices)| {
+                if str_pool.resolve(syntax_grammar.variables[*index].name) == report_symbol_name {
                     Some(state_indices)
                 } else {
                     None
@@ -537,15 +559,15 @@ fn report_state_info<'a>(
                 "symbol sequence: {}",
                 preceding_symbols
                     .iter()
-                    .map(|symbol| {
-                        if symbol.is_terminal() {
-                            str_pool.resolve(lexical_grammar.variables[symbol.index as usize].name)
-                        } else if symbol.is_external() {
-                            str_pool
-                                .resolve(syntax_grammar.external_tokens[symbol.index as usize].name)
-                        } else {
-                            str_pool.resolve(syntax_grammar.variables[symbol.index as usize].name)
-                        }
+                    .map(|symbol| match symbol.view() {
+                        SymbolView::Terminal(index) =>
+                            str_pool.resolve(lexical_grammar.variables[usize::from(index)].name,),
+                        SymbolView::External(index) => str_pool
+                            .resolve(syntax_grammar.external_tokens[usize::from(index)].name,),
+                        SymbolView::NonTerminal(index) =>
+                            str_pool.resolve(syntax_grammar.variables[usize::from(index)].name,),
+                        SymbolView::End => "<EOF>",
+                        SymbolView::EndOfNonTerminalExtra => "<END_OF_NONTERMINAL_EXTRA>",
                     })
                     .collect::<Vec<_>>()
                     .join(" ")

--- a/crates/generate/src/build_tables/build_lex_table.rs
+++ b/crates/generate/src/build_tables/build_lex_table.rs
@@ -12,7 +12,7 @@ use crate::{
     dedup::split_state_id_groups,
     grammars::{LexicalGrammar, SyntaxGrammar},
     nfa::{CharacterSet, NfaCursor},
-    rules::{Symbol, TokenSet},
+    rules::{Symbol, SymbolView, TokenSet},
     strpool::StrPool,
     tables::{AdvanceAction, LexState, LexStateId, LexTable, ParseStateId, ParseTable},
 };
@@ -49,18 +49,18 @@ pub fn build_lex_table(
             .keys()
             .copied()
             .chain(state.reserved_words.iter())
-            .filter_map(|token| {
-                if token.is_terminal() {
+            .filter_map(|token| match token.view() {
+                SymbolView::Terminal(_) => {
                     if keywords.contains(token) {
                         syntax_grammar.word_token
                     } else {
                         Some(token)
                     }
-                } else if token.is_eof() {
-                    Some(token)
-                } else {
-                    None
                 }
+                SymbolView::End => Some(token),
+                SymbolView::External(_)
+                | SymbolView::EndOfNonTerminalExtra
+                | SymbolView::NonTerminal(_) => None,
             })
             .collect();
 
@@ -167,12 +167,18 @@ impl<'a> LexTableBuilder<'a> {
         let mut eof_valid = false;
         let nfa_states = tokens
             .iter()
-            .filter_map(|token| {
-                if token.is_terminal() {
-                    Some(self.lexical_grammar.variables[token.index as usize].start_state)
-                } else {
+            .filter_map(|token| match token.view() {
+                SymbolView::Terminal(index) => {
+                    Some(self.lexical_grammar.variables[usize::from(index)].start_state)
+                }
+                SymbolView::End => {
                     eof_valid = true;
                     None
+                }
+                SymbolView::External(_)
+                | SymbolView::EndOfNonTerminalExtra
+                | SymbolView::NonTerminal(_) => {
+                    unreachable!()
                 }
             })
             .collect();
@@ -183,13 +189,13 @@ impl<'a> LexTableBuilder<'a> {
                 "entry point state: {state_id}, tokens: {:?}",
                 tokens
                     .iter()
-                    .map(|t| {
-                        if t.is_eof() {
-                            "<EOF>"
-                        } else {
-                            debug_assert!(t.is_terminal());
-                            str_pool.resolve(self.lexical_grammar.variables[t.index as usize].name)
-                        }
+                    .map(|t| match t.view() {
+                        SymbolView::Terminal(index) => str_pool
+                            .resolve(self.lexical_grammar.variables[usize::from(index)].name),
+                        SymbolView::End => "<EOF>",
+                        SymbolView::External(_)
+                        | SymbolView::EndOfNonTerminalExtra
+                        | SymbolView::NonTerminal(_) => unreachable!(),
                     })
                     .collect::<Vec<_>>()
             );
@@ -285,7 +291,7 @@ impl<'a> LexTableBuilder<'a> {
             self.table.states[state_id as usize].accept_action =
                 Some(Symbol::terminal(complete_id));
         } else if self.cursor.state_ids.is_empty() {
-            self.table.states[state_id as usize].accept_action = Some(Symbol::end());
+            self.table.states[state_id as usize].accept_action = Some(Symbol::End);
         }
     }
 }
@@ -328,14 +334,10 @@ fn merge_token_set(
 ) -> bool {
     if tokens
         .terminals()
-        .filter(|terminal| !other.contains_terminal(terminal.index as usize))
-        .any(|terminal| {
-            check_token_conflicts(
-                terminal.index as usize,
-                other,
-                token_conflict_map,
-                coincident_token_index,
-            )
+        .map(usize::from)
+        .filter(|&index| !other.contains_terminal(index))
+        .any(|index| {
+            check_token_conflicts(index, other, token_conflict_map, coincident_token_index)
         })
     {
         return false;
@@ -343,14 +345,10 @@ fn merge_token_set(
 
     if other
         .terminals()
-        .filter(|terminal| !tokens.contains_terminal(terminal.index as usize))
-        .any(|terminal| {
-            check_token_conflicts(
-                terminal.index as usize,
-                tokens,
-                token_conflict_map,
-                coincident_token_index,
-            )
+        .map(usize::from)
+        .filter(|&index| !tokens.contains_terminal(index))
+        .any(|index| {
+            check_token_conflicts(index, tokens, token_conflict_map, coincident_token_index)
         })
     {
         return false;

--- a/crates/generate/src/build_tables/build_lex_table.rs
+++ b/crates/generate/src/build_tables/build_lex_table.rs
@@ -13,6 +13,7 @@ use crate::{
     grammars::{LexicalGrammar, SyntaxGrammar},
     nfa::{CharacterSet, NfaCursor},
     rules::{Symbol, TokenSet},
+    strpool::StrPool,
     tables::{AdvanceAction, LexState, LexStateId, LexTable, ParseStateId, ParseTable},
 };
 
@@ -31,10 +32,11 @@ pub fn build_lex_table(
     keywords: &TokenSet,
     coincident_token_index: &CoincidentTokenIndex,
     token_conflict_map: &TokenConflictMap,
+    str_pool: &StrPool,
 ) -> LexTables {
     let keyword_lex_table = if syntax_grammar.word_token.is_some() {
         let mut builder = LexTableBuilder::new(lexical_grammar);
-        builder.add_state_for_tokens(keywords);
+        builder.add_state_for_tokens(keywords, str_pool);
         builder.table
     } else {
         LexTable::default()
@@ -83,7 +85,7 @@ pub fn build_lex_table(
 
     let mut builder = LexTableBuilder::new(lexical_grammar);
     for (tokens, parse_state_ids) in parse_state_ids_by_token_set {
-        let lex_state_id = builder.add_state_for_tokens(&tokens);
+        let lex_state_id = builder.add_state_for_tokens(&tokens, str_pool);
         for id in parse_state_ids {
             parse_table.states[id as usize].lex_state_id = lex_state_id;
         }
@@ -97,7 +99,7 @@ pub fn build_lex_table(
     for (variable_ix, _variable) in lexical_grammar.variables.iter().enumerate() {
         let symbol = Symbol::terminal(variable_ix);
         builder.reset();
-        builder.add_state_for_tokens(&TokenSet::from_iter([symbol]));
+        builder.add_state_for_tokens(&TokenSet::from_iter([symbol]), str_pool);
         for state in &builder.table.states {
             let mut characters = CharacterSet::empty();
             for (chars, action) in &state.advance_actions {
@@ -161,7 +163,7 @@ impl<'a> LexTableBuilder<'a> {
         self.state_ids_by_nfa_state_set.clear();
     }
 
-    fn add_state_for_tokens(&mut self, tokens: &TokenSet) -> LexStateId {
+    fn add_state_for_tokens(&mut self, tokens: &TokenSet, str_pool: &StrPool) -> LexStateId {
         let mut eof_valid = false;
         let nfa_states = tokens
             .iter()
@@ -181,7 +183,14 @@ impl<'a> LexTableBuilder<'a> {
                 "entry point state: {state_id}, tokens: {:?}",
                 tokens
                     .iter()
-                    .map(|t| &self.lexical_grammar.variables[t.index as usize].name)
+                    .map(|t| {
+                        if t.is_eof() {
+                            "<EOF>"
+                        } else {
+                            debug_assert!(t.is_terminal());
+                            str_pool.resolve(self.lexical_grammar.variables[t.index as usize].name)
+                        }
+                    })
                     .collect::<Vec<_>>()
             );
         }

--- a/crates/generate/src/build_tables/build_parse_table.rs
+++ b/crates/generate/src/build_tables/build_parse_table.rs
@@ -18,7 +18,7 @@ use crate::{
     build_tables::item::{LookaheadSetPool, START_PRODUCTION_ID, prec_display},
     grammars::{LexicalGrammar, PrecedenceEntry, ReservedWordSetId, SyntaxGrammar, VariableType},
     node_types::VariableInfo,
-    rules::{Associativity, Precedence, Symbol, SymbolType, TokenSet},
+    rules::{Associativity, NonTerminalIndex, Precedence, Symbol, SymbolView, TokenSet},
     strpool::StrPool,
     tables::{
         ActionList, ActionListPool, FieldLocation, GotoAction, ParseAction, ParseState,
@@ -305,7 +305,7 @@ impl<'a> ParseTableBuilder<'a> {
         self.add_parse_state(&Vec::new(), &Vec::new(), ParseItemSet::default());
 
         // Add the starting state at index 1.
-        let end_lookaheads = self.item_set_builder.lookaheads.singleton(Symbol::end());
+        let end_lookaheads = self.item_set_builder.lookaheads.singleton(Symbol::End);
         self.add_parse_state(
             &Vec::new(),
             &Vec::new(),
@@ -319,23 +319,25 @@ impl<'a> ParseTableBuilder<'a> {
         );
 
         // Compute the possible item sets for non-terminal extras.
-        let mut non_terminal_extra_item_sets_by_first_terminal = BTreeMap::new();
+        let mut non_terminal_extra_item_sets_by_first_terminal =
+            BTreeMap::<Symbol, ParseItemSet<'a>>::new();
         for extra_non_terminal in self
             .syntax_grammar
             .extra_symbols
             .iter()
-            .filter(|s| s.is_non_terminal())
+            .filter_map(|s| s.non_terminal_index())
         {
+            let extra_index = extra_non_terminal;
             for prod_id in self
                 .syntax_grammar
-                .variable_prod_ids(extra_non_terminal.index as usize)
+                .variable_prod_ids(usize::from(extra_index))
             {
                 let production = self.syntax_grammar.production(prod_id);
                 let entry = non_terminal_extra_item_sets_by_first_terminal
                     .entry(production.first_symbol().unwrap())
-                    .or_insert_with(ParseItemSet::default)
+                    .or_default()
                     .insert(ParseItem {
-                        variable_index: extra_non_terminal.index,
+                        variable_index: extra_index.into(),
                         prod_id,
                         step_index: 1,
                         keys: self.item_set_builder.key_map.keys_for(prod_id),
@@ -344,7 +346,7 @@ impl<'a> ParseTableBuilder<'a> {
                 entry.lookaheads = self
                     .item_set_builder
                     .lookaheads
-                    .insert(entry.lookaheads, Symbol::end_of_nonterminal_extra());
+                    .insert(entry.lookaheads, Symbol::EndOfNonTerminalExtra);
             }
         }
 
@@ -355,8 +357,9 @@ impl<'a> ParseTableBuilder<'a> {
         self.parse_table.states.reserve(non_terminal_sets_len);
         self.parse_state_queue.reserve(non_terminal_sets_len);
         // Add a state for each starting terminal of a non-terminal extra rule.
-        for (terminal, item_set) in non_terminal_extra_item_sets_by_first_terminal {
-            if terminal.is_non_terminal() {
+        for (terminal_key, item_set) in non_terminal_extra_item_sets_by_first_terminal {
+            let terminal = terminal_key;
+            if terminal.non_terminal_index().is_some() {
                 Err(ParseTableBuilderError::ImproperNonTerminalExtra(
                     self.symbol_name(terminal),
                 ))?;
@@ -455,14 +458,14 @@ impl<'a> ParseTableBuilder<'a> {
         state_id: ParseStateId,
         item_set: &ParseItemSet<'a>,
     ) -> BuildTableResult<()> {
-        let mut terminal_successors = BTreeMap::new();
-        let mut non_terminal_successors = BTreeMap::new();
+        let mut terminal_successors = BTreeMap::<Symbol, ParseItemSet<'a>>::new();
+        let mut non_terminal_successors = BTreeMap::<NonTerminalIndex, ParseItemSet<'a>>::new();
         let mut lookaheads_with_conflicts = TokenSet::new();
         let mut reduction_infos = FxHashMap::<Symbol, ReductionInfo>::default();
 
         // `get_auxiliary_node_info` scans every entry in `item_set`, and the same auxiliary
         // symbol typically appears across many entries in a state. Memoize per symbol.
-        let mut aux_node_info = FxHashMap::<Symbol, AuxiliarySymbolInfo>::default();
+        let mut aux_node_info = FxHashMap::<NonTerminalIndex, AuxiliarySymbolInfo>::default();
 
         // Each item in the item set contributes to either or a Shift action or a Reduce
         // action in this state.
@@ -477,48 +480,44 @@ impl<'a> ParseTableBuilder<'a> {
             // item into the successor item set.
             if let Some(next_symbol) = item.symbol(self.syntax_grammar) {
                 let mut successor = item.successor();
-                let successor_set = if next_symbol.is_non_terminal() {
-                    let variable = &self.syntax_grammar.variables[next_symbol.index as usize];
+                let successor_set =
+                    if let Some(non_terminal_index) = next_symbol.non_terminal_index() {
+                        let index = usize::from(non_terminal_index);
+                        let variable = &self.syntax_grammar.variables[index];
 
-                    // Keep track of where auxiliary non-terminals (repeat symbols) are
-                    // used within visible symbols. This information may be needed later
-                    // for conflict resolution.
-                    if variable.is_auxiliary() {
-                        preceding_auxiliary_symbols.push(
-                            aux_node_info
-                                .entry(next_symbol)
-                                .or_insert_with(|| {
-                                    self.get_auxiliary_node_info(item_set, next_symbol)
-                                })
-                                .clone(),
-                        );
-                    }
+                        // Keep track of where auxiliary non-terminals (repeat symbols) are
+                        // used within visible symbols. This information may be needed later
+                        // for conflict resolution.
+                        if variable.is_auxiliary() {
+                            preceding_auxiliary_symbols.push(
+                                aux_node_info
+                                    .entry(non_terminal_index)
+                                    .or_insert_with(|| {
+                                        self.get_auxiliary_node_info(item_set, next_symbol)
+                                    })
+                                    .clone(),
+                            );
+                        }
 
-                    // For most parse items, the symbols associated with the preceding children
-                    // don't matter: they have no effect on the REDUCE action that would be
-                    // performed at the end of the item. But the symbols *do* matter for
-                    // children that are hidden and have fields, because those fields are
-                    // "inherited" by the parent node.
-                    //
-                    // If this item has consumed a hidden child with fields, then the symbols
-                    // of its preceding children need to be taken into account when comparing
-                    // it with other items.
-                    if variable.is_hidden()
-                        && !self.variable_info[next_symbol.index as usize]
-                            .fields
-                            .is_empty()
-                    {
-                        successor.has_preceding_inherited_fields = true;
-                    }
+                        // For most parse items, the symbols associated with the preceding children
+                        // don't matter: they have no effect on the REDUCE action that would be
+                        // performed at the end of the item. But the symbols *do* matter for
+                        // children that are hidden and have fields, because those fields are
+                        // "inherited" by the parent node.
+                        //
+                        // If this item has consumed a hidden child with fields, then the symbols
+                        // of its preceding children need to be taken into account when comparing
+                        // it with other items.
+                        if variable.is_hidden() && !self.variable_info[index].fields.is_empty() {
+                            successor.has_preceding_inherited_fields = true;
+                        }
 
-                    non_terminal_successors
-                        .entry(next_symbol)
-                        .or_insert_with(ParseItemSet::default)
-                } else {
-                    terminal_successors
-                        .entry(next_symbol)
-                        .or_insert_with(ParseItemSet::default)
-                };
+                        non_terminal_successors
+                            .entry(non_terminal_index)
+                            .or_default()
+                    } else {
+                        terminal_successors.entry(next_symbol).or_default()
+                    };
                 let successor_entry = successor_set.insert(successor);
                 successor_entry.lookaheads = self
                     .item_set_builder
@@ -561,7 +560,7 @@ impl<'a> ParseTableBuilder<'a> {
                 }
                 for lookahead in self.item_set_builder.lookaheads.get(*lookaheads).iter() {
                     if item.production(self.syntax_grammar).requires_eof_lookahead
-                        && lookahead != Symbol::end()
+                        && lookahead != Symbol::End
                     {
                         continue;
                     }
@@ -622,7 +621,8 @@ impl<'a> ParseTableBuilder<'a> {
         // Having computed the successor item sets for each symbol, add a new
         // parse state for each of these item sets, and add a corresponding Shift
         // action to this state.
-        for (symbol, next_item_set) in terminal_successors {
+        for (symbol_key, next_item_set) in terminal_successors {
+            let symbol = symbol_key;
             preceding_symbols.push(symbol);
             let next_state_id = self.add_parse_state(
                 &preceding_symbols,
@@ -649,7 +649,8 @@ impl<'a> ParseTableBuilder<'a> {
                 });
         }
 
-        for (symbol, next_item_set) in non_terminal_successors {
+        for (index, next_item_set) in non_terminal_successors {
+            let symbol = Symbol::from(index);
             preceding_symbols.push(symbol);
             let next_state_id = self.add_parse_state(
                 &preceding_symbols,
@@ -731,18 +732,22 @@ impl<'a> ParseTableBuilder<'a> {
             // are added to every state except for those at the ends of non-terminal
             // extras.
             for extra_token in &self.syntax_grammar.extra_symbols {
-                if extra_token.is_non_terminal() {
-                    state
-                        .nonterminal_entries
-                        .insert(*extra_token, GotoAction::ShiftExtra);
-                } else {
-                    state
-                        .terminal_entries
-                        .entry(*extra_token)
-                        .or_insert(ParseTableEntry {
-                            reusable: true,
-                            actions: ActionList::One(ParseAction::ShiftExtra),
-                        });
+                match extra_token.view() {
+                    SymbolView::NonTerminal(_) => {
+                        state
+                            .nonterminal_entries
+                            .insert(*extra_token, GotoAction::ShiftExtra);
+                    }
+                    SymbolView::Terminal(_) | SymbolView::External(_) => {
+                        state
+                            .terminal_entries
+                            .entry(*extra_token)
+                            .or_insert(ParseTableEntry {
+                                reusable: true,
+                                actions: ActionList::One(ParseAction::ShiftExtra),
+                            });
+                    }
+                    SymbolView::End | SymbolView::EndOfNonTerminalExtra => unreachable!(),
                 }
             }
         }
@@ -936,7 +941,7 @@ impl<'a> ParseTableBuilder<'a> {
         let mut actual_conflict = Vec::new();
         for item in &conflicting_items {
             let symbol = Symbol::non_terminal(item.variable_index as usize);
-            if self.syntax_grammar.variables[symbol.index as usize].is_auxiliary() {
+            if self.syntax_grammar.variables[item.variable_index as usize].is_auxiliary() {
                 actual_conflict.extend(
                     preceding_auxiliary_symbols
                         .iter()
@@ -1108,9 +1113,12 @@ impl<'a> ParseTableBuilder<'a> {
                             false
                         }
                     }
-                    PrecedenceEntry::Symbol(n) => symbols
-                        .iter()
-                        .any(|s| &grammar.variables[s.index as usize].name == n),
+                    PrecedenceEntry::Symbol(n) => symbols.iter().any(|s| match s.view() {
+                        SymbolView::NonTerminal(index) => {
+                            &grammar.variables[usize::from(index)].name == n
+                        }
+                        _ => false,
+                    }),
                 }
             };
 
@@ -1202,12 +1210,12 @@ impl<'a> ParseTableBuilder<'a> {
                     });
             }
 
-            if step.symbol().kind == SymbolType::NonTerminal
-                && !self.syntax_grammar.variables[step.symbol().index as usize]
+            if let Some(index) = step.non_terminal_index()
+                && !self.syntax_grammar.variables[usize::from(index)]
                     .kind
                     .is_visible()
             {
-                let info = &self.variable_info[step.symbol().index as usize];
+                let info = &self.variable_info[usize::from(index)];
                 for &field_name in info.fields.keys() {
                     production_info
                         .field_map
@@ -1248,18 +1256,18 @@ impl<'a> ParseTableBuilder<'a> {
     }
 
     fn symbol_name(&self, symbol: Symbol) -> String {
-        match symbol.kind {
-            SymbolType::End | SymbolType::EndOfNonTerminalExtra => "EOF".to_string(),
-            SymbolType::External => self
+        match symbol.view() {
+            SymbolView::End | SymbolView::EndOfNonTerminalExtra => "EOF".to_string(),
+            SymbolView::External(index) => self
                 .str_pool
-                .resolve(self.syntax_grammar.external_tokens[symbol.index as usize].name)
+                .resolve(self.syntax_grammar.external_tokens[usize::from(index)].name)
                 .to_string(),
-            SymbolType::NonTerminal => self
+            SymbolView::NonTerminal(index) => self
                 .str_pool
-                .resolve(self.syntax_grammar.variables[symbol.index as usize].name)
+                .resolve(self.syntax_grammar.variables[usize::from(index)].name)
                 .to_string(),
-            SymbolType::Terminal => {
-                let variable = &self.lexical_grammar.variables[symbol.index as usize];
+            SymbolView::Terminal(index) => {
+                let variable = &self.lexical_grammar.variables[usize::from(index)];
                 if variable.kind == VariableType::Named {
                     self.str_pool.resolve(variable.name).to_string()
                 } else {

--- a/crates/generate/src/build_tables/coincident_tokens.rs
+++ b/crates/generate/src/build_tables/coincident_tokens.rs
@@ -1,4 +1,9 @@
-use crate::{grammars::LexicalGrammar, rules::Symbol, strpool::StrPool, tables::ParseTable};
+use crate::{
+    grammars::LexicalGrammar,
+    rules::{Symbol, SymbolView, TerminalIndex},
+    strpool::StrPool,
+    tables::ParseTable,
+};
 
 pub struct CoincidentTokenIndex {
     /// Flat bitset for fast [`contains()`](Self::contains) checks. Indexed as `a * n + b`
@@ -40,8 +45,10 @@ impl<'a> CoincidentTokenIndex {
                 state
                     .terminal_entries
                     .keys()
-                    .filter(|s| s.is_terminal())
-                    .map(|s| s.index),
+                    .filter_map(|s| match s.view() {
+                        SymbolView::Terminal(index) => Some(u32::from(index)),
+                        _ => None,
+                    }),
             );
             let has_word = word_token.is_some_and(|w| state.terminal_entries.contains_key(&w));
             for (i, &a) in terminal_indices.iter().enumerate() {
@@ -67,14 +74,14 @@ impl<'a> CoincidentTokenIndex {
     }
 
     #[must_use]
-    pub fn all_coincident_states_have_word(&self, a: Symbol, b: Symbol) -> bool {
-        let bit_index = a.index as usize * self.n + b.index as usize;
+    pub fn all_coincident_states_have_word(&self, a: TerminalIndex, b: TerminalIndex) -> bool {
+        let bit_index = usize::from(a) * self.n + usize::from(b);
         self.without_word_bits[bit_index / 64] & (1u64 << (bit_index % 64)) == 0
     }
 
     #[must_use]
-    pub fn contains(&self, a: Symbol, b: Symbol) -> bool {
-        let bit_index = a.index as usize * self.n + b.index as usize;
+    pub fn contains(&self, a: TerminalIndex, b: TerminalIndex) -> bool {
+        let bit_index = usize::from(a) * self.n + usize::from(b);
         self.contains_bits[bit_index / 64] & (1u64 << (bit_index % 64)) != 0
     }
 }
@@ -88,7 +95,10 @@ impl std::fmt::Debug for CoincidentTokenIndexDisplay<'_> {
         for i in 0..self.0.n {
             let mut coincident = Vec::new();
             for j in 0..self.0.n {
-                if self.0.contains(Symbol::terminal(i), Symbol::terminal(j)) {
+                if self
+                    .0
+                    .contains(TerminalIndex::new(i as u32), TerminalIndex::new(j as u32))
+                {
                     coincident.push(self.2.resolve(self.1.variables[j].name));
                 }
             }

--- a/crates/generate/src/build_tables/item.rs
+++ b/crates/generate/src/build_tables/item.rs
@@ -653,29 +653,33 @@ impl fmt::Display for TokenSetDisplay<'_> {
                 write!(f, ", ")?;
             }
 
-            if symbol.is_terminal() {
-                if let Some(variable) = self.2.variables.get(symbol.index as usize) {
-                    write!(
-                        f,
-                        "{}",
-                        display_variable_name(self.3.resolve(variable.name))
-                    )?;
-                } else {
-                    write!(f, "terminal-{}", symbol.index)?;
+            match symbol.kind {
+                SymbolType::Terminal => {
+                    if let Some(variable) = self.2.variables.get(symbol.index as usize) {
+                        write!(
+                            f,
+                            "{}",
+                            display_variable_name(self.3.resolve(variable.name))
+                        )?;
+                    } else {
+                        write!(f, "terminal-{}", symbol.index)?;
+                    }
                 }
-            } else if symbol.is_external() {
-                write!(
+                SymbolType::External => write!(
                     f,
                     "{}",
                     self.3
                         .resolve(self.1.external_tokens[symbol.index as usize].name)
-                )?;
-            } else {
-                write!(
+                )?,
+                SymbolType::NonTerminal => write!(
                     f,
                     "{}",
                     self.3.resolve(self.1.variables[symbol.index as usize].name)
-                )?;
+                )?,
+                SymbolType::End => write!(f, "<EOF>")?,
+                SymbolType::EndOfNonTerminalExtra => {
+                    write!(f, "<END_OF_NONTERMINAL_EXTRA>")?;
+                }
             }
         }
         write!(f, "]")?;

--- a/crates/generate/src/build_tables/item.rs
+++ b/crates/generate/src/build_tables/item.rs
@@ -9,7 +9,7 @@ use rustc_hash::{FxHashMap, FxHasher};
 
 use crate::{
     grammars::{LexicalGrammar, ProdRef, ProductionStep, ReservedWordSetId, SyntaxGrammar},
-    rules::{Associativity, Precedence, Symbol, SymbolType, TokenSet},
+    rules::{Associativity, Precedence, Symbol, SymbolType, SymbolView, TokenSet},
     strpool::StrPool,
 };
 
@@ -570,25 +570,32 @@ impl fmt::Display for ParseItemDisplay<'_> {
             }
 
             write!(f, " ")?;
-            if symbol.is_terminal() {
-                if let Some(variable) = self.2.variables.get(symbol.index as usize) {
-                    write!(f, "{}", self.3.resolve(variable.name))?;
-                } else {
-                    write!(f, "terminal-{}", symbol.index)?;
+            match symbol.view() {
+                SymbolView::Terminal(index) => {
+                    let index = u32::from(index);
+                    if let Some(variable) = self.2.variables.get(index as usize) {
+                        write!(f, "{}", self.3.resolve(variable.name))?;
+                    } else {
+                        write!(f, "terminal-{index}")?;
+                    }
                 }
-            } else if symbol.is_external() {
-                write!(
+                SymbolView::External(index) => write!(
                     f,
                     "{}",
                     self.3
-                        .resolve(self.1.external_tokens[symbol.index as usize].name)
-                )?;
-            } else {
-                write!(
-                    f,
-                    "{}",
-                    self.3.resolve(self.1.variables[symbol.index as usize].name)
-                )?;
+                        .resolve(self.1.external_tokens[usize::from(index)].name)
+                )?,
+                SymbolView::NonTerminal(index) => {
+                    write!(
+                        f,
+                        "{}",
+                        self.3.resolve(self.1.variables[usize::from(index)].name)
+                    )?;
+                }
+                SymbolView::End => write!(f, "<EOF>")?,
+                SymbolView::EndOfNonTerminalExtra => {
+                    write!(f, "<END_OF_NONTERMINAL_EXTRA>")?;
+                }
             }
 
             if let Some(alias) = &step.alias() {
@@ -653,31 +660,32 @@ impl fmt::Display for TokenSetDisplay<'_> {
                 write!(f, ", ")?;
             }
 
-            match symbol.kind {
-                SymbolType::Terminal => {
-                    if let Some(variable) = self.2.variables.get(symbol.index as usize) {
+            match symbol.view() {
+                SymbolView::Terminal(index) => {
+                    let index = u32::from(index);
+                    if let Some(variable) = self.2.variables.get(index as usize) {
                         write!(
                             f,
                             "{}",
                             display_variable_name(self.3.resolve(variable.name))
                         )?;
                     } else {
-                        write!(f, "terminal-{}", symbol.index)?;
+                        write!(f, "terminal-{index}")?;
                     }
                 }
-                SymbolType::External => write!(
+                SymbolView::External(index) => write!(
                     f,
                     "{}",
                     self.3
-                        .resolve(self.1.external_tokens[symbol.index as usize].name)
+                        .resolve(self.1.external_tokens[usize::from(index)].name)
                 )?,
-                SymbolType::NonTerminal => write!(
+                SymbolView::NonTerminal(index) => write!(
                     f,
                     "{}",
-                    self.3.resolve(self.1.variables[symbol.index as usize].name)
+                    self.3.resolve(self.1.variables[usize::from(index)].name)
                 )?,
-                SymbolType::End => write!(f, "<EOF>")?,
-                SymbolType::EndOfNonTerminalExtra => {
+                SymbolView::End => write!(f, "<EOF>")?,
+                SymbolView::EndOfNonTerminalExtra => {
                     write!(f, "<END_OF_NONTERMINAL_EXTRA>")?;
                 }
             }

--- a/crates/generate/src/build_tables/item_set_builder.rs
+++ b/crates/generate/src/build_tables/item_set_builder.rs
@@ -7,8 +7,10 @@ use super::item::{
 };
 use crate::{
     build_tables::item::{LookaheadSetId, LookaheadSetPool},
-    grammars::{InlinedProductionMap, LexicalGrammar, ReservedWordSetId, SyntaxGrammar},
-    rules::{Symbol, SymbolType, TokenSet},
+    grammars::{
+        InlinedProductionMap, LexicalGrammar, ProductionStep, ReservedWordSetId, SyntaxGrammar,
+    },
+    rules::{NonTerminalIndex, Symbol, SymbolView, TokenSet},
     strpool::StrPool,
 };
 
@@ -114,23 +116,30 @@ impl<'a> ParseItemSetBuilder<'a> {
         // Rather than computing these sets using recursion, we use an explicit stack
         // called `symbols_to_process`.
         let mut symbols_to_process = Vec::new();
-        let mut processed_non_terminals = FxHashSet::default();
+        let mut processed_non_terminals = FxHashSet::<NonTerminalIndex>::default();
         for i in 0..syntax_grammar.variables.len() {
+            let root_index = NonTerminalIndex::new(i as u32);
             let symbol = Symbol::non_terminal(i);
             let first_set = result.first_sets.entry(symbol).or_default();
             let reserved_first_set = result.reserved_first_sets.entry(symbol).or_default();
 
             processed_non_terminals.clear();
             symbols_to_process.clear();
-            symbols_to_process.push(symbol);
-            while let Some(sym) = symbols_to_process.pop() {
-                for prod_id in syntax_grammar.variable_prod_ids(sym.index as usize) {
+            symbols_to_process.push(root_index);
+            while let Some(index) = symbols_to_process.pop() {
+                for prod_id in syntax_grammar.variable_prod_ids(usize::from(index)) {
                     if let Some(step) = syntax_grammar.production(prod_id).steps.first() {
                         let symbol = step.symbol();
-                        if symbol.is_terminal() || symbol.is_external() {
-                            first_set.insert(symbol);
-                        } else if processed_non_terminals.insert(symbol) {
-                            symbols_to_process.push(symbol);
+                        match symbol.view() {
+                            SymbolView::Terminal(_) | SymbolView::External(_) => {
+                                first_set.insert(symbol);
+                            }
+                            SymbolView::NonTerminal(index) => {
+                                if processed_non_terminals.insert(index) {
+                                    symbols_to_process.push(index);
+                                }
+                            }
+                            SymbolView::End | SymbolView::EndOfNonTerminalExtra => unreachable!(),
                         }
                         *reserved_first_set =
                             (*reserved_first_set).max(ReservedWordSetId(u32::from(step.reserved)));
@@ -142,15 +151,21 @@ impl<'a> ParseItemSetBuilder<'a> {
             let last_set = result.last_sets.entry(symbol).or_default();
             processed_non_terminals.clear();
             symbols_to_process.clear();
-            symbols_to_process.push(symbol);
-            while let Some(sym) = symbols_to_process.pop() {
-                for prod_id in syntax_grammar.variable_prod_ids(sym.index as usize) {
+            symbols_to_process.push(root_index);
+            while let Some(index) = symbols_to_process.pop() {
+                for prod_id in syntax_grammar.variable_prod_ids(usize::from(index)) {
                     if let Some(step) = syntax_grammar.production(prod_id).steps.last() {
                         let symbol = step.symbol();
-                        if symbol.is_terminal() || symbol.is_external() {
-                            last_set.insert(symbol);
-                        } else if processed_non_terminals.insert(symbol) {
-                            symbols_to_process.push(symbol);
+                        match symbol.view() {
+                            SymbolView::Terminal(_) | SymbolView::External(_) => {
+                                last_set.insert(symbol);
+                            }
+                            SymbolView::NonTerminal(index) => {
+                                if processed_non_terminals.insert(index) {
+                                    symbols_to_process.push(index);
+                                }
+                            }
+                            SymbolView::End | SymbolView::EndOfNonTerminalExtra => unreachable!(),
                         }
                     }
                 }
@@ -194,7 +209,7 @@ impl<'a> ParseItemSetBuilder<'a> {
         // Rather than computing these additions recursively, we use an explicit stack.
         let empty_lookaheads = TokenSet::new();
         let mut eof_lookaheads = TokenSet::new();
-        eof_lookaheads.insert(Symbol::end());
+        eof_lookaheads.insert(Symbol::End);
         let mut stack = Vec::new();
         let mut follow_set_info_by_non_terminal = FxHashMap::<usize, FollowSetInfo>::default();
         for i in 0..syntax_grammar.variables.len() {
@@ -222,26 +237,28 @@ impl<'a> ParseItemSetBuilder<'a> {
 
                 for prod_id in syntax_grammar.variable_prod_ids(sym_ix) {
                     let production = syntax_grammar.production(prod_id);
-                    if let Some(symbol) = production.first_symbol()
-                        && symbol.is_non_terminal()
+                    if let Some(index) = production
+                        .first_symbol()
+                        .and_then(Symbol::non_terminal_index)
                     {
+                        let index = usize::from(index);
                         if let Some(next_step) = production.steps.get(1) {
                             stack.push((
-                                symbol.index as usize,
+                                index,
                                 &result.first_sets[&next_step.symbol()],
                                 result.reserved_first_sets[&next_step.symbol()],
                                 false,
                             ));
                         } else if production.requires_eof_lookahead {
                             stack.push((
-                                symbol.index as usize,
+                                index,
                                 &eof_lookaheads,
                                 ReservedWordSetId::default(),
                                 false,
                             ));
                         } else {
                             stack.push((
-                                symbol.index as usize,
+                                index,
                                 lookaheads,
                                 reserved_word_set_id,
                                 propagates_lookaheads,
@@ -361,23 +378,23 @@ impl<'a> ParseItemSetBuilder<'a> {
     }
 
     fn add_item(&mut self, set: &mut ParseItemSet<'a>, entry: &ParseItemSetEntry<'a>) {
-        if let Some(step) = entry.item.step(self.syntax_grammar)
-            && step.symbol().is_non_terminal()
+        if let Some(index) = entry
+            .item
+            .step(self.syntax_grammar)
+            .and_then(ProductionStep::non_terminal_index)
         {
             let next_step = entry.item.successor().step(self.syntax_grammar);
 
             // Determine which tokens can follow this non-terminal.
             let (following_tokens, following_reserved_tokens) = if let Some(next_step) = next_step {
-                (
-                    self.first_set_ids[&next_step.symbol()],
-                    self.reserved_first_sets[&next_step.symbol()],
-                )
+                let key = next_step.symbol();
+                (self.first_set_ids[&key], self.reserved_first_sets[&key])
             } else {
                 (entry.lookaheads, entry.following_reserved_word_set)
             };
 
             // Use the pre-computed *additions* to expand the non-terminal.
-            for addition in &self.transitive_closure_additions[step.symbol().index as usize] {
+            for addition in &self.transitive_closure_additions[usize::from(index)] {
                 let e = set.insert(addition.item);
                 e.lookaheads = self
                     .lookaheads
@@ -423,17 +440,18 @@ impl fmt::Debug for ParseItemSetBuilderDisplay<'_> {
 
         writeln!(f, "  first_sets: {{")?;
         for (symbol, first_set) in &self.0.first_sets {
-            let symbol_index = symbol.index as usize;
-            let name = match symbol.kind {
-                SymbolType::NonTerminal => self
+            let name = match symbol.view() {
+                SymbolView::NonTerminal(index) => self
                     .2
-                    .resolve(self.0.syntax_grammar.variables[symbol_index].name),
-                SymbolType::External => self
+                    .resolve(self.0.syntax_grammar.variables[usize::from(index)].name),
+                SymbolView::External(index) => self
                     .2
-                    .resolve(self.0.syntax_grammar.external_tokens[symbol_index].name),
-                SymbolType::Terminal => self.2.resolve(self.1.variables[symbol_index].name),
-                SymbolType::End => "<EOF>",
-                SymbolType::EndOfNonTerminalExtra => "<END_OF_NONTERMINAL_EXTRA>",
+                    .resolve(self.0.syntax_grammar.external_tokens[usize::from(index)].name),
+                SymbolView::Terminal(index) => {
+                    self.2.resolve(self.1.variables[usize::from(index)].name)
+                }
+                SymbolView::End => "<EOF>",
+                SymbolView::EndOfNonTerminalExtra => "<END_OF_NONTERMINAL_EXTRA>",
             };
             writeln!(
                 f,
@@ -445,17 +463,18 @@ impl fmt::Debug for ParseItemSetBuilderDisplay<'_> {
 
         writeln!(f, "  last_sets: {{")?;
         for (symbol, last_set) in &self.0.last_sets {
-            let symbol_index = symbol.index as usize;
-            let name = match symbol.kind {
-                SymbolType::NonTerminal => self
+            let name = match symbol.view() {
+                SymbolView::NonTerminal(index) => self
                     .2
-                    .resolve(self.0.syntax_grammar.variables[symbol_index].name),
-                SymbolType::External => self
+                    .resolve(self.0.syntax_grammar.variables[usize::from(index)].name),
+                SymbolView::External(index) => self
                     .2
-                    .resolve(self.0.syntax_grammar.external_tokens[symbol_index].name),
-                SymbolType::Terminal => self.2.resolve(self.1.variables[symbol_index].name),
-                SymbolType::End => "<EOF>",
-                SymbolType::EndOfNonTerminalExtra => "<END_OF_NONTERMINAL_EXTRA>",
+                    .resolve(self.0.syntax_grammar.external_tokens[usize::from(index)].name),
+                SymbolView::Terminal(index) => {
+                    self.2.resolve(self.1.variables[usize::from(index)].name)
+                }
+                SymbolView::End => "<EOF>",
+                SymbolView::EndOfNonTerminalExtra => "<END_OF_NONTERMINAL_EXTRA>",
             };
             writeln!(
                 f,

--- a/crates/generate/src/build_tables/item_set_builder.rs
+++ b/crates/generate/src/build_tables/item_set_builder.rs
@@ -432,7 +432,8 @@ impl fmt::Debug for ParseItemSetBuilderDisplay<'_> {
                     .2
                     .resolve(self.0.syntax_grammar.external_tokens[symbol_index].name),
                 SymbolType::Terminal => self.2.resolve(self.1.variables[symbol_index].name),
-                SymbolType::End | SymbolType::EndOfNonTerminalExtra => "END",
+                SymbolType::End => "<EOF>",
+                SymbolType::EndOfNonTerminalExtra => "<END_OF_NONTERMINAL_EXTRA>",
             };
             writeln!(
                 f,
@@ -453,7 +454,8 @@ impl fmt::Debug for ParseItemSetBuilderDisplay<'_> {
                     .2
                     .resolve(self.0.syntax_grammar.external_tokens[symbol_index].name),
                 SymbolType::Terminal => self.2.resolve(self.1.variables[symbol_index].name),
-                SymbolType::End | SymbolType::EndOfNonTerminalExtra => "END",
+                SymbolType::End => "<EOF>",
+                SymbolType::EndOfNonTerminalExtra => "<END_OF_NONTERMINAL_EXTRA>",
             };
             writeln!(
                 f,

--- a/crates/generate/src/build_tables/minimize_parse_table.rs
+++ b/crates/generate/src/build_tables/minimize_parse_table.rs
@@ -9,7 +9,7 @@ use crate::{
     OptLevel,
     dedup::split_state_id_groups,
     grammars::{LexicalGrammar, SyntaxGrammar, VariableType},
-    rules::{AliasMap, Symbol, SymbolType, TokenSet},
+    rules::{AliasMap, Symbol, SymbolType, SymbolView, TokenSet},
     strpool::StrPool,
     tables::{
         ActionList, ActionListId, GotoAction, ParseAction, ParseState, ParseStateId, ParseTable,
@@ -22,37 +22,29 @@ type NonterminalIndex = u32;
 
 /// A [`Symbol`] packed into a `u64` for O(1) sort-key comparison.
 ///
-/// Layout: high 3 bits = `kind` discriminant (5 variants fit in 3 bits), low 61 bits = `index`.
+/// Layout: high 32 bits = `kind` discriminant, low 32 bits = `index`.
 /// This preserves [`Symbol`]'s derived [`Ord`] ordering (kind first, then index) as a single
 /// integer comparison, and halves each entry's size vs storing a full `(Symbol, _)` tuple.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct SymbolKey(u64);
 
-const KEY_TAG_SHIFT: u32 = 61;
-const KEY_INDEX_MASK: u64 = (1u64 << KEY_TAG_SHIFT) - 1;
+const KEY_TAG_SHIFT: u32 = 32;
+const KEY_INDEX_MASK: u64 = u32::MAX as u64;
 
 impl SymbolKey {
     #[inline]
-    fn new(sym: Symbol) -> Self {
-        debug_assert!(
-            u64::from(sym.index) <= KEY_INDEX_MASK,
-            "symbol index too large"
-        );
-        Self((sym.kind as u64) << KEY_TAG_SHIFT | u64::from(sym.index))
+    const fn new(sym: Symbol) -> Self {
+        Self(sym.packed_key())
     }
 
     #[inline]
     const fn symbol(self) -> Symbol {
-        let kind = match self.0 >> KEY_TAG_SHIFT {
-            0 => SymbolType::External,
-            1 => SymbolType::End,
-            2 => SymbolType::EndOfNonTerminalExtra,
-            3 => SymbolType::Terminal,
-            _ => SymbolType::NonTerminal,
-        };
-        Symbol {
-            kind,
-            index: self.index(),
+        match self.0 >> KEY_TAG_SHIFT {
+            0 => Symbol::external(self.index() as usize),
+            1 => Symbol::End,
+            2 => Symbol::EndOfNonTerminalExtra,
+            3 => Symbol::terminal(self.index() as usize),
+            _ => Symbol::non_terminal(self.index() as usize),
         }
     }
 
@@ -62,15 +54,18 @@ impl SymbolKey {
     }
 
     #[inline]
-    #[expect(dead_code)]
-    const fn is_terminal(self) -> bool {
-        (self.0 >> KEY_TAG_SHIFT) == SymbolType::Terminal as u64
+    const fn tag(self) -> u64 {
+        self.0 >> KEY_TAG_SHIFT
     }
 
     #[inline]
-    #[expect(dead_code)]
-    const fn is_non_terminal(self) -> bool {
-        (self.0 >> KEY_TAG_SHIFT) == SymbolType::NonTerminal as u64
+    const fn is_external(self) -> bool {
+        self.tag() == SymbolType::External as u64
+    }
+
+    #[inline]
+    const fn is_terminal(self) -> bool {
+        self.tag() == SymbolType::Terminal as u64
     }
 }
 
@@ -118,6 +113,8 @@ struct ConflictBits {
     keywords: Vec<u64>,
     /// Tokens that are also external tokens.
     internal_external: Vec<u64>,
+    /// The grammar's word token, packed with the same ordering key as entries.
+    word_token: Option<SymbolKey>,
 }
 
 impl ConflictBits {
@@ -177,8 +174,10 @@ impl Minimizer<'_> {
                             && !self.syntax_grammar.supertype_symbols.contains(symbol)
                             && !self.syntax_grammar.extra_symbols.contains(symbol)
                             && !aliased_symbols.contains(symbol)
-                            && self.syntax_grammar.variables[symbol.index as usize].kind
-                                != VariableType::Named
+                            && matches!(symbol.non_terminal_index(), Some(index)
+                                    if self.syntax_grammar.variables[usize::from(index)].kind
+                                        != VariableType::Named
+                            )
                             && (unit_reduction_symbol.is_none()
                                 || unit_reduction_symbol == Some(symbol)) =>
                         {
@@ -313,8 +312,8 @@ impl Minimizer<'_> {
             let base = s * row_words;
             let row = &mut state_terminals[base..base + row_words];
             for symbol in state.terminal_entries.keys() {
-                if symbol.is_terminal() {
-                    set(row, symbol.index as usize);
+                if let Some(index) = symbol.terminal_index() {
+                    set(row, usize::from(index));
                 }
             }
         }
@@ -332,15 +331,18 @@ impl Minimizer<'_> {
 
         let mut keywords = vec![0u64; row_words];
         for symbol in self.keywords.iter() {
-            if symbol.is_terminal() {
-                set(&mut keywords, symbol.index as usize);
+            if let Some(index) = symbol.terminal_index() {
+                set(&mut keywords, usize::from(index));
             }
         }
 
         let mut internal_external = vec![0u64; row_words];
         for external in &self.syntax_grammar.external_tokens {
-            if let Some(token) = external.corresponding_internal_token {
-                set(&mut internal_external, token.index as usize);
+            if let Some(index) = external
+                .corresponding_internal_token
+                .and_then(Symbol::terminal_index)
+            {
+                set(&mut internal_external, usize::from(index));
             }
         }
 
@@ -350,6 +352,7 @@ impl Minimizer<'_> {
             conflict_rows,
             keywords,
             internal_external,
+            word_token: self.syntax_grammar.word_token.map(SymbolKey::new),
         };
 
         split_state_id_groups(
@@ -395,7 +398,12 @@ impl Minimizer<'_> {
                 let mut entries = state
                     .nonterminal_entries
                     .iter()
-                    .map(|(sym, action)| (sym.index, *action))
+                    .map(|(sym, action)| {
+                        let Some(index) = sym.non_terminal_index() else {
+                            unreachable!();
+                        };
+                        (u32::from(index), *action)
+                    })
                     .collect::<Vec<(NonterminalIndex, GotoAction)>>();
                 entries.sort_unstable_by_key(|&(idx, _)| idx);
                 entries
@@ -492,11 +500,10 @@ impl Minimizer<'_> {
                     // SAFETY: Equal is only reachable when i < len1 && j < len2.
                     let e1 = unsafe { entries1.get_unchecked(i) };
                     let e2 = unsafe { entries2.get_unchecked(j) };
-                    let token = e1.0.symbol();
                     if self.entries_conflict(
                         state1.id,
                         state2.id,
-                        token,
+                        e1.0,
                         e1.1,
                         e2.1,
                         group_ids_by_state_id,
@@ -509,8 +516,7 @@ impl Minimizer<'_> {
                 Ordering::Less => {
                     // SAFETY: Less is only reachable when i < len1.
                     let e1 = unsafe { entries1.get_unchecked(i) };
-                    let token = e1.0.symbol();
-                    if self.token_conflicts(state1.id, state2.id, state2, bits, token) {
+                    if self.token_conflicts(state1.id, state2.id, state2, bits, e1.0) {
                         return true;
                     }
                     i += 1;
@@ -518,8 +524,7 @@ impl Minimizer<'_> {
                 Ordering::Greater => {
                     // SAFETY: Greater is only reachable when j < len2.
                     let e2 = unsafe { entries2.get_unchecked(j) };
-                    let token = e2.0.symbol();
-                    if self.token_conflicts(state1.id, state2.id, state1, bits, token) {
+                    if self.token_conflicts(state1.id, state2.id, state1, bits, e2.0) {
                         return true;
                     }
                     j += 1;
@@ -609,7 +614,7 @@ impl Minimizer<'_> {
         &self,
         state_id1: ParseStateId,
         state_id2: ParseStateId,
-        token: Symbol,
+        token: SymbolKey,
         id1: ActionListId,
         id2: ActionListId,
         group_ids_by_state_id: &[ParseStateId],
@@ -623,7 +628,7 @@ impl Minimizer<'_> {
         if actions1.len() != actions2.len() {
             debug!(
                 "split states {state_id1} {state_id2} - differing action counts for token {}",
-                self.symbol_name(token)
+                self.symbol_name(token.symbol())
             );
             return true;
         }
@@ -648,13 +653,13 @@ impl Minimizer<'_> {
                 }
                 debug!(
                     "split states {state_id1} {state_id2} - successors for {} are split: {s1} {s2}",
-                    self.symbol_name(token),
+                    self.symbol_name(token.symbol()),
                 );
                 return true;
             } else if action1 != action2 {
                 debug!(
                     "split states {state_id1} {state_id2} - unequal actions for {}",
-                    self.symbol_name(token),
+                    self.symbol_name(token.symbol()),
                 );
                 return true;
             }
@@ -670,57 +675,72 @@ impl Minimizer<'_> {
         right_id: ParseStateId,
         right_state: &ParseState,
         bits: &ConflictBits,
-        new_token: Symbol,
+        new_token: SymbolKey,
     ) -> bool {
-        if new_token == Symbol::end_of_nonterminal_extra() {
-            debug!("split states {left_id} {right_id} - end of non-terminal extra");
-            return true;
-        }
+        let new_token_is_terminal = new_token.is_terminal();
+        let new_token_index = match new_token.tag() {
+            tag if tag == SymbolType::EndOfNonTerminalExtra as u64 => {
+                debug!("split states {left_id} {right_id} - end of non-terminal extra");
+                return true;
+            }
+            // Do not add external tokens, as they could conflict lexically with
+            // any of the state's existing lookahead tokens.
+            tag if tag == SymbolType::External as u64 => {
+                debug!(
+                    "split states {left_id} {right_id} - external token {}",
+                    self.symbol_name(new_token.symbol()),
+                );
+                return true;
+            }
+            tag if tag == SymbolType::End as u64 => 0,
+            tag if tag == SymbolType::Terminal as u64 => new_token.index() as usize,
+            _ => unreachable!(),
+        };
 
-        // Do not add external tokens; they could conflict lexically with any of the state's
-        // existing lookahead tokens.
-        if new_token.is_external() {
-            debug!(
-                "split states {left_id} {right_id} - external token {}",
-                self.symbol_name(new_token),
-            );
-            return true;
-        }
-
-        if right_state.reserved_words.contains(new_token) {
+        let is_reserved = if new_token_is_terminal {
+            right_state
+                .reserved_words
+                .contains_terminal(new_token_index)
+        } else {
+            right_state.reserved_words.contains(Symbol::End)
+        };
+        if is_reserved {
             return false;
         }
 
         // Do not add tokens which are both internal and external. Their validity could
         // influence the behavior of the external scanner. `bits.internal_external` is
-        // indexed by terminal index only, so gate on the kind
-        if new_token.is_terminal()
-            && bits.internal_external[new_token.index as usize / 64]
-                & (1 << (new_token.index as usize % 64))
-                != 0
+        // indexed by terminal index only.
+        if new_token_is_terminal
+            && bits.internal_external[new_token_index / 64] & (1 << (new_token_index % 64)) != 0
         {
             debug!(
                 "split states {left_id} {right_id} - internal/external token {}",
-                self.symbol_name(new_token),
+                self.symbol_name(new_token.symbol()),
             );
             return true;
         }
 
-        let word_token = self.syntax_grammar.word_token;
-        let new_token_is_word = word_token == Some(new_token);
-        let new_token_is_keyword = word_token.is_some() && self.keywords.contains(new_token);
+        let new_token_is_word = bits.word_token == Some(new_token);
+        let new_token_is_keyword = bits.word_token.is_some()
+            && if new_token_is_terminal {
+                bits.keywords[new_token_index / 64] & (1 << (new_token_index % 64)) != 0
+            } else {
+                self.keywords.contains(Symbol::End)
+            };
         // Do not add a token if it conflicts with an existing token. Test the candidate's
         // conflict row against the state's terminal bits, masking out the word/keyword
         // exemptions.
-        let row = bits.get_conflict_row(new_token.index as usize);
+        let row = bits.get_conflict_row(new_token_index);
         let right_terminal_bits = bits.get_state_row(right_state.id as usize);
         for (w, &row_word) in row.iter().enumerate() {
             let mut candidates = right_terminal_bits[w] & row_word;
             if new_token_is_keyword
-                && let Some(word) = word_token
-                && word.index as usize / 64 == w
+                && let Some(word) = bits.word_token
+                && (word.is_external() || word.is_terminal())
+                && word.index() as usize / 64 == w
             {
-                candidates &= !(1u64 << (word.index as usize % 64));
+                candidates &= !(1u64 << (word.index() as usize % 64));
             }
             if new_token_is_word {
                 candidates &= !bits.keywords[w];
@@ -730,7 +750,7 @@ impl Minimizer<'_> {
                     "split states {} {} - token {} conflicts with {}",
                     left_id,
                     right_id,
-                    self.symbol_name(new_token),
+                    self.symbol_name(new_token.symbol()),
                     self.symbol_name(Symbol::terminal(
                         w * 64 + candidates.trailing_zeros() as usize
                     )),
@@ -743,16 +763,18 @@ impl Minimizer<'_> {
     }
 
     fn symbol_name(&self, symbol: Symbol) -> &str {
-        let symbol_index = symbol.index as usize;
-        if symbol.is_non_terminal() {
-            self.str_pool
-                .resolve(self.syntax_grammar.variables[symbol_index].name)
-        } else if symbol.is_external() {
-            self.str_pool
-                .resolve(self.syntax_grammar.external_tokens[symbol_index].name)
-        } else {
-            self.str_pool
-                .resolve(self.lexical_grammar.variables[symbol_index].name)
+        match symbol.view() {
+            SymbolView::NonTerminal(index) => self
+                .str_pool
+                .resolve(self.syntax_grammar.variables[usize::from(index)].name),
+            SymbolView::External(index) => self
+                .str_pool
+                .resolve(self.syntax_grammar.external_tokens[usize::from(index)].name),
+            SymbolView::Terminal(index) => self
+                .str_pool
+                .resolve(self.lexical_grammar.variables[usize::from(index)].name),
+            SymbolView::End => "<EOF>",
+            SymbolView::EndOfNonTerminalExtra => "<END_OF_NONTERMINAL_EXTRA>",
         }
     }
 

--- a/crates/generate/src/build_tables/token_conflicts.rs
+++ b/crates/generate/src/build_tables/token_conflicts.rs
@@ -245,7 +245,7 @@ impl std::fmt::Debug for TokenConflictMapDisplay<'_> {
             writeln!(
                 f,
                 "    follow({:?}): {},",
-                self.1.variables[i].name,
+                self.2.resolve(self.1.variables[i].name),
                 TokenSetDisplay(following_tokens, &syntax_grammar, self.1, self.2)
             )?;
         }
@@ -256,7 +256,8 @@ impl std::fmt::Debug for TokenConflictMapDisplay<'_> {
             writeln!(
                 f,
                 "    {:?}: {:?},",
-                self.1.variables[i].name, self.0.starting_chars_by_index[i]
+                self.2.resolve(self.1.variables[i].name),
+                self.0.starting_chars_by_index[i]
             )?;
         }
         writeln!(f, "  }},")?;
@@ -266,19 +267,20 @@ impl std::fmt::Debug for TokenConflictMapDisplay<'_> {
             writeln!(
                 f,
                 "    {:?}: {:?},",
-                self.1.variables[i].name, self.0.following_chars_by_index[i]
+                self.2.resolve(self.1.variables[i].name),
+                self.0.following_chars_by_index[i]
             )?;
         }
         writeln!(f, "  }},")?;
 
         writeln!(f, "  status_matrix: {{")?;
         for i in 0..self.0.n {
-            writeln!(f, "    {:?}: {{", self.1.variables[i].name)?;
+            writeln!(f, "    {:?}: {{", self.2.resolve(self.1.variables[i].name))?;
             for j in 0..self.0.n {
                 writeln!(
                     f,
                     "      {:?}: {:?},",
-                    self.1.variables[j].name,
+                    self.2.resolve(self.1.variables[j].name),
                     self.0.status_matrix[matrix_index(self.0.n, i, j)]
                 )?;
             }

--- a/crates/generate/src/build_tables/token_conflicts.rs
+++ b/crates/generate/src/build_tables/token_conflicts.rs
@@ -8,7 +8,7 @@ use crate::{
     build_tables::item::TokenSetDisplay,
     grammars::{LexicalGrammar, SyntaxGrammar},
     nfa::{CharacterSet, NfaCursor, NfaTransition},
-    rules::TokenSet,
+    rules::{SymbolView, TokenSet},
     strpool::StrPool,
 };
 
@@ -319,8 +319,8 @@ fn get_following_chars(
         .map(|following_tokens| {
             let mut chars = CharacterSet::empty();
             for token in following_tokens.iter() {
-                if token.is_terminal() {
-                    chars = chars.add(&starting_chars[token.index as usize]);
+                if let SymbolView::Terminal(index) = token.view() {
+                    chars = chars.add(&starting_chars[usize::from(index)]);
                 }
             }
             chars

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 #[cfg(feature = "load")]
 use std::{
@@ -10,7 +9,6 @@ use std::{
 
 use bitflags::bitflags;
 use node_types::VariableInfo;
-use rules::Symbol;
 #[cfg(feature = "load")]
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -43,7 +41,7 @@ use render::render_c_code;
 pub use render::{ABI_VERSION_MAX, ABI_VERSION_MIN, RenderError};
 
 use crate::{
-    grammars::InputGrammar, prepare_grammar::PreparedGrammar, rules::Alias, strpool::StrPool,
+    grammars::InputGrammar, prepare_grammar::PreparedGrammar, rules::AliasMap, strpool::StrPool,
 };
 
 struct JSONOutput {
@@ -52,7 +50,7 @@ struct JSONOutput {
     syntax_grammar: SyntaxGrammar,
     lexical_grammar: LexicalGrammar,
     inlines: InlinedProductionMap,
-    simple_aliases: BTreeMap<Symbol, Alias>,
+    simple_aliases: AliasMap,
     variable_info: Vec<VariableInfo>,
     str_pool: StrPool,
 }

--- a/crates/generate/src/grammars.rs
+++ b/crates/generate/src/grammars.rs
@@ -2,7 +2,10 @@ use rustc_hash::FxHashMap;
 
 use crate::{
     node_types::ChildType,
-    rules::{Alias, AliasMap, Associativity, Precedence, RuleId, RulePool, SymbolType},
+    rules::{
+        Alias, AliasMap, Associativity, ExternalTokenIndex, NonTerminalIndex, Precedence, RuleId,
+        RulePool, SymbolType, SymbolView, TerminalIndex,
+    },
     strpool::StrId,
 };
 
@@ -88,14 +91,14 @@ impl ProductionStep {
     //     - 3-4 precedence tag (None 00, Integer 01, Name 10)
     //     - 5-6 associativity  (None 00, Left 01, Right 10)
     //     - 7   alias `is_named`
-    const KIND_MASK: u8    = 0b0000_0111;
-    const PREC_INTEGER: u8 = 0b0000_1000;
-    const PREC_NAME: u8    = 0b0001_0000;
-    const PREC_MASK: u8    = 0b0001_1000;
-    const ASSOC_LEFT: u8   = 0b0010_0000;
-    const ASSOC_RIGHT: u8  = 0b0100_0000;
-    const ASSOC_MASK: u8   = 0b0110_0000;
-    const ALIAS_NAMED: u8  = 0b1000_0000;
+    pub(crate) const KIND_MASK: u8    = 0b0000_0111;
+    pub(crate) const PREC_INTEGER: u8 = 0b0000_1000;
+    pub(crate) const PREC_NAME: u8    = 0b0001_0000;
+    pub(crate) const PREC_MASK: u8    = 0b0001_1000;
+    pub(crate) const ASSOC_LEFT: u8   = 0b0010_0000;
+    pub(crate) const ASSOC_RIGHT: u8  = 0b0100_0000;
+    pub(crate) const ASSOC_MASK: u8   = 0b0110_0000;
+    pub(crate) const ALIAS_NAMED: u8  = 0b1000_0000;
 
     /// `FStep::reserved` sentinel, meaning no reserved word set at all. Only the augmented
     /// start production carries it, and it must never index the reserved-sets table.
@@ -113,10 +116,17 @@ impl ProductionStep {
         field: Option<StrId>,
         reserved: u16,
     ) -> Self {
+        let (kind, sym_index) = match symbol.view() {
+            SymbolView::External(index) => (SymbolType::External, index.into()),
+            SymbolView::End => (SymbolType::End, 0),
+            SymbolView::EndOfNonTerminalExtra => (SymbolType::EndOfNonTerminalExtra, 0),
+            SymbolView::Terminal(index) => (SymbolType::Terminal, index.into()),
+            SymbolView::NonTerminal(index) => (SymbolType::NonTerminal, index.into()),
+        };
         let mut step = Self {
-            sym_index: symbol.index,
+            sym_index,
             reserved,
-            flags: symbol.kind as u8,
+            flags: kind as u8,
             ..Default::default()
         };
         step.set_precedence(prec);
@@ -128,15 +138,21 @@ impl ProductionStep {
 
     #[must_use]
     pub const fn symbol(self) -> Symbol {
-        Symbol {
-            kind: match self.flags & Self::KIND_MASK {
-                0 => SymbolType::External,
-                1 => SymbolType::End,
-                2 => SymbolType::EndOfNonTerminalExtra,
-                3 => SymbolType::Terminal,
-                _ => SymbolType::NonTerminal,
-            },
-            index: self.sym_index,
+        match self.flags & Self::KIND_MASK {
+            0 => ExternalTokenIndex::new(self.sym_index).symbol(),
+            1 => Symbol::End,
+            2 => Symbol::EndOfNonTerminalExtra,
+            3 => TerminalIndex::new(self.sym_index).symbol(),
+            _ => NonTerminalIndex::new(self.sym_index).symbol(),
+        }
+    }
+
+    #[must_use]
+    pub const fn non_terminal_index(self) -> Option<NonTerminalIndex> {
+        if self.flags & Self::KIND_MASK == SymbolType::NonTerminal as u8 {
+            Some(NonTerminalIndex::new(self.sym_index))
+        } else {
+            None
         }
     }
 

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -13,7 +13,7 @@ use crate::strpool::StrPool;
 
 use super::{
     grammars::{LexicalGrammar, SyntaxGrammar, VariableType},
-    rules::{Alias, AliasMap, Symbol, SymbolType},
+    rules::{Alias, AliasMap, Symbol, SymbolView},
     strpool::StrId,
 };
 
@@ -226,7 +226,10 @@ fn validate_supertype_aliases(
 ) -> VariableInfoResult<()> {
     let aliases_by_symbol = get_aliases_by_symbol(syntax_grammar, default_aliases);
     for supertype_symbol in &syntax_grammar.supertype_symbols {
-        let supertype = &syntax_grammar.variables[supertype_symbol.index as usize];
+        let SymbolView::NonTerminal(index) = supertype_symbol.view() else {
+            unreachable!();
+        };
+        let supertype = &syntax_grammar.variables[usize::from(index)];
         let collision = Alias {
             value: supertype.name,
             is_named: true,
@@ -311,8 +314,10 @@ fn compute_variable_info_fixed_point(
 
                         // Inherit the types and quantities of hidden children associated with
                         // fields.
-                        if child_is_hidden && child_symbol.is_non_terminal() {
-                            let child_variable_info = &result[child_symbol.index as usize];
+                        if child_is_hidden
+                            && let SymbolView::NonTerminal(index) = child_symbol.view()
+                        {
+                            let child_variable_info = &result[usize::from(index)];
                             did_change |= extend_sorted(
                                 &mut field_info.types,
                                 &child_variable_info.children.types,
@@ -332,9 +337,9 @@ fn compute_variable_info_fixed_point(
                     }
 
                     // Inherit all child information from hidden children.
-                    if child_is_hidden && child_symbol.is_non_terminal() {
+                    if child_is_hidden && let SymbolView::NonTerminal(index) = child_symbol.view() {
                         did_change |= inherit_hidden_child_info(
-                            &result[child_symbol.index as usize],
+                            &result[usize::from(index)],
                             step.field().is_none(),
                             &mut variable_info,
                             &mut production_field_quantities,
@@ -345,7 +350,13 @@ fn compute_variable_info_fixed_point(
 
                     // Note whether or not this production contains children whose summaries
                     // have not yet been computed.
-                    if child_symbol.index as usize >= i && !all_initialized {
+                    let child_index = match child_symbol.view() {
+                        SymbolView::External(index) => u32::from(index),
+                        SymbolView::Terminal(index) => u32::from(index),
+                        SymbolView::NonTerminal(index) => u32::from(index),
+                        SymbolView::End | SymbolView::EndOfNonTerminalExtra => unreachable!(),
+                    };
+                    if child_index as usize >= i && !all_initialized {
                         production_has_uninitialized_invisible_children = true;
                     }
                 }
@@ -455,13 +466,17 @@ fn validate_supertype_structure(
     };
 
     for supertype_symbol in &syntax_grammar.supertype_symbols {
-        if result[supertype_symbol.index as usize].has_multi_step_production {
-            let variable = &syntax_grammar.variables[supertype_symbol.index as usize];
+        let SymbolView::NonTerminal(supertype_index) = supertype_symbol.view() else {
+            unreachable!();
+        };
+        let supertype_index = usize::from(supertype_index);
+        if result[supertype_index].has_multi_step_production {
+            let variable = &syntax_grammar.variables[supertype_index];
             // A symbol can have a multi-step production either directly or via an inlined
             // anonymous child. In the latter case, we can report a more specific error.
 
             let hidden_child_name = syntax_grammar
-                .variable_prod_ids(supertype_symbol.index as usize)
+                .variable_prod_ids(supertype_index)
                 .filter(|&prod_id| syntax_grammar.production(prod_id).steps.len() == 1)
                 .find_map(|prod_id| {
                     let step = syntax_grammar.production(prod_id).steps[0];
@@ -469,12 +484,17 @@ fn validate_supertype_structure(
                     let child_type = step.child_type(default_aliases);
                     let child_is_hidden = !child_type_is_visible(&child_type)
                         && !syntax_grammar.supertype_symbols.contains(&child_symbol);
-                    (child_is_hidden
-                        && child_symbol.is_non_terminal()
-                        && result[child_symbol.index as usize].has_multi_step_production)
-                        .then(|| {
+                    let hidden_child_index = match child_symbol.view() {
+                        SymbolView::NonTerminal(index) if child_is_hidden => {
+                            Some(usize::from(index))
+                        }
+                        _ => None,
+                    };
+                    hidden_child_index
+                        .filter(|&index| result[index].has_multi_step_production)
+                        .map(|index| {
                             str_pool
-                                .resolve(syntax_grammar.variables[child_symbol.index as usize].name)
+                                .resolve(syntax_grammar.variables[index].name)
                                 .to_string()
                         })
                 });
@@ -500,7 +520,10 @@ fn strip_hidden_child_types(
     };
 
     for supertype_symbol in &syntax_grammar.supertype_symbols {
-        result[supertype_symbol.index as usize]
+        let SymbolView::NonTerminal(index) = supertype_symbol.view() else {
+            unreachable!();
+        };
+        result[usize::from(index)]
             .children
             .types
             .retain(child_type_is_visible);
@@ -712,29 +735,31 @@ fn child_type_to_node_type(
                     named: alias.is_named,
                 }
             } else {
-                match symbol.kind {
-                    SymbolType::NonTerminal => {
-                        let variable = &syntax_grammar.variables[symbol.index as usize];
+                match symbol.view() {
+                    SymbolView::NonTerminal(index) => {
+                        let variable = &syntax_grammar.variables[usize::from(index)];
                         NodeTypeRef {
                             kind: variable.name,
                             named: variable.kind != VariableType::Anonymous,
                         }
                     }
-                    SymbolType::Terminal => {
-                        let variable = &lexical_grammar.variables[symbol.index as usize];
+                    SymbolView::Terminal(index) => {
+                        let variable = &lexical_grammar.variables[usize::from(index)];
                         NodeTypeRef {
                             kind: variable.name,
                             named: variable.kind != VariableType::Anonymous,
                         }
                     }
-                    SymbolType::External => {
-                        let variable = &syntax_grammar.external_tokens[symbol.index as usize];
+                    SymbolView::External(index) => {
+                        let variable = &syntax_grammar.external_tokens[usize::from(index)];
                         NodeTypeRef {
                             kind: variable.name,
                             named: variable.kind != VariableType::Anonymous,
                         }
                     }
-                    _ => panic!("Unexpected symbol type"),
+                    SymbolView::End | SymbolView::EndOfNonTerminalExtra => {
+                        panic!("Unexpected symbol type")
+                    }
                 }
             }
         }
@@ -785,26 +810,28 @@ fn collect_extra_node_types(
                 .iter()
                 .map(|alias| {
                     let (kind, variable_type) = alias.as_ref().map_or_else(
-                        || match symbol.kind {
-                            SymbolType::NonTerminal => {
-                                let variable = &syntax_grammar.variables[symbol.index as usize];
-                                (&variable.name, variable.kind)
-                            }
-                            SymbolType::Terminal => {
-                                let variable = &lexical_grammar.variables[symbol.index as usize];
-                                (&variable.name, variable.kind)
-                            }
-                            SymbolType::External => {
+                        || match symbol.view() {
+                            SymbolView::NonTerminal(index) => {
                                 let variable =
-                                    &syntax_grammar.external_tokens[symbol.index as usize];
+                                    &syntax_grammar.variables[usize::from(index)];
+                                (&variable.name, variable.kind)
+                            }
+                            SymbolView::Terminal(index) => {
+                                let variable =
+                                    &lexical_grammar.variables[usize::from(index)];
+                                (&variable.name, variable.kind)
+                            }
+                            SymbolView::External(index) => {
+                                let variable = &syntax_grammar.external_tokens
+                                    [usize::from(index)];
                                 (&variable.name, variable.kind)
                             }
                             // `eof()` in an extra is rejected during lexical separator expansion, so
                             // `End` cannot reach `SyntaxGrammar::extra_symbols`.
-                            SymbolType::End
+                            SymbolView::End
                             // Lookahead marker that `build_parse_table` inserts for nonterminal
                             // extras _after_ this pass runs.
-                            | SymbolType::EndOfNonTerminalExtra => unreachable!(),
+                            | SymbolView::EndOfNonTerminalExtra => unreachable!(),
                         },
                         |alias| (&alias.value, alias.kind()),
                     );
@@ -1153,20 +1180,24 @@ fn variable_type_for_child_type(
             let is_inline = syntax_grammar.variables_to_inline.contains(symbol);
             debug_assert!(
                 !(is_supertype && is_inline),
-                "symbol {} is both a supertype and inlined",
-                symbol.index
+                "symbol {symbol:?} is both a supertype and inlined"
             );
             if is_supertype {
                 VariableType::Named
             } else if is_inline {
                 VariableType::Hidden
             } else {
-                let symbol_index = symbol.index as usize;
-                match symbol.kind {
-                    SymbolType::NonTerminal => syntax_grammar.variables[symbol_index].kind,
-                    SymbolType::Terminal => lexical_grammar.variables[symbol_index].kind,
-                    SymbolType::External => syntax_grammar.external_tokens[symbol_index].kind,
-                    _ => VariableType::Hidden,
+                match symbol.view() {
+                    SymbolView::NonTerminal(index) => {
+                        syntax_grammar.variables[usize::from(index)].kind
+                    }
+                    SymbolView::Terminal(index) => {
+                        lexical_grammar.variables[usize::from(index)].kind
+                    }
+                    SymbolView::External(index) => {
+                        syntax_grammar.external_tokens[usize::from(index)].kind
+                    }
+                    SymbolView::End | SymbolView::EndOfNonTerminalExtra => VariableType::Hidden,
                 }
             }
         }
@@ -3194,10 +3225,7 @@ mod tests {
         p.alias(content, value, is_named)
     }
     fn external(p: &mut RulePool, index: u32) -> RuleId {
-        p.push_node(Rule::Sym {
-            kind: SymbolType::External,
-            index,
-        })
+        p.push_node(Rule::from(Symbol::external(index as usize)))
     }
 
     fn build_syntax_grammar(

--- a/crates/generate/src/prepare_grammar/expand_repeats.rs
+++ b/crates/generate/src/prepare_grammar/expand_repeats.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use crate::{
     grammars::{InputGrammar, Variable, VariableType},
     prepare_grammar::extract_tokens::ExtractedGrammarMeta,
-    rules::{Rule, RuleId, RulePool, Symbol, SymbolType},
+    rules::{Rule, RuleId, RulePool, Symbol, SymbolView},
     strpool::{StrId, StrPool},
 };
 
@@ -193,15 +193,15 @@ impl ZeroWidth {
                         nullable: false,
                         eof_nullable: true,
                     }),
-                    Rule::Sym { kind, index } => {
-                        let width = match kind {
-                            SymbolType::End => Width {
+                    Rule::Sym(symbol) => {
+                        let width = match symbol.view() {
+                            SymbolView::End => Width {
                                 nullable: false,
                                 eof_nullable: true,
                             },
-                            SymbolType::NonTerminal => self
+                            SymbolView::NonTerminal(index) => self
                                 .by_variable
-                                .get(index as usize)
+                                .get(usize::from(index))
                                 .copied()
                                 .unwrap_or_default(),
                             // External scanners decide at runtime how far to advance
@@ -211,15 +211,15 @@ impl ZeroWidth {
                             // A scanner may gate itself on `lexer->eof`, but there's
                             // no way to determine that here. Assuming so would reject
                             // every grammar that `repeat`s an external.
-                            SymbolType::External => Width {
+                            SymbolView::External(_) => Width {
                                 nullable: true,
                                 eof_nullable: false,
                             },
                             // `expand_tokens` rejects tokens that match the empty string
-                            SymbolType::Terminal => Width::default(),
+                            SymbolView::Terminal(_) => Width::default(),
                             // Lookahead marker that `build_parse_table` inserts for nonterminal
                             // extras _after_ this pass runs.
-                            SymbolType::EndOfNonTerminalExtra => unreachable!(),
+                            SymbolView::EndOfNonTerminalExtra => unreachable!(),
                         };
                         self.values.push(width);
                     }
@@ -345,8 +345,6 @@ pub(super) fn expand_repeats(
 
 #[cfg(test)]
 mod tests {
-    use crate::rules::SymbolType;
-
     use super::*;
 
     #[test]
@@ -615,10 +613,7 @@ mod tests {
         // rule0: non_terminal(1) (unchanged)
         assert_eq!(
             g.pool.node(g.variables[0].root),
-            Rule::Sym {
-                kind: SymbolType::NonTerminal,
-                index: 1
-            }
+            Rule::from(Symbol::non_terminal(1))
         );
 
         // _rule1: choice(seq(nt1, nt1), terminal(11), terminal(12)) (inner choice flattened)
@@ -663,16 +658,10 @@ mod tests {
     }
 
     fn term(p: &mut RulePool, i: u32) -> RuleId {
-        p.push_node(Rule::Sym {
-            kind: SymbolType::Terminal,
-            index: i,
-        })
+        p.push_node(Rule::from(Symbol::terminal(i as usize)))
     }
     fn non_term(p: &mut RulePool, i: u32) -> RuleId {
-        p.push_node(Rule::Sym {
-            kind: SymbolType::NonTerminal,
-            index: i,
-        })
+        p.push_node(Rule::from(Symbol::non_terminal(i as usize)))
     }
 
     fn expand(

--- a/crates/generate/src/prepare_grammar/expand_tokens.rs
+++ b/crates/generate/src/prepare_grammar/expand_tokens.rs
@@ -304,9 +304,7 @@ impl NfaBuilder {
             }
             Rule::Blank => Ok(false),
             Rule::Eof => Err(ExpandRuleError::UnexpectedEof)?,
-            Rule::Sym { kind, index } => {
-                Err(ExpandRuleError::UnexpectedSymbol(Symbol { kind, index }))?
-            }
+            Rule::Sym(symbol) => Err(ExpandRuleError::UnexpectedSymbol(symbol))?,
             Rule::Reserved { ctx, .. } => Err(ExpandRuleError::UnexpectedReserved(
                 pool.resolve(ctx).to_string(),
             ))?,

--- a/crates/generate/src/prepare_grammar/extract_default_aliases.rs
+++ b/crates/generate/src/prepare_grammar/extract_default_aliases.rs
@@ -1,9 +1,7 @@
-use std::collections::BTreeMap;
-
 use crate::{
     grammars::{InputGrammar, LexicalVariable, ProductionStore},
     prepare_grammar::extract_tokens::ExtractedGrammarMeta,
-    rules::{Alias, AliasMap, Symbol, SymbolType},
+    rules::{Alias, AliasMap, Symbol, SymbolView},
 };
 
 #[derive(Clone, Default)]
@@ -36,12 +34,11 @@ pub(super) fn extract_default_aliases(
     for prod in &out.productions {
         for step in &out.steps[prod.step_range()] {
             let symbol = step.symbol();
-            let symbol_index = symbol.index as usize;
-            let status = match symbol.kind {
-                SymbolType::External => &mut external_status_list[symbol_index],
-                SymbolType::NonTerminal => &mut non_terminal_status_list[symbol_index],
-                SymbolType::Terminal => &mut terminal_status_list[symbol_index],
-                SymbolType::End | SymbolType::EndOfNonTerminalExtra => {
+            let status = match symbol.view() {
+                SymbolView::External(index) => &mut external_status_list[usize::from(index)],
+                SymbolView::NonTerminal(index) => &mut non_terminal_status_list[usize::from(index)],
+                SymbolView::Terminal(index) => &mut terminal_status_list[usize::from(index)],
+                SymbolView::End | SymbolView::EndOfNonTerminalExtra => {
                     panic!("Unexpected end token")
                 }
             };
@@ -68,12 +65,11 @@ pub(super) fn extract_default_aliases(
     }
 
     for symbol in &meta.extra_symbols {
-        let symbol_index = symbol.index as usize;
-        let status = match symbol.kind {
-            SymbolType::External => &mut external_status_list[symbol_index],
-            SymbolType::NonTerminal => &mut non_terminal_status_list[symbol_index],
-            SymbolType::Terminal => &mut terminal_status_list[symbol_index],
-            SymbolType::End | SymbolType::EndOfNonTerminalExtra => {
+        let status = match symbol.view() {
+            SymbolView::External(index) => &mut external_status_list[usize::from(index)],
+            SymbolView::NonTerminal(index) => &mut non_terminal_status_list[usize::from(index)],
+            SymbolView::Terminal(index) => &mut terminal_status_list[usize::from(index)],
+            SymbolView::End | SymbolView::EndOfNonTerminalExtra => {
                 panic!("Unexpected end token")
             }
         };
@@ -100,7 +96,7 @@ pub(super) fn extract_default_aliases(
     // For each symbol that always appears aliased, find the alias that occurs most often,
     // and designate that alias as the symbol's "default alias". Store all of these
     // default aliases in a map that will be returned.
-    let mut result = BTreeMap::new();
+    let mut result = AliasMap::default();
     for (symbol, status) in symbols_with_statuses {
         if status.appears_unaliased {
             status.aliases.clear();
@@ -127,12 +123,11 @@ pub(super) fn extract_default_aliases(
         for (i, prod) in productions.iter().enumerate() {
             for (j, step) in out.steps[prod.step_range()].iter().enumerate() {
                 let symbol = step.symbol();
-                let symbol_index = symbol.index as usize;
-                let status = match symbol.kind {
-                    SymbolType::External => &external_status_list[symbol_index],
-                    SymbolType::Terminal => &terminal_status_list[symbol_index],
-                    SymbolType::NonTerminal => &non_terminal_status_list[symbol_index],
-                    SymbolType::End | SymbolType::EndOfNonTerminalExtra => {
+                let status = match symbol.view() {
+                    SymbolView::External(index) => &external_status_list[usize::from(index)],
+                    SymbolView::Terminal(index) => &terminal_status_list[usize::from(index)],
+                    SymbolView::NonTerminal(index) => &non_terminal_status_list[usize::from(index)],
+                    SymbolView::End | SymbolView::EndOfNonTerminalExtra => {
                         panic!("Unexpected end token")
                     }
                 };

--- a/crates/generate/src/prepare_grammar/extract_tokens.rs
+++ b/crates/generate/src/prepare_grammar/extract_tokens.rs
@@ -10,7 +10,7 @@ use crate::{
         expand_tokens::{ExpandTokensResult, expand_tokens},
         intern_symbols::InternedGrammarMeta,
     },
-    rules::{MetadataParams, Rule, RuleId, RulePool, Symbol},
+    rules::{MetadataParams, Rule, RuleId, RulePool, Symbol, SymbolView},
     strpool::StrId,
 };
 
@@ -295,15 +295,15 @@ impl PendingTokenExtraction<'_> {
         }
 
         let replace_symbol = |symbol: Symbol| {
-            if !symbol.is_non_terminal() {
+            let SymbolView::NonTerminal(index) = symbol.view() else {
                 return symbol;
-            }
+            };
+            let index = u32::from(index);
 
-            syntax_variable_replacements.get(&symbol.index).map_or_else(
+            syntax_variable_replacements.get(&index).map_or_else(
                 || {
                     Symbol::non_terminal(
-                        symbol.index as usize
-                            - syntax_variable_shift[symbol.index as usize] as usize,
+                        index as usize - syntax_variable_shift[index as usize] as usize,
                     )
                 },
                 |&token_index| Symbol::terminal(token_index as usize),
@@ -366,16 +366,17 @@ pub(super) fn extract_tokens<'g>(
     retained.push(g.variables[0]);
     kinds.push(interned.kinds[0]);
     for (i, v) in g.variables.iter().enumerate().skip(1) {
-        if let Some(sym) = extractor.symbol_after_rewrites(&g.pool, v.root)
-            && sym.is_terminal()
-            && extractor.usage_counts[sym.index as usize] == 1
+        if let Some(SymbolView::Terminal(index)) = extractor
+            .symbol_after_rewrites(&g.pool, v.root)
+            .map(Symbol::view)
+            && extractor.usage_counts[usize::from(index)] == 1
         {
-            let lexical = &mut extractor.lexical[sym.index as usize];
+            let lexical = &mut extractor.lexical[usize::from(index)];
             if lexical.kind == VariableType::Auxiliary || interned.kinds[i] != VariableType::Hidden
             {
                 lexical.kind = interned.kinds[i];
                 lexical.name = v.name;
-                replacements.insert(i as u32, sym.index);
+                replacements.insert(i as u32, index.into());
                 continue;
             }
         }
@@ -394,11 +395,12 @@ pub(super) fn extract_tokens<'g>(
         }
     }
     let replace_symbol = |s: Symbol| {
-        if !s.is_non_terminal() {
+        let SymbolView::NonTerminal(index) = s.view() else {
             return s;
-        }
-        replacements.get(&s.index).map_or_else(
-            || Symbol::non_terminal(s.index as usize - shift[s.index as usize] as usize),
+        };
+        let index = u32::from(index);
+        replacements.get(&index).map_or_else(
+            || Symbol::non_terminal(index as usize - shift[index as usize] as usize),
             |&r| Symbol::terminal(r as usize),
         )
     };
@@ -421,10 +423,10 @@ pub(super) fn extract_tokens<'g>(
         .map(|&s| {
             let sym = replace_symbol(s);
             // A supertype that got absorbed into a token isn't allowed
-            if sym.is_terminal() {
+            if let SymbolView::Terminal(index) = sym.view() {
                 Err(ExtractTokensError::SupertypeTerminal(
                     g.pool
-                        .resolve(extractor.lexical[sym.index as usize].name)
+                        .resolve(extractor.lexical[usize::from(index)].name)
                         .to_string(),
                 ))
             } else {
@@ -462,48 +464,50 @@ pub(super) fn extract_tokens<'g>(
         else {
             Err(ExtractTokensError::NonSymbolExternalToken)?
         };
-        if s.is_non_terminal() {
+        if let SymbolView::NonTerminal(index) = s.view() {
             Err(ExtractTokensError::ExternalTokenNonTerminal(
                 g.pool
-                    .resolve(g.variables[s.index as usize].name)
+                    .resolve(g.variables[usize::from(index)].name)
                     .to_string(),
             ))?;
         }
-        external_tokens.push(if s.is_external() {
-            let Some(name) = name else {
-                Err(ExtractTokensError::NonSymbolExternalToken)?
-            };
-            ExternalToken {
-                name,
-                kind,
-                corresponding_internal_token: None,
+        external_tokens.push(match s.view() {
+            SymbolView::External(_) => {
+                let Some(name) = name else {
+                    Err(ExtractTokensError::NonSymbolExternalToken)?
+                };
+                ExternalToken {
+                    name,
+                    kind,
+                    corresponding_internal_token: None,
+                }
             }
-        } else {
-            ExternalToken {
-                name: extractor.lexical[s.index as usize].name,
+            SymbolView::Terminal(index) => ExternalToken {
+                name: extractor.lexical[usize::from(index)].name,
                 kind,
                 corresponding_internal_token: Some(s),
+            },
+            SymbolView::NonTerminal(_) | SymbolView::End | SymbolView::EndOfNonTerminalExtra => {
+                unreachable!()
             }
         });
     }
 
-    let word = match interned.word.map(replace_symbol) {
-        Some(token) if token.is_non_terminal() => {
-            let token_index = token.index as usize;
-            let word_root = g.variables[token_index].root;
-            let conflicting_symbol_name = g
-                .variables
-                .iter()
-                .enumerate()
-                .find(|(i, v)| *i != token_index && g.pool.subtree_eq(v.root, word_root))
-                .map(|(_, v)| g.pool.resolve(v.name).to_string());
-            Err(ExtractTokensError::WordToken(NonTerminalWordTokenError {
-                symbol_name: g.pool.resolve(g.variables[token_index].name).to_string(),
-                conflicting_symbol_name,
-            }))?
-        }
-        word => word,
-    };
+    let word = interned.word.map(replace_symbol);
+    if let Some(SymbolView::NonTerminal(index)) = word.map(Symbol::view) {
+        let token_index = usize::from(index);
+        let word_root = g.variables[token_index].root;
+        let conflicting_symbol_name = g
+            .variables
+            .iter()
+            .enumerate()
+            .find(|(i, v)| *i != token_index && g.pool.subtree_eq(v.root, word_root))
+            .map(|(_, v)| g.pool.resolve(v.name).to_string());
+        Err(ExtractTokensError::WordToken(NonTerminalWordTokenError {
+            symbol_name: g.pool.resolve(g.variables[token_index].name).to_string(),
+            conflicting_symbol_name,
+        }))?;
+    }
 
     let mut reserved_sets = Vec::with_capacity(g.reserved_sets.len());
     for set in &g.reserved_sets {
@@ -569,9 +573,8 @@ fn renumber_root(
             continue;
         }
         match pool.node(id) {
-            Rule::Sym { kind, index } => {
-                let s = Symbol { kind, index };
-                let replaced = replace(s);
+            Rule::Sym(symbol) => {
+                let replaced = replace(symbol);
                 pool.set_node(id, Rule::from(replaced));
             }
             Rule::Seq(range) | Rule::Choice(range) => {
@@ -590,7 +593,6 @@ mod test {
     use crate::{
         grammars::Variable,
         prepare_grammar::{extract_tokens, intern_symbols},
-        rules::SymbolType,
     };
 
     use super::*;
@@ -693,10 +695,7 @@ mod test {
         // two places (rule_0 and rule_2), so its terminal is used more than once.
         assert_eq!(
             grammar.pool.node(grammar.variables[1].root),
-            Rule::Sym {
-                kind: SymbolType::Terminal,
-                index: 1
-            }
+            Rule::from(Symbol::terminal(1))
         );
 
         // rule_3: seq(non_terminal(1), blank) -> rule_2 decremented after rule_1's removal
@@ -756,10 +755,7 @@ mod test {
         assert_eq!(names, ["rule_0"]);
         assert_eq!(
             grammar.pool.node(grammar.variables[0].root),
-            Rule::Sym {
-                kind: SymbolType::Terminal,
-                index: 0
-            }
+            Rule::from(Symbol::terminal(0))
         );
 
         let lex = lexical_grammar
@@ -943,12 +939,12 @@ mod test {
         #[rustfmt::skip]
         assert_eq!(
             grammar.pool.node(grammar.variables[0].root),
-            Rule::Sym { kind: SymbolType::NonTerminal, index: 1 }
+            Rule::from(Symbol::non_terminal(1))
         );
         #[rustfmt::skip]
         assert_eq!(
             grammar.pool.node(grammar.variables[1].root),
-            Rule::Sym { kind: SymbolType::Terminal, index: 0 }
+            Rule::from(Symbol::terminal(0))
         );
 
         let lex = lexical_grammar
@@ -991,16 +987,10 @@ mod test {
     }
 
     fn term(p: &mut RulePool, i: u32) -> RuleId {
-        p.push_node(Rule::Sym {
-            kind: SymbolType::Terminal,
-            index: i,
-        })
+        p.push_node(Rule::from(Symbol::terminal(i as usize)))
     }
     fn non_term(p: &mut RulePool, i: u32) -> RuleId {
-        p.push_node(Rule::Sym {
-            kind: SymbolType::NonTerminal,
-            index: i,
-        })
+        p.push_node(Rule::from(Symbol::non_terminal(i as usize)))
     }
 
     fn pool_grammar(pool: RulePool, variables: Vec<Variable>) -> InputGrammar {

--- a/crates/generate/src/prepare_grammar/flatten_grammar.rs
+++ b/crates/generate/src/prepare_grammar/flatten_grammar.rs
@@ -7,9 +7,7 @@ use crate::{
         InputGrammar, Production, ProductionStep, ProductionStore, SyntaxGrammar, SyntaxVariable,
     },
     prepare_grammar::extract_tokens::ExtractedGrammarMeta,
-    rules::{
-        Alias, Associativity, Precedence, Rule, RuleId, RulePool, Symbol, SymbolType, TokenSet,
-    },
+    rules::{Alias, Associativity, Precedence, Rule, RuleId, RulePool, Symbol, TokenSet},
     strpool::{StrId, StrPool},
 };
 
@@ -116,9 +114,9 @@ impl FlattenState {
         self.choices.begin_path();
     }
 
-    fn push_step(&mut self, kind: SymbolType, index: u32, ctx: FlattenCtx) {
+    fn push_step(&mut self, symbol: Symbol, ctx: FlattenCtx) {
         self.steps.push(ProductionStep::pack(
-            Symbol { kind, index },
+            symbol,
             ctx.prec,
             ctx.assoc,
             ctx.alias,
@@ -149,8 +147,8 @@ fn apply(
     st: &mut FlattenState,
 ) -> FlattenGrammarResult<bool> {
     match pool.node(node) {
-        Rule::Sym { kind, index } => {
-            st.push_step(kind, index, f_ctx);
+        Rule::Sym(symbol) => {
+            st.push_step(symbol, f_ctx);
             Ok(true)
         }
         Rule::Seq(range) => {
@@ -182,8 +180,7 @@ fn apply(
             apply(pool, reserved_ids, child, f_ctx, at_end, st)
         }
         Rule::Eof => {
-            let symbol = Symbol::end();
-            st.push_step(symbol.kind, symbol.index, f_ctx);
+            st.push_step(Symbol::End, f_ctx);
             Ok(true)
         }
         Rule::Metadata { params, rule } => {
@@ -241,7 +238,7 @@ fn emit(st: &mut FlattenState, out: &mut ProductionStore, prod_start: u32) -> bo
     let Some(eof_index) = st
         .steps
         .iter()
-        .position(|step| step.symbol() == Symbol::end())
+        .position(|step| step.symbol() == Symbol::End)
     else {
         return emit_ready(st, out, prod_start, false);
     };
@@ -728,16 +725,10 @@ mod tests {
     }
 
     fn term(p: &mut RulePool, i: u32) -> RuleId {
-        p.push_node(Rule::Sym {
-            kind: SymbolType::Terminal,
-            index: i,
-        })
+        p.push_node(Rule::from(Symbol::terminal(i as usize)))
     }
     fn non_term(p: &mut RulePool, i: u32) -> RuleId {
-        p.push_node(Rule::Sym {
-            kind: SymbolType::NonTerminal,
-            index: i,
-        })
+        p.push_node(Rule::from(Symbol::non_terminal(i as usize)))
     }
 
     #[derive(Debug, PartialEq)]

--- a/crates/generate/src/prepare_grammar/intern_symbols.rs
+++ b/crates/generate/src/prepare_grammar/intern_symbols.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use crate::{
     Diagnostic,
     grammars::{InputGrammar, VariableType},
-    rules::{Rule, RuleId, RulePool, Symbol},
+    rules::{Rule, RuleId, RulePool, Symbol, SymbolView},
     strpool::StrId,
 };
 
@@ -161,8 +161,8 @@ pub(super) fn intern_symbols(
         .transpose()?;
 
     for s in &supertypes {
-        if s.is_non_terminal() {
-            kinds[s.index as usize] = VariableType::Hidden;
+        if let SymbolView::NonTerminal(index) = s.view() {
+            kinds[usize::from(index)] = VariableType::Hidden;
         }
     }
 
@@ -191,13 +191,7 @@ fn intern_root(
     while let Some(id) = stack.pop() {
         match pool.node(id) {
             Rule::NamedSymbol(sid) => match name_of_symbol.get(&sid).copied() {
-                Some(s) => pool.set_node(
-                    id,
-                    Rule::Sym {
-                        kind: s.kind,
-                        index: s.index,
-                    },
-                ),
+                Some(s) => pool.set_node(id, Rule::from(s)),
                 None => Err(InternSymbolsError::Undefined(pool.resolve(sid).to_string()))?,
             },
             Rule::Seq(range) | Rule::Choice(range) => {
@@ -238,7 +232,7 @@ fn variable_type_for_name(name: &str) -> VariableType {
 
 #[cfg(test)]
 mod tests {
-    use crate::{grammars::Variable, rules::SymbolType};
+    use crate::grammars::Variable;
 
     use super::*;
 
@@ -511,16 +505,10 @@ mod tests {
     }
 
     fn nt(index: u32) -> Rule {
-        Rule::Sym {
-            kind: SymbolType::NonTerminal,
-            index,
-        }
+        Rule::from(Symbol::non_terminal(index as usize))
     }
 
     fn ext(index: u32) -> Rule {
-        Rule::Sym {
-            kind: SymbolType::External,
-            index,
-        }
+        Rule::from(Symbol::external(index as usize))
     }
 }

--- a/crates/generate/src/prepare_grammar/process_inlines.rs
+++ b/crates/generate/src/prepare_grammar/process_inlines.rs
@@ -10,7 +10,7 @@ use crate::{
         ProductionStore,
     },
     prepare_grammar::extract_tokens::ExtractedGrammarMeta,
-    rules::{Precedence, Symbol, SymbolType},
+    rules::{Precedence, Symbol, SymbolView},
 };
 
 struct InlineBuilder<'a> {
@@ -88,7 +88,10 @@ impl InlineBuilder<'_> {
 
             let removed_prod = std::mem::take(&mut scratch[i]);
             let removed_step = removed_prod.steps[si];
-            let (v_start, v_end) = self.out.var_prods[symbol.index as usize];
+            let SymbolView::NonTerminal(index) = symbol.view() else {
+                unreachable!();
+            };
+            let (v_start, v_end) = self.out.var_prods[usize::from(index)];
             let replacements = (v_start..v_end)
                 .filter_map(|p_idx| {
                     let p = self.out.productions[p_idx as usize];
@@ -190,21 +193,22 @@ pub(super) fn process_inlines(
         return Ok(InlinedProductionMap::default());
     }
     for symbol in &meta.inline {
-        match symbol.kind {
-            SymbolType::External => Err(ProcessInlinesError::ExternalToken(
+        match symbol.view() {
+            SymbolView::External(index) => Err(ProcessInlinesError::ExternalToken(
                 g.pool
-                    .resolve(meta.external_tokens[symbol.index as usize].name)
+                    .resolve(meta.external_tokens[usize::from(index)].name)
                     .to_string(),
             ))?,
-            SymbolType::Terminal => Err(ProcessInlinesError::Token(
+            SymbolView::Terminal(index) => Err(ProcessInlinesError::Token(
                 g.pool
-                    .resolve(lexical_variables[symbol.index as usize].name)
+                    .resolve(lexical_variables[usize::from(index)].name)
                     .to_string(),
             ))?,
-            SymbolType::NonTerminal if symbol.index == 0 => Err(ProcessInlinesError::FirstRule(
-                g.pool.resolve(g.variables[0].name).to_string(),
-            ))?,
-            _ => {}
+            SymbolView::NonTerminal(index) if u32::from(index) == 0 => Err(
+                ProcessInlinesError::FirstRule(g.pool.resolve(g.variables[0].name).to_string()),
+            )?,
+            SymbolView::NonTerminal(_) => {}
+            SymbolView::End | SymbolView::EndOfNonTerminalExtra => unreachable!(),
         }
     }
 

--- a/crates/generate/src/render.rs
+++ b/crates/generate/src/render.rs
@@ -19,7 +19,7 @@ use super::{
     nfa::CharacterSet,
     node_types::ChildType,
     rules::Alias,
-    rules::{AliasMap, Symbol, SymbolType, TokenSet},
+    rules::{AliasMap, Symbol, SymbolType, SymbolView, TokenSet},
     strpool::{StrId, StrPool},
     tables::{
         AdvanceAction, FieldLocation, GotoAction, LexState, LexTable, ParseAction, ParseTable,
@@ -198,8 +198,8 @@ impl Generator {
             self.assign_symbol_id(self.parse_table.symbols[i], &mut symbol_identifiers);
         }
         self.symbol_ids.insert(
-            Symbol::end_of_nonterminal_extra(),
-            self.symbol_ids[&Symbol::end()].clone(),
+            Symbol::EndOfNonTerminalExtra,
+            self.symbol_ids[&Symbol::End].clone(),
         );
 
         self.symbol_map = FxHashMap::default();
@@ -229,7 +229,7 @@ impl Generator {
             // should be represented with the same symbol in the public API. Examples:
             // * "<" and token(prec(1, "<"))
             // * "(" and token.immediate("(")
-            else if symbol.is_terminal() {
+            else if matches!(symbol.view(), SymbolView::Terminal(_)) {
                 let metadata = self.metadata_for_symbol(*symbol);
                 for other_symbol in &self.parse_table.symbols {
                     let other_metadata = self.metadata_for_symbol(*other_symbol);
@@ -388,16 +388,13 @@ impl Generator {
             .parse_table
             .symbols
             .iter()
-            .filter(|symbol| {
-                if symbol.is_terminal() || symbol.is_eof() {
-                    true
-                } else if symbol.is_external() {
-                    self.syntax_grammar.external_tokens[symbol.index as usize]
-                        .corresponding_internal_token
-                        .is_none()
-                } else {
-                    false
-                }
+            .filter(|symbol| match symbol.view() {
+                SymbolView::Terminal(_) | SymbolView::End => true,
+                SymbolView::External(index) => self.syntax_grammar.external_tokens
+                    [usize::from(index)]
+                .corresponding_internal_token
+                .is_none(),
+                SymbolView::EndOfNonTerminalExtra | SymbolView::NonTerminal(_) => false,
             })
             .count();
 
@@ -449,10 +446,10 @@ impl Generator {
     fn add_symbol_enum(&mut self) {
         add_line!(self, "enum ts_symbol_identifiers {{");
         indent!(self);
-        self.symbol_order.insert(Symbol::end(), 0);
+        self.symbol_order.insert(Symbol::End, 0);
         let mut i = 1;
         for symbol in &self.parse_table.symbols {
-            if *symbol != Symbol::end() {
+            if *symbol != Symbol::End {
                 self.symbol_order.insert(*symbol, i);
                 add_line!(self, "{} = {i},", self.symbol_ids[symbol]);
                 i += 1;
@@ -634,7 +631,7 @@ impl Generator {
             for prod_id in self.syntax_grammar.variable_prod_ids(i) {
                 for step in self.syntax_grammar.production(prod_id).steps {
                     if let Some(alias) = step.alias()
-                        && step.symbol().is_non_terminal()
+                        && matches!(step.symbol().view(), SymbolView::NonTerminal(_))
                         && Some(alias) != self.default_aliases.get(&step.symbol()).copied()
                         && self.symbol_ids.contains_key(&step.symbol())
                         && let Some(alias_id) = self.alias_ids.get(&alias)
@@ -1289,11 +1286,11 @@ impl Generator {
             if !self.parse_table.external_lex_states[i].is_empty() {
                 add_line!(self, "[{i}] = {{");
                 indent!(self);
-                for token in self.parse_table.external_lex_states[i].iter() {
+                for index in self.parse_table.external_lex_states[i].externals() {
                     add_line!(
                         self,
                         "[{}] = true,",
-                        self.external_token_id(token.index as usize)
+                        self.external_token_id(usize::from(index))
                     );
                 }
                 dedent!(self);
@@ -1740,7 +1737,7 @@ impl Generator {
 
     fn assign_symbol_id(&mut self, symbol: Symbol, used_identifiers: &mut FxHashSet<String>) {
         let mut id;
-        if symbol == Symbol::end() {
+        if symbol == Symbol::End {
             id = "ts_builtin_sym_end".to_string();
         } else {
             let (name, kind) = self.metadata_for_symbol(symbol);
@@ -1771,21 +1768,20 @@ impl Generator {
     }
 
     fn metadata_for_symbol(&self, symbol: Symbol) -> (StrId, VariableType) {
-        let symbol_index = symbol.index as usize;
-        match symbol.kind {
-            SymbolType::End | SymbolType::EndOfNonTerminalExtra => {
+        match symbol.view() {
+            SymbolView::End | SymbolView::EndOfNonTerminalExtra => {
                 (StrPool::END_NAME_ID, VariableType::Hidden)
             }
-            SymbolType::NonTerminal => {
-                let variable = &self.syntax_grammar.variables[symbol_index];
+            SymbolView::NonTerminal(index) => {
+                let variable = &self.syntax_grammar.variables[usize::from(index)];
                 (variable.name, variable.kind)
             }
-            SymbolType::Terminal => {
-                let variable = &self.lexical_grammar.variables[symbol_index];
+            SymbolView::Terminal(index) => {
+                let variable = &self.lexical_grammar.variables[usize::from(index)];
                 (variable.name, variable.kind)
             }
-            SymbolType::External => {
-                let token = &self.syntax_grammar.external_tokens[symbol_index];
+            SymbolView::External(index) => {
+                let token = &self.syntax_grammar.external_tokens[usize::from(index)];
                 (token.name, token.kind)
             }
         }

--- a/crates/generate/src/rules.rs
+++ b/crates/generate/src/rules.rs
@@ -62,32 +62,85 @@ pub struct MetadataParams {
     pub is_main_token: bool,
 }
 
+macro_rules! symbol_index {
+    ($($name:ident => $kind:ident),+ $(,)?) => {
+        $(
+            #[derive(
+                Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+            )]
+            #[repr(transparent)]
+            pub struct $name(u32);
+
+            impl From<$name> for u32 {
+                fn from(value: $name) -> Self {
+                    value.0
+                }
+            }
+
+            impl From<$name> for usize {
+                fn from(value: $name) -> Self {
+                    value.0 as Self
+                }
+            }
+
+            /// An index knows which table it belongs to, so it can name its own symbol
+            impl From<$name> for Symbol {
+                fn from(value: $name) -> Self {
+                    Self { kind: SymbolType::$kind, index: value.0 }
+                }
+            }
+
+            #[allow(dead_code)]
+            impl $name {
+                pub(crate) const fn new(value: u32) -> Self { Self(value) }
+
+                pub(crate) const fn symbol(self) -> Symbol {
+                    Symbol { kind: SymbolType::$kind, index: self.0 }
+                }
+            }
+        )+
+    };
+}
+
+symbol_index!(
+    ExternalTokenIndex => External,
+    TerminalIndex => Terminal,
+    NonTerminalIndex => NonTerminal,
+);
+
+/// A grammar symbol: a kind together with that kind's index into its own table.
+///
+/// An index is only reachable by destructuring [`Symbol::view`], and the
+/// `End`/`EndOfNonTerminalExtra` arms there carry no payload, so an end marker
+/// cannot hand out an index to be used against `variables` or `external_tokens`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Symbol {
-    pub kind: SymbolType,
-    pub index: u32,
+    kind: SymbolType,
+    index: u32,
+}
+
+/// The destructured form of a [`Symbol`], produced by [`Symbol::view`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SymbolView {
+    External(ExternalTokenIndex),
+    End,
+    EndOfNonTerminalExtra,
+    Terminal(TerminalIndex),
+    NonTerminal(NonTerminalIndex),
 }
 
 impl Symbol {
-    #[must_use]
-    pub fn is_terminal(self) -> bool {
-        self.kind == SymbolType::Terminal
-    }
+    #[allow(non_upper_case_globals)]
+    pub const End: Self = Self {
+        kind: SymbolType::End,
+        index: 0,
+    };
 
-    #[must_use]
-    pub fn is_non_terminal(self) -> bool {
-        self.kind == SymbolType::NonTerminal
-    }
-
-    #[must_use]
-    pub fn is_external(self) -> bool {
-        self.kind == SymbolType::External
-    }
-
-    #[must_use]
-    pub fn is_eof(self) -> bool {
-        self.kind == SymbolType::End
-    }
+    #[allow(non_upper_case_globals)]
+    pub const EndOfNonTerminalExtra: Self = Self {
+        kind: SymbolType::EndOfNonTerminalExtra,
+        index: 0,
+    };
 
     #[must_use]
     pub const fn non_terminal(index: usize) -> Self {
@@ -113,22 +166,67 @@ impl Symbol {
         }
     }
 
+    #[inline]
     #[must_use]
-    pub const fn end() -> Self {
-        Self {
-            kind: SymbolType::End,
-            index: 0,
+    pub const fn kind(self) -> SymbolType {
+        self.kind
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn view(self) -> SymbolView {
+        match self.kind {
+            SymbolType::External => SymbolView::External(ExternalTokenIndex(self.index)),
+            SymbolType::End => SymbolView::End,
+            SymbolType::EndOfNonTerminalExtra => SymbolView::EndOfNonTerminalExtra,
+            SymbolType::Terminal => SymbolView::Terminal(TerminalIndex(self.index)),
+            SymbolType::NonTerminal => SymbolView::NonTerminal(NonTerminalIndex(self.index)),
         }
     }
 
+    #[inline]
     #[must_use]
-    pub const fn end_of_nonterminal_extra() -> Self {
-        Self {
-            kind: SymbolType::EndOfNonTerminalExtra,
-            index: 0,
+    pub const fn external_index(self) -> Option<ExternalTokenIndex> {
+        if matches!(self.kind, SymbolType::External) {
+            Some(ExternalTokenIndex(self.index))
+        } else {
+            None
         }
     }
+
+    #[inline]
+    #[must_use]
+    pub const fn terminal_index(self) -> Option<TerminalIndex> {
+        if matches!(self.kind, SymbolType::Terminal) {
+            Some(TerminalIndex(self.index))
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn non_terminal_index(self) -> Option<NonTerminalIndex> {
+        if matches!(self.kind, SymbolType::NonTerminal) {
+            Some(NonTerminalIndex(self.index))
+        } else {
+            None
+        }
+    }
+
+    /// Packed `(kind, index)` identity, ordered exactly like `Ord`.
+    ///
+    /// A fast-path key for hot tables that would otherwise compare symbols
+    /// field-by-field.
+    #[inline]
+    #[must_use]
+    pub(crate) const fn packed_key(self) -> u64 {
+        (self.kind as u64) << 32 | self.index as u64
+    }
 }
+
+const _: () = assert!(std::mem::size_of::<Symbol>() == 8);
+const _: () = assert!(std::mem::size_of::<Option<Symbol>>() == 8);
 
 /// A pooled rule node.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -137,7 +235,7 @@ pub enum Rule {
     String(StrId),
     Pattern(StrId, StrId),
     NamedSymbol(StrId),
-    Sym { kind: SymbolType, index: u32 },
+    Sym(Symbol),
     Seq(RuleIdRange),
     Choice(RuleIdRange),
     Repeat(RuleId),
@@ -150,17 +248,14 @@ const _: () = assert!(std::mem::size_of::<Rule>() <= 12);
 
 impl From<Symbol> for Rule {
     fn from(value: Symbol) -> Self {
-        Self::Sym {
-            kind: value.kind,
-            index: value.index,
-        }
+        Self::Sym(value)
     }
 }
 
 impl Rule {
     pub const fn symbol(self) -> Option<Symbol> {
         match self {
-            Self::Sym { kind, index } => Some(Symbol { kind, index }),
+            Self::Sym(symbol) => Some(symbol),
             _ => None,
         }
     }
@@ -402,10 +497,7 @@ impl RulePool {
                     p.hash(&mut hasher);
                     f.hash(&mut hasher);
                 }
-                Rule::Sym { kind, index } => {
-                    (kind as u8).hash(&mut hasher);
-                    index.hash(&mut hasher);
-                }
+                Rule::Sym(symbol) => symbol.hash(&mut hasher),
                 Rule::Seq(range) | Rule::Choice(range) => {
                     hasher.write_u32(range.len);
                     let base = stack.len();
@@ -445,7 +537,7 @@ impl RulePool {
                         return false;
                     }
                 }
-                (n1 @ Rule::Sym { .. }, n2 @ Rule::Sym { .. }) => {
+                (n1 @ Rule::Sym(_), n2 @ Rule::Sym(_)) => {
                     if n1 != n2 {
                         return false;
                     }
@@ -519,9 +611,7 @@ impl RulePool {
                 self.rule_is_referenced(rule, target, is_external)
             }
             Rule::Repeat(inner) => self.rule_is_referenced(inner, target, false),
-            Rule::Blank | Rule::Eof | Rule::String(_) | Rule::Pattern(..) | Rule::Sym { .. } => {
-                false
-            }
+            Rule::Blank | Rule::Eof | Rule::String(_) | Rule::Pattern(..) | Rule::Sym(_) => false,
         }
     }
 
@@ -544,7 +634,7 @@ impl RulePool {
                 self.collect_referenced_ids(rule, skip_top_level, out);
             }
             Rule::Repeat(inner) => self.collect_referenced_ids(inner, false, out),
-            Rule::Blank | Rule::Eof | Rule::String(_) | Rule::Pattern(..) | Rule::Sym { .. } => {}
+            Rule::Blank | Rule::Eof | Rule::String(_) | Rule::Pattern(..) | Rule::Sym(_) => {}
         }
     }
 }
@@ -639,33 +729,35 @@ impl TokenSet {
         SetBitsIter::new(self.terminal_bits.as_slice())
             .map(Symbol::terminal)
             .chain(SetBitsIter::new(self.external_bits.as_slice()).map(Symbol::external))
-            .chain(if self.eof { Some(Symbol::end()) } else { None })
+            .chain(if self.eof { Some(Symbol::End) } else { None })
             .chain(if self.end_of_nonterminal_extra {
-                Some(Symbol::end_of_nonterminal_extra())
+                Some(Symbol::EndOfNonTerminalExtra)
             } else {
                 None
             })
     }
 
-    pub fn terminals(&self) -> impl Iterator<Item = Symbol> + '_ {
-        SetBitsIter::new(self.terminal_bits.as_slice()).map(Symbol::terminal)
+    pub fn terminals(&self) -> impl Iterator<Item = TerminalIndex> + '_ {
+        SetBitsIter::new(self.terminal_bits.as_slice()).map(|i| TerminalIndex(i as u32))
+    }
+
+    pub fn externals(&self) -> impl Iterator<Item = ExternalTokenIndex> + '_ {
+        SetBitsIter::new(self.external_bits.as_slice()).map(|i| ExternalTokenIndex(i as u32))
     }
 
     #[inline]
     #[must_use]
     pub fn contains(&self, symbol: Symbol) -> bool {
-        match symbol.kind {
-            SymbolType::NonTerminal => panic!("Cannot store non-terminals in a TokenSet"),
-            SymbolType::Terminal => self
-                .terminal_bits
-                .get(symbol.index as usize)
-                .unwrap_or(false),
-            SymbolType::External => self
-                .external_bits
-                .get(symbol.index as usize)
-                .unwrap_or(false),
-            SymbolType::End => self.eof,
-            SymbolType::EndOfNonTerminalExtra => self.end_of_nonterminal_extra,
+        match symbol.view() {
+            SymbolView::NonTerminal(_) => panic!("Cannot store non-terminals in a TokenSet"),
+            SymbolView::Terminal(index) => {
+                self.terminal_bits.get(usize::from(index)).unwrap_or(false)
+            }
+            SymbolView::External(index) => {
+                self.external_bits.get(usize::from(index)).unwrap_or(false)
+            }
+            SymbolView::End => self.eof,
+            SymbolView::EndOfNonTerminalExtra => self.end_of_nonterminal_extra,
         }
     }
 
@@ -683,20 +775,19 @@ impl TokenSet {
     }
 
     pub fn insert(&mut self, other: Symbol) {
-        let vec = match other.kind {
-            SymbolType::NonTerminal => panic!("Cannot store non-terminals in a TokenSet"),
-            SymbolType::Terminal => &mut self.terminal_bits,
-            SymbolType::External => &mut self.external_bits,
-            SymbolType::End => {
+        let (vec, other_index) = match other.view() {
+            SymbolView::NonTerminal(_) => panic!("Cannot store non-terminals in a TokenSet"),
+            SymbolView::Terminal(index) => (&mut self.terminal_bits, usize::from(index)),
+            SymbolView::External(index) => (&mut self.external_bits, usize::from(index)),
+            SymbolView::End => {
                 self.eof = true;
                 return;
             }
-            SymbolType::EndOfNonTerminalExtra => {
+            SymbolView::EndOfNonTerminalExtra => {
                 self.end_of_nonterminal_extra = true;
                 return;
             }
         };
-        let other_index = other.index as usize;
         if other_index >= vec.len() {
             vec.resize(other_index + 1, false);
         }
@@ -704,11 +795,11 @@ impl TokenSet {
     }
 
     pub fn remove(&mut self, other: Symbol) -> bool {
-        let vec = match other.kind {
-            SymbolType::NonTerminal => panic!("Cannot store non-terminals in a TokenSet"),
-            SymbolType::Terminal => &mut self.terminal_bits,
-            SymbolType::External => &mut self.external_bits,
-            SymbolType::End => {
+        let (vec, other_index) = match other.view() {
+            SymbolView::NonTerminal(_) => panic!("Cannot store non-terminals in a TokenSet"),
+            SymbolView::Terminal(index) => (&mut self.terminal_bits, usize::from(index)),
+            SymbolView::External(index) => (&mut self.external_bits, usize::from(index)),
+            SymbolView::End => {
                 return if self.eof {
                     self.eof = false;
                     true
@@ -716,7 +807,7 @@ impl TokenSet {
                     false
                 };
             }
-            SymbolType::EndOfNonTerminalExtra => {
+            SymbolView::EndOfNonTerminalExtra => {
                 return if self.end_of_nonterminal_extra {
                     self.end_of_nonterminal_extra = false;
                     true
@@ -725,7 +816,6 @@ impl TokenSet {
                 };
             }
         };
-        let other_index = other.index as usize;
         if other_index < vec.len() && vec[other_index] {
             vec.set(other_index, false);
             while vec.last() == Some(false) {

--- a/crates/generate/src/tables.rs
+++ b/crates/generate/src/tables.rs
@@ -352,7 +352,7 @@ impl<T> ParseState<T> {
     #[must_use]
     pub fn is_end_of_non_terminal_extra(&self) -> bool {
         self.terminal_entries
-            .contains_key(&Symbol::end_of_nonterminal_extra())
+            .contains_key(&Symbol::EndOfNonTerminalExtra)
     }
 }
 
@@ -451,7 +451,7 @@ mod tests {
         let mut state = ParseState::default();
         state
             .terminal_entries
-            .insert(Symbol::end(), ActionListId::new(0, true));
+            .insert(Symbol::End, ActionListId::new(0, true));
         table.states.push(state);
 
         // Slot 1 is unreferenced, so `f` must never see state 1 (else this indexes out of bounds).


### PR DESCRIPTION
This addresses https://github.com/tree-sitter/tree-sitter/issues/5925#issuecomment-5593723823. As part of #5811, some debug logging printed `StrId`s rather than resolved `strs`, which isn't helpful. Threading the pool and resolving the pooled strings through took all of 5 minutes, but I threw an agent at it to make sure I hadn't missed any other prints. The agent noticed that `add_state_for_tokens` was using each `Symbol`'s `index` to index into `lexical_grammar.variables` without checking the type! Some quick background:

`Symbol` is defined  on master like so:

```rust
pub struct Symbol {
    pub kind: SymbolType,
    pub index: u32,
}
```

The `index` field means something different based on the `kind`:

```rust
pub enum SymbolType {
    External = 0,
    End = 1,
    EndOfNonTerminalExtra = 2,
    Terminal = 3,
    NonTerminal = 4,
}
```

Importantly here, for `End` and `EndOfNonTerminalExtra`, the `index` is meaningless! So while `Symbol` is defined as a struct, it's really being used as a union. This kind of index mis-use can lead to silently incorrect results, out of bounds accesses, and other decidedly unfun bugs. The obvious solution is to just do this:

```rust
pub enum Symbol {
    External(u32),
    End,
    EndOfNonTerminalExtra,
    Terminal(u32),
    NonTerminal(u32),
}
```

However, this change resulted in up to a 5% walltime regression measuring on the nvim-treesitter corpus. After several wrong turns, red herrings, and a lot of AI assistance, I was able to find the main culprit:

```asm
5a7a15: cmp    $0x3,%r14d
5a7a19: ja     5a8519 <...add_actions+0xdb9>
5a7a1f: lea    -0x471642(%rip),%rcx  # 1363e4 <anon...>
5a7a26: movslq (%rcx,%r14,4),%rax
5a7a2a: add    %rcx,%rax
5a7a2d: jmp    *%rax
```

This is a variant-dispatch jump table. Check the discriminant, load the PC-relative branch offset for that variant, add it to the table base, and perform an indirect jump. For repeated operations in several of `build_tables`'s hot loops, this was disastrous, particularly for larger grammars. For example, Ada:

| Metric | Delta from baseline |
| --- | ---: |
| Cycles | +7.2% |
| Instructions | +5.5% |
| Branches | +11.5% |
| Branch misses | +28.7% |

The solution is to keep the existing `Symbol` representation, but make its fields private, and control access. When we know what type a symbol is, only its `index` is needed. When it isn't needed, we can match on a thin "view" to see if it has an index and how we should use it. The high line count in this PR is mostly mechanical churn from all of these access/usage sites. The final result:

| Metric | Clean baseline | Final type-safe implementation | Delta |
| --- | ---: | ---: | ---: |
| Aggregate generation time | 220.425s | 218.722s | **-0.77%** |
| Peak RSS | 2248.4 MB | 2246.4 MB | **-0.09%** |

The aggregate win is concentrated in the large grammars where the optimized paths account for meaningful absolute time:

| Grammar | Baseline | Candidate | Delta |
| --- | ---: | ---: | ---: |
| Ada | 14.365s | 13.604s | -5.3% |
| Odin | 7.790s | 7.654s | -1.7% |
| Hoon | 2.837s | 2.750s | -3.1% |
| Nim | 8.208s | 8.130s | -1.0% |
| SQL | 11.534s | 11.458s | -0.7% |
| t32 | 14.822s | 14.757s | -0.4% |

Smaller grammars are either performance neutral, or ~1% slower. Note that some drift could be attributed to lucky/unlucky "hash rolls", as we utilize a fair number of maps in the pipeline. 

The type safety wins here are nice, but I didn't think they were worth a regression. It took a few extra days of work, but I think this branch's current state gives us both safety and performance in reasonable amounts.

--------------------- 

NOTE: I'm planning on backporting the first commit here separately. 

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
gpt5.6-sol used as the initial reviewer that caught the index misuse. Combination of 5.6-sol, astra, and opus 5 used for the `Symbol` rework in the second commit.  
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
