### PR TITLE
feat(generate)!: mirror `regex_syntax` error kinds

### DIFF
--- a/.github/workflows/regex_error_kinds.yml
+++ b/.github/workflows/regex_error_kinds.yml
@@ -1,0 +1,33 @@
+name: Check Regex Error Kinds
+
+on:
+  pull_request:
+    paths:
+      - Cargo.lock
+      - crates/generate/src/prepare_grammar/pattern.rs
+      - crates/xtask/src/**
+  push:
+    branches: [master]
+    paths:
+      - Cargo.lock
+      - crates/generate/src/prepare_grammar/pattern.rs
+      - crates/xtask/src/**
+
+jobs:
+  check-regex-error-kinds:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Set up stable Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      # rustdoc's JSON output is nightly-only and unstable
+      - name: Set up pinned nightly Rust toolchain
+        run: rustup toolchain install nightly-2026-09-03 --profile minimal
+
+      - name: Check regex error kinds
+        run: cargo xtask check-regex-error-kinds

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ once_cell = "1.21.3"
 pretty_assertions = "1.4.1"
 rand = "0.10.1"
 regex = "1.12.3"
-regex-syntax = "0.8.9"
+regex-syntax = "0.8.11"
 rustc-hash = "2.1.1"
 schemars = "1.2.1"
 semver = { features = [ "serde" ], version = "1.0.27" }

--- a/crates/generate/src/build_tables.rs
+++ b/crates/generate/src/build_tables.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeSet;
 
 pub use build_lex_table::LARGE_CHARACTER_RANGE_COUNT;
 use build_parse_table::BuildTableResult;
-pub use build_parse_table::ParseTableBuilderError;
+pub use build_parse_table::{AmbiguousExtraError, ConflictError, ParseTableBuilderError};
 use log::{debug, info};
 use rustc_hash::FxHashMap;
 

--- a/crates/generate/src/build_tables/build_parse_table.rs
+++ b/crates/generate/src/build_tables/build_parse_table.rs
@@ -86,48 +86,54 @@ pub type BuildTableResult<T> = Result<T, ParseTableBuilderError>;
 #[derive(Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ParseTableBuilderError {
     #[error("Unresolved conflict for symbol sequence:\n\n{0}")]
-    Conflict(#[from] ConflictError),
+    Conflict(Box<ConflictError>),
     #[error("Extra rules must have unambiguous endings. Conflicting rules: {0}")]
     AmbiguousExtra(#[from] AmbiguousExtraError),
     #[error(
         "The non-terminal rule `{0}` is used in a non-terminal `extra` rule, which is not allowed."
     )]
-    ImproperNonTerminalExtra(String),
+    ImproperNonTerminalExtra(Box<str>),
     #[error("State count `{0}` exceeds the max value {max}.", max=u16::MAX)]
     StateCount(usize),
 }
 
+impl From<ConflictError> for ParseTableBuilderError {
+    fn from(error: ConflictError) -> Self {
+        Self::Conflict(Box::new(error))
+    }
+}
+
 #[derive(Default, Debug, Serialize, Error, Deserialize, PartialEq, Eq)]
 pub struct ConflictError {
-    pub symbol_sequence: Vec<String>,
-    pub conflicting_lookahead: String,
+    pub symbol_sequence: Box<[Box<str>]>,
+    pub conflicting_lookahead: Box<str>,
     pub possible_interpretations: Vec<Interpretation>,
     pub possible_resolutions: Vec<Resolution>,
 }
 
 #[derive(Default, Debug, Serialize, Error, Deserialize, PartialEq, Eq)]
 pub struct Interpretation {
-    pub preceding_symbols: Vec<String>,
-    pub variable_name: String,
-    pub production_step_symbols: Vec<String>,
+    pub preceding_symbols: Box<[Box<str>]>,
+    pub variable_name: Box<str>,
+    pub production_step_symbols: Box<[Box<str>]>,
     pub step_index: u32,
     pub done: bool,
-    pub conflicting_lookahead: String,
-    pub precedence: Option<String>,
-    pub associativity: Option<String>,
+    pub conflicting_lookahead: Box<str>,
+    pub precedence: Option<Box<str>>,
+    pub associativity: Option<Box<str>>,
     pub requires_eof_lookahead: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Resolution {
-    Precedence { symbols: Vec<String> },
-    Associativity { symbols: Vec<String> },
-    AddConflict { symbols: Vec<String> },
+    Precedence { symbols: Box<[Box<str>]> },
+    Associativity { symbols: Box<[Box<str>]> },
+    AddConflict { symbols: Box<[Box<str>]> },
 }
 
 #[derive(Debug, Serialize, Deserialize, Error, PartialEq, Eq)]
 pub struct AmbiguousExtraError {
-    pub parent_symbols: Vec<String>,
+    pub parent_symbols: Box<[Box<str>]>,
 }
 
 impl std::fmt::Display for ConflictError {
@@ -397,7 +403,7 @@ impl<'a> ParseTableBuilder<'a> {
                 .map(|conf| conf.iter().map(|&s| self.symbol_name(s)).collect())
                 .collect::<Vec<_>>();
             conflicts.sort_unstable();
-            diagnostics.push(Diagnostic::UnnecessaryConflicts(conflicts));
+            diagnostics.push(Diagnostic::UnnecessaryConflicts(conflicts.into()));
         }
 
         Ok((
@@ -704,9 +710,9 @@ impl<'a> ParseTableBuilder<'a> {
                     .map(|&variable_index| {
                         self.str_pool
                             .resolve(self.syntax_grammar.variables[variable_index as usize].name)
-                            .to_string()
+                            .into()
                     })
-                    .collect::<Vec<_>>();
+                    .collect();
 
                 Err(AmbiguousExtraError {
                     parent_symbols: parent_symbol_names,
@@ -973,13 +979,14 @@ impl<'a> ParseTableBuilder<'a> {
             return Ok(());
         }
 
-        let mut conflict_error = ConflictError::default();
-        for &symbol in preceding_symbols {
-            conflict_error
-                .symbol_sequence
-                .push(self.symbol_name(symbol));
-        }
-        conflict_error.conflicting_lookahead = self.symbol_name(conflicting_lookahead);
+        let mut conflict_error = ConflictError {
+            symbol_sequence: preceding_symbols
+                .iter()
+                .map(|&symbol| self.symbol_name(symbol))
+                .collect(),
+            conflicting_lookahead: self.symbol_name(conflicting_lookahead),
+            ..Default::default()
+        };
 
         let interpretations = conflicting_items
             .iter()
@@ -988,31 +995,30 @@ impl<'a> ParseTableBuilder<'a> {
                     .iter()
                     .take(preceding_symbols.len() - item.step_index as usize)
                     .map(|&symbol| self.symbol_name(symbol))
-                    .collect::<Vec<_>>();
+                    .collect();
 
                 let variable_name = self
                     .str_pool
                     .resolve(self.syntax_grammar.variables[item.variable_index as usize].name)
-                    .to_string();
+                    .into();
 
                 let production_step_symbols = item
                     .production(self.syntax_grammar)
                     .steps
                     .iter()
                     .map(|step| self.symbol_name(step.symbol()))
-                    .collect::<Vec<_>>();
+                    .collect();
 
                 let precedence = match item.precedence(self.syntax_grammar) {
                     Precedence::None => None,
-                    _ => Some(prec_display(
-                        item.precedence(self.syntax_grammar),
-                        self.str_pool,
-                    )),
+                    _ => Some(
+                        prec_display(item.precedence(self.syntax_grammar), self.str_pool).into(),
+                    ),
                 };
 
                 let associativity = item
                     .associativity(self.syntax_grammar)
-                    .map(|assoc| format!("{assoc:?}"));
+                    .map(|assoc| format!("{assoc:?}").into());
 
                 Interpretation {
                     preceding_symbols,
@@ -1043,7 +1049,7 @@ impl<'a> ParseTableBuilder<'a> {
         shift_items.sort_unstable();
         reduce_items.sort_unstable();
 
-        let get_rule_names = |items: &[&ParseItem]| -> Vec<String> {
+        let get_rule_names = |items: &[&ParseItem]| -> Box<[Box<str>]> {
             let mut last_rule_id = None;
             let mut result = Vec::with_capacity(items.len());
             for item in items {
@@ -1054,7 +1060,7 @@ impl<'a> ParseTableBuilder<'a> {
                 result.push(self.symbol_name(Symbol::non_terminal(item.variable_index as usize)));
             }
 
-            result
+            result.into()
         };
 
         if actual_conflict.len() > 1 {
@@ -1070,7 +1076,7 @@ impl<'a> ParseTableBuilder<'a> {
                 conflict_error
                     .possible_resolutions
                     .push(Resolution::Precedence {
-                        symbols: vec![name],
+                        symbols: [name].into(),
                     });
             }
         }
@@ -1255,7 +1261,7 @@ impl<'a> ParseTableBuilder<'a> {
         id
     }
 
-    fn symbol_name(&self, symbol: Symbol) -> String {
+    fn symbol_name(&self, symbol: Symbol) -> Box<str> {
         match symbol.view() {
             SymbolView::End | SymbolView::EndOfNonTerminalExtra => "EOF".to_string(),
             SymbolView::External(index) => self
@@ -1275,6 +1281,7 @@ impl<'a> ParseTableBuilder<'a> {
                 }
             }
         }
+        .into()
     }
 }
 

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -29,14 +29,20 @@ mod rules;
 mod strpool;
 mod tables;
 
-pub use build_tables::ParseTableBuilderError;
+pub use build_tables::{AmbiguousExtraError, ConflictError, ParseTableBuilderError};
 use build_tables::build_tables;
 use grammars::{InlinedProductionMap, LexicalGrammar, SyntaxGrammar};
 pub use node_types::{InvalidSupertypeError, SuperTypeCycleError, VariableInfoError};
 pub use parse_grammar::ParseGrammarError;
 use parse_grammar::parse_grammar;
 use prepare_grammar::prepare_grammar;
-pub use prepare_grammar::{PatternSpan, PrepareGrammarError, RegexError, RegexErrorKind};
+pub use prepare_grammar::{
+    ConflictingPrecedenceOrderingError, ExpandRegexError, ExpandRepeatsError, ExpandRuleError,
+    ExpandTokensError, ExpandTokensProcessingError, ExtractTokensError, FlattenGrammarError,
+    IndirectRecursionError, InternSymbolsError, NonAsciiByteClassError,
+    NonTerminalWordTokenError, PatternSpan, PrepareGrammarError, ProcessInlinesError, RegexError,
+    RegexErrorKind, UndeclaredPrecedenceError, ValidatePrecedenceError,
+};
 use render::render_c_code;
 pub use render::{ABI_VERSION_MAX, ABI_VERSION_MIN, RenderError};
 

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -29,8 +29,8 @@ mod rules;
 mod strpool;
 mod tables;
 
-pub use build_tables::{AmbiguousExtraError, ConflictError, ParseTableBuilderError};
 use build_tables::build_tables;
+pub use build_tables::{AmbiguousExtraError, ConflictError, ParseTableBuilderError};
 use grammars::{InlinedProductionMap, LexicalGrammar, SyntaxGrammar};
 pub use node_types::{InvalidSupertypeError, SuperTypeCycleError, VariableInfoError};
 pub use parse_grammar::ParseGrammarError;
@@ -39,9 +39,9 @@ use prepare_grammar::prepare_grammar;
 pub use prepare_grammar::{
     ConflictingPrecedenceOrderingError, ExpandRegexError, ExpandRepeatsError, ExpandRuleError,
     ExpandTokensError, ExpandTokensProcessingError, ExtractTokensError, FlattenGrammarError,
-    IndirectRecursionError, InternSymbolsError, NonAsciiByteClassError,
-    NonTerminalWordTokenError, PatternSpan, PrepareGrammarError, ProcessInlinesError, RegexError,
-    RegexErrorKind, UndeclaredPrecedenceError, ValidatePrecedenceError,
+    IndirectRecursionError, InternSymbolsError, NonAsciiByteClassError, NonTerminalWordTokenError,
+    PatternSpan, PrepareGrammarError, ProcessInlinesError, RegexError, RegexErrorKind,
+    UndeclaredPrecedenceError, ValidatePrecedenceError,
 };
 use render::render_c_code;
 pub use render::{ABI_VERSION_MAX, ABI_VERSION_MIN, RenderError};
@@ -193,9 +193,9 @@ pub enum LoadGrammarError {
 #[derive(Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ParseVersionError {
     #[error("{0}")]
-    Version(String),
+    Version(Box<str>),
     #[error("{0}")]
-    JSON(String),
+    JSON(Box<str>),
     #[error(transparent)]
     IO(IoError),
 }
@@ -207,53 +207,53 @@ pub type JSResult<T> = Result<T, JSError>;
 #[derive(Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
 pub enum JSError {
     #[error("Failed to run `{runtime}` -- {error}")]
-    JSRuntimeSpawn { runtime: String, error: String },
+    JSRuntimeSpawn { runtime: Box<str>, error: Box<str> },
     #[error("Got invalid UTF8 from `{runtime}` -- {error}")]
-    JSRuntimeUtf8 { runtime: String, error: String },
+    JSRuntimeUtf8 { runtime: Box<str>, error: Box<str> },
     #[error("`{runtime}` process exited with status {code}")]
-    JSRuntimeExit { runtime: String, code: i32 },
+    JSRuntimeExit { runtime: Box<str>, code: i32 },
     #[error("Failed to open stdin for `{runtime}`")]
-    JSRuntimeStdin { runtime: String },
+    JSRuntimeStdin { runtime: Box<str> },
     #[error("Failed to write {item} to `{runtime}`'s stdin -- {error}")]
     JSRuntimeWrite {
-        runtime: String,
-        item: String,
-        error: String,
+        runtime: Box<str>,
+        item: Box<str>,
+        error: Box<str>,
     },
     #[error("Failed to read output from `{runtime}` -- {error}")]
-    JSRuntimeRead { runtime: String, error: String },
+    JSRuntimeRead { runtime: Box<str>, error: Box<str> },
     #[error(transparent)]
     IO(IoError),
     #[cfg(feature = "qjs-rt")]
     #[error("Failed to get relative path")]
     RelativePath,
     #[error("Could not parse this package's version as semver -- {0}")]
-    Semver(String),
+    Semver(Box<str>),
     #[error("Failed to serialize grammar JSON -- {0}")]
-    Serialzation(String),
+    Serialization(Box<str>),
     #[cfg(feature = "qjs-rt")]
     #[error("QuickJS error: {0}")]
-    QuickJS(String),
+    QuickJS(Box<str>),
 }
 
 #[cfg(feature = "load")]
 impl From<serde_json::Error> for JSError {
     fn from(value: serde_json::Error) -> Self {
-        Self::Serialzation(value.to_string())
+        Self::Serialization(value.to_string().into())
     }
 }
 
 #[cfg(feature = "load")]
 impl From<semver::Error> for JSError {
     fn from(value: semver::Error) -> Self {
-        Self::Semver(value.to_string())
+        Self::Semver(value.to_string().into())
     }
 }
 
 #[cfg(feature = "qjs-rt")]
 impl From<rquickjs::Error> for JSError {
     fn from(value: rquickjs::Error) -> Self {
-        Self::QuickJS(value.to_string())
+        Self::QuickJS(value.to_string().into())
     }
 }
 
@@ -272,12 +272,12 @@ impl Default for OptLevel {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Diagnostic {
-    UnnecessaryConflicts(Vec<Vec<String>>),
-    UnaryChoice { name: Option<String> },
-    UnarySeq { name: Option<String> },
-    EmptyStringMatch(String),
-    UnsupportedRegexFlag { flag: char, pattern: String },
-    SupertypeInlined { name: String },
+    UnnecessaryConflicts(Box<[Box<[Box<str>]>]>),
+    UnaryChoice { name: Option<Box<str>> },
+    UnarySeq { name: Option<Box<str>> },
+    EmptyStringMatch(Box<str>),
+    UnsupportedRegexFlag { flag: char, pattern: Box<str> },
+    SupertypeInlined { name: Box<str> },
 }
 
 impl std::fmt::Display for Diagnostic {
@@ -576,17 +576,22 @@ fn read_grammar_version(repo_path: &Path) -> Result<Option<Version>, ParseVersio
                 let contents = fs::read_to_string(path.as_path())
                     .map_err(|e| ParseVersionError::IO(IoError::new(e, Some(path.as_path()))))?;
                 serde_json::from_str::<TreeSitterJson>(&contents).map_err(|e| {
-                    ParseVersionError::JSON(format!("Failed to parse `{}` -- {e}", path.display()))
+                    ParseVersionError::JSON(
+                        format!("Failed to parse `{}` -- {e}", path.display()).into(),
+                    )
                 })
             })
             .transpose()?;
         if let Some(json) = json {
             return Version::parse(&json.metadata.version)
                 .map_err(|e| {
-                    ParseVersionError::Version(format!(
-                        "Failed to parse `{}` version as semver -- {e}",
-                        path.display()
-                    ))
+                    ParseVersionError::Version(
+                        format!(
+                            "Failed to parse `{}` version as semver -- {e}",
+                            path.display()
+                        )
+                        .into(),
+                    )
                 })
                 .map(Some);
         }
@@ -651,15 +656,15 @@ fn load_js_grammar_file(grammar_path: &Path, js_runtime: Option<&str>) -> JSResu
         .stdout(Stdio::piped())
         .spawn()
         .map_err(|e| JSError::JSRuntimeSpawn {
-            runtime: js_runtime.to_string(),
-            error: e.to_string(),
+            runtime: js_runtime.to_string().into(),
+            error: e.to_string().into(),
         })?;
 
     let mut js_stdin = js_process
         .stdin
         .take()
         .ok_or_else(|| JSError::JSRuntimeStdin {
-            runtime: js_runtime.to_string(),
+            runtime: js_runtime.to_string().into(),
         })?;
 
     let cli_version = Version::parse(env!("CARGO_PKG_VERSION"))?;
@@ -671,30 +676,30 @@ fn load_js_grammar_file(grammar_path: &Path, js_runtime: Option<&str>) -> JSResu
         cli_version.major, cli_version.minor, cli_version.patch,
     )
     .map_err(|e| JSError::JSRuntimeWrite {
-        runtime: js_runtime.to_string(),
-        item: "tree-sitter version".to_string(),
-        error: e.to_string(),
+        runtime: js_runtime.to_string().into(),
+        item: "tree-sitter version".to_string().into(),
+        error: e.to_string().into(),
     })?;
     js_stdin
         .write(include_bytes!("./dsl.js"))
         .map_err(|e| JSError::JSRuntimeWrite {
-            runtime: js_runtime.to_string(),
-            item: "grammar dsl".to_string(),
-            error: e.to_string(),
+            runtime: js_runtime.to_string().into(),
+            item: "grammar dsl".to_string().into(),
+            error: e.to_string().into(),
         })?;
     drop(js_stdin);
 
     let output = js_process
         .wait_with_output()
         .map_err(|e| JSError::JSRuntimeRead {
-            runtime: js_runtime.to_string(),
-            error: e.to_string(),
+            runtime: js_runtime.to_string().into(),
+            error: e.to_string().into(),
         })?;
     match output.status.code() {
         Some(0) => {
             let stdout = String::from_utf8(output.stdout).map_err(|e| JSError::JSRuntimeUtf8 {
-                runtime: js_runtime.to_string(),
-                error: e.to_string(),
+                runtime: js_runtime.to_string().into(),
+                error: e.to_string().into(),
             })?;
 
             let mut grammar_json = &stdout[..];
@@ -721,11 +726,11 @@ fn load_js_grammar_file(grammar_path: &Path, js_runtime: Option<&str>) -> JSResu
             >(grammar_json)?)?)
         }
         Some(code) => Err(JSError::JSRuntimeExit {
-            runtime: js_runtime.to_string(),
+            runtime: js_runtime.to_string().into(),
             code,
         }),
         None => Err(JSError::JSRuntimeExit {
-            runtime: js_runtime.to_string(),
+            runtime: js_runtime.to_string().into(),
             code: -1,
         }),
     }

--- a/crates/generate/src/generate.rs
+++ b/crates/generate/src/generate.rs
@@ -35,8 +35,8 @@ use grammars::{InlinedProductionMap, LexicalGrammar, SyntaxGrammar};
 pub use node_types::{InvalidSupertypeError, SuperTypeCycleError, VariableInfoError};
 pub use parse_grammar::ParseGrammarError;
 use parse_grammar::parse_grammar;
-pub use prepare_grammar::PrepareGrammarError;
 use prepare_grammar::prepare_grammar;
+pub use prepare_grammar::{PatternSpan, PrepareGrammarError, RegexError, RegexErrorKind};
 use render::render_c_code;
 pub use render::{ABI_VERSION_MAX, ABI_VERSION_MIN, RenderError};
 

--- a/crates/generate/src/node_types.rs
+++ b/crates/generate/src/node_types.rs
@@ -147,13 +147,13 @@ pub enum VariableInfoError {
     #[error(transparent)]
     InvalidSupertype(InvalidSupertypeError),
     #[error("Named alias `{0}` conflicts with a supertype of the same name.")]
-    SupertypeAliasCollision(String),
+    SupertypeAliasCollision(Box<str>),
 }
 
 #[derive(Debug, Error, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InvalidSupertypeError {
-    supertype: String,
-    child: Option<String>,
+    supertype: Box<str>,
+    child: Option<Box<str>>,
 }
 
 impl std::fmt::Display for InvalidSupertypeError {
@@ -239,7 +239,7 @@ fn validate_supertype_aliases(
             .any(|aliases| aliases.contains(&Some(collision)))
         {
             return Err(VariableInfoError::SupertypeAliasCollision(
-                str_pool.resolve(supertype.name).to_string(),
+                str_pool.resolve(supertype.name).to_string().into(),
             ));
         }
     }
@@ -495,12 +495,12 @@ fn validate_supertype_structure(
                         .map(|index| {
                             str_pool
                                 .resolve(syntax_grammar.variables[index].name)
-                                .to_string()
+                                .into()
                         })
                 });
 
             Err(VariableInfoError::InvalidSupertype(InvalidSupertypeError {
-                supertype: str_pool.resolve(variable.name).to_string(),
+                supertype: str_pool.resolve(variable.name).to_string().into(),
                 child: hidden_child_name,
             }))?;
         }
@@ -615,7 +615,7 @@ pub type SuperTypeCycleResult<T> = Result<T, SuperTypeCycleError>;
 
 #[derive(Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SuperTypeCycleError {
-    items: Vec<String>,
+    items: Box<[Box<str>]>,
 }
 
 impl std::fmt::Display for SuperTypeCycleError {
@@ -1028,10 +1028,12 @@ fn sort_subtype_map_topologically(
             (true, true) => break,
             (true, false) => {
                 let mut items = top_sort
-                    .map(|node_type| str_pool.resolve(node_type.kind).to_string())
-                    .collect::<Vec<String>>();
+                    .map(|node_type| str_pool.resolve(node_type.kind).into())
+                    .collect::<Vec<Box<str>>>();
                 items.sort();
-                return Err(SuperTypeCycleError { items });
+                return Err(SuperTypeCycleError {
+                    items: items.into(),
+                });
             }
             (false, _) => {
                 sort_node_type_refs(&mut next_node_types, str_pool);

--- a/crates/generate/src/parse_grammar.rs
+++ b/crates/generate/src/parse_grammar.rs
@@ -118,7 +118,7 @@ pub type ParseGrammarResult<T> = Result<T, ParseGrammarError>;
 #[derive(Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ParseGrammarError {
     #[error("{0}")]
-    Serialization(String),
+    Serialization(Box<str>),
     #[error("Rules in the `extras` array must not contain empty strings")]
     InvalidExtra,
     #[error("Invalid rule in precedences array. Only strings and symbols are allowed")]
@@ -126,12 +126,12 @@ pub enum ParseGrammarError {
     #[error("Reserved word sets must be arrays")]
     InvalidReservedWordSet,
     #[error("Grammar Error: Unexpected rule `{0}` in `token()` call")]
-    UnexpectedRule(String),
+    UnexpectedRule(Box<str>),
 }
 
 impl From<serde_json::Error> for ParseGrammarError {
     fn from(value: serde_json::Error) -> Self {
-        Self::Serialization(value.to_string())
+        Self::Serialization(value.to_string().into())
     }
 }
 
@@ -207,7 +207,7 @@ impl InputGrammar {
             };
             if matches_empty {
                 diagnostics.push(Diagnostic::EmptyStringMatch(
-                    self.pool.resolve(v.name).to_string(),
+                    self.pool.resolve(v.name).to_string().into(),
                 ));
             }
         }
@@ -375,7 +375,7 @@ impl RulePool {
                             if c != 'u' && c != 'v' {
                                 diagnostics.push(Diagnostic::UnsupportedRegexFlag {
                                     flag: c,
-                                    pattern: value.clone(),
+                                    pattern: value.as_str().into(),
                                 });
                             }
                             false
@@ -389,7 +389,7 @@ impl RulePool {
             }
             RuleJSON::SYMBOL { name } => {
                 if is_token {
-                    Err(ParseGrammarError::UnexpectedRule(name))?
+                    Err(ParseGrammarError::UnexpectedRule(name.into()))?
                 } else {
                     let sid = self.intern(&name);
                     Ok(self.named_symbol(sid))

--- a/crates/generate/src/prepare_grammar.rs
+++ b/crates/generate/src/prepare_grammar.rs
@@ -13,10 +13,14 @@ use std::{
     mem,
 };
 
-pub use expand_tokens::ExpandTokensError;
+pub use expand_repeats::ExpandRepeatsError;
 #[cfg(test)]
 pub use expand_tokens::expand_tokens;
-pub use extract_tokens::ExtractTokensError;
+pub use expand_tokens::{
+    ExpandRegexError, ExpandRuleError, ExpandTokensError, ExpandTokensProcessingError,
+    NonAsciiByteClassError,
+};
+pub use extract_tokens::{ExtractTokensError, NonTerminalWordTokenError};
 pub use flatten_grammar::FlattenGrammarError;
 use indexmap::IndexMap;
 pub use intern_symbols::InternSymbolsError;
@@ -32,7 +36,7 @@ use crate::{
 };
 
 use self::{
-    expand_repeats::{ExpandRepeatsError, expand_repeats},
+    expand_repeats::expand_repeats,
     extract_default_aliases::extract_default_aliases,
     extract_tokens::extract_tokens,
     flatten_grammar::flatten_grammar,

--- a/crates/generate/src/prepare_grammar.rs
+++ b/crates/generate/src/prepare_grammar.rs
@@ -36,12 +36,9 @@ use crate::{
 };
 
 use self::{
-    expand_repeats::expand_repeats,
-    extract_default_aliases::extract_default_aliases,
-    extract_tokens::extract_tokens,
-    flatten_grammar::flatten_grammar,
-    intern_symbols::intern_symbols,
-    process_inlines::process_inlines,
+    expand_repeats::expand_repeats, extract_default_aliases::extract_default_aliases,
+    extract_tokens::extract_tokens, flatten_grammar::flatten_grammar,
+    intern_symbols::intern_symbols, process_inlines::process_inlines,
 };
 use super::{
     Diagnostic,
@@ -76,7 +73,7 @@ pub enum ValidatePrecedenceError {
 }
 
 #[derive(Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
-pub struct IndirectRecursionError(pub Vec<String>);
+pub struct IndirectRecursionError(pub Box<[Box<str>]>);
 
 impl std::fmt::Display for IndirectRecursionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -94,15 +91,15 @@ impl std::fmt::Display for IndirectRecursionError {
 #[derive(Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
 #[error("Undeclared precedence '{}' in rule '{}'", self.precedence, self.rule)]
 pub struct UndeclaredPrecedenceError {
-    pub precedence: String,
-    pub rule: String,
+    pub precedence: Box<str>,
+    pub rule: Box<str>,
 }
 
 #[derive(Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
 #[error("Conflicting orderings for precedences {} and {}", self.precedence_1, self.precedence_2)]
 pub struct ConflictingPrecedenceOrderingError {
-    pub precedence_1: String,
-    pub precedence_2: String,
+    pub precedence_1: Box<str>,
+    pub precedence_2: Box<str>,
 }
 
 pub struct PreparedGrammar {
@@ -191,7 +188,7 @@ fn validate_indirect_recursion(grammar: &InputGrammar) -> Result<(), IndirectRec
         {
             let cycle_symbols = path[start_idx..=end_idx]
                 .iter()
-                .map(|&s| grammar.pool.resolve(s).to_string())
+                .map(|&s| grammar.pool.resolve(s).to_string().into())
                 .collect();
             return Err(IndirectRecursionError(cycle_symbols));
         }
@@ -269,8 +266,8 @@ fn validate_precedences(grammar: &InputGrammar) -> ValidatePrecedenceResult<()> 
                     hash_map::Entry::Occupied(e) => {
                         if e.get() != &ordering {
                             Err(ConflictingPrecedenceOrderingError {
-                                precedence_1: display(&entry1),
-                                precedence_2: display(&entry2),
+                                precedence_1: display(&entry1).into(),
+                                precedence_2: display(&entry2).into(),
                             })?;
                         }
                     }
@@ -304,8 +301,8 @@ fn validate_precedences(grammar: &InputGrammar) -> ValidatePrecedenceResult<()> 
                         && !precedence_names.contains(&sid)
                     {
                         Err(UndeclaredPrecedenceError {
-                            precedence: grammar.pool.resolve(sid).to_string(),
-                            rule: grammar.pool.resolve(variable.name).to_string(),
+                            precedence: grammar.pool.resolve(sid).to_string().into(),
+                            rule: grammar.pool.resolve(variable.name).to_string().into(),
                         })?;
                     }
                     stack.push(rule);
@@ -377,8 +374,8 @@ mod tests {
         assert_eq!(
             validate_precedences(&grammar).unwrap_err(),
             ValidatePrecedenceError::Undeclared(UndeclaredPrecedenceError {
-                precedence: "omg".to_string(),
-                rule: "v2".to_string()
+                precedence: "omg".to_string().into(),
+                rule: "v2".to_string().into()
             })
         );
     }
@@ -403,8 +400,8 @@ mod tests {
         assert_eq!(
             validate_precedences(&grammar).unwrap_err(),
             ValidatePrecedenceError::Ordering(ConflictingPrecedenceOrderingError {
-                precedence_1: "'a'".to_string(),
-                precedence_2: "'b'".to_string()
+                precedence_1: "'a'".to_string().into(),
+                precedence_2: "'b'".to_string().into()
             })
         );
     }
@@ -463,13 +460,8 @@ mod tests {
             ]
         });
 
-        let err1 = IndirectRecursionError(vec!["a".to_string(), "b".to_string(), "a".to_string()]);
-        let err3 = IndirectRecursionError(vec![
-            "b".to_string(),
-            "c".to_string(),
-            "d".to_string(),
-            "b".to_string(),
-        ]);
+        let err1 = IndirectRecursionError(["a".into(), "b".into(), "a".into()].into());
+        let err3 = IndirectRecursionError(["b".into(), "c".into(), "d".into(), "b".into()].into());
 
         for (g, expected) in &[(case1, Err(err1)), (case2, Ok(())), (case3, Err(err3))] {
             assert_eq!(*expected, validate_indirect_recursion(g));

--- a/crates/generate/src/prepare_grammar.rs
+++ b/crates/generate/src/prepare_grammar.rs
@@ -20,6 +20,7 @@ pub use extract_tokens::ExtractTokensError;
 pub use flatten_grammar::FlattenGrammarError;
 use indexmap::IndexMap;
 pub use intern_symbols::InternSymbolsError;
+pub use pattern::{PatternSpan, RegexError, RegexErrorKind};
 pub use process_inlines::ProcessInlinesError;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};

--- a/crates/generate/src/prepare_grammar/expand_repeats.rs
+++ b/crates/generate/src/prepare_grammar/expand_repeats.rs
@@ -26,7 +26,7 @@ enum Task {
 
 #[derive(Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
 #[error("Rule `{0}` contains a repetition that can match the empty string at end of input")]
-pub struct ExpandRepeatsError(pub String);
+pub struct ExpandRepeatsError(pub Box<str>);
 
 impl Expander {
     /// Post-order repeat expansion over one root. Children expand first, and `Reserved`
@@ -62,7 +62,9 @@ impl Expander {
                 Task::Expand { id, content } => {
                     let width = self.zero_width.eval(pool, content);
                     if width.eof_nullable {
-                        return Err(ExpandRepeatsError(pool.resolve(var_name).to_string()));
+                        return Err(ExpandRepeatsError(
+                            pool.resolve(var_name).to_string().into(),
+                        ));
                     }
                     // For repetitions, introduce an auxiliary rule that contains the
                     // repeated content, but can also contain a recursive binary tree structure.
@@ -324,7 +326,9 @@ pub(super) fn expand_repeats(
                 .eval(&grammar.pool, content)
                 .eof_nullable
             {
-                return Err(ExpandRepeatsError(grammar.pool.resolve(name).to_string()));
+                return Err(ExpandRepeatsError(
+                    grammar.pool.resolve(name).to_string().into(),
+                ));
             }
             expander.expand_root(&mut grammar.pool, content, name, &mut aux_repeat_count)?;
             grammar.variables[i].root =
@@ -653,7 +657,7 @@ mod tests {
         };
         assert_eq!(
             expand_repeats(&mut grammar, &mut meta).unwrap_err(),
-            ExpandRepeatsError("rule0".to_string())
+            ExpandRepeatsError("rule0".to_string().into())
         );
     }
 

--- a/crates/generate/src/prepare_grammar/expand_tokens.rs
+++ b/crates/generate/src/prepare_grammar/expand_tokens.rs
@@ -5,7 +5,10 @@ use thiserror::Error;
 use crate::{
     grammars::{LexicalGrammar, LexicalVariable},
     nfa::{CharacterSet, Nfa, NfaState},
-    prepare_grammar::{LexicalToken, pattern},
+    prepare_grammar::{
+        LexicalToken,
+        pattern::{self, RegexError},
+    },
     rules::{Precedence, Rule, RuleId, RulePool, Symbol},
 };
 
@@ -168,8 +171,8 @@ pub enum ExpandRuleError {
         so use `eof()` only at the end of a syntactic rule."
     )]
     UnexpectedEof,
-    #[error("{0}")]
-    Parse(String),
+    #[error(transparent)]
+    Parse(#[from] RegexError),
     #[error(transparent)]
     ExpandRegex(ExpandRegexError),
 }
@@ -230,8 +233,7 @@ impl NfaBuilder {
                 // Parse WITHOUT case folding and fold ourselves (see
                 // `case_fold_ascii_safe`). Letting `regex_syntax` fold would pull the
                 // long s `ſ` and Kelvin sign `K` into ASCII `s`/`k`.
-                let hir = pattern::parse(&s, pool.resolve(f).contains('i'))
-                    .map_err(|e| ExpandRuleError::Parse(e.to_string()))?;
+                let hir = pattern::parse(&s, pool.resolve(f).contains('i'))?;
                 self.expand_regex(&hir, next_state_id)
                     .map_err(ExpandRuleError::ExpandRegex)
             }

--- a/crates/generate/src/prepare_grammar/expand_tokens.rs
+++ b/crates/generate/src/prepare_grammar/expand_tokens.rs
@@ -28,7 +28,7 @@ Tree-sitter does not support syntactic rules that match the empty string
 unless they are used only as the grammar's start rule.
 "
     )]
-    EmptyString(String),
+    EmptyString(Box<str>),
     #[error(transparent)]
     Processing(ExpandTokensProcessingError),
     #[error(transparent)]
@@ -37,7 +37,7 @@ unless they are used only as the grammar's start rule.
 
 #[derive(Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExpandTokensProcessingError {
-    rule: String,
+    rule: Box<str>,
     error: ExpandRuleError,
 }
 
@@ -89,7 +89,7 @@ pub fn expand_tokens(
     for (i, variable) in lexical_variables.iter().enumerate() {
         if pool.subtree_matches_empty_str(variable.root) {
             Err(ExpandTokensError::EmptyString(
-                pool.resolve(variable.name).to_string(),
+                pool.resolve(variable.name).to_string().into(),
             ))?;
         }
         let is_immediate_token = match pool.node(variable.root) {
@@ -107,7 +107,7 @@ pub fn expand_tokens(
             .expand_rule(pool, variable.root, last_state_id)
             .map_err(|e| {
                 ExpandTokensError::Processing(ExpandTokensProcessingError {
-                    rule: pool.resolve(variable.name).to_string(),
+                    rule: pool.resolve(variable.name).to_string().into(),
                     error: e,
                 })
             })?;
@@ -164,7 +164,7 @@ pub enum ExpandRuleError {
     #[error("unexpected symbol {0:?}")]
     UnexpectedSymbol(Symbol),
     #[error("unexpected reserved-word context {0}")]
-    UnexpectedReserved(String),
+    UnexpectedReserved(Box<str>),
     #[error(
         "`eof()` cannot be used inside a token. \
         A lexical rule cannot check for end of input, \
@@ -172,7 +172,7 @@ pub enum ExpandRuleError {
     )]
     UnexpectedEof,
     #[error(transparent)]
-    Parse(#[from] RegexError),
+    Parse(#[from] Box<RegexError>),
     #[error(transparent)]
     ExpandRegex(ExpandRegexError),
 }
@@ -182,7 +182,7 @@ pub type ExpandRegexResult<T> = Result<T, ExpandRegexError>;
 #[derive(Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ExpandRegexError {
     #[error("{0}")]
-    Utf8(String),
+    Utf8(Box<str>),
     #[error("Regex error: Assertions are not supported")]
     Assertion,
     #[error(transparent)]
@@ -308,7 +308,7 @@ impl NfaBuilder {
             Rule::Eof => Err(ExpandRuleError::UnexpectedEof)?,
             Rule::Sym(symbol) => Err(ExpandRuleError::UnexpectedSymbol(symbol))?,
             Rule::Reserved { ctx, .. } => Err(ExpandRuleError::UnexpectedReserved(
-                pool.resolve(ctx).to_string(),
+                pool.resolve(ctx).to_string().into(),
             ))?,
             // `NamedSymbol` is interned to `Sym` by intern_symbols
             Rule::NamedSymbol(_) => unreachable!(),
@@ -320,7 +320,7 @@ impl NfaBuilder {
             HirKind::Empty => Ok(false),
             HirKind::Literal(literal) => {
                 for character in std::str::from_utf8(&literal.0)
-                    .map_err(|e| ExpandRegexError::Utf8(e.to_string()))?
+                    .map_err(|e| ExpandRegexError::Utf8(e.to_string().into()))?
                     .chars()
                     .rev()
                 {
@@ -1183,7 +1183,7 @@ mod tests {
         assert_eq!(
             expand_tokens(&mut pool, &vars, &[]).unwrap_err(),
             ExpandTokensError::Processing(ExpandTokensProcessingError {
-                rule: "tok".to_string(),
+                rule: "tok".into(),
                 error: ExpandRuleError::ExpandRegex(ExpandRegexError::NonAsciiByteClass(
                     NonAsciiByteClassError {
                         start: 0xa9,

--- a/crates/generate/src/prepare_grammar/extract_tokens.rs
+++ b/crates/generate/src/prepare_grammar/extract_tokens.rs
@@ -25,23 +25,23 @@ Tree-sitter does not support syntactic rules that contain an empty string
 unless they are used only as the grammar's start rule.
 "
     )]
-    EmptyString(String),
+    EmptyString(Box<str>),
     #[error("Terminal rule '{0}' cannot be used as a supertype")]
-    SupertypeTerminal(String),
+    SupertypeTerminal(Box<str>),
     #[error("Rule '{0}' cannot be used as both an external token and a non-terminal rule")]
-    ExternalTokenNonTerminal(String),
+    ExternalTokenNonTerminal(Box<str>),
     #[error("Non-symbol rules cannot be used as external tokens")]
     NonSymbolExternalToken,
     #[error(transparent)]
     WordToken(NonTerminalWordTokenError),
     #[error("Reserved word '{0}' must be a token")]
-    NonTokenReservedWord(String),
+    NonTokenReservedWord(Box<str>),
 }
 
 #[derive(Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
 pub struct NonTerminalWordTokenError {
-    pub symbol_name: String,
-    pub conflicting_symbol_name: Option<String>,
+    pub symbol_name: Box<str>,
+    pub conflicting_symbol_name: Option<Box<str>>,
 }
 
 impl std::fmt::Display for NonTerminalWordTokenError {
@@ -111,7 +111,7 @@ impl TokenExtractor {
         let (name, kind) = if let Some(sid) = string_name {
             if pool.resolve(sid).is_empty() && !is_first {
                 Err(ExtractTokensError::EmptyString(
-                    var_name.map_or_else(String::new, |v| pool.resolve(v).to_string()),
+                    var_name.map_or_else(Box::default, |v| pool.resolve(v).to_string().into()),
                 ))?;
             }
             (sid, VariableType::Anonymous)
@@ -427,7 +427,7 @@ pub(super) fn extract_tokens<'g>(
                 Err(ExtractTokensError::SupertypeTerminal(
                     g.pool
                         .resolve(extractor.lexical[usize::from(index)].name)
-                        .to_string(),
+                        .into(),
                 ))
             } else {
                 Ok(sym)
@@ -466,9 +466,7 @@ pub(super) fn extract_tokens<'g>(
         };
         if let SymbolView::NonTerminal(index) = s.view() {
             Err(ExtractTokensError::ExternalTokenNonTerminal(
-                g.pool
-                    .resolve(g.variables[usize::from(index)].name)
-                    .to_string(),
+                g.pool.resolve(g.variables[usize::from(index)].name).into(),
             ))?;
         }
         external_tokens.push(match s.view() {
@@ -502,9 +500,9 @@ pub(super) fn extract_tokens<'g>(
             .iter()
             .enumerate()
             .find(|(i, v)| *i != token_index && g.pool.subtree_eq(v.root, word_root))
-            .map(|(_, v)| g.pool.resolve(v.name).to_string());
+            .map(|(_, v)| g.pool.resolve(v.name).into());
         Err(ExtractTokensError::WordToken(NonTerminalWordTokenError {
-            symbol_name: g.pool.resolve(g.variables[token_index].name).to_string(),
+            symbol_name: g.pool.resolve(g.variables[token_index].name).into(),
             conflicting_symbol_name,
         }))?;
     }
@@ -529,7 +527,7 @@ pub(super) fn extract_tokens<'g>(
                     Rule::String(s) | Rule::Pattern(s, _) => g.pool.resolve(s).to_string(),
                     _ => "unknown".to_string(),
                 };
-                Err(ExtractTokensError::NonTokenReservedWord(token_name))?;
+                Err(ExtractTokensError::NonTokenReservedWord(token_name.into()))?;
             }
         }
         reserved_sets.push((set.name, symbols));
@@ -899,7 +897,7 @@ mod test {
         let err = extract(&mut grammar).unwrap_err();
         assert_eq!(
             err,
-            ExtractTokensError::ExternalTokenNonTerminal("rule_1".to_string())
+            ExtractTokensError::ExternalTokenNonTerminal("rule_1".to_string().into())
         );
     }
 
@@ -969,7 +967,7 @@ mod test {
         let mut grammar = pool_grammar(pool, variables);
         assert_eq!(
             extract(&mut grammar).unwrap_err(),
-            ExtractTokensError::EmptyString("_rule_1".to_string())
+            ExtractTokensError::EmptyString("_rule_1".to_string().into())
         );
     }
 

--- a/crates/generate/src/prepare_grammar/flatten_grammar.rs
+++ b/crates/generate/src/prepare_grammar/flatten_grammar.rs
@@ -16,7 +16,7 @@ pub type FlattenGrammarResult<T> = Result<T, FlattenGrammarError>;
 #[derive(Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
 pub enum FlattenGrammarError {
     #[error("No such reserved word set: {0}")]
-    NoReservedWordSet(String),
+    NoReservedWordSet(Box<str>),
     #[error("Reserved word set count {0} exceeds the maximum of {max}", max = u16::MAX)]
     TooManyReservedWordSets(usize),
     #[error(
@@ -26,11 +26,11 @@ Tree-sitter does not support syntactic rules that match the empty string
 unless they are used only as the grammar's start rule.
 "
     )]
-    EmptyString(String),
+    EmptyString(Box<str>),
     #[error("Rule `{0}` cannot be inlined because it contains a reference to itself")]
-    RecursiveInline(String),
+    RecursiveInline(Box<str>),
     #[error("Rule `{0}` has no reachable productions.")]
-    NoReachableProductions(String),
+    NoReachableProductions(Box<str>),
 }
 
 #[derive(Clone, Copy, Default)]
@@ -220,7 +220,7 @@ fn apply(
         Rule::Reserved { rule, ctx } => {
             let Some(&reserved) = reserved_ids.get(&ctx) else {
                 return Err(FlattenGrammarError::NoReservedWordSet(
-                    pool.resolve(ctx).to_string(),
+                    pool.resolve(ctx).to_string().into(),
                 ));
             };
             let inner = FlattenCtx { reserved, ..f_ctx };
@@ -315,7 +315,7 @@ pub(super) fn flatten_grammar(
         }
         if dropped_for_eof && prod_start == out.productions.len() as u32 {
             return Err(FlattenGrammarError::NoReachableProductions(
-                g.pool.resolve(v.name).to_string(),
+                g.pool.resolve(v.name).to_string().into(),
             ));
         }
         out.var_prods
@@ -337,7 +337,7 @@ fn check(
         for p in &out.productions[p_start as usize..p_end as usize] {
             if used && p.steps_len == 0 && !p.requires_eof_lookahead {
                 Err(FlattenGrammarError::EmptyString(
-                    g.pool.resolve(g.variables[i].name).to_string(),
+                    g.pool.resolve(g.variables[i].name).to_string().into(),
                 ))?;
             }
             if inlined
@@ -346,7 +346,7 @@ fn check(
                     .any(|s| s.symbol() == symbol)
             {
                 Err(FlattenGrammarError::RecursiveInline(
-                    g.pool.resolve(g.variables[i].name).to_string(),
+                    g.pool.resolve(g.variables[i].name).to_string().into(),
                 ))?;
             }
         }
@@ -648,7 +648,7 @@ mod tests {
         };
         assert_eq!(
             run(pg, meta).unwrap_err(),
-            FlattenGrammarError::RecursiveInline("test".to_string())
+            FlattenGrammarError::RecursiveInline("test".to_string().into())
         );
     }
 
@@ -663,7 +663,7 @@ mod tests {
         .unwrap_err();
         assert_eq!(
             err,
-            FlattenGrammarError::NoReservedWordSet("nope".to_string())
+            FlattenGrammarError::NoReservedWordSet("nope".to_string().into())
         );
     }
 
@@ -694,7 +694,7 @@ mod tests {
         };
         assert_eq!(
             run(pg, meta).unwrap_err(),
-            FlattenGrammarError::EmptyString("b".to_string())
+            FlattenGrammarError::EmptyString("b".to_string().into())
         );
     }
 

--- a/crates/generate/src/prepare_grammar/intern_symbols.rs
+++ b/crates/generate/src/prepare_grammar/intern_symbols.rs
@@ -16,13 +16,13 @@ pub enum InternSymbolsError {
     #[error("A grammar's start rule must be visible.")]
     HiddenStartRule,
     #[error("Undefined symbol `{0}`")]
-    Undefined(String),
+    Undefined(Box<str>),
     #[error("Undefined symbol `{0}` in grammar's supertypes array")]
-    UndefinedSupertype(String),
+    UndefinedSupertype(Box<str>),
     #[error("Undefined symbol `{0}` in grammar's conflicts array")]
-    UndefinedConflict(String),
+    UndefinedConflict(Box<str>),
     #[error("Undefined symbol `{0}` as grammar's word token")]
-    UndefinedWordToken(String),
+    UndefinedWordToken(Box<str>),
 }
 
 /// The non-pool outputs of the intern pass. The rule bodies are rewritten in place
@@ -110,8 +110,9 @@ pub(super) fn intern_symbols(
         .supertype_names
         .iter()
         .map(|&s| {
-            lookup(s)
-                .ok_or_else(|| InternSymbolsError::UndefinedSupertype(pool.resolve(s).to_string()))
+            lookup(s).ok_or_else(|| {
+                InternSymbolsError::UndefinedSupertype(pool.resolve(s).to_string().into())
+            })
         })
         .collect::<InternSymbolsResult<Vec<_>>>()?;
     let conflicts = grammar
@@ -121,7 +122,7 @@ pub(super) fn intern_symbols(
             c.iter()
                 .map(|&s| {
                     lookup(s).ok_or_else(|| {
-                        InternSymbolsError::UndefinedConflict(pool.resolve(s).to_string())
+                        InternSymbolsError::UndefinedConflict(pool.resolve(s).to_string().into())
                     })
                 })
                 .collect::<InternSymbolsResult<Vec<_>>>()
@@ -144,7 +145,7 @@ pub(super) fn intern_symbols(
         .filter_map(|(&name, symbol)| {
             if inline.contains(&symbol) {
                 diagnostics.push(Diagnostic::SupertypeInlined {
-                    name: pool.resolve(name).to_string(),
+                    name: pool.resolve(name).into(),
                 });
                 None
             } else {
@@ -155,8 +156,9 @@ pub(super) fn intern_symbols(
     let word = grammar
         .word_name
         .map(|s| {
-            lookup(s)
-                .ok_or_else(|| InternSymbolsError::UndefinedWordToken(pool.resolve(s).to_string()))
+            lookup(s).ok_or_else(|| {
+                InternSymbolsError::UndefinedWordToken(pool.resolve(s).to_string().into())
+            })
         })
         .transpose()?;
 
@@ -192,7 +194,7 @@ fn intern_root(
         match pool.node(id) {
             Rule::NamedSymbol(sid) => match name_of_symbol.get(&sid).copied() {
                 Some(s) => pool.set_node(id, Rule::from(s)),
-                None => Err(InternSymbolsError::Undefined(pool.resolve(sid).to_string()))?,
+                None => Err(InternSymbolsError::Undefined(pool.resolve(sid).into()))?,
             },
             Rule::Seq(range) | Rule::Choice(range) => {
                 let children = pool.child_slice(range);
@@ -201,7 +203,7 @@ fn intern_root(
                 if children.len() == 1
                     && matches!(pool.node(children[0]), Rule::String(_) | Rule::Pattern(..))
                 {
-                    let name = var_name.map(|s| pool.resolve(s).to_string());
+                    let name = var_name.map(|s| pool.resolve(s).into());
                     diagnostics.push(if matches!(pool.node(id), Rule::Choice(_)) {
                         Diagnostic::UnaryChoice { name }
                     } else {
@@ -398,7 +400,7 @@ mod tests {
         assert!(result.is_err(), "Expected an error but got none");
         assert_eq!(
             result.unwrap_err(),
-            InternSymbolsError::Undefined("y".to_string())
+            InternSymbolsError::Undefined("y".to_string().into())
         );
     }
 
@@ -441,9 +443,7 @@ mod tests {
         assert_eq!(meta.inline, vec![Symbol::non_terminal(1)]);
         assert_eq!(
             diagnostics,
-            [Diagnostic::SupertypeInlined {
-                name: "_v2".to_string()
-            }]
+            [Diagnostic::SupertypeInlined { name: "_v2".into() }]
         );
     }
 

--- a/crates/generate/src/prepare_grammar/pattern.rs
+++ b/crates/generate/src/prepare_grammar/pattern.rs
@@ -29,6 +29,9 @@
 //! nothing and it compiles exactly what is would have with our fold in place of
 //! its own.
 
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
 use regex_syntax::{
     ast::{
         self, Ast, ClassBracketed, ClassSet, ClassSetItem, ClassSetRange, ClassSetUnion, Flag,
@@ -66,14 +69,11 @@ struct Expander<'a> {
 }
 
 /// Parse a token pattern into an [`Hir`], folding any `i` flag manually.
-pub(super) fn parse(
-    pattern: &str,
-    case_insensitive: bool,
-) -> Result<Hir, Box<regex_syntax::Error>> {
+pub(super) fn parse(pattern: &str, case_insensitive: bool) -> Result<Hir, RegexError> {
     let mut ast = ParserBuilder::new()
         .build()
         .parse(pattern)
-        .map_err(|e| Box::new(e.into()))?;
+        .map_err(|e| RegexError::new(&e.into()))?;
 
     let mut expander = Expander {
         translator: TranslatorBuilder::new()
@@ -87,11 +87,13 @@ pub(super) fn parse(
             unicode: true,
         },
     };
-    expander.expand(&mut ast).map_err(|e| Box::new(e.into()))?;
+    expander
+        .expand(&mut ast)
+        .map_err(|e| RegexError::new(&e.into()))?;
     expander
         .translator
         .translate(pattern, &ast)
-        .map_err(|e| Box::new(e.into()))
+        .map_err(|e| RegexError::new(&e.into()))
 }
 
 impl Expander<'_> {
@@ -331,5 +333,180 @@ impl Expander<'_> {
         class.case_fold_simple();
         class.difference(&exotic);
         class.union(&asked_for);
+    }
+}
+
+/// Mirror of [`regex_syntax::ast::ErrorKind`] with [`serde::Serialize`].
+macro_rules! mirror_regex_error_kinds {
+    (
+        ast { $($av:ident => $am:literal,)* }
+        hir { $($hv:ident => $hm:literal,)* }
+    ) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
+        pub enum RegexErrorKind {
+            $(#[error($am)] $av,)*
+            $(#[error($hm)] $hv,)*
+            #[error("duplicate flag")]
+            FlagDuplicate,
+            #[error("flag negation operator repeated")]
+            FlagRepeatedNegation,
+            #[error("duplicate capture group name")]
+            GroupNameDuplicate,
+            #[error("exceed the maximum number of nested parentheses/brackets ({0})")]
+            NestLimitExceeded(u32),
+            /// A kind `regex_syntax` added after this mirror was written.
+            #[error("{0}")]
+            Other(Box<str>),
+        }
+
+        impl From<&ast::ErrorKind> for RegexErrorKind {
+            fn from(kind: &ast::ErrorKind) -> Self {
+                match kind {
+                    $(ast::ErrorKind::$av => Self::$av,)*
+                    ast::ErrorKind::FlagDuplicate { .. } => Self::FlagDuplicate,
+                    ast::ErrorKind::FlagRepeatedNegation { .. } => Self::FlagRepeatedNegation,
+                    ast::ErrorKind::GroupNameDuplicate { .. } => Self::GroupNameDuplicate,
+                    ast::ErrorKind::NestLimitExceeded(limit) => Self::NestLimitExceeded(*limit),
+                    other => Self::Other(other.to_string().into_boxed_str()),
+                }
+            }
+        }
+
+        impl From<&hir::ErrorKind> for RegexErrorKind {
+            fn from(kind: &hir::ErrorKind) -> Self {
+                match kind {
+                    $(hir::ErrorKind::$hv => Self::$hv,)*
+                    other => Self::Other(other.to_string().into_boxed_str()),
+                }
+            }
+        }
+    };
+}
+
+mirror_regex_error_kinds! {
+    ast {
+        CaptureLimitExceeded => "exceeded the maximum number of capturing groups (4294967295)",
+        ClassEscapeInvalid => "invalid escape sequence found in character class",
+        ClassRangeInvalid => "invalid character class range, the start must be <= the end",
+        ClassRangeLiteral => "invalid range boundary, must be a literal",
+        ClassUnclosed => "unclosed character class",
+        DecimalEmpty => "decimal literal empty",
+        DecimalInvalid => "decimal literal invalid",
+        EscapeHexEmpty => "hexadecimal literal empty",
+        EscapeHexInvalid => "hexadecimal literal is not a Unicode scalar value",
+        EscapeHexInvalidDigit => "invalid hexadecimal digit",
+        EscapeUnexpectedEof => "incomplete escape sequence, reached end of pattern prematurely",
+        EscapeUnrecognized => "unrecognized escape sequence",
+        FlagDanglingNegation => "dangling flag negation operator",
+        FlagUnexpectedEof => "expected flag but got end of regex",
+        FlagUnrecognized => "unrecognized flag",
+        GroupNameEmpty => "empty capture group name",
+        GroupNameInvalid => "invalid capture group character",
+        GroupNameUnexpectedEof => "unclosed capture group name",
+        GroupUnclosed => "unclosed group",
+        GroupUnopened => "unopened group",
+        RepetitionCountInvalid => "invalid repetition count range, the start must be <= the end",
+        RepetitionCountDecimalEmpty => "repetition quantifier expects a valid decimal",
+        RepetitionCountUnclosed => "unclosed counted repetition",
+        RepetitionMissing => "repetition operator missing expression",
+        SpecialWordBoundaryUnclosed => "special word boundary assertion is either unclosed or contains an invalid character",
+        SpecialWordBoundaryUnrecognized => "unrecognized special word boundary assertion, valid choices are: start, end, start-half or end-half",
+        SpecialWordOrRepetitionUnexpectedEof => "found either the beginning of a special word boundary or a bounded repetition on a \\b with an opening brace, but no closing brace",
+        UnicodeClassInvalid => "invalid Unicode character class",
+        UnsupportedBackreference => "backreferences are not supported",
+        UnsupportedLookAround => "look-around, including look-ahead and look-behind, is not supported",
+    }
+    hir {
+        UnicodeNotAllowed => "Unicode not allowed here",
+        InvalidUtf8 => "pattern can match invalid UTF-8",
+        InvalidLineTerminator => "invalid line terminator, must be ASCII",
+        UnicodePropertyNotFound => "Unicode property not found",
+        UnicodePropertyValueNotFound => "Unicode property value not found",
+        UnicodePerlClassNotFound => "Unicode-aware Perl class not found (make sure the unicode-perl feature is enabled)",
+        UnicodeCaseUnavailable => "Unicode-aware case insensitivity matching is not available (make sure the unicode-case feature is enabled)",
+    }
+}
+
+/// Byte range within a pattern string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PatternSpan {
+    pub start: u32,
+    pub end: u32,
+}
+
+impl PatternSpan {
+    const fn new(span: &Span) -> Self {
+        Self {
+            start: span.start.offset as u32,
+            end: span.end.offset as u32,
+        }
+    }
+}
+
+/// A pattern rejected by [`parse`], carrying the pattern and the offending
+/// range inside it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
+pub struct RegexError {
+    pub pattern: String,
+    pub kind: RegexErrorKind,
+    pub span: Option<PatternSpan>,
+    pub aux_span: Option<PatternSpan>,
+}
+
+impl RegexError {
+    fn new(error: &regex_syntax::Error) -> Self {
+        let (pattern, kind, span, aux_span) = match error {
+            regex_syntax::Error::Parse(e) => (
+                e.pattern().to_string(),
+                RegexErrorKind::from(e.kind()),
+                Some(e.span()),
+                e.auxiliary_span(),
+            ),
+            regex_syntax::Error::Translate(e) => (
+                e.pattern().to_string(),
+                RegexErrorKind::from(e.kind()),
+                Some(e.span()),
+                None,
+            ),
+            other => (
+                String::new(),
+                RegexErrorKind::Other(other.to_string().into_boxed_str()),
+                None,
+                None,
+            ),
+        };
+        Self {
+            pattern,
+            kind,
+            span: span.map(PatternSpan::new),
+            aux_span: aux_span.map(PatternSpan::new),
+        }
+    }
+
+    fn column(&self, offset: u32) -> usize {
+        self.pattern[..offset as usize].chars().count()
+    }
+}
+
+impl std::fmt::Display for RegexError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "regex parse error:")?;
+        writeln!(f, "    {}", self.pattern)?;
+        if self.span.is_some() {
+            let mut spans = [self.span, self.aux_span];
+            spans.sort_unstable_by_key(|span| span.map(|s| (s.start, s.end)));
+
+            write!(f, "    ")?;
+            let mut column = 0;
+            for span in spans.into_iter().flatten() {
+                let start = self.column(span.start);
+                let width = self.column(span.end).saturating_sub(start).max(1);
+                let pad = start.saturating_sub(column);
+                write!(f, "{:pad$}{}", "", "^".repeat(width))?;
+                column = column.max(start) + width;
+            }
+            writeln!(f)?;
+        }
+        write!(f, "error: {}", self.kind)
     }
 }

--- a/crates/generate/src/prepare_grammar/pattern.rs
+++ b/crates/generate/src/prepare_grammar/pattern.rs
@@ -69,11 +69,11 @@ struct Expander<'a> {
 }
 
 /// Parse a token pattern into an [`Hir`], folding any `i` flag manually.
-pub(super) fn parse(pattern: &str, case_insensitive: bool) -> Result<Hir, RegexError> {
+pub(super) fn parse(pattern: &str, case_insensitive: bool) -> Result<Hir, Box<RegexError>> {
     let mut ast = ParserBuilder::new()
         .build()
         .parse(pattern)
-        .map_err(|e| RegexError::new(&e.into()))?;
+        .map_err(|e| Box::new(RegexError::new(&e.into())))?;
 
     let mut expander = Expander {
         translator: TranslatorBuilder::new()
@@ -89,11 +89,11 @@ pub(super) fn parse(pattern: &str, case_insensitive: bool) -> Result<Hir, RegexE
     };
     expander
         .expand(&mut ast)
-        .map_err(|e| RegexError::new(&e.into()))?;
+        .map_err(|e| Box::new(RegexError::new(&e.into())))?;
     expander
         .translator
         .translate(pattern, &ast)
-        .map_err(|e| RegexError::new(&e.into()))
+        .map_err(|e| Box::new(RegexError::new(&e.into())))
 }
 
 impl Expander<'_> {
@@ -447,7 +447,7 @@ impl PatternSpan {
 /// range inside it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub struct RegexError {
-    pub pattern: String,
+    pub pattern: Box<str>,
     pub kind: RegexErrorKind,
     pub span: Option<PatternSpan>,
     pub aux_span: Option<PatternSpan>,
@@ -457,19 +457,19 @@ impl RegexError {
     fn new(error: &regex_syntax::Error) -> Self {
         let (pattern, kind, span, aux_span) = match error {
             regex_syntax::Error::Parse(e) => (
-                e.pattern().to_string(),
+                e.pattern().into(),
                 RegexErrorKind::from(e.kind()),
                 Some(e.span()),
                 e.auxiliary_span(),
             ),
             regex_syntax::Error::Translate(e) => (
-                e.pattern().to_string(),
+                e.pattern().into(),
                 RegexErrorKind::from(e.kind()),
                 Some(e.span()),
                 None,
             ),
             other => (
-                String::new(),
+                Box::default(),
                 RegexErrorKind::Other(other.to_string().into_boxed_str()),
                 None,
                 None,

--- a/crates/generate/src/prepare_grammar/process_inlines.rs
+++ b/crates/generate/src/prepare_grammar/process_inlines.rs
@@ -174,13 +174,13 @@ pub type ProcessInlinesResult<T> = Result<T, ProcessInlinesError>;
 #[derive(Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ProcessInlinesError {
     #[error("External token `{0}` cannot be inlined")]
-    ExternalToken(String),
+    ExternalToken(Box<str>),
     #[error("Token `{0}` cannot be inlined")]
-    Token(String),
+    Token(Box<str>),
     #[error("Rule `{0}` cannot be inlined because it is the first rule")]
-    FirstRule(String),
+    FirstRule(Box<str>),
     #[error("Rule `{0}` has no reachable productions after inlining")]
-    NoReachableProductions(String),
+    NoReachableProductions(Box<str>),
 }
 
 pub(super) fn process_inlines(
@@ -197,15 +197,15 @@ pub(super) fn process_inlines(
             SymbolView::External(index) => Err(ProcessInlinesError::ExternalToken(
                 g.pool
                     .resolve(meta.external_tokens[usize::from(index)].name)
-                    .to_string(),
+                    .into(),
             ))?,
             SymbolView::Terminal(index) => Err(ProcessInlinesError::Token(
                 g.pool
                     .resolve(lexical_variables[usize::from(index)].name)
-                    .to_string(),
+                    .into(),
             ))?,
             SymbolView::NonTerminal(index) if u32::from(index) == 0 => Err(
-                ProcessInlinesError::FirstRule(g.pool.resolve(g.variables[0].name).to_string()),
+                ProcessInlinesError::FirstRule(g.pool.resolve(g.variables[0].name).into()),
             )?,
             SymbolView::NonTerminal(_) => {}
             SymbolView::End | SymbolView::EndOfNonTerminalExtra => unreachable!(),
@@ -229,7 +229,7 @@ pub(super) fn process_inlines(
             let symbol = Symbol::non_terminal(i);
             if i == 0 || out.steps.iter().any(|s| s.symbol() == symbol) {
                 Err(ProcessInlinesError::NoReachableProductions(
-                    g.pool.resolve(g.variables[i].name).to_string(),
+                    g.pool.resolve(g.variables[i].name).to_string().into(),
                 ))?;
             }
         }
@@ -550,7 +550,10 @@ mod tests {
         let result = process_inlines(&g, &meta, &lexical_variables, &mut out);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert_eq!(err, ProcessInlinesError::Token("something".to_string()));
+        assert_eq!(
+            err,
+            ProcessInlinesError::Token("something".to_string().into())
+        );
     }
 
     fn make_lexical_variables_through(
@@ -650,7 +653,7 @@ mod tests {
         };
         assert_eq!(
             process_inlines(&g, &meta, &lexical_variables, &mut out).unwrap_err(),
-            ProcessInlinesError::NoReachableProductions("rule1".to_string())
+            ProcessInlinesError::NoReachableProductions("rule1".to_string().into())
         );
     }
 

--- a/crates/generate/src/quickjs.rs
+++ b/crates/generate/src/quickjs.rs
@@ -23,14 +23,14 @@ impl<T> JSResultExt<T> for Result<T, rquickjs::Error> {
         match self {
             Ok(v) => Ok(v),
             Err(rquickjs::Error::Exception) => Err(format_js_exception(ctx.catch())),
-            Err(e) => Err(JSError::QuickJS(e.to_string())),
+            Err(e) => Err(JSError::QuickJS(e.to_string().into())),
         }
     }
 }
 
 fn format_js_exception(v: Value) -> JSError {
     let Some(exception) = v.into_exception() else {
-        return JSError::QuickJS("Expected a JS exception".to_string());
+        return JSError::QuickJS("Expected a JS exception".to_string().into());
     };
 
     let error_obj = exception.as_object();
@@ -43,9 +43,9 @@ fn format_js_exception(v: Value) -> JSError {
     }
 
     if parts.is_empty() {
-        JSError::QuickJS(exception.to_string())
+        JSError::QuickJS(exception.to_string().into())
     } else {
-        JSError::QuickJS(parts.join("\n"))
+        JSError::QuickJS(parts.join("\n").into())
     }
 }
 

--- a/crates/xtask/src/check_regex_error_kinds.rs
+++ b/crates/xtask/src/check_regex_error_kinds.rs
@@ -1,0 +1,154 @@
+use std::{collections::BTreeSet, fmt::Write as _, path::Path, process::Command};
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde_json::Value;
+
+use crate::bail_on_err;
+
+/// The rustdoc JSON schema this reader was written against.
+const FORMAT_VERSION: u64 = 61;
+
+/// The toolchain that emits [`FORMAT_VERSION`].
+const TOOLCHAIN: &str = "nightly-2026-09-03";
+
+/// The enums [`RegexErrorKind`] mirrors, by their public path upstream.
+const UPSTREAM_ENUMS: [&[&str]; 2] = [
+    &["regex_syntax", "ast", "ErrorKind"],
+    &["regex_syntax", "hir", "ErrorKind"],
+];
+
+pub fn run() -> Result<()> {
+    let target_dir = target_directory()?;
+
+    let upstream_doc = rustdoc_json(&target_dir, "regex-syntax", "regex_syntax")?;
+    let mut upstream = BTreeSet::new();
+    for path in UPSTREAM_ENUMS {
+        let id = find_enum(&upstream_doc, |p| p == path)
+            .with_context(|| format!("no enum `{}` upstream", path.join("::")))?;
+        upstream.extend(variant_names(&upstream_doc, &id)?);
+    }
+
+    let our_doc = rustdoc_json(&target_dir, "tree-sitter-generate", "tree_sitter_generate")?;
+    let id = find_enum(&our_doc, |p| p.last() == Some(&"RegexErrorKind"))
+        .context("no enum `RegexErrorKind` in `tree-sitter-generate`")?;
+    let mut ours = variant_names(&our_doc, &id)?;
+
+    if !ours.remove("Other") {
+        bail!("`RegexErrorKind::Other` is gone, so unmirrored kinds no longer degrade");
+    }
+
+    // A reader that matches nothing would otherwise report two empty sets as
+    // being in sync.
+    if upstream.is_empty() || ours.is_empty() {
+        bail!("read no variants, the rustdoc JSON reader is broken");
+    }
+
+    let missing = upstream.difference(&ours).copied().collect::<Vec<_>>();
+    let extra = ours.difference(&upstream).copied().collect::<Vec<_>>();
+    if missing.is_empty() && extra.is_empty() {
+        return Ok(());
+    }
+
+    let mut message = String::from("`RegexErrorKind` no longer mirrors `regex_syntax`:\n");
+    if !missing.is_empty() {
+        write!(
+            message,
+            "\n  upstream kinds that degrade to `Other`, add them to the macro table:\n    {}\n",
+            missing.join("\n    ")
+        )?;
+    }
+    if !extra.is_empty() {
+        write!(
+            message,
+            "\n  mirrored kinds upstream no longer has, drop them:\n    {}\n",
+            extra.join("\n    ")
+        )?;
+    }
+    Err(anyhow!(message))
+}
+
+/// The workspace's target directory, which is where `cargo rustdoc` writes.
+fn target_directory() -> Result<String> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .output()
+        .context("Failed to run cargo metadata")?;
+    bail_on_err(&output, "Failed to run cargo metadata")?;
+
+    let metadata = serde_json::from_slice::<Value>(&output.stdout)?;
+    metadata["target_directory"]
+        .as_str()
+        .map(ToOwned::to_owned)
+        .context("cargo metadata reported no target directory")
+}
+
+/// Document `package` and read the rustdoc JSON it produces for `crate_name`.
+fn rustdoc_json(target_dir: &str, package: &str, crate_name: &str) -> Result<Value> {
+    let output = Command::new("cargo")
+        .arg(format!("+{TOOLCHAIN}"))
+        .args(["rustdoc", "--package", package, "--lib", "--"])
+        .args(["-Zunstable-options", "--output-format", "json"])
+        .output()
+        .with_context(|| format!("Failed to run cargo rustdoc for `{package}`"))?;
+    bail_on_err(&output, &format!("Failed to document `{package}`"))?;
+
+    let path = Path::new(target_dir)
+        .join("doc")
+        .join(format!("{crate_name}.json"));
+    let doc = serde_json::from_slice::<Value>(
+        &std::fs::read(&path).with_context(|| format!("Failed to read {}", path.display()))?,
+    )?;
+
+    let version = doc["format_version"].as_u64();
+    if version != Some(FORMAT_VERSION) {
+        bail!(
+            "rustdoc JSON is format version {}, this reader expects {FORMAT_VERSION}",
+            version.map_or_else(|| "absent".to_owned(), |v| v.to_string())
+        );
+    }
+
+    Ok(doc)
+}
+
+/// The id of an enum whose path satisfies `matches`.
+///
+/// Paths are where an item is defined rather than where it is re-exported from,
+/// so matching on the trailing segment survives a move between modules.
+fn find_enum(doc: &Value, matches: impl Fn(&[&str]) -> bool) -> Option<String> {
+    doc["paths"].as_object()?.iter().find_map(|(id, item)| {
+        let path = item["path"]
+            .as_array()?
+            .iter()
+            .map(Value::as_str)
+            .collect::<Option<Vec<_>>>()?;
+        (item["kind"] == "enum" && matches(&path)).then(|| id.clone())
+    })
+}
+
+fn variant_names<'a>(doc: &'a Value, id: &str) -> Result<BTreeSet<&'a str>> {
+    let index = doc["index"]
+        .as_object()
+        .context("rustdoc JSON has no item index")?;
+    // Items from other crates are listed in `paths` but carry no `index` entry.
+    let variants = index
+        .get(id)
+        .map(|item| &item["inner"]["enum"]["variants"])
+        .and_then(Value::as_array)
+        .with_context(|| format!("item {id} is not a local enum"))?;
+
+    variants
+        .iter()
+        .map(|variant| {
+            // Variants are referenced by number but indexed by string.
+            let key = match variant {
+                Value::Number(id) => id.to_string(),
+                Value::String(id) => id.clone(),
+                _ => bail!("variant id {variant} is neither a number nor a string"),
+            };
+            index
+                .get(&key)
+                .and_then(|variant| variant["name"].as_str())
+                .with_context(|| format!("no name for variant {key}"))
+        })
+        .collect()
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,6 +1,7 @@
 mod benchmark;
 mod build_wasm;
 mod bump;
+mod check_regex_error_kinds;
 mod check_wasm_exports;
 mod clippy;
 mod embed_sources;
@@ -29,6 +30,8 @@ enum Commands {
     BuildWasmStdlib,
     /// Bumps the version of the workspace.
     BumpVersion(BumpVersion),
+    /// Checks that `RegexErrorKind` still mirrors `regex_syntax`'s error kinds.
+    CheckRegexErrorKinds,
     /// Checks that Wasm exports are synced.
     CheckWasmExports(CheckWasmExports),
     /// Runs `cargo clippy`.
@@ -229,6 +232,7 @@ fn run() -> Result<()> {
         Commands::BuildWasm(build_wasm_options) => build_wasm::run_wasm(&build_wasm_options)?,
         Commands::BuildWasmStdlib => build_wasm::run_wasm_stdlib()?,
         Commands::BumpVersion(bump_options) => bump::run(bump_options)?,
+        Commands::CheckRegexErrorKinds => check_regex_error_kinds::run()?,
         Commands::CheckWasmExports(check_options) => check_wasm_exports::run(&check_options)?,
         Commands::Clippy(clippy_options) => clippy::run(&clippy_options)?,
         Commands::FetchEmscripten => fetch::run_emscripten()?,


### PR DESCRIPTION
`regex_syntax` errors are not serializable, so `ExpandRuleError::Parse`
had a `String` instead of structured data.

Add `RegexError`, a serializable mirror carrying the pattern, the error
kind, and the spans `regex_syntax` reports.

BREAKING CHANGE: Alters public error types for the generate crate.

------

This is a continuation of the same "improve generate as a library" effort from prior PRs. Since we're manually mirroring the error types from this crate, I added a CI job that ensures they're in sync anytime a related file is modified. The maintenance burden for this _should be_ small. If other complications (or upstream changes) complicate this, we can reconsider. The payoff will be evident in an upcoming feature.

While I was working on generate's error types, I found that several weren't publicly exported, so that has now been resolved. In addition to the visibility issue, I changed several to hold `Box<str>` instead of `String` for their payload types. This shrinks `Result` sizes across the crate, which is neutral to marginally better perf-wise.

### AI Policy

- [x] I have read the [AI Policy](https://tree-sitter.github.io/tree-sitter/6-contributing.html#ai-policy) and this PR complies with it.
- [x] If AI tools were used: I have disclosed the tool and extent of usage below.
Used Opus 5 to help design and implement the check job.
<!-- If you used AI tools, state which tool and how it was used. Delete this section if not applicable. -->
